### PR TITLE
feat(HACBS-2488): change revision to legacy

### DIFF
--- a/catalog/pipeline/deploy-release/0.5/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.5/deploy-release.yaml
@@ -44,7 +44,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:

--- a/catalog/pipeline/deploy-release/0.5/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.5/samples/sample_release_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.5/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.5/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.5/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.6/deploy-release.yaml
@@ -48,7 +48,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -99,7 +99,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.6/samples/sample_release_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.6/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.6/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.6/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.6/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.7/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.7/deploy-release.yaml
@@ -58,7 +58,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -113,7 +113,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/deploy-release/0.7/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.7/samples/sample_release_PipelineRun.yaml
@@ -29,6 +29,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.7/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.7/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.7/tests/run.yaml
@@ -29,6 +29,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.7/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.8/deploy-release.yaml
+++ b/catalog/pipeline/deploy-release/0.8/deploy-release.yaml
@@ -58,7 +58,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.4/collect-data.yaml
       params:
@@ -113,7 +113,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/deploy-release/0.8/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/deploy-release/0.8/samples/sample_release_PipelineRun.yaml
@@ -29,6 +29,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.8/deploy-release.yaml

--- a/catalog/pipeline/deploy-release/0.8/tests/run.yaml
+++ b/catalog/pipeline/deploy-release/0.8/tests/run.yaml
@@ -29,6 +29,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/deploy-release/0.8/deploy-release.yaml

--- a/catalog/pipeline/fbc-release/0.17/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.17/fbc-release.yaml
@@ -89,7 +89,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
       params:
@@ -177,7 +177,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
       params:
@@ -205,7 +205,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
       params:
@@ -242,7 +242,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.6/create-internal-request.yaml
       params:
@@ -277,7 +277,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       params:

--- a/catalog/pipeline/fbc-release/0.17/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.17/samples/sample_release_PipelineRun.yaml
@@ -49,6 +49,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.17/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.17/tests/run.yaml
@@ -49,6 +49,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.17/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.18/fbc-release.yaml
@@ -93,7 +93,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -146,7 +146,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -185,7 +185,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
       params:
@@ -213,7 +213,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -252,7 +252,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -289,7 +289,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.18/samples/sample_release_PipelineRun.yaml
@@ -49,6 +49,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.18/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.18/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.18/tests/run.yaml
@@ -49,6 +49,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.18/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.19/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.19/fbc-release.yaml
@@ -99,7 +99,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -154,7 +154,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -193,7 +193,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
       params:
@@ -221,7 +221,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -260,7 +260,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -297,7 +297,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/fbc-release/0.19/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.19/samples/sample_release_PipelineRun.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.19/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.19/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.19/tests/run.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.19/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.20/fbc-release.yaml
@@ -103,7 +103,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -157,7 +157,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/get-ocp-version/0.1/get-ocp-version.yaml
       params:
@@ -172,7 +172,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml
       params:
@@ -194,7 +194,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -235,7 +235,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
       params:
@@ -263,7 +263,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -302,7 +302,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -339,7 +339,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/fbc-release/0.20/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.20/samples/sample_release_PipelineRun.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.20/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.20/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.20/tests/run.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.20/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.21/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.21/fbc-release.yaml
@@ -107,7 +107,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -161,7 +161,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/get-ocp-version/0.1/get-ocp-version.yaml
       params:
@@ -176,7 +176,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml
       params:
@@ -198,7 +198,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -239,7 +239,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.2/kubernetes-actions.yaml
       params:
@@ -267,7 +267,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -306,7 +306,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/extract-index-image/0.1/extract-index-image.yaml
       params:
@@ -322,7 +322,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.7/create-internal-request.yaml
       params:
@@ -359,7 +359,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/fbc-release/0.21/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.21/samples/sample_release_PipelineRun.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.21/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.21/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.21/tests/run.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.21/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.22/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.22/fbc-release.yaml
@@ -111,7 +111,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.4/collect-data.yaml
       params:
