### PR TITLE
fix(RHTAPREL-635): run-file-updates uses data.json in pipeline

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -17,6 +17,10 @@ Tekton pipeline to push images to an external registry.
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
+## Changes since 1.0.0
+- Updated fileUpdatesPath parameter in run-file-updates task to use data.json
+  instead of extra_data.json
+
 ## Changes since 0.23.0
 - Removed tag, addGitShaTag, addSourceShaTag, addTimestampTag parameters
   - These are now provided in the data json that is collected in the collect-data task

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -262,7 +262,7 @@ spec:
     - name: run-file-updates
       params:
         - name: fileUpdatesPath
-          value: $(context.pipelineRun.uid)/extra_data.json
+          value: $(context.pipelineRun.uid)/data.json
         - name: jsonKey
           value: ".fileUpdates"
         - name: snapshotPath


### PR DESCRIPTION
The push-to-external-registry pipeline was recently switched to using data.json instead of extra_data.json. This commit updates the run-file-updates task in the pipeline to use the proper fileUpdatesPath.