### PR TITLE
feat(HACBS-2227): snapshot data model can be used in update expressions

### DIFF
--- a/catalog/task/run-file-updates/0.2/README.md
+++ b/catalog/task/run-file-updates/0.2/README.md
@@ -1,0 +1,21 @@
+# run-file-udpates
+
+Tekton task to create InternalRequests for each repository that needs to be updated. This information is extracted from
+the field `spec.extraData.fileUpdates` in the ReleasePlanAdmission resource.
+
+## Parameters
+
+| Name            | Description                                                   | Optional | Default value                 |
+|-----------------|---------------------------------------------------------------|----------|-------------------------------|
+| jsonKey         | JSON key where the information is defined                     | Yes      | .spec.extraData.fileUpdates[] |
+| fileUpdatesPath | Path to the JSON file containing the key                      | No       |                               |
+| snapshotPath    | Path to the JSON string of the Snapshot spec in the data workspace | No | snapshot_spec.json |
+| request         | Type of request to be created                                 | Yes      | file-updates                  |
+| synchronously   | Whether the task should wait for InternalRequests to complete | Yes      | true                          |
+
+## Changelog
+
+### changes since 0.1
+- adds parameter `snapshotPath`.
+- calls `update-paths` script to run the `{{ }}` enclosed yq updates set in the `paths` key
+  of the defined `fileUpdatesPath` file.

--- a/catalog/task/run-file-updates/0.2/run-file-updates.yaml
+++ b/catalog/task/run-file-updates/0.2/run-file-updates.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-file-updates
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to run file updates
+  params:
+    - name: jsonKey
+      type: string
+      description: The json key containing the file updates
+      default: ".spec.extraData.fileUpdates"
+    - name: fileUpdatesPath
+      type: string
+      description: The path to the file containing the file updates
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      default: "snapshot_spec.json"
+    - name: request
+      type: string
+      description: Name of the request
+      default: "file-updates"
+    - name: synchronously
+      type: string
+      description: Whether to run synchronously or not
+      default: "true"
+  workspaces:
+    - name: data
+      description: Workspace where the file updates to apply are defined
+  steps:
+    - name: run-script
+      image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+      script: |
+        #!/bin/sh
+        #
+        #
+        set -ex
+
+        # Extract the key from the JSON file
+        fileUpdates=$(jq -rc "$(params.jsonKey)" $(workspaces.data.path)/$(params.fileUpdatesPath))
+  
+        # Iterate over the extracted array and call the script
+        fileUpdatesLength=$(jq '. | length' <<< "${fileUpdates}")
+        for((i=0; i<fileUpdatesLength; i++)); do
+          item=$(jq -cr ".[$i]" <<< "${fileUpdates}")
+
+          repo=$(jq -cr '.repo' <<< "${item}")
+          ref=$(jq -cr '.ref // "main"' <<< "${item}")
+          paths=$(jq -cr '.paths // "[]"' <<< "${item}")
+
+          updatedPaths=$(update-paths -p "${paths}" -f $(workspaces.data.path)/$(params.snapshotPath))
+
+          internal-request -r "$(params.request)" \
+                           -p repo="${repo}" \
+                           -p ref="${ref}" \
+                           -p paths="${updatedPaths}" \
+                           -s "$(params.synchronously)"
+        done

--- a/catalog/task/run-file-updates/0.2/samples/sample_run-file-updates_TaskRun.yaml
+++ b/catalog/task/run-file-updates/0.2/samples/sample_run-file-updates_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: run-file-updates
+spec:
+  params:
+    - name: fileUpdatePath
+      value: "rpa.json"
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/run-file-updates/0.2/run-file-updates.yaml