@@ -165,7 +165,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/get-ocp-version/0.2/get-ocp-version.yaml
       params:
@@ -180,7 +180,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-ocp-tag/0.2/update-ocp-tag.yaml
       params:
@@ -202,7 +202,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
       params:
@@ -243,7 +243,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/upstream/tekton/kubernetes-actions/0.3/kubernetes-actions.yaml
       params:
@@ -271,7 +271,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
       params:
@@ -310,7 +310,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/extract-index-image/0.2/extract-index-image.yaml
       params:
@@ -326,7 +326,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
       params:
@@ -363,7 +363,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/fbc-release/0.22/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.22/samples/sample_release_PipelineRun.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.22/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.22/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.22/tests/run.yaml
@@ -53,6 +53,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/fbc-release/0.22/fbc-release.yaml

--- a/catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml
@@ -82,7 +82,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:
@@ -130,7 +130,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
       params:
@@ -178,7 +178,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
       params:
@@ -202,7 +202,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -224,7 +224,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -245,7 +245,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.14/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.14/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.14/tests/run.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.14/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml
@@ -82,7 +82,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:
@@ -130,7 +130,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
       params:
@@ -178,7 +178,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -202,7 +202,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -224,7 +224,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -245,7 +245,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.15/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.15/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.15/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.15/tests/run.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.15/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml
@@ -82,7 +82,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -132,7 +132,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -182,7 +182,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -208,7 +208,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -232,7 +232,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -255,7 +255,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.16/tests/run.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.16/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.17/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.17/push-to-external-registry.yaml
@@ -88,7 +88,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -138,7 +138,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -190,7 +190,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -216,7 +216,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -240,7 +240,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -263,7 +263,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.17/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.17/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.17/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.17/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.17/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.17/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml
@@ -92,7 +92,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -196,7 +196,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -222,7 +222,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -277,7 +277,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/run-file-updates/0.2/run-file-updates.yaml
         resolver: git
@@ -292,7 +292,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.18/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.18/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.18/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.18/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.19/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.19/push-to-external-registry.yaml
@@ -92,7 +92,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.4/collect-data.yaml
       params:
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.7/apply-mapping.yaml
       params:
@@ -196,7 +196,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.11/push-snapshot.yaml
       params:
@@ -222,7 +222,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.5/create-pyxis-image.yaml
       params:
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.3/push-sbom-to-pyxis.yaml
       params:
@@ -277,7 +277,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/run-file-updates/0.4/run-file-updates.yaml
         resolver: git
@@ -292,7 +292,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/push-to-external-registry/0.19/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.19/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.19/push-to-external-registry.yaml

--- a/catalog/pipeline/push-to-external-registry/0.19/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.19/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/push-to-external-registry/0.19/push-to-external-registry.yaml

--- a/catalog/pipeline/release/0.17/release.yaml
+++ b/catalog/pipeline/release/0.17/release.yaml
@@ -64,7 +64,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:
@@ -112,7 +112,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
       params:
@@ -160,7 +160,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
       params:
@@ -179,7 +179,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/release/0.17/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.17/samples/sample_release_PipelineRun.yaml
@@ -33,6 +33,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/pipeline/release/0.17/tests/run.yaml
+++ b/catalog/pipeline/release/0.17/tests/run.yaml
@@ -33,6 +33,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.17/release.yaml

--- a/catalog/pipeline/release/0.18/release.yaml
+++ b/catalog/pipeline/release/0.18/release.yaml
@@ -64,7 +64,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -114,7 +114,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -164,7 +164,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
       params:
@@ -185,7 +185,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.18/samples/sample_release_PipelineRun.yaml
@@ -33,6 +33,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.18/release.yaml

--- a/catalog/pipeline/release/0.18/tests/run.yaml
+++ b/catalog/pipeline/release/0.18/tests/run.yaml
@@ -33,6 +33,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.18/release.yaml

