### PR TITLE
refactor(RHTAPREL-634): create-pyxis-image pulls tag from data json

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -14,9 +14,15 @@ by a new line.
 | server | The server type to use. Options are 'production' and 'stage' | Yes | production |
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
-| tag | The tag to use when pushing the container image metadata to Pyxis | No | - |
 | isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
+| dataPath | Path to the JSON string of the merged data to use in the data workspace | Yes | data.json |
+
+## Changes since 0.5
+* The tag parameter is removed
+  * The default tag is now provided by the 'images.defaultTag' key in the data JSON file as the pipeline parameter will
+    no longer be passed.
+  * dataPath parameter to point to the data JSON file in the data workspace was added.
 
 ## Changes since 0.4
 * Update Tekton API to v1

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,9 +24,6 @@ spec:
       type: string
       description: If set to true, the images will be marked as certified in their Pyxis entries
       default: "false"
-    - name: tag
-      type: string
-      description: Default tag to use if mapping entry does not contain a tag
     - name: isLatest
       type: string
       description: If set to true, the images will have a latest tag added with their Pyxis entries
@@ -35,9 +32,13 @@ spec:
       type: string
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
       default: mapped_snapshot.json
+    - name: dataPath
+      type: string
+      description: Path to the JSON string of the merged data to use in the data workspace
+      default: data.json
   workspaces:
     - name: data
-      description: The workspace where the snapshot spec json file resides
+      description: The workspace where the snapshot spec and data json files reside
   results:
     - name: containerImageIDs
       type: string
@@ -78,6 +79,12 @@ spec:
             exit 1
         fi
 
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
         echo "${pyxisCert}" > /tmp/crt
         echo "${pyxisKey}" > /tmp/key
 
@@ -89,7 +96,7 @@ spec:
             PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
               --pyxis-url $PYXIS_URL \
               --certified $(params.certified) \
-              --tag $(params.tag) \
+              --tag $(jq -r '.images.defaultTag' "${DATA_FILE}") \
               --is-latest $(params.isLatest) \
               --verbose \
               --skopeo-result /tmp/skopeo-inspect.json \

--- a/tasks/create-pyxis-image/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/tasks/create-pyxis-image/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -7,8 +7,6 @@ spec:
   params:
     - name: pyxisSecret
       value: ""
-    - name: tag
-      value: ""
   taskRef:
     resolver: "git"
     params:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-no-data-file.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-no-data-file.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-fail-no-data-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-pyxis-image task with the no data file present in the default filepath of
+    data.json. The task should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multiple-containerimages.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multiple-containerimages.yaml
@@ -42,6 +42,14 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "testtag"
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: create-pyxis-image
@@ -50,8 +58,6 @@ spec:
           value: test-create-pyxis-image-cert
         - name: server
           value: stage
-        - name: tag
-          value: testtag
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
@@ -34,6 +34,14 @@ spec:
                 ]
               }
               EOF
+
+              cat > $(workspaces.data.path)/mydata.json << EOF
+              {
+                "images": {
+                  "defaultTag": "testtag"
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: create-pyxis-image
@@ -42,8 +50,8 @@ spec:
           value: test-create-pyxis-image-cert
         - name: server
           value: stage
-        - name: tag
-          value: testtag
+        - name: dataPath
+          value: mydata.json
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
With the API changes, the default tag to use is no longer passed as a pipeline parameter. This commit reworks the create-pyxis-image task to pull that value from the data json file instead.