### PR TITLE
refactor: get test pipeline name using metadata

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -91,8 +91,7 @@ do
   do
     echo "  Installing test pipeline: $TEST_PATH"
     kubectl apply -f $TEST_PATH
-    TEST_NAME=${TEST_PATH##*/}
-    TEST_NAME=${TEST_NAME%.*}
+    TEST_NAME=$(yq '.metadata.name' $TEST_PATH)
 
     # Sometimes the pipeline is not available immediately
     while ! kubectl get pipeline $TEST_NAME > /dev/null 2>&1


### PR DESCRIPTION
This commit changes the test_tekton_tasks.sh script to use the test pipeline's metadata to find its name instead of relying on it being the same as the file name.