--- a/catalog/pipeline/release/0.19/release.yaml
+++ b/catalog/pipeline/release/0.19/release.yaml
@@ -74,7 +74,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -124,7 +124,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -178,7 +178,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.9/push-snapshot.yaml
       params:
@@ -199,7 +199,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/release/0.19/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.19/samples/sample_release_PipelineRun.yaml
@@ -37,6 +37,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.19/release.yaml

--- a/catalog/pipeline/release/0.19/tests/run.yaml
+++ b/catalog/pipeline/release/0.19/tests/run.yaml
@@ -37,6 +37,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.19/release.yaml

--- a/catalog/pipeline/release/0.20/release.yaml
+++ b/catalog/pipeline/release/0.20/release.yaml
@@ -74,7 +74,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.4/collect-data.yaml
       params:
@@ -124,7 +124,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.7/apply-mapping.yaml
       params:
@@ -178,7 +178,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.11/push-snapshot.yaml
       params:
@@ -199,7 +199,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/release/0.20/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.20/samples/sample_release_PipelineRun.yaml
@@ -37,6 +37,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.20/release.yaml

--- a/catalog/pipeline/release/0.20/tests/run.yaml
+++ b/catalog/pipeline/release/0.20/tests/run.yaml
@@ -37,6 +37,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/release/0.20/release.yaml

--- a/catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml
@@ -82,7 +82,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.1/collect-data.yaml
       params:
@@ -130,7 +130,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.5/apply-mapping.yaml
       params:
@@ -178,7 +178,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -202,7 +202,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -224,7 +224,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -244,7 +244,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml
       params:
@@ -264,7 +264,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
       params:
@@ -280,7 +280,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/rhtap-service-push/0.1/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.1/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.1/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.1/tests/run.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.1/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml
@@ -82,7 +82,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -132,7 +132,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -182,7 +182,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -208,7 +208,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -232,7 +232,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -254,7 +254,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml
       params:
@@ -274,7 +274,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
       params:
@@ -292,7 +292,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.2/tests/run.yaml
@@ -39,6 +39,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.2/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml
@@ -92,7 +92,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -196,7 +196,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -222,7 +222,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -268,7 +268,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml
       params:
@@ -288,7 +288,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
       params:
@@ -306,7 +306,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/rhtap-service-push/0.3/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.3/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.3/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.3/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.3/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.4/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.4/rhtap-service-push.yaml
@@ -92,7 +92,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.2/collect-data.yaml
       params:
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.6/apply-mapping.yaml
       params:
@@ -196,7 +196,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.10/push-snapshot.yaml
       params:
@@ -222,7 +222,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml
       params:
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml
       params:
@@ -268,7 +268,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml
       params:
@@ -292,7 +292,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
       params:
@@ -310,7 +310,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/rhtap-service-push/0.4/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.4/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.4/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.4/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.4/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.4/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.5/rhtap-service-push.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.5/rhtap-service-push.yaml
@@ -92,7 +92,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/collect-data/0.4/collect-data.yaml
       params:
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/apply-mapping/0.7/apply-mapping.yaml
       params:
@@ -196,7 +196,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-snapshot/0.11/push-snapshot.yaml
       params:
@@ -222,7 +222,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/create-pyxis-image/0.5/create-pyxis-image.yaml
       params:
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/push-sbom-to-pyxis/0.3/push-sbom-to-pyxis.yaml
       params:
@@ -268,7 +268,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/update-infra-deployments/0.3/update-infra-deployments.yaml
       params:
@@ -292,7 +292,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/slack-webhook-notification/0.2/slack-webhook-notification.yaml
       params:
@@ -310,7 +310,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/release-service-bundles.git
           - name: revision
-            value: main
+            value: legacy
           - name: pathInRepo
             value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
       when:

--- a/catalog/pipeline/rhtap-service-push/0.5/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.5/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.5/rhtap-service-push.yaml

