### PR TITLE
chore: update required advisory keys in check-data-keys

### DIFF
--- a/tasks/check-data-keys/check-data-keys.yaml
+++ b/tasks/check-data-keys/check-data-keys.yaml
@@ -33,10 +33,10 @@ spec:
 
         KEYS_JSON='{
             "advisory": [
+                "repo",
                 "spec.product_id",
                 "spec.cpe",
                 "spec.type",
-                "spec.issues.fixed",
                 "spec.content.images",
                 "spec.synopsis",
                 "spec.topic",

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-advisory-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-advisory-key.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with the advisory key missing the product_id in the data json and
+    Run the check-data-keys task with the advisory key missing the spec.product_id in the data json and
     verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
@@ -29,21 +29,10 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "advisory": {
+                  "repo": "somerepo",
                   "spec": {
                     "cpe": "cpe:/a:example:openstack:el8",
                     "type": "RHSA",
-                    "issues": {
-                      "fixed": [
-                        {
-                          "id": "RHOSP-12345",
-                          "source": "issues.example.com"
-                        },
-                        {
-                          "id": 1234567,
-                          "source": "bugzilla.example.com"
-                        }
-                      ]
-                    },
                     "content": {
                       "images": [
                         {

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -29,6 +29,7 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "advisory": {
+                  "repo": "somerepo",
                   "spec": {
                     "product_id": 123,
                     "cpe": "cpe:/a:example:openstack:el8",

--- a/tasks/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys.yaml
@@ -26,6 +26,7 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "advisory": {
+                  "repo": "somerepo",
                   "spec": {
                     "product_id": 123,
                     "cpe": "cpe:/a:example:openstack:el8",


### PR DESCRIPTION
Removed spec.type as a required key as the create advisory task will calculate it for us so we don't need to pass it. Also removed issues.fixed as I think enhancement advisories may not have fixed issues.