### PR TITLE
feat(RHTAPREL-624): update push-snapshot to publish source container

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -4,11 +4,18 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 
 ## Parameters
 
-| Name         | Description                                                               | Optional | Default value        |
-|--------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | mapped_snapshot.json |
-| dataPath     | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
-| retries      | Retry copy N times                                                        | Yes      | 0                    |
+| Name               | Description                                                               | Optional | Default value        |
+|--------------------|---------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | mapped_snapshot.json |
+| dataPath           | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
+| pushSourceContainer| Push the source container to the mapped target                            | Yes      | false                |
+| retries            | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes since 1.0.1
+* The new functionality is added to publish source containers to a given target
+  * A new parameter exists called pushSourceContainer to enable/disable the source container push,
+    the value is set to false by default 
+  * a new tag `sourceTag = <prefix>-<integer timestamp>-source` is added for source container push
 
 ## Changes since 1.0.0
 * Fixed bug where the defaultTag was not being properly read

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -20,6 +20,10 @@ spec:
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
       default: "data.json"
+    - name: pushSourceContainer
+      type: string
+      description: Push the source container to the mapped target
+      default: "false"
     - name: retries
       description: Retry copy N times.
       type: string
@@ -106,7 +110,16 @@ spec:
             --no-tags \
             --format '{{.Digest}}' \
             "docker://${repository}:${tag}" 2>/dev/null || true)
+          # Extract the SHA
+          if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
+          then
+            sha=$(echo "${containerImage}" | cut -d ':' -f 2)
+          else
+            sha=""
+          fi
+
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
+            # Push the container image
             push_image "${name}" "${containerImage}" "${repository}" "${tag}"
             if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
               timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
@@ -122,14 +135,24 @@ spec:
               fi
             fi
             if [[ $(jq -r ".images.addSourceShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
-              if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
-              then
-                sha=$(echo "${containerImage}" | cut -d ':' -f 2)
+              if [ -n "$sha" ]; then
                 push_image "${name}" "${containerImage}" "${repository}" "${sha}"
               else
                 printf 'Asked to create source sha based tag, but no sha found in %s\n' "${containerImage}"
                 exit 1
               fi
+            fi
+            # Push the associated source container using the common tag
+            if [[ "$(params.pushSourceContainer)" == "true" ]] ; then # Default to false
+              # Calculate the source container image based on the provided container image
+              sourceContainer="${containerImage%@sha256:*}@sha256:${sha}.src"
+              # Check if the source container exists
+              if ! skopeo inspect --no-tags "docker://${sourceContainer}" &>/dev/null; then
+                echo "Error: Source container ${sourceContainer} not found!"
+                exit 1
+              fi              
+              sourceTag="${prefixedTag}-source"
+              push_image "${name}" "${sourceContainer}" "${repository}" "${sourceTag}"
             fi
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \

--- a/tasks/push-snapshot/samples/sample_push-snapshot_TaskRun.yaml
+++ b/tasks/push-snapshot/samples/sample_push-snapshot_TaskRun.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: dataPath
       value: "data.json"
+    - name: pushSourceContainer
+      value: "false"
   taskRef:
     resolver: "git"
     params:

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -28,14 +28,17 @@ function skopeo() {
   echo Mock skopeo called with: $*
   echo $* >> $(workspaces.data.path)/mock_skopeo.txt
 
-  if [[ "$*" != "inspect --no-tags --format {{.Digest}} docker://"* ]]
-  then
-    echo Error: Unexpected call
-    exit 1
+  if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://"* ]]; then
+    echo $5
+    return
+  fi
+  if [[ "$*" == "inspect --no-tags docker://"* ]]; then
+    return
   fi
 
-  # echo the docker:// image string so the task knows if two images are the same
-  echo $5
+  # If neither of the above matched, it's an unexpected call
+  echo Error: Unexpected call
+  exit 1
 }
 
 function date() {

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer
+spec:
+  description: |
+    Run the push-snapshot task when pushSourceContainer is set to "true"
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:abcdefg",
+                    "repository": "prod-registry.io/prod-location"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false,
+                  "tagPrefix": "testprefix"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: pushSourceContainer
+          value: "true"
+        - name: retries
+          value: 0
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: commonTag
+          value: $(tasks.run-task.results.commonTag)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: commonTag
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:85ab98a7ec63c3d8d9ec3c4982ff0e581bcb3c83
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
+                echo Error: cosign was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 3 ]; then
+                echo Error: skopeo was expected to be called 3 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              [[ "$(params.commonTag)" ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt)" ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
* The new functionality is added to publish source containers to a given target
  * A new parameter exists called pushSourceContainer to enable/disable the source container push,
    the value is set to false by default 
  * a new tag `sourceTag = <prefix>-<integer timestamp>-source` is added for source container push