### PR TITLE
feat(HACBS-2643): add new create-github-release task

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,8 @@
 rules:
   line-length:
     max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
   indentation:
     spaces: consistent
   comments:

--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -1,0 +1,15 @@
+# create-github-release
+
+Tekton task that creates a release in GitHub.com via the API.
+
+It assumes that a workspace is provided that includes `*.zip`, `*.json` and `*SHA256SUMS` files in
+a `release` dir.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| githubSecret | The kubernetes secret to use to authenticate to GitHub | No | - |
+| repository | The github repository to release to | No | - |
+| release_version | The version string to use creating the release | No | - |
+| content_directory | The directory inside the workspace to find files for release | No | - |

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: create-github-release
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that creates a release on github.com via the GitHub API
+  params:
+    - name: repository
+      type: string
+      description: "The github repository where the release should be created"
+    - name: release_version
+      type: string
+      description: "The version string of the new release"
+    - name: githubSecret
+      type: string
+      description: "The kube secret to use to authenticate to GitHub, containing one key: token"
+    - name: content_directory
+      type: string
+      description: "The directory inside the workspace to find files for release"
+  workspaces:
+    - name: data
+      description: The workspace where the binaries to release reside
+  results:
+    - name: url
+      type: string
+      description: URL to inspect the created release
+  steps:
+    - name: create-release-from-binaries
+      image: registry.access.redhat.com/ubi9/ubi:latest@sha256:351ed8b24d440c348486efd99587046e88bb966890a9207a5851d3a34a4dd346
+      script: |
+        curl -L \
+          https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz \
+          --output gh_2.32.1_linux_amd64.tar.gz
+        tar -zvxf gh_2.32.1_linux_amd64.tar.gz
+        mv gh_2.32.1_linux_amd64/bin/gh /bin/gh
+        chmod +x /bin/gh
+        cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
+        gh release create "$RELEASE_VERSION" *.zip *.json *SHA256SUMS --repo "$REPOSITORY"
+        # We will add .sig file when we have the sigining step is done
+        #gh release create $RELEASE_VERSION *.zip *.json *.sig --repo $REPO
+        echo -n "https://github.com/$REPOSITORY/releases/tag/$RELEASE_VERSION" >  $(results.url.path)
+      env:
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.githubSecret)
+              key: token
+        - name: REPOSITORY
+          value: $(params.repository)
+        - name: RELEASE_VERSION
+          value: $(params.release_version)
+        - name: CONTENT_DIRECTORY
+          value: $(params.content_directory)

--- a/tasks/create-github-release/samples/sample_create-github-release_TaskRun.yaml
+++ b/tasks/create-github-release/samples/sample_create-github-release_TaskRun.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: create-github-release
+spec:
+  params:
+    - name: githubSecret
+      value: ""
+    - name: repository
+      value: "foo/bar"
+    - name: release_version
+      value: 1.2.3
+    - name: content_directory
+      value: release/
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/create-github-release/create-github-release.yaml

--- a/tasks/create-github-release/tests/mocks.sh
+++ b/tasks/create-github-release/tests/mocks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function gh() {
+  echo "Mock gh called with: $*"
+  echo "$*" >> $(workspaces.data.path)/mock_gh.txt
+
+  if [[ "$*" != "release create 1.2.3 foo.zip foo.json foo_SHA256SUMS --repo foo/bar" ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/tasks/create-github-release/tests/pre-apply-task-hook.sh
+++ b/tasks/create-github-release/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../create-github-release.yaml
+
+# Create a dummy github secret (and delete it first if it exists)
+kubectl delete secret test-create-github-release-token --ignore-not-found
+kubectl create secret generic test-create-github-release-token --from-literal=token=mytoken

--- a/tasks/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-release.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-github-release
+spec:
+  description: |
+    Run the create-github-release task
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir $(workspaces.data.path)/release/
+              cat > $(workspaces.data.path)/release/foo.json << EOF
+              { "example github release file": "just mock data" }
+              EOF
+              touch $(workspaces.data.path)/release/foo.zip
+              touch $(workspaces.data.path)/release/foo_SHA256SUMS
+    - name: run-task
+      taskRef:
+        name: create-github-release
+      params:
+        - name: githubSecret
+          value: test-create-github-release-token
+        - name: repository
+          value: foo/bar
+        - name: release_version
+          value: 1.2.3
+        - name: content_directory
+          value: release/
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: $(tasks.run-task.results.url)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: url
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_gh.txt | wc -l) != 1 ]; then
+                echo Error: gh was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_gh.txt
+                exit 1
+              fi
+
+              if [ "$(params.url)" != \
+                  "https://github.com/foo/bar/releases/tag/1.2.3" ]; then
+                  echo Error: Unexpected url result
+                  exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit adds a new create-github-release task which can release arbitrary binaries from a provided workspace.

Assumed usage is to extract those binaries from images provided to the pipeline in a Snapshot, to be created next in HACBS-2644.