### PR TITLE
feat(RHTAPREL-392): create task for an advisory internalrequest

### DIFF
--- a/tasks/create-advisory-internal-request/README.md
+++ b/tasks/create-advisory-internal-request/README.md
@@ -1,0 +1,15 @@
+# create-advisory-internal-request
+
+Tekton task to create an advisory via an InternalRequest. The advisory data is pulled from the data JSON. The origin workspace from
+the ReleasePlanAdmission and Application from the Snapshot are also used. The advisory is created in a GitLab repository.
+
+## Parameters
+
+| Name                     | Description                                                             | Optional | Default value               |
+|--------------------------|-------------------------------------------------------------------------|----------|-----------------------------|
+| jsonKey                  | The json key containing the advisory data                               | Yes      | .advisory                   |
+| releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the data workspace | Yes      | release_plan_admission.json |
+| snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace        | Yes      | snapshot_spec.json          |
+| dataPath                 | Path to data JSON in the data workspace                                 | Yes      | data.json                   |
+| request                  | Type of request to be created                                           | Yes      | create-advisory             |
+| synchronously            | Whether the task should wait for InternalRequests to complete           | Yes      | true                        |

--- a/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: create-advisory-internal-request
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to create an advisory via an InternalRequest
+  params:
+    - name: jsonKey
+      type: string
+      description: The json key containing the advisory data
+      default: ".advisory"
+    - name: releasePlanAdmissionPath
+      type: string
+      description: Path to the JSON string of the ReleasePlanAdmission in the data workspace
+      default: "release_plan_admission.json"
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      default: "snapshot_spec.json"
+    - name: dataPath
+      type: string
+      description: Path to the data JSON in the data workspace
+      default: "data.json"
+    - name: request
+      type: string
+      description: Type of request to be created
+      default: "create-advisory"
+    - name: synchronously
+      type: string
+      description: Whether the task should wait for InternalRequests to complete
+      default: "true"
+  workspaces:
+    - name: data
+      description: Workspace where the json files are stored
+  steps:
+    - name: run-script
+      image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+      script: |
+        #!/bin/sh
+        #
+        #
+        set -e
+
+        # Obtain application from snapshot
+        application=$(jq -rc .application $(workspaces.data.path)/$(params.snapshotPath))
+
+        # Obtain origin workspace from releasePlanAdmission
+        origin=$(jq -rc '.spec.origin' $(workspaces.data.path)/$(params.releasePlanAdmissionPath))
+
+        # Extract the advisory key from the data JSON file
+        advisoryData=$(jq -c "$(params.jsonKey)" $(workspaces.data.path)/$(params.dataPath))
+
+        echo "Creating InternalRequest to create advisory..."
+        internal-request -r "$(params.request)" \
+                         -p application="${application}" \
+                         -p origin="${origin}" \
+                         -p advisory_json="${advisoryData}" \
+                         -s "$(params.synchronously)" \
+                         > $(workspaces.data.path)/ir-result.txt || \
+                         (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
+        
+        internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
+        echo "done (${internalRequest})"
+
+        results=$(kubectl get internalrequest $internalRequest -o=jsonpath='{.status.results}')
+        if [[ "$(echo ${results} | jq -r '.result')" == "Success" ]]; then
+          echo "Advisory created"
+        else
+          echo "Advisory creation failed"
+          echo "$results"
+          exit 1
+        fi

--- a/tasks/create-advisory-internal-request/samples/sample_create-advisory-internal-request_TaskRun.yaml
+++ b/tasks/create-advisory-internal-request/samples/sample_create-advisory-internal-request_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: create-advisory-internal-request
+spec:
+  params:
+    - name: dataPath
+      value: "data.json"
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/create-advisory-internal-request/create-advisory-internal-request.yaml

--- a/tasks/create-advisory-internal-request/tests/mocks.sh
+++ b/tasks/create-advisory-internal-request/tests/mocks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  then
+    echo '{"result":"Success"}'
+  else
+    kubectl $*
+  fi
+}

--- a/tasks/create-advisory-internal-request/tests/pre-apply-task-hook.sh
+++ b/tasks/create-advisory-internal-request/tests/pre-apply-task-hook.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../create-advisory-internal-request.yaml

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-internal-request-fail-no-data
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-advisory-internal-request task with no data JSON and verify the taks fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                      {
+                        "name": "url",
+                        "value": "github.com"
+                      },
+                      {
+                        "name": "revision",
+                        "value": "main"
+                      },
+                      {
+                        "name": "pathInRepo",
+                        "value": "pipeline.yaml"
+                      }
+                    ]
+                  },
+                  "serviceAccount": "sa",
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "repo"
+                  }
+                ]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory-internal-request
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: synchronously
+          value: "false"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-internal-request-fail-no-rpa
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-advisory-internal-request task with no ReleasePlanAdmission and verify the taks fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "advisory": {
+                  "repo": "myrepo.com",
+                  "spec": {
+                    "foo": "bar"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory-internal-request
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: synchronously
+          value: "false"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-snapshot.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-snapshot.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-internal-request-fail-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-advisory-internal-request task with no Snapshot and verify the taks fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                      {
+                        "name": "url",
+                        "value": "github.com"
+                      },
+                      {
+                        "name": "revision",
+                        "value": "main"
+                      },
+                      {
+                        "name": "pathInRepo",
+                        "value": "pipeline.yaml"
+                      }
+                    ]
+                  },
+                  "serviceAccount": "sa",
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "advisory": {
+                  "repo": "myrepo.com",
+                  "spec": {
+                    "foo": "bar"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory-internal-request
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: synchronously
+          value: "false"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-internal-request
+spec:
+  description: |
+    Run the create-advisory-internal-request task and verify the internalrequest was created with the proper params
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                      {
+                        "name": "url",
+                        "value": "github.com"
+                      },
+                      {
+                        "name": "revision",
+                        "value": "main"
+                      },
+                      {
+                        "name": "pathInRepo",
+                        "value": "pipeline.yaml"
+                      }
+                    ]
+                  },
+                  "serviceAccount": "sa",
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "advisory": {
+                  "repo": "myrepo.com",
+                  "spec": {
+                    "foo": "bar"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory-internal-request
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: synchronously
+          value: "false"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:6e92a6f8df8ef1cbecfb4c25b73ec6d92bded527
+            script: |
+              #!/bin/sh
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the request field
+              if [ "$(echo "$internalRequest" | jq -r '.spec.request' )" != "create-advisory" ]; then
+                echo "InternalRequest doesn't contain 'create-advisory' in 'request' field"
+                exit 1
+              fi
+
+              # Check the application parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.application' )" != "myapp" ]; then
+                echo "InternalRequest has the wrong application parameter"
+                exit 1
+              fi
+
+              # Check the origin parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.origin' )" != "dev" ]; then
+                echo "InternalRequest has the wrong origin parameter"
+                exit 1
+              fi
+
+              # Check the advisory_json parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_json' )" != \
+              '{"repo":"myrepo.com","spec":{"foo":"bar"}}' ]; then
+                echo "InternalRequest has the wrong advisory_json parameter"
+                exit 1
+              fi


### PR DESCRIPTION
This commit adds a task that creates an InternalRequest that will create an advisory in a GitLab repo.