### PR TITLE
refactor(RHTAPREL-283): apply-mapping pulls from RPA

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -3,9 +3,10 @@
 Tekton task to apply a mapping to an Snapshot.
 
 The purpose of this task is to merge a mapping with the components contained in an Snapshot.
-The mapping is expected to be present in the passed `extraConfigPath`. If the file is not found or
-the file contains no `mapping` key, the original Snapshot is returned. If there is a
-`mapping` key, it is merged with the `components` key in the Snapshot based on component name.
+The mapping is expected to be present in the data field of the ReleasePlanAdmission provided in
+the `releasePlanAdmissionPath`. If the data field does not contain a `mapping` key, the original
+Snapshot is returned. If there is a `mapping` key, it is merged with the `components` key in the
+Snapshot based on component name.
 
 A `mapped` result is also returned from this task containing a simple true/false value that is
 meant to inform whether a mapped Snapshot is being returned or the original one.
@@ -15,8 +16,13 @@ meant to inform whether a mapped Snapshot is being returned or the original one.
 | Name | Description | Optional | Default value |
 |------|-------------|----------|---------------|
 | snapshotPath | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | Yes | snapshot_spec.json |
-| extraConfigPath | The path to the config file containing the mapping | Yes | - |
+| releasePlanAdmissionPath | Path to the JSON string of the ReleasePlanAdmission in the config workspace which contains the mapping to apply | Yes | release_plan_admission.json |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
+
+## Changes since 0.7.0
+  * No longer uses extraConfigPath
+    * The mapping is provided by the ReleasePlanAdmission now instead. This change includes replacing the `extraConfigPath`
+      parameter with the `releasePlanAdmissionPath` parameter
 
 ## Changes since 0.6
   * Update Tekton API to v1

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -16,10 +16,12 @@ spec:
       type: string
       description: Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to
       default: "snapshot_spec.json"
-    - name: extraConfigPath
+    - name: releasePlanAdmissionPath
       type: string
-      description: The path to the config file containing the mapping
-      default: ""
+      description: |
+        Path to the JSON string of the ReleasePlanAdmission in the
+        config workspace which contains the mapping to apply
+      default: "release_plan_admission.json"
     - name: failOnEmptyResult
       type: string
       description: Fail the task if the resulting snapshot contains 0 components
@@ -40,34 +42,35 @@ spec:
         set -eux
 
         SNAPSHOT_SPEC_FILE="$(workspaces.config.path)/$(params.snapshotPath)"
+        RPA_FILE="$(workspaces.config.path)/$(params.releasePlanAdmissionPath)"
         SNAPSHOT_SPEC_FILE_ORIG="${SNAPSHOT_SPEC_FILE}.orig"
+
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
-            echo "No valid snapshot file was provided."
+            echo "No valid snapshot file was found."
             exit 1
         fi
 
         # Copy the original Snapshot spec file before overriding
         cp "${SNAPSHOT_SPEC_FILE}" "${SNAPSHOT_SPEC_FILE_ORIG}"
 
-        CONFIG_FILE="$(workspaces.config.path)/$(params.extraConfigPath)"
-        if [ ! -f "${CONFIG_FILE}" ] ; then
-            echo "No valid config file was provided."
-            echo "false" | tee $(results.mapped.path)
-            exit 0
-        fi
-        if [[ $(yq '.mapping' "${CONFIG_FILE}") == "null" ]] ; then
-            echo "Config file contains no mapping key."
+        if [ ! -f "${RPA_FILE}" ] ; then
+            echo "No ReleasePlanAdmission file was found."
             echo "false" | tee $(results.mapped.path)
             exit 0
         fi
 
-        # Create JSON representation of the config so we can use jq
-        CONFIG_JSON=$(yq -o=json -I=0 '.' "${CONFIG_FILE}")
+        MAPPING=$(jq '.spec.data.mapping' "${RPA_FILE}")
 
-        # Merge the mapping key in the config file with the components key in the snapshot based on component name
-        # Save the output as a compact json in mapped_snapshot.json file in the workspace
-        { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${CONFIG_JSON}"; } | jq -c -s '.[0] as $snapshot
-          | .[0].components + .[1].mapping.components | group_by(.name) | [.[] | select(length > 1)]
+        if [[ $MAPPING == "null" ]] ; then
+            echo "ReleasePlanAdmission Data struct contains no mapping key."
+            echo "false" | tee $(results.mapped.path)
+            exit 0
+        fi
+
+        # Merge the mapping key contents in the ReleasePlanAdmission data with the components key in the snapshot based
+        # on component name. Save the output as a compact json in mapped_snapshot.json file in the workspace
+        { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${MAPPING}"; } | jq -c -s '.[0] as $snapshot
+          | .[0].components + .[1].components | group_by(.name) | [.[] | select(length > 1)]
           | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents | $snapshot | .components = $mergedComponents' \
           > "${SNAPSHOT_SPEC_FILE}"
 

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-rpa-data.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-rpa-data.yaml
@@ -2,14 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-fail-on-empty
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-apply-mapping-no-rpa-data
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json and ReleasePlanAdmission
-    mapping that results in empty component list. Set task parameter failOnEmptyResult
-    to true and verify that the task fails as expected.
+    Run the apply-mapping task with a snapshot.spec json and a ReleasePlanAdmission
+    that does not contain data in its spec and verify that the returned json is the
+    same as the one in the input.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -28,7 +26,6 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
-
               cat > $(workspaces.config.path)/release_plan_admission.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -60,21 +57,7 @@ spec:
                     ]
                   },
                   "serviceAccount": "sa",
