### PR TITLE
fix: adds reading of Rejected reason

### DIFF
--- a/tasks/create-internal-request/create-internal-request.yaml
+++ b/tasks/create-internal-request/create-internal-request.yaml
@@ -163,7 +163,7 @@ spec:
             REASON=\$(kubectl get internalrequest \${IR} -o \
                 jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}')
             case "\${REASON}" in
-              Succeeded | Failed )
+              Succeeded | Failed | Rejected )
                 echo "InternalRequest finished"
                 echo \${REASON} | tee $(results.requestReason.path)
                 kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].message}' \


### PR DESCRIPTION
This PR adds also `Rejected` to be considered as a valid reason, so in case it reads this reason it
can also exit the script.