--- a/catalog/pipeline/rhtap-service-push/0.5/tests/run.yaml
+++ b/catalog/pipeline/rhtap-service-push/0.5/tests/run.yaml
@@ -43,6 +43,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/pipeline/rhtap-service-push/0.5/rhtap-service-push.yaml

--- a/catalog/task/apply-mapping/0.5/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.5/samples/sample_apply-mapping_TaskRun.yaml
@@ -10,6 +10,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/apply-mapping/0.5/apply-mapping.yaml

--- a/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.6/samples/sample_apply-mapping_TaskRun.yaml
@@ -10,6 +10,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/apply-mapping/0.6/apply-mapping.yaml

--- a/catalog/task/apply-mapping/0.7/samples/sample_apply-mapping_TaskRun.yaml
+++ b/catalog/task/apply-mapping/0.7/samples/sample_apply-mapping_TaskRun.yaml
@@ -10,6 +10,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/apply-mapping/0.7/apply-mapping.yaml

--- a/catalog/task/cleanup-workspace/0.2/samples/sample_cleanup-workspace_TaskRun.yaml
+++ b/catalog/task/cleanup-workspace/0.2/samples/sample_cleanup-workspace_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/cleanup-workspace/0.2/cleanup-workspace.yaml

--- a/catalog/task/cleanup-workspace/0.3/samples/sample_cleanup-workspace_TaskRun.yaml
+++ b/catalog/task/cleanup-workspace/0.3/samples/sample_cleanup-workspace_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml

--- a/catalog/task/collect-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.1/samples/sample_collect-extra-data_TaskRun.yaml
@@ -21,6 +21,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/collect-data/0.1/collect-data.yaml

--- a/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.2/samples/sample_collect-extra-data_TaskRun.yaml
@@ -21,6 +21,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/collect-data/0.2/collect-data.yaml

--- a/catalog/task/collect-data/0.3/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.3/samples/sample_collect-extra-data_TaskRun.yaml
@@ -21,6 +21,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/collect-data/0.3/collect-data.yaml

--- a/catalog/task/collect-data/0.4/samples/sample_collect-extra-data_TaskRun.yaml
+++ b/catalog/task/collect-data/0.4/samples/sample_collect-extra-data_TaskRun.yaml
@@ -21,6 +21,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/collect-data/0.4/collect-data.yaml

--- a/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.6/samples/sample_create-internal-request_TaskRun.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.6/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.6/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.6/tests/run.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.6/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.7/samples/sample_create-internal-request_TaskRun.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.7/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.7/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.7/tests/run.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.7/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.8/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.8/samples/sample_create-internal-request_TaskRun.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.8/create-internal-request.yaml

--- a/catalog/task/create-internal-request/0.8/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.8/tests/run.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-internal-request/0.8/create-internal-request.yaml

--- a/catalog/task/create-pyxis-image/0.4/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.4/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-pyxis-image/0.4/create-pyxis-image.yaml

--- a/catalog/task/create-pyxis-image/0.5/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.5/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/create-pyxis-image/0.5/create-pyxis-image.yaml

--- a/catalog/task/extract-index-image/0.1/samples/extract-index-image_TaskRun.yaml
+++ b/catalog/task/extract-index-image/0.1/samples/extract-index-image_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/extract-index-image/0.1/extract-index-image.yaml

--- a/catalog/task/extract-index-image/0.2/samples/extract-index-image_TaskRun.yaml
+++ b/catalog/task/extract-index-image/0.2/samples/extract-index-image_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/extract-index-image/0.2/extract-index-image.yaml

--- a/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
+++ b/catalog/task/get-ocp-version/0.1/samples/sample_get-ocp-version_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/get-ocp-version/0.1/get-ocp-version.yaml

--- a/catalog/task/get-ocp-version/0.2/samples/sample_get-ocp-version_TaskRun.yaml
+++ b/catalog/task/get-ocp-version/0.2/samples/sample_get-ocp-version_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/get-ocp-version/0.2/get-ocp-version.yaml

