### PR TITLE
feat(HACBS-2590): adding upstream_repo param to run-file-updates task

### DIFF
--- a/catalog/task/run-file-updates/0.2/run-file-updates.yaml
+++ b/catalog/task/run-file-updates/0.2/run-file-updates.yaml
@@ -52,12 +52,14 @@ spec:
           item=$(jq -cr ".[$i]" <<< "${fileUpdates}")
 
           repo=$(jq -cr '.repo' <<< "${item}")
+          upstream_repo=$(jq -cr '.upstream_repo' <<< "${item}")
           ref=$(jq -cr '.ref // "main"' <<< "${item}")
           paths=$(jq -cr '.paths // "[]"' <<< "${item}")
 
           updatedPaths=$(update-paths -p "${paths}" -f $(workspaces.data.path)/$(params.snapshotPath))
 
           internal-request -r "$(params.request)" \
+                           -p upstream_repo="${upstream_repo}" \
                            -p repo="${repo}" \
                            -p ref="${ref}" \
                            -p paths="${updatedPaths}" \


### PR DESCRIPTION
This PR adds the new parameter `upstream_repo` to the run-file-updates task to enable creating MRs from a fork.