### PR TITLE
refactor: update-ocp-tag reads parameters from data json

### DIFF
--- a/tasks/update-ocp-tag/README.md
+++ b/tasks/update-ocp-tag/README.md
@@ -8,10 +8,13 @@ Tekton task to update version tag of FBC pull-spec
 
 | Name | Description | Optional | Default value |
 |------|-------------|----------|---------------|
-| fromIndex | The source Index image (catalog of catalogs) FBC fragment | No | - |
-| targetIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
-| binaryImage | OCP binary image to be baked into the index image | No | - |
+| dataPath | Path to the JSON string of the merged data to use in the data workspace | Yes | data.json |
 | ocpVersion |  OCP version fetched from fbcFragment | No | - |
+
+## Changes since 0.2
+* A new parameter exists called dataPath that specifies the path to the JSON string of merged data in the workspace
+* fromIndex, targetIndex, and binaryImage are no longer task parameters
+    * They are now pulled from the data json.
 
 ## Changes since 0.1
 - update Tekton API to v1

--- a/tasks/update-ocp-tag/samples/sample_update-ocp-tag_TaskRun.yaml
+++ b/tasks/update-ocp-tag/samples/sample_update-ocp-tag_TaskRun.yaml
@@ -5,12 +5,8 @@ metadata:
   name: update-ocp-tag-run-empty-params
 spec:
   params:
-    - name: fromIndex
-      value: ""
-    - name: targetIndex
-      value: ""
-    - name: binaryImage
-      value: ""
+    - name: dataPath
+      value: "data.json"
     - name: ocpVersion
       value: ""  
   taskRef:

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
@@ -10,21 +10,42 @@ spec:
   workspaces:
     - name: tests-workspace
   tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12",
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.12",
+                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: update-ocp-tag
       params:
-        - name: fromIndex
-          value: >-
-            "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12"
-        - name: targetIndex
-          value: >-
-            "quay.io/redhat/redhat----preview-operator-index:v4.12"
-        - name: binaryImage
-          value: >-
-            "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: dataPath
+          value: data.json
         - name: ocpVersion
           value: "v4.13"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
     - name: check-result
       params:
         - name: updated-fromIndex

--- a/tasks/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/update-ocp-tag.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-ocp-tag
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -13,15 +13,10 @@ spec:
     Tekton task to update pull-spec tag with
     valid OCP version from get-ocp-version task.
   params:
-    - name: fromIndex
-      description: The source Index image (catalog of catalogs) FBC fragment
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-    - name: targetIndex
-      description: Index image (catalog of catalogs) the FBC fragment will be added to
-      type: string
-    - name: binaryImage
-      description: OCP binary image to be baked into the index image
-      type: string
+      default: "data.json"
     - name: ocpVersion
       description: OCP version tag to replace the current set tags on index images
       type: string
@@ -35,12 +30,21 @@ spec:
     - name: updated-binaryImage
       type: string
       description: OCP binary image to be baked into the index image with updated tag
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: update-ocp-tag
       image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
       script: |
        #!/usr/bin/env sh
        set -eu
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
 
         # Function to replace tag in an image
         replace_tag() {
@@ -49,9 +53,9 @@ spec:
         }
 
         # Access the updated image
-        updatedFromIndex=$(replace_tag "$(params.fromIndex)")
-        updatedTargetIndex=$(replace_tag "$(params.targetIndex)")
-        updatedBinaryImage=$(replace_tag "$(params.binaryImage)")
+        updatedFromIndex=$(replace_tag "$(jq -r '.fbc.fromIndex' $DATA_FILE)")
+        updatedTargetIndex=$(replace_tag "$(jq -r '.fbc.targetIndex' $DATA_FILE)")
+        updatedBinaryImage=$(replace_tag "$(jq -r '.fbc.binaryImage' $DATA_FILE)")
 
         echo "Updated values"
         echo -n "$updatedFromIndex" | tee $(results.updated-fromIndex.path)


### PR DESCRIPTION
With the API changes, many parameters are no longer passed to FBC release pipelines. This commit reworks the `update-ocp-tag`  task to read some of its parameters from the data JSON file instead of expecting them as tekton task parameters.