### PR TITLE
fix: pass RPA path to apply-mapping

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -18,7 +18,10 @@ Tekton pipeline to push images to an external registry.
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
-## Changs since 1.0.1
+## Changes since 1.1.0
+- Pass path to ReleasePlanAdmission to the apply-mapping task
+
+## Changes since 1.0.1
 - Switch back to using bundle resolvers for the verify-enterprise-contract task
 
 ## Changes since 1.0.0

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -148,6 +148,8 @@ spec:
       params:
         - name: failOnEmptyResult
           value: "true"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:


### PR DESCRIPTION
In push-to-external-registry pipeline, the RPA path needs to be passed since it is in a subdir.