### PR TITLE
feat(RHTAPREL-264): add new task validate-single-component to validate allowed component

### DIFF
--- a/catalog/pipeline/fbc-release/0.23/README.md
+++ b/catalog/pipeline/fbc-release/0.23/README.md
@@ -1,0 +1,143 @@
+# FBC Release Pipeline
+
+Tekton release pipeline to interact with FBC Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
+| releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
+| releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
+| snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
+| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
+| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | "" |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | "[]" |
+| addArches | List of arches the index image should be built for | Yes | "[]" |
+| signingConfigMapName | The ConfigMap to be used by the signing Pipeline | Yes | "hacbs-signing-pipeline-config" |
+| iibServiceConfigSecret | Secret that contains IIB's service configuration | Yes | "iib-services-config" |
+| iibOverwriteFromIndexCredential | Secret that stores IIB's overwrite_from_index_token parameter value | Yes | "iib-overwrite-fromimage-credentials" |
+| fbcPublishingCredentials | Secret used to publish the built index image | Yes | "fbc-publishing-credentials" |
+| requestUpdateTimeout | Max seconds to wait until the status is updated | Yes | - |
+| buildTimeoutSeconds | Max seconds to wait until the build finishes | Yes | - |
+| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
+| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changelog
+
+### Changes since 0.22
+- adds new tasks `validate-single-component` to validates that the 
+  snapshot only contains a single component. A pipeline should fail otherwise.
+
+### Changes since 0.21
+- update Tekton API to v1
+    - includes bumping all tasks to versions that use Tekton API v1
+
+### Changes since 0.20
+- iibIndexImage and iibIndexImageResolved pipelineResults were added. These come from the
+  task results in extract-index-image
+
+### Changes since 0.19
+- adds new tasks `get-ocp-version` and `update-ocp-tag` to update version tag
+  for `targetIndex`, `fromIndex` and `binaryImage` with valid OCP Version
+- add new enterpriseContractPublicKey parameter
+
+### Changes since 0.18
+- explicitly set IGNORE_REKOR value to "true" in the verify-enterprise-contract task
+- use git resolvers for the verify-enterprise-contract task
+    - the verify_ec_task_bundle parameter was placed with verify_ec_task_git_url,
+      verify_ec_task_git_revision, and verify_ec_task_git_pathInRepo
+
+### Changes since 0.17
+- use new version of collect-data task with subdirectory parameter
+- use PipelineRun UID for subdirectory inside the workspace
+    - this will avoid the issue of parallel PipelineRuns overriding each other's data
+- use new version of create-internal-requests task with subdirectory parameter
+
+### Changes since 0.16
+- git resolvers are used in place of release bundle resolvers
+
+### Changes since 0.15
+- the collect-data task was added
+    - this includes adding the required parameters releaseplan, releaseplanadmission, and
+      releasestrategy as pipeline parameters
+- the snapshot parameter is now a namespaced name instead of a JSON string
+    - task versions were updated in accordance with this change
+
+### Changes since 0.14
+- adds parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential`
+  to enable the build of pre-GA and prod FBC components in the same namespace
+
+### Changes since 0.13
+- adds back the parameter `fbcPublishingCredentials` as different secrets
+  might be set for the same namespace
+
+### Changes since 0.12
+- the release parameter was added and the requester parameter was removed
+    - the value to use for signing is now pulled from the release resource status
+
+### Changes since 0.11
+- updates tasks that use `create-internal-request` task to 0.6 as now they need to
+  rely on its `genericResult` result
+- the task `publish-index-image` now uses `create-internal-request` so the publishing
+  is done by the cluster running the internal-services-controller
+- only executes `publish-index-image` and `sign-index-image` when genericResult result of
+  the tasks using `create-internal-request` has `fbc_opt_in=true` value set
+- removes `fbcPublishingCredentials` parameter
+- removes `overwriteFromIndex` parameter
+
+### Changes since 0.10
+- the verify_ec_task_bundle parameter was added
+    - with this addition, the verify-enterprise-contract task version is no longer static
+
+### Changes since 0.9
+- changes on the following tasks due to `create-internal-request` changes:
+    - `add-fbc-contribution-to-index-image` now accepts dynamic parameters
+    - `sign-index-image` now accepts dynamic parameters
+- changes on `publish-index-image` task to read data from its `inputDataFile` parameter
+- adds cleanup task
+
+### Changes since 0.8
+- fixes in the README.md file
+- adds param `fbcPublishingCredentials`
+- removes param `overwriteFromIndex`
+- adds new task `publish-index-image`
+
+### Changes since 0.7
+The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+bundles resolver is used with new format.
+
+### Changes since 0.6
+- adds sign-index-image task
+- refactor task and change its reference name from `create-internal-request`
+  to `add-fbc-contribution-to-index-image`
+- adds `requester` and `signingConfigMapName` parameters
+- removes `resolvedIndexImage` result
+
+### Changes since 0.5
+- updates `create-internal-request` task version to 0.3
+
+### Changes since 0.4
+- updates `create-internal-request` task version to 0.2
+- adds `resolvedIndexImage` result
+
+### Changes since 0.3
+- removes param `fbcFragment`
+- adds param `buildTimeoutSeconds`
+
+### Changes since 0.2
+- renames the pipeline to `fbc-release`
+- forces the pipeline to run after `verify-enterprise-contract`
+
+### Changes since 0.1
+- adds param `requestUpdateTimeout`
+- adds task result values to the pipeline results
+  - `requestMessage` gets `$(tasks.create-internal-request.results.requestMessage)`
+  - `requestReason` gets `$(tasks.create-internal-request.results.requestReason)`
+  - `requestResults` gets `$(tasks.create-internal-request.results.requestResults)`
+- changes `verify-enterprise-contract` task version

--- a/catalog/pipeline/fbc-release/0.23/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.23/fbc-release.yaml
@@ -1,0 +1,393 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fbc-release
+  labels:
+    app.kubernetes.io/version: "0.23"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releaseplan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releaseplanadmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releasestrategy
+      type: string
+      description: The namespaced name (namespace/name) of the releaseStrategy
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: enterpriseContractPublicKey
+      type: string
+      description: Public key to use for validation by the enterprise contract
+      default: k8s://openshift-pipelines/public-key
+    - name: fromIndex
+      type: string
+      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: targetIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: binaryImage
+      type: string
+      default: ""
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      default: "[]"
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      default: "[]"
+      description: List of arches the index image should be built for
+    - name: signingConfigMapName
+      type: string
+      default: "hacbs-signing-pipeline-config"
+      description: The ConfigMap to be used by the signing Pipeline
+    - name: iibServiceConfigSecret
+      default: "iib-services-config"
+      type: string
+      description: Secret that contains IIB's service configuration
+    - name: iibOverwriteFromIndexCredential
+      default: "iib-overwrite-fromimage-credentials"
+      type: string
+      description: Secret that stores IIB's overwrite_from_index_token parameter value
+    - name: fbcPublishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: Secret used to publish the built index image
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
+    - name: buildTimeoutSeconds
+      type: string
+      description: Max seconds to wait until the build finishes
+    - name: verify_ec_task_git_url
+      type: string
+      description: The git repo url of the verify-enterprise-contract task
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git repo revision the verify-enterprise-contract task
+    - name: verify_ec_task_git_pathInRepo
+      type: string
+      description: The location of the verify-enterprise-contract task in its repo
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  results:
+    - name: requestMessage
+      type: string
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestMessage)
+    - name: requestReason
+      type: string
+      value: $(tasks.add-fbc-contribution-to-index-image.results.requestReason)
+    - name: iibIndexImage
+      type: string
+      value: $(tasks.extract-index-image.results.indexImage)
+    - name: iibIndexImageResolved
+      type: string
+      value: $(tasks.extract-index-image.results.indexImageResolved)
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/collect-data/0.4/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releaseplan
+          value: $(params.releaseplan)
+        - name: releaseplanadmission
+          value: $(params.releaseplanadmission)
+        - name: releasestrategy
+          value: $(params.releasestrategy)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: validate-single-component
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/validate-single-component/0.1/validate-single-component.yaml
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      runAfter:
+        - collect-data    
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.verify_ec_task_git_url)
+          - name: revision
+            value: $(params.verify_ec_task_git_revision)
+          - name: pathInRepo
+            value: $(params.verify_ec_task_git_pathInRepo)
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: PUBLIC_KEY
+          value: $(params.enterpriseContractPublicKey)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - validate-single-component
+    - name: get-ocp-version
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/get-ocp-version/0.2/get-ocp-version.yaml
+      params:
+        - name: fbcFragment
+          value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: update-ocp-tag
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/update-ocp-tag/0.2/update-ocp-tag.yaml
+      params:
+        - name: fromIndex
+          value: "$(params.fromIndex)"
+        - name: targetIndex
+          value: "$(params.targetIndex)"
+        - name: binaryImage
+          value: "$(params.binaryImage)"
+        - name: ocpVersion
+          value: "$(tasks.get-ocp-version.results.stored-version)"
+    - name: add-fbc-contribution-to-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: request
+          value: "iib"
+        - name: updateGenericResult
+          value: "true"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: requestUpdateTimeout
+          value: "$(params.requestUpdateTimeout)"
+        - name: params
+          value:
+            - name: binaryImage
+              value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
+            - name: fromIndex
+              value: "$(tasks.update-ocp-tag.results.updated-fromIndex)"
+            - name: buildTags
+              value: "$(params.buildTags)"
+            - name: addArches
+              value: "$(params.addArches)"
+            - name: buildTimeoutSeconds
+              value: "$(params.buildTimeoutSeconds)"
+            - name: iibServiceConfigSecret
+              value: "$(params.iibServiceConfigSecret)"
+            - name: iibOverwriteFromIndexCredential
+              value: "$(params.iibOverwriteFromIndexCredential)"
+            - name: fbcFragment
+              value: "$(tasks.collect-data.results.fbcFragment)"
+      runAfter:
+        - verify-enterprise-contract
+    - name: extract-requester-from-release
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/upstream/tekton/kubernetes-actions/0.3/kubernetes-actions.yaml
+      params:
+        - name: image
+          value: "quay.io/hacbs-release/cloud-builders-kubectl\
+            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
+        - name: script
+          value: |
+            set -x
+
+            NAMESPACE=$(echo $(params.release) | cut -d '/' -f 1)
+            NAME=$(echo $(params.release) | cut -d '/' -f 2)
+
+            AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
+            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+
+            if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
+    - name: sign-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "hacbs-signing-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: params
+          value:
+            - name: manifest_digest
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: pipeline_image
+              value: "quay.io/redhat-isv/operator-pipelines-images:released"
+            - name: reference
+              value: $(params.targetIndex)
+            - name: requester
+              value: $(tasks.extract-requester-from-release.results.output-result)
+            - name: config_map_name
+              value: $(params.signingConfigMapName)
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+    - name: extract-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/extract-index-image/0.2/extract-index-image.yaml
+      params:
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+    - name: publish-index-image
+      workspaces:
+        - name: input
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/create-internal-request/0.8/create-internal-request.yaml
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: inputDataFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: request
+          value: "publish-index-image-pipeline"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: params
+          value:
+            - name: sourceIndex
+              value: "sharedRequestFile:json:.jsonBuildInfo"
+              jsonKey: ".index_image_resolved"
+            - name: targetIndex
+              value: $(tasks.update-ocp-tag.results.updated-targetIndex)
+            - name: publishingCredentials
+              value: $(params.fbcPublishingCredentials)
+            - name: retries
+              value: "0"
+      when:
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.genericResult)"
+          operator: in
+          values: ["fbc_opt_in=true"]
+      runAfter:
+        - sign-index-image
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-bundles.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: catalog/task/cleanup-workspace/0.3/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/fbc-release/0.23/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.23/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.23/fbc-release.yaml

--- a/catalog/pipeline/fbc-release/0.23/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.23/tests/run.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: release
+      value: ""
+    - name: releaseplan
+      value: ""
+    - name: releaseplanadmission
+      value: ""
+    - name: releasestrategy
+      value: ""
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: release
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: targetIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: addArches
+      value: ""
+    - name: signingConfigMapName
+      value: ""
+    - name: iibServiceConfigSecret
+      value: ""
+    - name: iibOverwriteFromIndexCredential
+      value: ""
+    - name: fbcPublishingCredentials
+      value: ""
+    - name: requestUpdateTimeout
+      value: ""
+    - name: buildTimeoutSeconds
+      value: ""
+    - name: verify_ec_task_git_url
+      value: ""
+    - name: verify_ec_task_git_revision
+      value: ""
+    - name: verify_ec_task_git_pathInRepo
+      value: ""
+  pipelineRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/pipeline/fbc-release/0.23/fbc-release.yaml

--- a/catalog/task/validate-single-component/0.1/README.md
+++ b/catalog/task/validate-single-component/0.1/README.md
@@ -1,0 +1,10 @@
+# validate-single-component
+
+Tekton task validates that the snapshot only contains a 
+single component. The task will fail otherwise.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace | Yes | snapshot_spec.json |

--- a/catalog/task/validate-single-component/0.1/samples/sample_validate-single-component_TaskRun.yaml
+++ b/catalog/task/validate-single-component/0.1/samples/sample_validate-single-component_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: validate-single-component-run-empty-params
+spec:
+  params:
+    - name: snapshotPath
+      value: ""
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-bundles.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: catalog/task/validate-single-component/0.1/validate-single-component.yaml

--- a/catalog/task/validate-single-component/0.1/tests/test-validate-single-component-multiple-component.yaml
+++ b/catalog/task/validate-single-component/0.1/tests/test-validate-single-component-multiple-component.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-single-component-multiple-component 
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the validate-single-component task and check condition when multiple
+    components are detected in snapshot and it should fail
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: add-snapshot
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              yq -o json > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      },
+                      {
+                       "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }
+                      ]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: validate-single-component
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/catalog/task/validate-single-component/0.1/tests/test-validate-single-component.yaml
+++ b/catalog/task/validate-single-component/0.1/tests/test-validate-single-component.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-single-component
+spec:
+  description: |
+    Run the validate-single-component task where sample snapshot
+    contain single component and pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: add-snapshot
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              yq -o json > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: validate-single-component
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/catalog/task/validate-single-component/0.1/validate-single-component.yaml
+++ b/catalog/task/validate-single-component/0.1/validate-single-component.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-single-component
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task validates that the snapshot only contains a 
+    single component. The task will fail otherwise.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      type: string
+      default: "snapshot_spec.json"
+  workspaces:
+    - name: data
+      description: Workspace where the snapshot is stored
+  steps:
+    - name: validate-single-component
+      image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        COMPONENT_COUNT=$(jq '.components | length' "$(workspaces.data.path)/$(params.snapshotPath)")
+        if [ "$COMPONENT_COUNT" -gt 1 ]; then
+          echo "found $COMPONENT_COUNT components, only one component per application is supported."
+          exit 1
+        fi

--- a/catalog/task/validate-single-component/OWNERS
+++ b/catalog/task/validate-single-component/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This PR adds a new task `validate-single-component`
to FBC release pipeline because only a single component is allowed
in FBC releases. This new task will validate that the snapshot
only contains a single component. A pipeline should fail otherwise.