### PR TITLE
fix: the get-ocp-version test by update fbcFragmen value

### DIFF
--- a/catalog/task/get-ocp-version/0.1/tests/test-get-ocp-version.yaml
+++ b/catalog/task/get-ocp-version/0.1/tests/test-get-ocp-version.yaml
@@ -16,7 +16,7 @@ spec:
       params:
         - name: fbcFragment
           value: >-
-            quay.io/hacbs-release-tests/managed-release-team-tenant/sample-fbc-application/sample-fbc-component@sha256:3bab7aa91d6e62c6e6f8cd6e701b78124d477eab3d8d1e1d3bce59c81204b1d7
+            quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297
     - name: check-result
       params:
         - name: stored-version


### PR DESCRIPTION
The test for `get-ocp-version` task is failing because the quay.io repo no longer exists.
This commit adds a valid fragment value for the test.