### PR TITLE
fix: skip upstream tasks when running tekton tasks

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -44,6 +44,8 @@ jobs:
         with:
           files: |
             catalog/task/*/*/*
+          files_ignore: |
+            catalog/task/upstream/*
           dir_names: "true"
           dir_names_max_depth: "4"
       - name: Show changed dirs


### PR DESCRIPTION
This caused issues in this PR:
https://github.com/redhat-appstudio/release-service-bundles/pull/192