### PR TITLE
feat(RHTAPREL-617): push-snaphot can push to registry.redhat.io

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -7,11 +7,17 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | Name            | Description                                                                                     | Optional | Default value        |
 |-----------------|-------------------------------------------------------------------------------------------------|----------|----------------------|
 | snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace                       | Yes      | mapped_snapshot.json |
-| tag             | Default tag to use if mapping entry does not contain a tag                                      | Yes      | latest               |
+| tag             | Default tag to use if mapping entry does not contain a tag. Not used when tagPrefix is set      | Yes      | latest               |
+| tagPrefix       | The prefix used to build the tag in <prefix>-<timestamp> format                                 | Yes      | ""                   |
+| timestampFormat | Timestamp format used to build the tag when tagPrefix is set                                    | Yes      | %s                   |
 | retries         | Retry copy N times                                                                              | Yes      | 0                    |
 | addGitShaTag    | Also push a tag with the git sha for each image in the Snapshot                                 | Yes      | true                 |
 | addSourceShaTag | Also push a tag with the source sha for each image in the Snapshot                              | Yes      | true                 |
 | addTimestampTag | Also push a tag with the current timestamp for each image in the Snapshot                       | Yes      | false                |
+
+## Changes since 0.11
+* Adds `tagPrefix` parameter
+* The task now generates a tag in <prefix>-<timestamp> format when `tagPrefix` length is non zero
 
 ## Changes since 0.10
 * Update Tekton API to v1

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "0.11.0"
+    app.kubernetes.io/version: "0.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -17,9 +17,17 @@ spec:
       type: string
       default: "mapped_snapshot.json"
     - name: tag
-      description: Default tag to use if mapping entry does not contain a tag
+      description: Default tag to use if mapping entry does not contain a tag. Not used when tagPrefix is set
       type: string
       default: "latest"
+    - name: tagPrefix
+      description: The prefix used to build the tag in <prefix>-<timestamp> format
+      type: string
+      default: ""
+    - name: timestampFormat
+      description: Timestamp format used to build the tag when tagPrefix is set
+      type: string
+      default: "%s"
     - name: retries
       description: Retry copy N times.
       type: string
@@ -36,6 +44,10 @@ spec:
       description: Also push a tag with the current timestamp for each image in the Snapshot
       type: string
       default: "false"
+  results:
+    - name: commonTag
+      type: string
+      description: Common tag for downstream tasks. Only set if tagPrefix length is nonzero
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -66,6 +78,12 @@ spec:
             exit 1
         fi
 
+        prefixedTag=""
+        if [ -n "$(params.tagPrefix)" ]; then
+            prefixedTag="$(params.tagPrefix)-$(date "+$(params.timestampFormat)")"
+        fi
+        echo -n "${prefixedTag}" > $(results.commonTag.path)
+
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
         for component in $(jq -rc '.components[]' "${SNAPSHOT_SPEC_FILE}")
@@ -74,10 +92,20 @@ spec:
           repository=$(jq -r '.repository' <<< $component)
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
-          # take tag if present in mapping file, otherwise take ReleaseStrategy default provided as a task param
-          tag=$(params.tag)
-          if [ $(jq 'has("tag")' <<< $component) == "true" ] ; then
-              tag=$(jq -r '.tag' <<< $component)
+          #
+          # The tag is determined as follows:
+          #
+          # If the value of the task parameter `tagPrefix` has a non-zero length, the tag value is built by
+          # the task in `<prefix>-<timestamp>` format, where prefix is the value of `tagPrefix` and `timestamp`
+          # is the output of the date command using the value of `timestampFormat` as argument.
+          #
+          # Otherwise the tag used is the one existent in the component or in case it is absent, it uses
+          # the value set for the task parameter `tag`.
+          #
+          if [ -n "${prefixedTag}" ] ; then
+              tag="${prefixedTag}"
+          else
+              tag=$(jq -r '.tag // "$(params.tag)"' <<< $component)
           fi
 
           source_digest=$(skopeo inspect \

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -37,3 +37,20 @@ function skopeo() {
   # echo the docker:// image string so the task knows if two images are the same
   echo $5
 }
+
+function date() {
+  echo $* >> $(workspaces.data.path)/mock_date.txt
+
+  case "$*" in
+      "+%Y-%m-%dT%H:%M:%SZ")
+          echo "2023-10-10T15:00:00Z" |tee $(workspaces.data.path)/mock_date_iso_format.txt
+          ;;
+      "+%s")
+          echo "1696946200" | tee $(workspaces.data.path)/mock_date_epoch.txt
+          ;;
+      "*")
+          echo Error: Unexpected call
+          exit 1
+          ;;
+  esac
+}

--- a/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-tagprefix
+spec:
+  description: |
+    Run the push-snapshot task with tagPrefix set
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag",
+                    "repository": "prod-registry.io/prod-location"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: tag
+          value: latest
+        - name: retries
+          value: 0
+        - name: addGitShaTag
+          value: false
+        - name: addSourceShaTag
+          value: false
+        - name: addTimestampTag
+          value: false
+        - name: tagPrefix
+          value: "testprefix"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: commonTag
+          value: $(tasks.run-task.results.commonTag)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: commonTag
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 1 ]; then
+                echo Error: cosign was expected to be called 1 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              [[ "$(params.commonTag)" ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt)" ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
This PR adds the `tagPrefix` parameter to build the tag in `<tagPrefix>-<timestamp>` format and also adds the result `commonTag` to share the tag with the downstream tasks