### PR TITLE
fix(RHTAPREL-18): fileUpdates - if yq expression fails the step ignores it

### DIFF
--- a/tasks/run-file-updates/run-file-updates.yaml
+++ b/tasks/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,7 +36,7 @@ spec:
       description: Workspace where the file updates to apply are defined
   steps:
     - name: run-script
-      image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+      image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
       script: |
         #!/bin/sh
         #


### PR DESCRIPTION
This PR updates the image version to the newer one that includes the new version of internal-request script, which introduces a new error handling.