### PR TITLE
fix(RHTAPBUGS-738): fbc release pipelinerun fails on task add-fbc-contribution-to-index-image

### DIFF
--- a/catalog/task/create-internal-request/0.7/README.md
+++ b/catalog/task/create-internal-request/0.7/README.md
@@ -19,6 +19,9 @@ Creates an InternalRequest resource to call IIB service
 - add new subdirectory parameter to be used for storing of results file
     - this will enable us to clean up only the current pipelinerun's
       data in the fbc-release pipeline
+- changes the task step `watch-internal-request-status` to check for
+  `.status.condition[0].reason` instead of `.status.condition[0].status` to determine
+  if the request has Succeeded of Failed.
 
 ### changes since 0.5
 - adds `updateGenericResult` parameter to control whether the `genericResult`

--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -161,7 +161,7 @@ spec:
             case "\${REASON}" in
               Succeeded | Failed )
                 echo "InternalRequest finished"
-                echo ${REASON} | tee $(results.requestReason.path)
+                echo \${REASON} | tee $(results.requestReason.path)
                 kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}' \
                 | tee $(results.requestMessage.path)
                 if [ "$(params.updateGenericResult)" == "true" ]; then

--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -156,13 +156,13 @@ spec:
 
           IR="ir-$(params.pipelineRunName)-$(params.request)"
           while true; do
-            STATUS=\$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}')
-            case "\${STATUS}" in
-              True | False )
+            REASON=\$(kubectl get internalrequest \${IR} -o \
+                jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}'
+            case "\${REASON}" in
+              Succeeded | Failed )
                 echo "InternalRequest finished"
-                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].reason}' \
-                | tee $(results.requestReason.path)
-                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].message}' \
+                echo ${REASON} | tee $(results.requestReason.path)
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}' \
                 | tee $(results.requestMessage.path)
                 if [ "$(params.updateGenericResult)" == "true" ]; then
                     kubectl get internalrequest \${IR} -o jsonpath='{.status.results.genericResult}' \
@@ -177,7 +177,8 @@ spec:
             esac
             sleep 30
           done
-          [ \$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}') == "True" ]
+          [ \$(kubectl get internalrequest \${IR} -o \
+            jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}') == "Succeeded" ]
           SH
           chmod +x ${TASKRUN}
           timeout $(params.requestUpdateTimeout) ${TASKRUN}


### PR DESCRIPTION
fix(RHTAPBUGS-738): fbc release pipelinerun fails on task add-fbc-contribution-to-index-image

This PR changes the task step `watch-internal-request-status` to check for
`.status.condition[0].reason` instead of `.status.condition[0].status` to determine 
if the request has Succeeded of Failed.