--- a/catalog/task/prepare-validation/0.3/samples/sample_prepare-validation_TaskRun.yaml
+++ b/catalog/task/prepare-validation/0.3/samples/sample_prepare-validation_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/prepare-validation/0.3/prepare-validation.yaml

--- a/catalog/task/prepare-validation/0.3/tests/run.yaml
+++ b/catalog/task/prepare-validation/0.3/tests/run.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/prepare-validation/0.3/prepare-validation.yaml

--- a/catalog/task/prepare-validation/0.4/samples/sample_prepare-validation_TaskRun.yaml
+++ b/catalog/task/prepare-validation/0.4/samples/sample_prepare-validation_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/prepare-validation/0.4/prepare-validation.yaml

--- a/catalog/task/prepare-validation/0.4/tests/run.yaml
+++ b/catalog/task/prepare-validation/0.4/tests/run.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/prepare-validation/0.4/prepare-validation.yaml

--- a/catalog/task/publish-index-image/0.2/samples/publish-index-image_TaskRun.yaml
+++ b/catalog/task/publish-index-image/0.2/samples/publish-index-image_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/publish-index-image/0.2/publish-index-image.yaml

--- a/catalog/task/publish-index-image/0.2/tests/run.yaml
+++ b/catalog/task/publish-index-image/0.2/tests/run.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/publish-index-image/0.2/publish-index-image.yaml

--- a/catalog/task/publish-index-image/0.3/samples/publish-index-image_TaskRun.yaml
+++ b/catalog/task/publish-index-image/0.3/samples/publish-index-image_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/publish-index-image/0.3/publish-index-image.yaml

--- a/catalog/task/publish-index-image/0.3/tests/run.yaml
+++ b/catalog/task/publish-index-image/0.3/tests/run.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/publish-index-image/0.3/publish-index-image.yaml

--- a/catalog/task/push-sbom-to-pyxis/0.2/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.2/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-sbom-to-pyxis/0.2/push-sbom-to-pyxis.yaml

--- a/catalog/task/push-sbom-to-pyxis/0.3/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
+++ b/catalog/task/push-sbom-to-pyxis/0.3/sample/sample_push-sbom-to-pyxis_TaskRun.yaml
@@ -15,6 +15,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-sbom-to-pyxis/0.3/push-sbom-to-pyxis.yaml

--- a/catalog/task/push-snapshot/0.10/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.10/samples/sample_push-snapshot_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-snapshot/0.10/push-snapshot.yaml

--- a/catalog/task/push-snapshot/0.11/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.11/samples/sample_push-snapshot_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-snapshot/0.11/push-snapshot.yaml

--- a/catalog/task/push-snapshot/0.9/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.9/samples/sample_push-snapshot_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-snapshot/0.9/push-snapshot.yaml

--- a/catalog/task/push-snapshot/0.9/tests/run.yaml
+++ b/catalog/task/push-snapshot/0.9/tests/run.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/push-snapshot/0.9/push-snapshot.yaml

--- a/catalog/task/run-file-updates/0.2/samples/sample_run-file-updates_TaskRun.yaml
+++ b/catalog/task/run-file-updates/0.2/samples/sample_run-file-updates_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/run-file-updates/0.2/run-file-updates.yaml

--- a/catalog/task/run-file-updates/0.3/samples/sample_run-file-updates_TaskRun.yaml
+++ b/catalog/task/run-file-updates/0.3/samples/sample_run-file-updates_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/run-file-updates/0.3/run-file-updates.yaml

--- a/catalog/task/run-file-updates/0.4/samples/sample_run-file-updates_TaskRun.yaml
+++ b/catalog/task/run-file-updates/0.4/samples/sample_run-file-updates_TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/run-file-updates/0.4/run-file-updates.yaml

--- a/catalog/task/sign-index-image/0.1/samples/sign-index-image_TaskRun.yaml
+++ b/catalog/task/sign-index-image/0.1/samples/sign-index-image_TaskRun.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/sign-index-image/0.1/sign-index-image.yaml

