### PR TITLE
refactor: rename references from hacbs-contact to enterprise-contract

### DIFF
--- a/catalog/pipeline/deploy-release/0.1/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.1/deploy-release.yaml
@@ -22,7 +22,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/deploy-release/0.2/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.2/deploy-release.yaml
@@ -24,7 +24,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/fbc-release/0.10/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.10/fbc-release.yaml
@@ -69,7 +69,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/fbc-release/0.2/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.2/fbc-release.yaml
@@ -52,7 +52,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.3/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.3/fbc-release.yaml
@@ -52,7 +52,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.4/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.4/fbc-release.yaml
@@ -55,7 +55,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.5/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.5/fbc-release.yaml
@@ -57,7 +57,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.6/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.6/fbc-release.yaml
@@ -57,7 +57,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.7/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.7/fbc-release.yaml
@@ -63,7 +63,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(params.snapshot)

--- a/catalog/pipeline/fbc-release/0.8/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.8/fbc-release.yaml
@@ -65,7 +65,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/fbc-release/0.9/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.9/fbc-release.yaml
@@ -66,7 +66,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/push-to-external-registry/0.1/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.1/push-to-external-registry.yaml
@@ -83,7 +83,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/push-to-external-registry/0.10/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.10/push-to-external-registry.yaml
@@ -112,7 +112,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/push-to-external-registry/0.2/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.2/push-to-external-registry.yaml
@@ -83,7 +83,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
@@ -83,7 +83,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/push-to-external-registry/0.4/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.4/push-to-external-registry.yaml
@@ -91,7 +91,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
@@ -95,7 +95,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/push-to-external-registry/0.6/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.6/push-to-external-registry.yaml
@@ -110,7 +110,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.7/push-to-external-registry.yaml
@@ -110,7 +110,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/push-to-external-registry/0.8/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.8/push-to-external-registry.yaml
@@ -110,7 +110,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.9/push-to-external-registry.yaml
@@ -112,7 +112,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:snapshot
+            value: quay.io/enterprise-contract/ec-task-bundle:snapshot
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.10/release.yaml
+++ b/catalog/pipeline/release/0.10/release.yaml
@@ -92,7 +92,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:7f2e25e9fc6c64c95238628b0b2bdbd1aeb79454
+            value: quay.io/enterprise-contract/ec-task-bundle:fc6c3170b0996818114b7a9c4c2da9788885ea34
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.11/release.yaml
+++ b/catalog/pipeline/release/0.11/release.yaml
@@ -92,7 +92,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
+            value: quay.io/enterprise-contract/ec-task-bundle:fc6c3170b0996818114b7a9c4c2da9788885ea34
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.12/release.yaml
+++ b/catalog/pipeline/release/0.12/release.yaml
@@ -94,7 +94,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
+            value: quay.io/enterprise-contract/ec-task-bundle:fc6c3170b0996818114b7a9c4c2da9788885ea34
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.13/release.yaml
+++ b/catalog/pipeline/release/0.13/release.yaml
@@ -94,7 +94,7 @@ spec:
         resolver: "bundles"
         params:
           - name: bundle
-            value: quay.io/hacbs-contract/ec-task-bundle:cf58b68b872dacbbcb2cc571efac135b2989d638
+            value: quay.io/enterprise-contract/ec-task-bundle:fc6c3170b0996818114b7a9c4c2da9788885ea34
           - name: kind
             value: task
           - name: name

--- a/catalog/pipeline/release/0.6/release.yaml
+++ b/catalog/pipeline/release/0.6/release.yaml
@@ -74,7 +74,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/release/0.7/release.yaml
+++ b/catalog/pipeline/release/0.7/release.yaml
@@ -74,7 +74,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/release/0.8/release.yaml
+++ b/catalog/pipeline/release/0.8/release.yaml
@@ -74,7 +74,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)

--- a/catalog/pipeline/release/0.9/release.yaml
+++ b/catalog/pipeline/release/0.9/release.yaml
@@ -74,7 +74,7 @@ spec:
     - name: verify-enterprise-contract
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:7f2e25e9fc6c64c95238628b0b2bdbd1aeb79454
+        bundle: quay.io/enterprise-contract/ec-task-bundle:fc6c3170b0996818114b7a9c4c2da9788885ea34
       params:
         - name: IMAGES
           value: $(tasks.apply-mapping.results.snapshot)


### PR DESCRIPTION
The EC team is removing the hacbs name from the quay org used. This update also updates the tag used for the ec task to the latest.