### PR TITLE
fix: bump collect-data image for bug fix

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -1,9 +1,9 @@
 # collect-data
 
-Tekton task to collect the information added to the extraData field of the release resources.
+Tekton task to collect the information added to the data field of the release resources.
 
-The purpose of this task is to collect all the extra data and supply it to the other task in the pipeline by creating
-a json file called `extra-data.json` in the workspace.
+The purpose of this task is to collect all the data and supply it to the other task in the pipeline by creating
+a json file called `data.json` in the workspace.
 
 This task also stores the passed resources as json files in a workspace.
 
@@ -22,6 +22,10 @@ also a task result for the fbcFragment extracted from the snapshot's first compo
 | releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
+
+## Changes since 1.0.0
+  * Replace all references to extraData with data due to change in the Release CRDs
+  * Bump the image used in the task to get a bug fix in the merge-json script
 
 ## Changes since 0.4
   * Remove releasestrategy param and result from the task

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,13 +4,13 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task to collect extra data from release resources and optionally save CRs to a workspace
+    Tekton task to collect data from release resources and optionally save CRs to a workspace
   params:
     - name: release
       type: string
@@ -52,7 +52,7 @@ spec:
       description: The relative path in the workspace to the stored data json
   steps:
     - name: collect-data
-      image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+      image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
       env:
         - name: "RELEASE"
           value: '$(params.release)'
@@ -101,7 +101,7 @@ spec:
         merged_output=$(merge-json "$release_result" "$release_plan_result")
 
         # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
-        merged_output=$(merge-json "$release_result" "$release_plan_admission_result")
+        merged_output=$(merge-json "$merged_output" "$release_plan_admission_result")
 
         DATA_PATH=$(params.subdirectory)/data.json
         echo -n $DATA_PATH > $(results.data.path)

--- a/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -7,7 +7,10 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-data task without a snapshot cr and verify that the task fails as expected.
+    Run the collect-data task without a ReleasePlanAdmission cr and verify that the task fails as expected.
+    This test cannot rely on the snapshot not existing as the snapshot is retrieved with a jsonpath added
+    (.spec). The `get-resource` command doesn't fail when a jsonpath is provided, it just returns {} if
+    the key is not found per the new implementation.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -15,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -44,24 +47,19 @@ spec:
               EOF
               kubectl apply -f releaseplan
 
-              cat > releaseplanadmission << EOF
+              cat > snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
-              kind: ReleasePlanAdmission
+              kind: Snapshot
               metadata:
-                name: releaseplanadmission-sample
+                name: snapshot-sample
                 namespace: default
               spec:
                 application: foo
-                origin: foo
-                policy: foo
-                pipelineRef:
-                  resolver: cluster
-                  params:
-                    - name: release-pipeline
-                      namespace: default
-                      kind: pipeline
+                components:
+                  - name: name
+                    containerImage: newimage
               EOF
-              kubectl apply -f releaseplanadmission
+              kubectl apply -f snapshot
     - name: run-task
       taskRef:
         name: collect-data
@@ -86,11 +84,11 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
 
               kubectl delete release release-sample
               kubectl delete releaseplan releaseplan-sample
-              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete snapshot snapshot-sample

--- a/tasks/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data-with-data.yaml
@@ -2,12 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-with-extra-data
+  name: test-collect-data-with-data
 spec:
   description: |
-    Run the collect-data task and verify that extraData task result is accurate.
-    Releases and ReleasePlans don't currently support extraData, so it is only
-    added to the ReleasePlanAdmission.
+    Run the collect-data task and verify that data task result is accurate.
+    Releases don't currently support data, so none is added there.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -15,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -41,6 +40,9 @@ spec:
               spec:
                 application: foo
                 target: foo
+                data:
+                  foo: bar
+                  one: one
               EOF
               kubectl apply -f releaseplan
 
@@ -55,7 +57,6 @@ spec:
                   - foo
                 origin: foo
                 data:
-                  foo: bar
                   one:
                     two: three
                     four:
@@ -65,9 +66,12 @@ spec:
                 pipelineRef:
                   resolver: cluster
                   params:
-                    - name: release-pipeline
-                      namespace: default
-                      kind: pipeline
+                    - name: name
+                      value: release-pipeline
+                    - name: namespace
+                      value: default
+                    - name: kind
+                      value: pipeline
               EOF
               kubectl apply -f releaseplanadmission
 
@@ -115,7 +119,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -128,7 +132,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -49,15 +49,19 @@ spec:
                 name: releaseplanadmission-sample
                 namespace: default
               spec:
-                application: foo
+                applications:
+                  - foo
                 origin: foo
                 policy: foo
                 pipelineRef:
                   resolver: cluster
                   params:
-                    - name: release-pipeline
-                      namespace: default
-                      kind: pipeline
+                    - name: name
+                      value: release-pipeline
+                    - name: namespace
+                      value: default
+                    - name: kind
+                      value: pipeline
               EOF
               kubectl apply -f releaseplanadmission
 
@@ -126,7 +130,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -151,7 +155,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/hacbs-release/release-utils:4d8649dbb2b626f5fe9f4ff83c1bc3be268fad31
+            image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
Bump the image used in the collect-data task to get a bug fix in the merge-json script (https://github.com/redhat-appstudio/release-service-utils/pull/67). Also removes all references to extraData in the task and replaces it with data to align with recent API changes.