### PR TITLE
feat(RHTAPREL-358): remove releasestrategy field

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -9,13 +9,15 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
-| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.9.0
+- Remove releasestrategy parameter
 
 ## Changes since 0.8.0
 - Introduce new initial task - verify-access-to-resources

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.9.0"
+    app.kubernetes.io/version: "0.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name (namespace/name) of the releaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -121,8 +118,6 @@ spec:
           value: $(params.releaseplan)
         - name: releaseplanadmission
           value: $(params.releaseplanadmission)
-        - name: releasestrategy
-          value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/deploy-release/tests/run.yaml
+++ b/pipelines/deploy-release/tests/run.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -9,7 +9,6 @@ Tekton release pipeline to interact with FBC Pipeline
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
-| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -28,7 +27,8 @@ Tekton release pipeline to interact with FBC Pipeline
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
-## Changelog
+## Changelog since 0.24.0
+- Remove releasestrategy parameter
 
 ### Changes since 0.23.0
 - adds new tasks `validate-single-component` to validate that the 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.25.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name (namespace/name) of the releaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -174,8 +171,6 @@ spec:
           value: $(params.releaseplan)
         - name: releaseplanadmission
           value: $(params.releaseplanadmission)
-        - name: releasestrategy
-          value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/fbc-release/tests/run.yaml
+++ b/pipelines/fbc-release/tests/run.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -9,7 +9,6 @@ Tekton pipeline to push images to an external registry.
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
-| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -27,6 +26,9 @@ Tekton pipeline to push images to an external registry.
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
+## Changes since 0.20.0
+- Remove releasestrategy parameter
+- 
 ## Changes since 0.19.0
 - Introduce new initial task - verify-access-to-resources
   - protection to verify that service accounts have required permissions to access
@@ -112,4 +114,3 @@ bundles resolver is used with new format.
 
 * Upgrade create-pyxis-image task to version 0.2
   * correct incorrect snapshot param
-

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/version: "0.21.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name (namespace/name) of the releaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -155,8 +152,6 @@ spec:
           value: $(params.releaseplan)
         - name: releaseplanadmission
           value: $(params.releaseplanadmission)
-        - name: releasestrategy
-          value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/push-to-external-registry/tests/run.yaml
+++ b/pipelines/push-to-external-registry/tests/run.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/release/README.md
+++ b/pipelines/release/README.md
@@ -9,7 +9,6 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
-| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -22,6 +21,9 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
+## Changes since 0.21.0
+- Remove releasestrategy parameter
+- 
 ## Changes since 0.20.0
 - Introduce new initial task - verify-access-to-resources
   - protection to verify that service accounts have required permissions to access

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.22.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name (namespace/name) of the releaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -137,8 +134,6 @@ spec:
           value: $(params.releaseplan)
         - name: releaseplanadmission
           value: $(params.releaseplanadmission)
-        - name: releasestrategy
-          value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/release/samples/sample_release_PipelineRun.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/release/tests/run.yaml
+++ b/pipelines/release/tests/run.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -11,7 +11,6 @@
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releaseplan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releaseplanadmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
-| releasestrategy | The namespaced name (namespace/name) of the releaseStrategy | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -29,6 +28,9 @@
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
+## Changes since 0.6.0
+- Remove releasestrategy parameter
+- 
 ## Changes since 0.5.0
 - Introduce new initial task - verify-access-to-resources
   - protection to verify that service accounts have required permissions to access

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "0.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name (namespace/name) of the releaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -155,8 +152,6 @@ spec:
           value: $(params.releaseplan)
         - name: releaseplanadmission
           value: $(params.releaseplanadmission)
-        - name: releasestrategy
-          value: $(params.releasestrategy)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/pipelines/rhtap-service-push/tests/run.yaml
+++ b/pipelines/rhtap-service-push/tests/run.yaml
@@ -11,8 +11,6 @@ spec:
       value: ""
     - name: releaseplanadmission
       value: ""
-    - name: releasestrategy
-      value: ""
     - name: snapshot
       value: ""
     - name: enterpriseContractPolicy

--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -20,9 +20,12 @@ also a task result for the fbcFragment extracted from the snapshot's first compo
 | release              | Namespaced name of the Release                     | No       | -             |
 | releaseplan          | Namespaced name of the ReleasePlan                 | No       | -             |
 | releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
-| releasestrategy      | Namespaced name of the ReleaseStrategy             | No       | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
+
+## Changes since 0.4
+  * Remove releasestrategy param and result from the task
+  * Collect data field instead of extraData as the Release Service API has changed
 
 ## Changes since 0.3
   * Update Tekton API to v1

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -21,9 +21,6 @@ spec:
     - name: releaseplanadmission
       type: string
       description: The namespaced name of the ReleasePlanAdmission
-    - name: releasestrategy
-      type: string
-      description: The namespaced name of the ReleaseStrategy
     - name: snapshot
       type: string
       description: The namespaced name of the Snapshot
