### PR TITLE
feat: add CODEOWNERS file to auto assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @redhat-appstudio/release-team will be requested for
+# review when someone opens a pull request.
+*       @redhat-appstudio/release-team


### PR DESCRIPTION
This will automatically add everybody on the team
as reviewers for new pull requests (unless
they are created as a draft).