--- a/catalog/task/sign-index-image/0.1/tests/run.yaml
+++ b/catalog/task/sign-index-image/0.1/tests/run.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/sign-index-image/0.1/sign-index-image.yaml

--- a/catalog/task/sign-index-image/0.2/samples/sign-index-image_TaskRun.yaml
+++ b/catalog/task/sign-index-image/0.2/samples/sign-index-image_TaskRun.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/sign-index-image/0.2/sign-index-image.yaml

--- a/catalog/task/sign-index-image/0.2/tests/run.yaml
+++ b/catalog/task/sign-index-image/0.2/tests/run.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/sign-index-image/0.2/sign-index-image.yaml

--- a/catalog/task/slack-webhook-notification/0.1/samples/slack-webhook-notification-TaskRun.yaml
+++ b/catalog/task/slack-webhook-notification/0.1/samples/slack-webhook-notification-TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml

--- a/catalog/task/slack-webhook-notification/0.1/tests/run.yaml
+++ b/catalog/task/slack-webhook-notification/0.1/tests/run.yaml
@@ -17,6 +17,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml

--- a/catalog/task/slack-webhook-notification/0.2/samples/slack-webhook-notification-TaskRun.yaml
+++ b/catalog/task/slack-webhook-notification/0.2/samples/slack-webhook-notification-TaskRun.yaml
@@ -13,6 +13,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/slack-webhook-notification/0.2/slack-webhook-notification.yaml

--- a/catalog/task/slack-webhook-notification/0.2/tests/run.yaml
+++ b/catalog/task/slack-webhook-notification/0.2/tests/run.yaml
@@ -17,6 +17,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/slack-webhook-notification/0.2/slack-webhook-notification.yaml

--- a/catalog/task/update-infra-deployments/0.1/samples/update-infra-deployments_TaskRun.yaml
+++ b/catalog/task/update-infra-deployments/0.1/samples/update-infra-deployments_TaskRun.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml

--- a/catalog/task/update-infra-deployments/0.1/tests/run.yaml
+++ b/catalog/task/update-infra-deployments/0.1/tests/run.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.1/update-infra-deployments.yaml

--- a/catalog/task/update-infra-deployments/0.2/samples/update-infra-deployments_TaskRun.yaml
+++ b/catalog/task/update-infra-deployments/0.2/samples/update-infra-deployments_TaskRun.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.2/update-infra-deployments.yaml

--- a/catalog/task/update-infra-deployments/0.2/tests/run.yaml
+++ b/catalog/task/update-infra-deployments/0.2/tests/run.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.2/update-infra-deployments.yaml

--- a/catalog/task/update-infra-deployments/0.3/samples/update-infra-deployments_TaskRun.yaml
+++ b/catalog/task/update-infra-deployments/0.3/samples/update-infra-deployments_TaskRun.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.3/update-infra-deployments.yaml

--- a/catalog/task/update-infra-deployments/0.3/tests/run.yaml
+++ b/catalog/task/update-infra-deployments/0.3/tests/run.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-infra-deployments/0.3/update-infra-deployments.yaml

--- a/catalog/task/update-ocp-tag/0.1/samples/sample_update-ocp-tag_TaskRun.yaml
+++ b/catalog/task/update-ocp-tag/0.1/samples/sample_update-ocp-tag_TaskRun.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-ocp-tag/0.1/update-ocp-tag.yaml

--- a/catalog/task/update-ocp-tag/0.2/samples/sample_update-ocp-tag_TaskRun.yaml
+++ b/catalog/task/update-ocp-tag/0.2/samples/sample_update-ocp-tag_TaskRun.yaml
@@ -19,6 +19,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-bundles.git
       - name: revision
-        value: main
+        value: legacy
       - name: pathInRepo
         value: catalog/task/update-ocp-tag/0.2/update-ocp-tag.yaml


### PR DESCRIPTION
This is the first change before removing versions in a feature branch. After merging this branch, all pipelines bundles will get generated again and keep a reference to the right paths in the repository even after removing the versions.