-                  "origin": "dev",
-                  "data": {
-                    "mapping": {
-                      "components": [
-                        {
-                          "name": "comp3",
-                          "repository": "repo3"
-                        },
-                        {
-                          "name": "comp4",
-                          "customfield": "repo4"
-                        }
-                      ]
-                    }
-                  }
+                  "origin": "dev"
                 }
               }
               EOF
@@ -107,10 +90,27 @@ spec:
           value: "snapshot_spec.json"
         - name: releasePlanAdmissionPath
           value: "release_plan_admission.json"
-        - name: failOnEmptyResult
-          value: "true"
       workspaces:
         - name: config
           workspace: tests-workspace
       runAfter:
         - setup
+    - name: check-result
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # the resulting json is exactly the same as the original one (since no mapping was used)
+              test "$(cat $(workspaces.config.path)/snapshot_spec.json|jq --sort-keys .)" \
+                == "$(cat $(workspaces.config.path)/snapshot_spec.json.orig|jq --sort-keys .)"
+      runAfter:
+        - run-task

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-rpa-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-rpa-mapping.yaml
@@ -2,14 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-fail-on-empty
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-apply-mapping-no-rpa-mapping
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json and ReleasePlanAdmission
-    mapping that results in empty component list. Set task parameter failOnEmptyResult
-    to true and verify that the task fails as expected.
+    Run the apply-mapping task with a snapshot.spec json and a ReleasePlanAdmission
+    that does not contain a mapping in its data section and verify that the returned
+    json is the same as the one in the input.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -28,7 +26,6 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
-
               cat > $(workspaces.config.path)/release_plan_admission.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -62,18 +59,7 @@ spec:
                   "serviceAccount": "sa",
                   "origin": "dev",
                   "data": {
-                    "mapping": {
-                      "components": [
-                        {
-                          "name": "comp3",
-                          "repository": "repo3"
-                        },
-                        {
-                          "name": "comp4",
-                          "customfield": "repo4"
-                        }
-                      ]
-                    }
+                    "foo": "bar"
                   }
                 }
               }
@@ -107,10 +93,27 @@ spec:
           value: "snapshot_spec.json"
         - name: releasePlanAdmissionPath
           value: "release_plan_admission.json"
-        - name: failOnEmptyResult
-          value: "true"
       workspaces:
         - name: config
           workspace: tests-workspace
       runAfter:
         - setup
+    - name: check-result
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # the resulting json is exactly the same as the original one (since no mapping was used)
+              test "$(cat $(workspaces.config.path)/snapshot_spec.json|jq --sort-keys .)" \
+                == "$(cat $(workspaces.config.path)/snapshot_spec.json.orig|jq --sort-keys .)"
+      runAfter:
+        - run-task

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-rpa.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-rpa.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-no-mapping
+  name: test-apply-mapping-no-rpa
 spec:
   description: |
-    Run the apply-mapping with a basic snapshot.spec json without any extra config
-    and verify that the returned json is the same as the one on the input.
+    Run the apply-mapping with a basic snapshot.spec json without a ReleasePlanAdmission
+    provided and verify that the returned json is the same as the one in the input.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -54,9 +54,6 @@ spec:
     - name: run-task
       taskRef:
         name: apply-mapping
-      params:
-        - name: extraConfigPath
-          value: ""
       workspaces:
         - name: config
           workspace: tests-workspace
@@ -76,7 +73,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              # the resulting json is exactly the same as the original one (since no mapping file was used)
+              # the resulting json is exactly the same as the original one (since no mapping was used)
               test "$(cat $(workspaces.config.path)/snapshot_spec.json|jq --sort-keys .)" \
                 == "$(cat $(workspaces.config.path)/snapshot_spec.json.orig|jq --sort-keys .)"
       runAfter:

--- a/tasks/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping.yaml
@@ -5,8 +5,8 @@ metadata:
   name: test-apply-mapping
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json and a custom mapping file
-    and verify that the resulting json contains the expected values.
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the releasePlanAdmission and verify that the resulting json contains the expected values.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -24,19 +24,62 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              CONFIG_PATH="$(workspaces.config.path)/config.yaml"
-              cat > $CONFIG_PATH << EOF
-              ---
-              mapping:
-                components:
-                  - name: comp1
-                    repository: repo1
-                  - name: comp2
-                    repository: repo2
-                  - name: comp3
-                    repository: repo3a
-                  - name: comp4
-                    customfield: custom
+              cat > $(workspaces.config.path)/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "managed"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                      {
+                        "name": "url",
+                        "value": "github.com"
+                      },
+                      {
+                        "name": "revision",
+                        "value": "main"
+                      },
+                      {
+                        "name": "pathInRepo",
+                        "value": "pipeline.yaml"
+                      }
+                    ]
+                  },
+                  "serviceAccount": "sa",
+                  "origin": "dev",
+                  "data": {
+                    "mapping": {
+                      "components": [
+                        {
+                          "name": "comp1",
+                          "repository": "repo1"
+                        },
+                        {
+                          "name": "comp2",
+                          "repository": "repo2"
+                        },
+                        {
+                          "name": "comp3",
+                          "repository": "repo3a"
+                        },
+                        {
+                          "name": "comp4",
+                          "customfield": "custom"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
               EOF
 
               cat > $(workspaces.config.path)/test_snapshot_spec.json << EOF
@@ -74,8 +117,8 @@ spec:
       params:
         - name: snapshotPath
           value: test_snapshot_spec.json
-        - name: extraConfigPath
-          value: "config.yaml"
+        - name: releasePlanAdmissionPath
+          value: test_release_plan_admission.json
       runAfter:
         - setup
       workspaces:


### PR DESCRIPTION
This commit reworks the apply-mapping task to pull the mapping from the data field in the ReleasePlanAdmission spec instead of from a config file.