### PR TITLE
feat(HACBS-2293): add a task to update FBC index tag

### DIFF
--- a/catalog/pipeline/fbc-release/0.20/README.md
+++ b/catalog/pipeline/fbc-release/0.20/README.md
@@ -1,0 +1,129 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| iibServiceConfigSecret | Secret that contains IIB's service configuration | Yes | "iib-services-config" |
+| iibOverwriteFromIndexCredential | Secret that stores IIB's overwrite_from_index_token parameter value | Yes | "iib-overwrite-fromimage-credentials" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changelog
+
+### Changes since 0.19
+- adds new tasks `get-ocp-version` and `update-ocp-tag` to update version tag
+  for `targetIndex`, `fromIndex` and `binaryImage` with valid OCP Version
+
+### Changes since 0.18
+- explicitly set IGNORE_REKOR value to "true" in the verify-enterprise-contract task
+- use git resolvers for the verify-enterprise-contract task
+    - the verify_ec_task_bundle parameter was placed with verify_ec_task_git_url,
+      verify_ec_task_git_revision, and verify_ec_task_git_pathInRepo
+
+### Changes since 0.17
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- use new version of create-internal-requests task with subdirectory parameter
+
+### Changes since 0.16
+- git resolvers are used in place of release bundle resolvers
+
+### Changes since 0.15
+- the collect-data task was added
+    - this includes adding the required parameters releaseplan, releaseplanadmission, and
+      releasestrategy as pipeline parameters
+- the snapshot parameter is now a namespaced name instead of a JSON string
+    - task versions were updated in accordance with this change
+
+### Changes since 0.14
+- adds parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential`
+  to enable the build of pre-GA and prod FBC components in the same namespace
+
+### Changes since 0.13
+- adds back the parameter `fbcPublishingCredentials` as different secrets
+  might be set for the same namespace
+
+### Changes since 0.12
+- the release parameter was added and the requester parameter was removed
+    - the value to use for signing is now pulled from the release resource status
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
@@ -1,0 +1,346 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.20"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: iibServiceConfigSecret
+      default: "iib-services-config"
+      type: string
+      description: Secret that contains IIB's service configuration
+    - name: iibOverwriteFromIndexCredential
+      default: "iib-overwrite-fromimage-credentials"
+      type: string
+      description: Secret that stores IIB's overwrite_from_index_token parameter value
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_git_url
+      type: string
+      description: The git repo url of the verify-enterprise-contract task
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git repo revision the verify-enterprise-contract task
+    - name: verify_ec_task_git_pathInRepo
+      type: string
+      description: The location of the verify-enterprise-contract task in its repo
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.2/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.verify_ec_task_git_url)
+          - name: revision
+            value: $(params.verify_ec_task_git_revision)
+          - name: pathInRepo
+            value: $(params.verify_ec_task_git_pathInRepo)
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: get-ocp-version
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/get-ocp-version/0.1/get-ocp-version.yaml
+      params:
+        - name: fbcFragment
+          value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: update-ocp-tag
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml
+      params:
+        - name: fromIndex
+          value: "$(params.fromIndex)"
+        - name: targetIndex
+          value: "$(params.targetIndex)"
+        - name: binaryImage
+          value: "$(params.binaryImage)"
+        - name: ocpVersion
+          value: "$(tasks.get-ocp-version.results.stored-version)"
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
+            - name: fromIndex
+              value: "$(tasks.update-ocp-tag.results.updated-fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: iibServiceConfigSecret
+              value: "$(params.iibServiceConfigSecret)"
+            - name: iibOverwriteFromIndexCredential
+              value: "$(params.iibOverwriteFromIndexCredential)"
+            - name: fbcFragment
+              value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: extract-requester-from-release
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
+      params:
+        - name: image
+          value: "quay.io/hacbs-release/cloud-builders-kubectl\
+            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
+        - name: script
+          value: |
+            set -x
+
+            NAMESPACE=$(echo $(params.release) | cut -d '/' -f 1)
+            NAME=$(echo $(params.release) | cut -d '/' -f 2)
+
+            AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
+            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+
+            if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(tasks.extract-requester-from-release.results.output-result)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(tasks.update-ocp-tag.results.updated-targetIndex)
+            - name: publishingCredentials
+              value: $(params.fbcPublishingCredentials)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.20/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.20/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.20/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.20/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.20/tests/run.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.20/fbc-release.yaml

--- a/catalog/task/update-ocp-tag/0.1/README.md
+++ b/catalog/task/update-ocp-tag/0.1/README.md
@@ -1,0 +1,14 @@
+# update-ocp-tag
+
+Tekton task to update version tag of FBC pull-spec
+ `fromIndex`, `targetIndex` and `binaryImage` with the 
+ provided OCP version.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | No | - |
+| ocpVersion |  OCP version fetched from fbcFragment | No | - |

--- a/catalog/task/update-ocp-tag/0.1/samples/sample_update-ocp-tag_TaskRun.yaml
+++ b/catalog/task/update-ocp-tag/0.1/samples/sample_update-ocp-tag_TaskRun.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: update-ocp-tag-run-empty-params
+spec:
+  params:
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: ocpVersion
+      value: ""  
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml

--- a/catalog/task/update-ocp-tag/0.1/tests/test-update-ocp-tag.yaml
+++ b/catalog/task/update-ocp-tag/0.1/tests/test-update-ocp-tag.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-update-ocp-tag
+spec:
+  description: |
+    Run the update-ocp-tag task with sample values
+    and verify that all tags get updated to the new OCP version.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: update-ocp-tag
+      params:
+        - name: fromIndex
+          value: >-
+            "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12"
+        - name: targetIndex
+          value: >-
+            "quay.io/redhat/redhat----preview-operator-index:v4.12"
+        - name: binaryImage
+          value: >-
+            "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: ocpVersion
+          value: "v4.13"
+    - name: check-result
+      params:
+        - name: updated-fromIndex
+          value: $(tasks.run-task.results.updated-fromIndex)
+        - name: updated-targetIndex
+          value: $(tasks.run-task.results.updated-targetIndex)
+        - name: updated-binaryImage
+          value: $(tasks.run-task.results.updated-binaryImage)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: updated-fromIndex
+            type: string
+          - name: updated-targetIndex
+            type: string
+          - name: updated-binaryImage
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            env:
+              - name: "UPDATED_FROMINDEX"
+                value: '$(params.updated-fromIndex)'
+              - name: "UPDATED_TARGETINDEX"
+                value: '$(params.updated-targetIndex)'
+              - name: "UPDATED_BINARYIMAGE"
+                value: '$(params.updated-binaryImage)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo "Validate all tags got updated to v4.13"
+              test "$(echo $UPDATED_FROMINDEX)" == \
+              "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
+              test "$(echo $UPDATED_TARGETINDEX)" == "quay.io/redhat/redhat----preview-operator-index:v4.13"
+              test "$(echo $UPDATED_BINARYIMAGE)" == "registry.redhat.io/openshift4/ose-operator-registry:v4.13"

--- a/catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml
+++ b/catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: update-ocp-tag
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to update pull-spec tag with
+    valid OCP version from get-ocp-version task.
+  params:
+    - name: fromIndex
+      description: The source Index image (catalog of catalogs) FBC fragment
+      type: string
+    - name: targetIndex
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+      type: string
+    - name: binaryImage
+      description: OCP binary image to be baked into the index image
+      type: string
+    - name: ocpVersion
+      description: OCP version tag to replace the current set tags on index images
+      type: string
+  results:
+    - name: updated-fromIndex
+      description: source Index image (catalog of catalogs) FBC fragment with updated tag
+    - name: updated-targetIndex
+      description: Index image (catalog of catalogs) the FBC fragment will be added to with updated tag
+    - name: updated-binaryImage
+      description: OCP binary image to be baked into the index image with updated tag
+  steps:
+    - name: update-ocp-tag
+      image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+      script: |
+       #!/usr/bin/env sh
+       set -eu
+
+        # Function to replace tag in an image
+        replace_tag() {
+            local updatedImage="${1%:*}:$(params.ocpVersion)"
+            echo "$updatedImage"
+        }
+
+        # Access the updated image
+        updatedFromIndex=$(replace_tag "$(params.fromIndex)")
+        updatedTargetIndex=$(replace_tag "$(params.targetIndex)")
+        updatedBinaryImage=$(replace_tag "$(params.binaryImage)")
+
+        echo "Updated values"
+        echo -n "$updatedFromIndex" | tee $(results.updated-fromIndex.path)
+        echo
+        echo -n "$updatedTargetIndex" | tee $(results.updated-targetIndex.path)
+        echo
+        echo -n "$updatedBinaryImage" | tee $(results.updated-binaryImage.path)
+        echo

--- a/catalog/task/update-ocp-tag/OWNERS
+++ b/catalog/task/update-ocp-tag/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
- This commit adds a new task, `update-ocp-tag` for updating `fromIndex`, `targetIndex`, and `binaryImage`version tags with the version fetched from fbcFragment by `get-ocp-version` task.
- Adds both `get-ocp-version` and `update-ocp-tag` tasks to fbc-release pipeline to accomplish the end results.