### PR TITLE
feat(HACBS-2228): Add run-fileupdates to push-external pipeline

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.18/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.18/README.md
@@ -1,0 +1,103 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.17
+- run-file-updates now included
+
+## Changes since 0.16
+- explicitly set IGNORE_REKOR value to "true" in the verify-enterprise-contract task
+- use git resolvers for the verify-enterprise-contract task
+    - the verify_ec_task_bundle parameter was placed with verify_ec_task_git_url,
+      verify_ec_task_git_revision, and verify_ec_task_git_pathInRepo
+
+## Changes since 0.15
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- also use new version of apply-mapping which overrides the original snapshot_spec file
+    - and specify snapshotPath for this task to point to the subdir
+
+## Changes since 0.14
+* update push-snapshot task to be v0.10
+
+## Changes since 0.13
+* git resolvers are used in place of release bundle resolvers
+
+## Changes since 0.12
+* the push-snapshot task was updated to version 0.9 to use `cosign copy` instead of `skopeo copy`
+
+## Changes since 0.11
+* the collect-data task was added
+  * this includes adding the required parameters release, releaseplan, releaseplanadmission,
+      and releasestrategy as pipeline parameters
+* the snapshot parameter is now a namespaced name instead of a JSON string
+  * task versions were updated in accordance with this change
+
+## Changes since 0.10
+* the verify_ec_task_bundle parameter was added
+  * with this addition, the verify-enterprise-contract task version is no longer static
+
+## Changes since 0.9
+* addGitShaTag now defaults to true instead of false
+
+## Changes since 0.8
+* Use version 0.4 of apply-mapping task and set the new failOnEmptyResult parameter to true
+  * This will ensure that if the result of mapping is an empty component list, the task will fail
+
+## Changes since 0.7
+* Upgrade push-snapshot task to version 0.7
+  * Only the first 7 characters are used for the git sha tag in Quay.
+
+## Changes since 0.6
+Add `push-sbom-to-pyxis` task to the pipeline. This will ensure that sbom components
+for the image are pushed to Pyxis as part of this pipeline.
+
+## Changes since 0.5
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml
@@ -1,0 +1,301 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.18"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "true"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+    - name: verify_ec_task_git_url
+      type: string
+      description: The git repo url of the verify-enterprise-contract task
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git repo revision the verify-enterprise-contract task
+    - name: verify_ec_task_git_pathInRepo
+      type: string
+      description: The location of the verify-enterprise-contract task in its repo
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.2/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: clone-config-file
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/build-definitions.git
+          - name: revision
+            value: dedce1f59906394ea777606683eec9eb2de465ac
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)/extraConfig"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
+      params:
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
+        - name: failOnEmptyResult
+          value: "true"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.verify_ec_task_git_url)
+          - name: revision
+            value: $(params.verify_ec_task_git_revision)
+          - name: pathInRepo
+            value: $(params.verify_ec_task_git_pathInRepo)
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
+    - name: push-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
+      params:
+        - name: tag
+          value: $(params.tag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-snapshot
+    - name: push-sbom-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
+      params:
+        - name: containerImageIDs
+          value: $(tasks.create-pyxis-image.results.containerImageIDs)
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: run-file-updates
+      params:
+        - name: fileUpdatesPath
+          value: $(context.pipelineRun.uid)/extra_data.json
+        - name: jsonKey
+          value: ".fileUpdates"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      runAfter:
+        - push-sbom-to-pyxis
+      taskRef:
+        kind: Task
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/run-file-updates/0.2/run-file-updates.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.18/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.18/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml


### PR DESCRIPTION
- only activated by the presence of a extraData.fileUpdates section in a RPA

```
diff catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml catalog/pipeline/push-to-external-registry/0.17/push-to-external-registry.yaml
7c7
<     app.kubernetes.io/version: "0.18"
---
>     app.kubernetes.io/version: "0.17"
255,277d254
<       workspaces:
<         - name: data
<           workspace: release-workspace
<     - name: run-file-updates
<       params:
<         - name: fileUpdatesPath
<           value: $(context.pipelineRun.uid)/extra_data.json
<         - name: jsonKey
<           value: ".fileUpdates"
<         - name: snapshotPath
<           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
<       runAfter:
<         - push-sbom-to-pyxis
<       taskRef:
<         kind: Task
<         params:
<           - name: url
<             value: https://github.com/redhat-appstudio/release-service-bundles.git
<           - name: revision
<             value: main
<           - name: pathInRepo
<             value: catalog/task/run-file-updates/0.2/run-file-updates.yaml
<         resolver: git
diff catalog/pipeline/push-to-external-registry/0.18/README.md catalog/pipeline/push-to-external-registry/0.17/README.md
29,31d28
< ## Changes since 0.17
< - run-file-updates now included
< 

```