### PR TITLE
fix(HACBS-2505): allow override of request timeout

### DIFF
--- a/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
@@ -200,6 +200,8 @@ spec:
           value: "true"
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: requestUpdateTimeout
+          value: "$(params.requestUpdateTimeout)"
         - name: params
           value:
             - name: binaryImage


### PR DESCRIPTION
- the pipeline param for the requestTimeout was not being passed to the task
- the side effect was that the default was always being used.