### PR TITLE
fix(RHTAPBUGS-756): include mediaType when creating image in Pyxis

### DIFF
--- a/catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
+++ b/catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
@@ -44,7 +44,7 @@ spec:
   steps:
     - name: create-pyxis-image
       image:
-        quay.io/hacbs-release/release-utils@sha256:5298e31e7e7a97cab005750096abe8dbfca3f422cf049fd87de76a117072a9b5
+        quay.io/hacbs-release/release-utils:b198ed78e14490f194f69cc33137900abe07b848
       env:
         - name: pyxisCert
           valueFrom:
@@ -82,6 +82,7 @@ spec:
 
         for containerImage in $(jq -r '.components[].repository' "${SNAPSHOT_SPEC_FILE}") ; do
 
+            MEDIA_TYPE=$(skopeo inspect --raw "docker://${containerImage}" | jq -r .mediaType)
             skopeo inspect --no-tags "docker://${containerImage}" > /tmp/skopeo-inspect.json
 
             PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
@@ -90,7 +91,8 @@ spec:
               --tag $(params.tag) \
               --is-latest $(params.isLatest) \
               --verbose \
-              --skopeo-result /tmp/skopeo-inspect.json | tee /tmp/output
+              --skopeo-result /tmp/skopeo-inspect.json \
+              --media-type "$MEDIA_TYPE" | tee /tmp/output
 
             grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageIDs.path)
         done

--- a/catalog/task/create-pyxis-image/0.4/tests/mocks.sh
+++ b/catalog/task/create-pyxis-image/0.4/tests/mocks.sh
@@ -7,18 +7,24 @@ function create_container_image() {
   echo Mock create_container_image called with: $* >> $(workspaces.data.path)/mock_create_container_image.txt
   echo The image id is 0000
 
-  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tag testtag --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json" ]]
+  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tag testtag --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type" ]]
   then
     echo Error: Unexpected call
+    echo Mock create_container_image called with: $*
     exit 1
   fi
 }
 
 function skopeo() {
-  echo Mock skopeo called with: $*
-  if [[ "$*" != "inspect --no-tags docker://"* ]]
+  if [[ "$*" == "inspect --raw docker://"* ]]
   then
-    echo Error: Unexpected call
-    exit 1
+    echo '{"mediaType": "my_media_type"}'
+  else
+    echo Mock skopeo called with: $*
+    if [[ "$*" != "inspect --no-tags docker://"* ]]
+    then
+      echo Error: Unexpected call
+      exit 1
+    fi
   fi
 }


### PR DESCRIPTION
Based on the mediaType returned by `skopeo inspect --raw`, the create_container_image will determine if the image is single arch or multi arch and based on that
it will populate either manifest_schema2_digest
or manifest_list_digest in the embedded
ContainerImageRepo object when creating a new
image in Pyxis.

This PR requires https://github.com/redhat-appstudio/release-service-utils/pull/58 which is merged now, so the image used by the task step is updated.

Note that I might want to wait for this one to be merged first (in which case I will need to modify this PR to change the new version instead): https://github.com/redhat-appstudio/release-service-bundles/pull/192 Or if this is approved first, I will reach out to Troy before merging.