### PR TITLE
test(RHTAPREL-646): add release data in collect-data test

### DIFF
--- a/tasks/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data-with-data.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   description: |
     Run the collect-data task and verify that data task result is accurate.
-    Releases don't currently support data, so none is added there.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -28,6 +27,9 @@ spec:
               spec:
                 snapshot: foo
                 releasePlan: foo
+                data:
+                  rkey: rvalue
+                  foo: shouldGetOverwritten
               EOF
               kubectl apply -f release
 
@@ -126,7 +128,7 @@ spec:
 
               echo Test that data result was set properly
               test $(cat "$(workspaces.data.path)/$(params.data)") \
-                == '{"foo":"bar","one":{"four":["five","six"],"two":"three"}}'
+                == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"}}'
   finally:
     - name: cleanup
       taskSpec:


### PR DESCRIPTION
Now that the Release CRD accepts the Data field in its Spec, add to the collect-data test to add data to the Release and ensure it works properly.