### PR TITLE
feat(HACBS-529): action to push Dockerfile to Quay

### DIFF
--- a/.github/workflows/dockerfile_push.yaml
+++ b/.github/workflows/dockerfile_push.yaml
@@ -1,0 +1,32 @@
+name: Push Dockerfile to Quay
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+jobs:
+  push-dockerfile:
+    name: Push dockerfile
+    runs-on: ubuntu-20.04
+    env:
+      QUAY_ORG: hacbs-release
+      QUAY_REPO: release-utils
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USER }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Build container and push it to Quay
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile
+          tags: |
+            quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_REPO }}:main
+            quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_REPO }}:${{ github.sha }}


### PR DESCRIPTION
This commit adds a github action to push the container described in
./Dockerfile to Quay whenever a change is committed to the file in
the main branch of the repository.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>