--- a/catalog/task/run-file-updates/0.2/tests/pre-apply-task-hook.sh
+++ b/catalog/task/run-file-updates/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/catalog/task/run-file-updates/0.2/tests/test-run-file-updates.yaml
+++ b/catalog/task/run-file-updates/0.2/tests/test-run-file-updates.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-run-file-updates
+spec:
+  description: |
+    Run the run-file-updates task and verify if the internalrequests were created and the replacements were done
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              yq -o json > "$(workspaces.data.path)/rpa.json" << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                application: foo
+                origin: foo
+                releaseStrategy: foo
+                extraData:
+                      fileUpdates:
+                        - repo: https://gitlab.cee.redhat.com/foo
+                          paths:
+                            - path: foo
+                              replacements:
+                                - key: bar
+                                  replacement: baz
+                        - repo: https://gitlab.cee.redhat.com/bar
+                          paths:
+                            - path: bar
+                              replacements:
+                                - key: baz
+                                  replacement: qux
+                        - repo: https://gitlab.cee.redhat.com/foobar
+                          paths:
+                            - path: foobar
+                              replacements:
+                                - key: ".spec.containers[].image"
+                                  replacement: "|image:.*|image: {{ .components[].containerImage }}|"
+              EOF
+
+              yq -o json > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: run-file-updates
+      params:
+        - name: fileUpdatesPath
+          value: "rpa.json"
+        - name: synchronously
+          value: "false"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/bin/sh
+              set -ex
+
+              # Parse the input json file
+              fileUpdates=$(jq -r '.spec.extraData.fileUpdates | length' "$(workspaces.data.path)/rpa.json")
+              
+              # Fetch all the InternalRequest resources
+              allRequests=$(kubectl get InternalRequest -o json)
+              
+              # Count the number of InternalRequests
+              requestsCount=$(echo "$allRequests" | jq -r '.items | length')
+              
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne "$fileUpdates" ]; then
+                echo "Unexpected number of InternalRequests. Expected: $fileUpdates, Found: $requestsCount"
+                exit 1
+              fi
+                
+              # Loop over the fileUpdates
+              i=0
+              while [ "$i" -lt "$fileUpdates" ]
+              do
+                repo=$(jq -r --argjson i "$i" '.spec.extraData.fileUpdates[$i].repo' \
+                        "$(workspaces.data.path)/rpa.json")
+                paths=$(jq -r --argjson i "$i" '.spec.extraData.fileUpdates[$i].paths' \
+                        "$(workspaces.data.path)/rpa.json")
+              
+                # Check if ref is present in the input file. If not, set it to 'main'
+                ref=$(jq -r --argjson i "$i" '.spec.extraData.fileUpdates[$i].ref // "main"' \
+                        "$(workspaces.data.path)/rpa.json")
+              
+                # Check if an InternalRequest with the same repo exists
+                requestRepo=$(echo "$allRequests" | \
+                              jq -r --arg repo "$repo" '.items[] | select(.spec.params.repo == $repo)')
+              
+                if [ -z "$requestRepo" ]; then
+                echo "No InternalRequest found with repo: $repo"
+                  exit 1
+                fi
+                
+                # Check if the 'request' field contains 'file-updates'
+                if [ "$(echo "$requestRepo" | jq -r '.spec.request' )" != "file-updates" ]; then
+                  echo "InternalRequest for repo: $repo doesn't contain 'file-updates' in 'request' field"
+                  exit 1
+                fi
+                
+                # Check if the 'ref' field matches
+                if [ "$(echo "$requestRepo" | jq -r '.spec.params.ref')" != "$ref" ]; then
+                  echo "InternalRequest for repo: $repo has different 'ref'. Expected: $ref"
+                  exit 1
+                fi
+
+                requestPaths="$(echo "$requestRepo" | jq -r '.spec.params.paths')"
+                replacements="$(echo "$requestPaths" | jq '.[] | select(.path == "foobar") | .replacements[]')"
+                if [ -n "${replacements}" ]; then
+                  if [[ ! $(echo "${replacements}" | jq '.replacement') =~ "test-container-foo:bar" ]]; then
+                    echo "InternalRequest for repo: $repo has different 'replacement' for foobar. 
+                          Expected: 'test-container-foo:bar'"
+                    exit 1
+                  fi
+                fi
+
+                i=$((i+1))
+              done
+                
+              echo "All checks passed successfully."


### PR DESCRIPTION
Modifies the task run-file-updates enabling the feature of through yq
expression to update the fileUpdates paths replacements using the
snapshot model

Requires: https://github.com/redhat-appstudio/release-service-utils/pull/54


Signed-off-by: Leandro Mendes <lmendes@redhat.com>