### PR TITLE
refactor(RHTAPREL-633): push-snapshot reads parameters from data json

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -4,16 +4,19 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 
 ## Parameters
 
-| Name            | Description                                                                                     | Optional | Default value        |
-|-----------------|-------------------------------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace                       | Yes      | mapped_snapshot.json |
-| tag             | Default tag to use if mapping entry does not contain a tag. Not used when tagPrefix is set      | Yes      | latest               |
-| tagPrefix       | The prefix used to build the tag in <prefix>-<timestamp> format                                 | Yes      | ""                   |
-| timestampFormat | Timestamp format used to build the tag when tagPrefix is set                                    | Yes      | %s                   |
-| retries         | Retry copy N times                                                                              | Yes      | 0                    |
-| addGitShaTag    | Also push a tag with the git sha for each image in the Snapshot                                 | Yes      | true                 |
-| addSourceShaTag | Also push a tag with the source sha for each image in the Snapshot                              | Yes      | true                 |
-| addTimestampTag | Also push a tag with the current timestamp for each image in the Snapshot                       | Yes      | false                |
+| Name         | Description                                                               | Optional | Default value        |
+|--------------|---------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | mapped_snapshot.json |
+| dataPath     | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
+| retries      | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes since 0.12
+* The tag parameters are now pulled from the images key in the data json
+  * A new parameter exists called dataPath that specifies the path to the JSON string of merged data in the workspace
+  * tag, tagPrefix, timestampFormat, addGitShaTag, addSourceShaTag, and addTimestampTag are no longer task parameters
+    * They are now pulled from the data json. The boolean ones accept "true" and "false"
+    * Their defaults were kept, namely addTimestampTag defaults to true and addGitShaTag and addSourceShaTag default
+      to true
 
 ## Changes since 0.11
 * Adds `tagPrefix` parameter

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "0.12.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -16,41 +16,21 @@ spec:
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
       type: string
       default: "mapped_snapshot.json"
-    - name: tag
-      description: Default tag to use if mapping entry does not contain a tag. Not used when tagPrefix is set
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-      default: "latest"
-    - name: tagPrefix
-      description: The prefix used to build the tag in <prefix>-<timestamp> format
-      type: string
-      default: ""
-    - name: timestampFormat
-      description: Timestamp format used to build the tag when tagPrefix is set
-      type: string
-      default: "%s"
+      default: "data.json"
     - name: retries
       description: Retry copy N times.
       type: string
       default: "0"
-    - name: addGitShaTag
-      description: Also push a tag with the git sha for each image in the Snapshot
-      type: string
-      default: "true"
-    - name: addSourceShaTag
-      description: Also push a tag with the source sha for each image in the Snapshot
-      type: string
-      default: "true"
-    - name: addTimestampTag
-      description: Also push a tag with the current timestamp for each image in the Snapshot
-      type: string
-      default: "false"
   results:
     - name: commonTag
       type: string
-      description: Common tag for downstream tasks. Only set if tagPrefix length is nonzero
+      description: Common tag for downstream tasks. Only set if tagPrefix length in the data JSON is nonzero
   workspaces:
     - name: data
-      description: The workspace where the snapshot spec json file resides
+      description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
       image:
@@ -78,9 +58,16 @@ spec:
             exit 1
         fi
 
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
         prefixedTag=""
-        if [ -n "$(params.tagPrefix)" ]; then
-            prefixedTag="$(params.tagPrefix)-$(date "+$(params.timestampFormat)")"
+        timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
+        if [ $(jq '.images | has("tagPrefix")' $DATA_FILE) == true ]; then
+            prefixedTag="$(jq -r '.images.tagPrefix' $DATA_FILE)-$(date "+$timestampFormat")"
         fi
         echo -n "${prefixedTag}" > $(results.commonTag.path)
 
@@ -105,7 +92,8 @@ spec:
           if [ -n "${prefixedTag}" ] ; then
               tag="${prefixedTag}"
           else
