### PR TITLE
fix: pass RPA path to apply-mapping

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -18,6 +18,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_git_revision | The git repo revision the verify-enterprise-contract task | No | - |
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
+## Changes since 1.1.0
+* Pass path to ReleasePlanAdmission to the apply-mapping task
+
 ## Changes since 1.0.0
 * Switch back to using bundle resolvers for the verify-enterprise-contract task
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -148,6 +148,8 @@ spec:
       params:
         - name: failOnEmptyResult
           value: "true"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
       workspaces:


### PR DESCRIPTION
In rh-push-to-registry-redhat-io pipeline, the RPA path needs to be passed since it is in a subdir.