### PR TITLE
refactor(RHTAPREL-654): use bundle resolvers for verify-ec task

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -12,9 +12,13 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.10.0
+- Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 0.9.0
 - Remove releasestrategy parameter

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.10.0"
+    app.kubernetes.io/version: "0.11.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,15 +32,23 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -129,14 +137,14 @@ spec:
         - verify-access-to-resources
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
@@ -15,6 +15,8 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
+    - name: verify_ec_task_git_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/deploy-release/tests/run.yaml
+++ b/pipelines/deploy-release/tests/run.yaml
@@ -15,6 +15,8 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
+    - name: verify_ec_task_git_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -14,6 +14,10 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 0.1.0
+* Switch to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -33,15 +33,23 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -75,14 +83,14 @@ spec:
           workspace: release-workspace
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/e2e/samples/e2e-pipelinerun.yaml
+++ b/pipelines/e2e/samples/e2e-pipelinerun.yaml
@@ -15,6 +15,8 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/e2e/tests/run.yaml
+++ b/pipelines/e2e/tests/run.yaml
@@ -15,6 +15,8 @@ spec:
       value: ""
     - name: enterpriseContractPolicy
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -12,10 +12,14 @@ Tekton release pipeline to interact with FBC Pipeline
 | snapshot                        | The namespaced name (namespace/name) of the snapshot                                                     | No        | -                                               |
 | enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                               |
 | enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key            |
+| verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                               |
 | verify_ec_task_git_url          | The git repo url of the verify-enterprise-contract task                                                  | No        | -                                               |
 | verify_ec_task_git_revision     | The git repo revision the verify-enterprise-contract task                                                | No        | -                                               |
 | verify_ec_task_git_pathInRepo   | The location of the verify-enterprise-contract task in its repo                                          | No        | -                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                            |
+
+### Changes since 1.0.0
+- Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ### Changes since 0.26.0
 - change pipeline and tasks definitions to support usage of data JSON file

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,15 +32,23 @@ spec:
       type: string
       description: Public key to use for validation by the enterprise contract
       default: k8s://openshift-pipelines/public-key
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -160,14 +168,14 @@ spec:
         - collect-data
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
@@ -19,6 +19,8 @@ spec:
       value: ""
     - name: requestUpdateTimeout
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/fbc-release/tests/run.yaml
+++ b/pipelines/fbc-release/tests/run.yaml
@@ -19,6 +19,8 @@ spec:
       value: ""
     - name: requestUpdateTimeout
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -13,9 +13,13 @@ Tekton pipeline to push images to an external registry.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | Switch back to using bundle resolvers for the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changs since 1.0.1
+- Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 1.0.0
 - Updated fileUpdatesPath parameter in run-file-updates task to use data.json

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,15 +36,23 @@ spec:
       type: string
       description: Cleans up workspace after finishing executing the pipeline
       default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:
@@ -149,14 +157,14 @@ spec:
         - collect-data
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/push-to-external-registry/tests/run.yaml
+++ b/pipelines/push-to-external-registry/tests/run.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/release/README.md
+++ b/pipelines/release/README.md
@@ -13,9 +13,13 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 1.0.0
+- Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 0.23.0
 - Removed addGitShaTag parameter. This is now provided in the data json collected in the collect-data task

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,15 +36,23 @@ spec:
       type: string
       description: Cleans up workspace after finishing executing the pipeline
       default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:
@@ -149,14 +157,14 @@ spec:
         - collect-data
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/release/samples/sample_release_PipelineRun.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/release/tests/run.yaml
+++ b/pipelines/release/tests/run.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -13,9 +13,13 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 1.0.0
+* Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 0.1.0
 * Removed tagPrefix, timestampFormat, tag, addGitShaTag, addSourceShaTag, addTimestampTag parameters

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,15 +36,23 @@ spec:
       type: string
       description: Cleans up workspace after finishing executing the pipeline
       default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:
@@ -149,14 +157,14 @@ spec:
         - collect-data
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -15,9 +15,13 @@
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+| verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
+
+## Changes since 1.0.1
+- Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 1.0.0
 - Added parameter for releasePlanAdmissionPath to apply-mapping as the file is in a subdirectory

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,15 +36,23 @@ spec:
       type: string
       description: Cleans up workspace after finishing executing the pipeline
       default: "true"
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
+        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
     - name: verify_ec_task_git_url
       type: string
       description: The git repo url of the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_revision
       type: string
       description: The git repo revision the verify-enterprise-contract task
+      default: "dummy-value-to-prevent-failure"
     - name: verify_ec_task_git_pathInRepo
       type: string
       description: The location of the verify-enterprise-contract task in its repo
+      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:
@@ -151,14 +159,14 @@ spec:
         - collect-data
     - name: verify-enterprise-contract
       taskRef:
-        resolver: "git"
+        resolver: "bundles"
         params:
-          - name: url
-            value: $(params.verify_ec_task_git_url)
-          - name: revision
-            value: $(params.verify_ec_task_git_revision)
-          - name: pathInRepo
-            value: $(params.verify_ec_task_git_pathInRepo)
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
       params:
         - name: IMAGES
           value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"

--- a/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision

--- a/pipelines/rhtap-service-push/tests/run.yaml
+++ b/pipelines/rhtap-service-push/tests/run.yaml
@@ -17,6 +17,8 @@ spec:
       value: ""
     - name: postCleanUp
       value: ""
+    - name: verify_ec_task_bundle
+      value: ""
     - name: verify_ec_task_git_url
       value: ""
     - name: verify_ec_task_git_revision


### PR DESCRIPTION
There will be a followup PR to remove the old ec git resolver params (without bumping the version). I am doing it this way to work around CI. That PR will also remove the default for the EC bundle