-              tag=$(jq -r '.tag // "$(params.tag)"' <<< $component)
+              defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
+              tag=$(jq -r '.tag // "${defaultTag}"' <<< $component)
           fi
 
           source_digest=$(skopeo inspect \
@@ -120,11 +108,11 @@ spec:
             "docker://${repository}:${tag}" 2>/dev/null || true)
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
             push_image "${name}" "${containerImage}" "${repository}" "${tag}"
-            if [ $(params.addTimestampTag) = true ] ; then
+            if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
               timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
               push_image "${name}" "${containerImage}" "${repository}" "$timestamp"
             fi
-            if [ $(params.addGitShaTag) = true ] ; then
+            if [[ $(jq -r ".images.addGitShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
               if [ "${git_sha}" != "null" ] ; then
                 push_image "${name}" "${containerImage}" "${repository}" "${git_sha:0:7}"
                 push_image "${name}" "${containerImage}" "${repository}" "${git_sha}"
@@ -133,7 +121,7 @@ spec:
                 exit 1
               fi
             fi
-            if [ $(params.addSourceShaTag) = true ] ; then
+            if [[ $(jq -r ".images.addSourceShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
               if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
               then
                 sha=$(echo "${containerImage}" | cut -d ':' -f 2)

--- a/tasks/push-snapshot/samples/sample_push-snapshot_TaskRun.yaml
+++ b/tasks/push-snapshot/samples/sample_push-snapshot_TaskRun.yaml
@@ -5,8 +5,8 @@ metadata:
   name: push-snapshot-run-empty-params
 spec:
   params:
-    - name: tag
-      value: "test"
+    - name: dataPath
+      value: "data.json"
   taskRef:
     resolver: "git"
     params:

--- a/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
@@ -40,16 +40,19 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "addGitShaTag": true,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
-      params:
-        - name: addGitShaTag
-          value: true
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
@@ -35,16 +35,19 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": true
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
-      params:
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: true
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
@@ -35,16 +35,19 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "addGitShaTag": false,
+                  "addTimestampTag": true,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
-      params:
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: true
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -37,16 +37,20 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
       params:
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-addsourceshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-addsourceshatag.yaml
@@ -38,16 +38,19 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": true
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
-      params:
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: true
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -2,12 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-fail-addgitshatag
+  name: test-push-snapshot-fail-no-data-file
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-snapshot task with addGitShaTag enabled but no git.revision for the component.
+    Run the push-snapshot task with the no data file present in the default filepath of
+    data.json. The task should fail.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -35,16 +36,6 @@ spec:
                     "repository": "prod-registry.io/prod-location"
                   }
                 ]
-              }
-              EOF
-
-              cat > $(workspaces.data.path)/data.json << EOF
-              {
-                "images": {
-                  "addGitShaTag": true,
-                  "addTimestampTag": false,
-                  "addSourceShaTag": false
-                }
               }
               EOF
     - name: run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -35,22 +35,27 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/mydata.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
       params:
         - name: snapshotPath
           value: snapshot.json
-        - name: tag
-          value: latest
+        - name: dataPath
+          value: mydata.json
         - name: retries
           value: 3
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
@@ -35,24 +35,26 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false,
+                  "tagPrefix": "testprefix"
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
       params:
         - name: snapshotPath
           value: snapshot.json
-        - name: tag
-          value: latest
         - name: retries
           value: 0
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: false
-        - name: tagPrefix
-          value: "testprefix"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot.yaml
@@ -35,22 +35,27 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: push-snapshot
       params:
         - name: snapshotPath
           value: snapshot.json
-        - name: tag
-          value: latest
+        - name: dataPath
+          value: data.json
         - name: retries
           value: 0
-        - name: addGitShaTag
-          value: false
-        - name: addSourceShaTag
-          value: false
-        - name: addTimestampTag
-          value: false
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
With the API changes, many parameters are no longer passed to release pipelines. This commit reworks the push-snapshot task to read some of its parameters from the data json file instead of expecting them as tekton task parameters.