### PR TITLE
refactor(HACBS-2415): explicitly set IGNORE_REKOR value

### DIFF
--- a/catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml
@@ -180,6 +180,8 @@ spec:
           value: $(params.enterpriseContractPolicy)
         - name: STRICT
           value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
         - name: PUBLIC_KEY
           value: $(params.enterpriseContractPublicKey)
       workspaces:


### PR DESCRIPTION
This commit adds the IGNORE_REKOR value to the 0.3 version of the rhtap-service-push pipeline which had been omitted initially.