### PR TITLE
chore(RHTAPREL-216): adds extra checks and validations to the fileUpdates task

### DIFF
--- a/tasks/run-file-updates/run-file-updates.yaml
+++ b/tasks/run-file-updates/run-file-updates.yaml
@@ -41,7 +41,7 @@ spec:
         #!/bin/sh
         #
         #
-        set -ex
+        set -e
 
         # Obtain application from snapshot
         application=$(jq -rc .application $(workspaces.data.path)/$(params.snapshotPath))
@@ -59,13 +59,38 @@ spec:
           ref=$(jq -cr '.ref // "main"' <<< "${item}")
           paths=$(jq -cr '.paths // "[]"' <<< "${item}")
 
-          updatedPaths=$(update-paths -p "${paths}" -f $(workspaces.data.path)/$(params.snapshotPath))
+          echo "=== Updates for repo: ${repo} ==="
 
+          echo -en "  Evaluating '{{ }}' expressions..."
+          updatedPaths=$(update-paths -p "${paths}" -f $(workspaces.data.path)/$(params.snapshotPath))
+          echo "done"
+
+          echo -en "  Creating InternalRequest to produce file-updates..."
           internal-request -r "$(params.request)" \
                            -p upstream_repo="${upstream_repo}" \
                            -p repo="${repo}" \
                            -p ref="${ref}" \
                            -p paths="${updatedPaths}" \
                            -p application=${application} \
-                           -s "$(params.synchronously)"
+                           -s "$(params.synchronously)" \
+                           > $(workspaces.data.path)/ir-result.txt || \
+                           (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
+          
+          internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
+          echo "done (${internalRequest})"
+
+          results=$(kubectl get internalrequest $internalRequest -o=jsonpath='{.status.results}')
+          if [ $(jq -jr '.buildState' <<< "${results}") == "Failed" ]; then
+            echo -en "  FileUpdates Error: "
+            jq -r '.jsonBuildInfo | fromjson | .error' <<< "${results}"
+            echo -e "  Diff (content might be truncated): "
+            jq -r '.jsonBuildInfo | fromjson | .str | tostring' <<< "${results}" | awk '{ print "\t"$0 }'
+            echo -e "=== Finished ===\n"
+            exit 1
+          else
+            echo -en "  MR Created: "
+            jq -r '.jsonBuildInfo | fromjson | fromjson | .merge_request' <<< "${results}"
+          fi
+          echo -e "=== Finished ===\n"
+
         done

--- a/tasks/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/run-file-updates/tests/test-run-file-updates.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -97,7 +97,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/hacbs-release/release-utils:a918b3a7cbd40add5955a2f1acb4c3dbb29c44e9
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
             script: |
               #!/bin/sh
               set -ex


### PR DESCRIPTION
This PR changes the task to expose the InternalRequest results and adds messages instead of the shell debug.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>

Requires: https://github.com/hacbs-release/app-interface-deployments/pull/54