### PR TITLE
feat(RHTAPREL-264): add task validate-single-component to fbc-release

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -30,6 +30,10 @@ Tekton release pipeline to interact with FBC Pipeline
 
 ## Changelog
 
+### Changes since 0.23.0
+- adds new tasks `validate-single-component` to validate that the 
+  snapshot only contains a single component. The pipeline should fail otherwise.
+
 ## Changes since 0.22.0
 - Introduce new initial task - verify-access-to-resources
   - protection to verify that service accounts have required permissions to access

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "0.23.0"
+    app.kubernetes.io/version: "0.24.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -185,6 +185,21 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: validate-single-component
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/validate-single-component/validate-single-component.yaml
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      runAfter:
+        - collect-data
     - name: verify-enterprise-contract
       taskRef:
         resolver: "git"
@@ -212,7 +227,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - collect-data
+        - validate-single-component
     - name: get-ocp-version
       taskRef:
         resolver: "git"

--- a/tasks/validate-single-component/README.md
+++ b/tasks/validate-single-component/README.md
@@ -1,0 +1,10 @@
+# validate-single-component
+
+A tekton task that validates the snapshot only contains a 
+single component. The task will fail otherwise.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace | Yes | snapshot_spec.json |

--- a/tasks/validate-single-component/samples/sample_validate-single-component_TaskRun.yaml
+++ b/tasks/validate-single-component/samples/sample_validate-single-component_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: validate-single-component-run-empty-params
+spec:
+  params:
+    - name: snapshotPath
+      value: ""
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/validate-single-component/validate-single-component.yaml

--- a/tasks/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
+++ b/tasks/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-single-component-multiple-component 
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the validate-single-component task and check condition when multiple
+    components are detected in snapshot and it should fail
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: add-snapshot
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              yq -o json > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      },
+                      {
+                       "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }
+                      ]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: validate-single-component
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/validate-single-component/tests/test-validate-single-component.yaml
+++ b/tasks/validate-single-component/tests/test-validate-single-component.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-single-component
+spec:
+  description: |
+    Run the validate-single-component task where sample snapshot
+    contain single component and pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: add-snapshot
+            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              yq -o json > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "test-container-foo:bar",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: validate-single-component
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/validate-single-component/validate-single-component.yaml
+++ b/tasks/validate-single-component/validate-single-component.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-single-component
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task validates that the snapshot only contains a 
+    single component. The task will fail otherwise.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      type: string
+      default: "snapshot_spec.json"
+  workspaces:
+    - name: data
+      description: Workspace where the snapshot is stored
+  steps:
+    - name: validate-single-component
+      image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        COMPONENT_COUNT=$(jq '.components | length' "$(workspaces.data.path)/$(params.snapshotPath)")
+        if [ "$COMPONENT_COUNT" -gt 1 ]; then
+          echo "found $COMPONENT_COUNT components, only one component per application is supported."
+          exit 1
+        fi


### PR DESCRIPTION
This PR adds a new task, `validate-single-component` to the FBC release pipeline because only a single component is allowed in FBC releases. This new task will validate that the snapshot only contains a single component. A pipeline should fail otherwise.