### PR TITLE
fix: fix workspace name

### DIFF
--- a/tasks/extract-index-image/extract-index-image.yaml
+++ b/tasks/extract-index-image/extract-index-image.yaml
@@ -15,7 +15,7 @@ spec:
     - name: inputDataFile
       type: string
   workspaces:
-    - name: input
+    - name: data
       description: Workspace where the inputDataFile is stored
   results:
     - name: indexImage

--- a/tasks/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: input
+        - name: data
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: input
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/hacbs-release/release-utils:5b1a1cd9fd68625cab5573ce62e0d87e6f93f341
@@ -24,7 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > $(workspaces.input.path)/file.json << EOF
+              cat > $(workspaces.data.path)/file.json << EOF
               {
                 "jsonBuildInfo": {
                   "arches": [
@@ -65,11 +65,11 @@ spec:
         name: extract-index-image
       params:
         - name: inputDataFile
-          value: $(workspaces.input.path)/file.json
+          value: $(workspaces.data.path)/file.json
       runAfter:
         - setup
       workspaces:
-        - name: input
+        - name: data
           workspace: tests-workspace
     - name: check-result
       params:


### PR DESCRIPTION
This PR fix the workspace name. It was set to `input` but now it should be `data`.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>