@@ -44,18 +41,15 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The relative path in the workspace to the stored releasePlanAdmission json
-    - name: releaseStrategy
-      type: string
-      description: The relative path in the workspace to the stored releaseStrategy json
     - name: snapshotSpec
       type: string
       description: The relative path in the workspace to the stored snapshotSpec json
     - name: fbcFragment
       type: string
       description: The first component's containerImage in the snapshot to use in the fbc pipelines
-    - name: extraData
+    - name: data
       type: string
-      description: The relative path in the workspace to the stored extraData json
+      description: The relative path in the workspace to the stored data json
   steps:
     - name: collect-data
       image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
@@ -66,8 +60,6 @@ spec:
           value: '$(params.releaseplan)'
         - name: "RELEASE_PLAN_ADMISSION"
           value: '$(params.releaseplanadmission)'
-        - name: "RELEASE_STRATEGY"
-          value: '$(params.releasestrategy)'
         - name: "SNAPSHOT"
           value: '$(params.snapshot)'
       script: |
@@ -91,10 +83,6 @@ spec:
         get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
           > $(workspaces.data.path)/$RELEASEPLANADMISSION_PATH
 
-        RELEASESTRATEGY_PATH=$(params.subdirectory)/release_strategy.json
-        echo -n $RELEASESTRATEGY_PATH > $(results.releaseStrategy.path)
-        get-resource "releasestrategy" "${RELEASE_STRATEGY}" > $(workspaces.data.path)/$RELEASESTRATEGY_PATH
-
         SNAPSHOTSPEC_PATH=$(params.subdirectory)/snapshot_spec.json
         echo -n $SNAPSHOTSPEC_PATH > $(results.snapshotSpec.path)
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > $(workspaces.data.path)/$SNAPSHOTSPEC_PATH
@@ -102,12 +90,12 @@ spec:
         cat $(workspaces.data.path)/$SNAPSHOTSPEC_PATH | jq -cr '.components[0].containerImage' | tr -d "\n" \
           | tee $(results.fbcFragment.path)
 
-        release_result=$(get-resource "release" "${RELEASE}" "{.spec.extraData}")
+        release_result=$(get-resource "release" "${RELEASE}" "{.spec.data}")
 
-        release_plan_result=$(get-resource "releaseplan" "${RELEASE_PLAN}" "{.spec.extraData}")
+        release_plan_result=$(get-resource "releaseplan" "${RELEASE_PLAN}" "{.spec.data}")
 
         release_plan_admission_result=$(get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-            "{.spec.extraData}")
+            "{.spec.data}")
 
         # Merge Release and ReleasePlan keys. ReleasePlan has higher priority
         merged_output=$(merge-json "$release_result" "$release_plan_result")
@@ -115,6 +103,6 @@ spec:
         # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
         merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
 
-        EXTRADATA_PATH=$(params.subdirectory)/extra_data.json
-        echo -n $EXTRADATA_PATH > $(results.extraData.path)
-        echo "$merged_output" > $(workspaces.data.path)/$EXTRADATA_PATH
+        DATA_PATH=$(params.subdirectory)/data.json
+        echo -n $DATA_PATH > $(results.data.path)
+        echo "$merged_output" > $(workspaces.data.path)/$DATA_PATH

--- a/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -53,21 +53,15 @@ spec:
               spec:
                 application: foo
                 origin: foo
-                releaseStrategy: foo
+                policy: foo
+                pipelineRef:
+                  resolver: cluster
+                  params:
+                    - name: release-pipeline
+                      namespace: default
+                      kind: pipeline
               EOF
               kubectl apply -f releaseplanadmission
-
-              cat > releasestrategy << EOF
-              apiVersion: appstudio.redhat.com/v1alpha1
-              kind: ReleaseStrategy
-              metadata:
-                name: releasestrategy-sample
-                namespace: default
-              spec:
-                pipeline: foo
-                policy: foo
-              EOF
-              kubectl apply -f releasestrategy
     - name: run-task
       taskRef:
         name: collect-data
@@ -78,8 +72,6 @@ spec:
           value: default/releaseplan-sample
         - name: releaseplanadmission
           value: default/releaseplanadmission-sample
-        - name: releasestrategy
-          value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
         - name: subdirectory
@@ -102,4 +94,3 @@ spec:
               kubectl delete release release-sample
               kubectl delete releaseplan releaseplan-sample
               kubectl delete releaseplanadmission releaseplanadmission-sample
-              kubectl delete releasestrategy releasestrategy-sample

--- a/tasks/collect-data/tests/test-collect-data-with-extra-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data-with-extra-data.yaml
@@ -51,30 +51,25 @@ spec:
                 name: releaseplanadmission-sample
                 namespace: default
               spec:
-                application: foo
+                applications:
+                  - foo
                 origin: foo
