### PR TITLE
refactor(RHTAPREL-654): remove EC git resolver params

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -13,9 +13,6 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 ## Changes since 0.10.0
 - Switch back to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -35,20 +35,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
@@ -17,12 +17,6 @@ spec:
       value: ""
     - name: verify_ec_task_git_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/deploy-release/tests/run.yaml
+++ b/pipelines/deploy-release/tests/run.yaml
@@ -17,12 +17,6 @@ spec:
       value: ""
     - name: verify_ec_task_git_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -15,9 +15,6 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 ## Changes since 0.1.0
 * Switch to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -36,20 +36,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/e2e/samples/e2e-pipelinerun.yaml
+++ b/pipelines/e2e/samples/e2e-pipelinerun.yaml
@@ -17,12 +17,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/e2e/tests/run.yaml
+++ b/pipelines/e2e/tests/run.yaml
@@ -17,12 +17,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -13,9 +13,6 @@ Tekton release pipeline to interact with FBC Pipeline
 | enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                               |
 | enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key            |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                               |
-| verify_ec_task_git_url          | The git repo url of the verify-enterprise-contract task                                                  | No        | -                                               |
-| verify_ec_task_git_revision     | The git repo revision the verify-enterprise-contract task                                                | No        | -                                               |
-| verify_ec_task_git_pathInRepo   | The location of the verify-enterprise-contract task in its repo                                          | No        | -                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                            |
 
 ### Changes since 1.0.0

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -35,20 +35,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
@@ -21,12 +21,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/fbc-release/tests/run.yaml
+++ b/pipelines/fbc-release/tests/run.yaml
@@ -21,12 +21,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -14,9 +14,6 @@ Tekton pipeline to push images to an external registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | Switch back to using bundle resolvers for the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 ## Changes since 1.1.0
 - Pass path to ReleasePlanAdmission to the apply-mapping task

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -39,20 +39,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/push-to-external-registry/tests/run.yaml
+++ b/pipelines/push-to-external-registry/tests/run.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/release/README.md
+++ b/pipelines/release/README.md
@@ -14,9 +14,6 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 ## Changes since 1.0.0
 - Switch back to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -39,20 +39,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/release/samples/sample_release_PipelineRun.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/release/tests/run.yaml
+++ b/pipelines/release/tests/run.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -14,9 +14,6 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 
 ## Changes since 1.3.0

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -39,20 +39,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -16,9 +16,6 @@
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_url | The git repo url of the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
-| verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 ## Changes since 1.0.1
 - Switch back to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -39,20 +39,6 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
-      default: "quay.io/enterprise-contract/ec-task-bundle:8fb3bb337a971236e7f4a5a2f5b91e58f\
-        286f3bf@sha256:181f0de265fd8c425ed42da70ef86537a275a171525ec3faacf3f70ea237508a"
-    - name: verify_ec_task_git_url
-      type: string
-      description: The git repo url of the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_revision
-      type: string
-      description: The git repo revision the verify-enterprise-contract task
-      default: "dummy-value-to-prevent-failure"
-    - name: verify_ec_task_git_pathInRepo
-      type: string
-      description: The location of the verify-enterprise-contract task in its repo
-      default: "dummy-value-to-prevent-failure"
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:

--- a/pipelines/rhtap-service-push/tests/run.yaml
+++ b/pipelines/rhtap-service-push/tests/run.yaml
@@ -19,12 +19,6 @@ spec:
       value: ""
     - name: verify_ec_task_bundle
       value: ""
-    - name: verify_ec_task_git_url
-      value: ""
-    - name: verify_ec_task_git_revision
-      value: ""
-    - name: verify_ec_task_git_pathInRepo
-      value: ""
   pipelineRef:
     resolver: "git"
     params:


### PR DESCRIPTION
This commit removes the pipeline parameters related to the verify-enterprise-contract git resolver and removes the bundle default value as this will be passed from the operator.