### PR TITLE
fix(RHTAPREL-435): delay cleanup for finally tasks

### DIFF
--- a/tasks/cleanup-workspace/README.md
+++ b/tasks/cleanup-workspace/README.md
@@ -4,9 +4,10 @@ Tekton task to delete a given directory in a passed workspace.
 
 ## Parameters
 
-| Name | Description | Optional | Default value |
-|------|-------------|----------|---------------|
-| subdirectory | The directory to remove within the workspace | No | - |
+| Name         | Description                                                                                                      | Optional | Default value |
+|--------------|------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| subdirectory | The directory to remove within the workspace                                                                     | No       | -             |
+| delay        | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
 
 ## Example usage
 
@@ -25,6 +26,10 @@ tasks:
       - name: input
         workspace: input_workspace
 ```
+
+## Changes since 0.3.0
+
+* Add delay parameter with a default of 60 (in seconds)
 
 ## Changes since 0.2
 

--- a/tasks/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/cleanup-workspace/cleanup-workspace.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: cleanup-workspace
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -15,13 +15,16 @@ spec:
     - name: subdirectory
       type: string
       description: The directory to remove within the workspace
+    - name: delay
+      type: string
+      default: 60
+      description: Time in seconds to delay the cleanup action
   workspaces:
     - name: input
       description: Workspace where the directory to cleanup exists
   steps:
     - name: cleanup
-      image:
-        quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
+      image: quay.io/hacbs-release/release-utils@sha256:5733ece907aa70d6ebced36484c936731e8b27bfcf87fed226a0ecf95047a6b8
       script: |
         #!/usr/bin/env sh
         set -eux
@@ -30,6 +33,9 @@ spec:
             echo "The empty string is not a valid subdirectory"
             exit 0
         fi
+
+        echo "Delaying execution by $(params.delay) seconds"
+        sleep $(params.delay)
 
         CLEANUP_DIR="$(workspaces.input.path)/$(params.subdirectory)"
 

--- a/tasks/cleanup-workspace/tests/mocks.sh
+++ b/tasks/cleanup-workspace/tests/mocks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function sleep() {
+  echo "mocked sleep with arg:" "$*"
+}

--- a/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
+++ b/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../cleanup-workspace.yaml


### PR DESCRIPTION
- adds a delay with a default of 60 to the cleanup action.
- this is needed since all finally tasks are started in parallel.
- some finally tasks might need data in the workspace to startup.
- this gives them a chance to get the data.

the slack task is one such example