-                releaseStrategy: foo
-                extraData:
+                data:
                   foo: bar
                   one:
                     two: three
                     four:
                       - five
                       - six
+                policy: foo
+                pipelineRef:
+                  resolver: cluster
+                  params:
+                    - name: release-pipeline
+                      namespace: default
+                      kind: pipeline
               EOF
               kubectl apply -f releaseplanadmission
-
-              cat > releasestrategy << EOF
-              apiVersion: appstudio.redhat.com/v1alpha1
-              kind: ReleaseStrategy
-              metadata:
-                name: releasestrategy-sample
-                namespace: default
-              spec:
-                pipeline: foo
-                policy: foo
-              EOF
-              kubectl apply -f releasestrategy
 
               cat > snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
@@ -96,8 +91,6 @@ spec:
           value: default/releaseplan-sample
         - name: releaseplanadmission
           value: default/releaseplanadmission-sample
-        - name: releasestrategy
-          value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
         - name: subdirectory
@@ -109,8 +102,8 @@ spec:
           workspace: tests-workspace
     - name: check-result
       params:
-        - name: extraData
-          value: $(tasks.run-task.results.extraData)
+        - name: data
+          value: $(tasks.run-task.results.data)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -118,7 +111,7 @@ spec:
         - run-task
       taskSpec:
         params:
-          - name: extraData
+          - name: data
             type: string
         steps:
           - name: check-result
@@ -127,8 +120,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              echo Test that extraData result was set properly
-              test $(cat "$(workspaces.data.path)/$(params.extraData)") \
+              echo Test that data result was set properly
+              test $(cat "$(workspaces.data.path)/$(params.data)") \
                 == '{"foo":"bar","one":{"four":["five","six"],"two":"three"}}'
   finally:
     - name: cleanup
@@ -143,5 +136,4 @@ spec:
               kubectl delete release release-sample
               kubectl delete releaseplan releaseplan-sample
               kubectl delete releaseplanadmission releaseplanadmission-sample
-              kubectl delete releasestrategy releasestrategy-sample
               kubectl delete snapshot snapshot-sample

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -51,21 +51,15 @@ spec:
               spec:
                 application: foo
                 origin: foo
-                releaseStrategy: foo
+                policy: foo
+                pipelineRef:
+                  resolver: cluster
+                  params:
+                    - name: release-pipeline
+                      namespace: default
+                      kind: pipeline
               EOF
               kubectl apply -f releaseplanadmission
-
-              cat > releasestrategy << EOF
-              apiVersion: appstudio.redhat.com/v1alpha1
-              kind: ReleaseStrategy
-              metadata:
-                name: releasestrategy-sample
-                namespace: default
-              spec:
-                pipeline: foo
-                policy: foo
-              EOF
-              kubectl apply -f releasestrategy
 
               cat > snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
@@ -90,8 +84,6 @@ spec:
           value: default/releaseplan-sample
         - name: releaseplanadmission
           value: default/releaseplanadmission-sample
-        - name: releasestrategy
-          value: default/releasestrategy-sample
         - name: snapshot
           value: default/snapshot-sample
         - name: subdirectory
@@ -109,8 +101,6 @@ spec:
           value: $(tasks.run-task.results.releasePlan)
         - name: releasePlanAdmission
           value: $(tasks.run-task.results.releasePlanAdmission)
-        - name: releaseStrategy
-          value: $(tasks.run-task.results.releaseStrategy)
         - name: snapshotSpec
           value: $(tasks.run-task.results.snapshotSpec)
         - name: fbcFragment
@@ -127,8 +117,6 @@ spec:
           - name: releasePlan
             type: string
           - name: releasePlanAdmission
-            type: string
-          - name: releaseStrategy
             type: string
           - name: snapshotSpec
             type: string
@@ -153,10 +141,6 @@ spec:
               test $(cat "$(workspaces.data.path)/$(params.releasePlanAdmission)" \
                   | jq -r '.metadata.name') == releaseplanadmission-sample
 
-              echo Test that ReleaseStrategy CR was saved to workspace
-              test $(cat "$(workspaces.data.path)/$(params.releaseStrategy)" \
-                  | jq -r '.metadata.name') == releasestrategy-sample
-
               echo Test that Snapshot spec was saved to workspace
               test $(cat "$(workspaces.data.path)/$(params.snapshotSpec)" | jq -r '.application') == foo
 
@@ -175,5 +159,4 @@ spec:
               kubectl delete release release-sample
               kubectl delete releaseplan releaseplan-sample
               kubectl delete releaseplanadmission releaseplanadmission-sample
-              kubectl delete releasestrategy releasestrategy-sample
               kubectl delete snapshot snapshot-sample


### PR DESCRIPTION
This change removes the releasestrategy field from collect-data and from pipelines using this tasks. In addition, extraData is not collected anymore and data is collected instead. This change is triggered by a release-service PR containing both of those changes.