### PR TITLE
feat(RHTAPREL-270): remove git-clone task from Pipelines

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -12,9 +12,6 @@ Tekton pipeline to push images to an external registry.
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
-| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
-| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
-| extraConfigPath | Path to the extra config file within the repository | No | - |
 | tag | The default tag to use when mapping file does not contain a tag | No | - |
 | addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
 | addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
@@ -23,6 +20,11 @@ Tekton pipeline to push images to an external registry.
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.22.0
+- Remove extraConfig parameters as the information is now passed in the RPA data field
+- Remove the git clone task
+- Fix apply-mapping parameters
 
 ## Changes since 0.21.0
 - pyxisSecret and pyxisServerType parameters were removed

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.22.0"
+    app.kubernetes.io/version: "0.23.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,18 +32,6 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
-    - name: extraConfigGitUrl
-      type: string
-      description: URL to the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigGitRevision
-      type: string
-      description: Revision to fetch from the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigPath
-      type: string
-      description: Path to the extra config file within the repository
-      default: ""
     - name: tag
       type: string
       description: The default tag to use when mapping file does not contain a tag
@@ -154,30 +142,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
-    - name: clone-config-file
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: https://github.com/redhat-appstudio/build-definitions.git
-          - name: revision
-            value: dedce1f59906394ea777606683eec9eb2de465ac
-          - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
-      when:
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
-      params:
-        - name: url
-          value: $(params.extraConfigGitUrl)
-        - name: revision
-          value: $(params.extraConfigGitRevision)
-        - name: subdirectory
-          value: "$(context.pipelineRun.uid)/extraConfig"
-      workspaces:
-        - name: output
-          workspace: release-workspace
     - name: apply-mapping
       taskRef:
         resolver: "git"
@@ -189,16 +153,10 @@ spec:
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
-        - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
-      when:
-        - input: $(tasks.clone-config-file.results.commit)
-          operator: notin
-          values: [""]
       workspaces:
         - name: config
           workspace: release-workspace

--- a/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: tag
       value: ""
     - name: postCleanUp

--- a/pipelines/push-to-external-registry/tests/run.yaml
+++ b/pipelines/push-to-external-registry/tests/run.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: tag
       value: ""
     - name: postCleanUp

--- a/pipelines/release/README.md
+++ b/pipelines/release/README.md
@@ -12,14 +12,16 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
-| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
-| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
-| extraConfigPath | Path to the extra config file within the repository | No | - |
 | addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.22.0
+- Remove extraConfig parameters as the information is now passed in the RPA data field
+- Remove the git clone task
+- Fix apply-mapping parameters
 
 ## Changes since 0.21.0
 - Remove releasestrategy parameter

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "0.22.0"
+    app.kubernetes.io/version: "0.23.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,18 +32,6 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
-    - name: extraConfigGitUrl
-      type: string
-      description: URL to the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigGitRevision
-      type: string
-      description: Revision to fetch from the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigPath
-      type: string
-      description: Path to the extra config file within the repository
-      default: ""
     - name: addGitShaTag
       type: string
       description: When pushing the snapshot components, also push a tag with the image git sha
@@ -143,30 +131,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
-    - name: clone-config-file
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: https://github.com/redhat-appstudio/build-definitions.git
-          - name: revision
-            value: dedce1f59906394ea777606683eec9eb2de465ac
-          - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
-      when:
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
-      params:
-        - name: url
-          value: $(params.extraConfigGitUrl)
-        - name: revision
-          value: $(params.extraConfigGitRevision)
-        - name: subdirectory
-          value: "$(context.pipelineRun.uid)/extraConfig"
-      workspaces:
-        - name: output
-          workspace: release-workspace
     - name: apply-mapping
       taskRef:
         resolver: "git"
@@ -178,16 +142,10 @@ spec:
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
-        - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
-      when:
-        - input: $(tasks.clone-config-file.results.commit)
-          operator: notin
-          values: [""]
       workspaces:
         - name: config
           workspace: release-workspace

--- a/pipelines/release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/release/samples/sample_release_PipelineRun.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: postCleanUp
       value: ""
     - name: verify_ec_task_git_url

--- a/pipelines/release/tests/run.yaml
+++ b/pipelines/release/tests/run.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: postCleanUp
       value: ""
     - name: verify_ec_task_git_url

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -14,9 +14,6 @@
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
-| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
-| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
-| extraConfigPath | Path to the extra config file within the repository | No | - |
 | tag | The default tag to use when mapping file does not contain a tag | No | - |
 | addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | true |
 | addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
@@ -25,6 +22,11 @@
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.8.0
+- Remove extraConfig parameters as the information is now passed in the RPA data field
+- Remove the git clone task
+- Fix apply-mapping parameters
 
 ## Changes since 0.7.0
 - pyxisSecret and pyxisServerType parameters were removed

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: "0.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,18 +32,6 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
-    - name: extraConfigGitUrl
-      type: string
-      description: URL to the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigGitRevision
-      type: string
-      description: Revision to fetch from the remote Git repository containing the extra config
-      default: ""
-    - name: extraConfigPath
-      type: string
-      description: Path to the extra config file within the repository
-      default: ""
     - name: tag
       type: string
       description: The default tag to use when mapping file does not contain a tag
@@ -154,30 +142,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
-    - name: clone-config-file
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: https://github.com/redhat-appstudio/build-definitions.git
-          - name: revision
-            value: dedce1f59906394ea777606683eec9eb2de465ac
-          - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
-      when:
-        - input: $(params.extraConfigGitUrl)
-          operator: notin
-          values: [""]
-      params:
-        - name: url
-          value: $(params.extraConfigGitUrl)
-        - name: revision
-          value: $(params.extraConfigGitRevision)
-        - name: subdirectory
-          value: "$(context.pipelineRun.uid)/extraConfig"
-      workspaces:
-        - name: output
-          workspace: release-workspace
     - name: apply-mapping
       taskRef:
         resolver: "git"
@@ -189,16 +153,10 @@ spec:
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
-        - name: extraConfigPath
-          value: "$(context.pipelineRun.uid)/extraConfig/$(params.extraConfigPath)"
         - name: failOnEmptyResult
           value: "true"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
-      when:
-        - input: $(tasks.clone-config-file.results.commit)
-          operator: notin
-          values: [""]
       workspaces:
         - name: config
           workspace: release-workspace

--- a/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: tag
       value: ""
     - name: postCleanUp

--- a/pipelines/rhtap-service-push/tests/run.yaml
+++ b/pipelines/rhtap-service-push/tests/run.yaml
@@ -15,12 +15,6 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
-    - name: extraConfigGitUrl
-      value: ""
-    - name: extraConfigGitRevision
-      value: ""
-    - name: extraConfigPath
-      value: ""
     - name: tag
       value: ""
     - name: postCleanUp


### PR DESCRIPTION
The mapping data is passed now through the RPA data so the task is not needed anymore.