### PR TITLE
fix: create-internal-request emits result reason twice

### DIFF
--- a/catalog/task/create-internal-request/0.7/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.7/create-internal-request.yaml
@@ -162,7 +162,7 @@ spec:
               Succeeded | Failed )
                 echo "InternalRequest finished"
                 echo \${REASON} | tee $(results.requestReason.path)
-                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}' \
+                kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].message}' \
                 | tee $(results.requestMessage.path)
                 if [ "$(params.updateGenericResult)" == "true" ]; then
                     kubectl get internalrequest \${IR} -o jsonpath='{.status.results.genericResult}' \


### PR DESCRIPTION
The create-internal-request task emits both a requestReason and a requestMessage. The requestMessage was using the reason from the internal request instead of the message. This commit fixes it to properly use the message.