### PR TITLE
fix(RHTAPREL-435): make update-infra-deployments task more robust

### DIFF
--- a/tasks/update-infra-deployments/README.md
+++ b/tasks/update-infra-deployments/README.md
@@ -19,6 +19,9 @@
 | githubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
 | githubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
 
+## Changes since 0.4.0
+- add protection to prevent failures if there are no updated files.
+
 ## Changes since 0.3
 - extraDataJsonPath is renamed to dataJsonPath to more closely match the API spec
 

--- a/tasks/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/update-infra-deployments/update-infra-deployments.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
@@ -294,6 +294,14 @@ spec:
                 print(json_output)
 
         def main():
+
+            with open(r"updated_files.txt'", 'r') as ufiles:
+            updated_files = len(ufiles.readlines())
+            print('Total Number of updated files: ', updated_files)
+            if updated_files == 0:
+                print("No files to add to a PR. exiting...")
+                sys.exit()
+
             with open(os.environ['GITHUBAPP_KEY_PATH'], 'rb') as key_file:
                 key = key_file.read()
 
@@ -313,12 +321,17 @@ spec:
             infra_pr = github_app.create_mr()
             if "url" not in infra_pr:
                 infra_pr = github_app.get_pr()
-            description = infra_pr["body"]
-            if description == None:
-                description = "Included PRs:"
-            new_pr_link = github_app.get_pr_url_from_sha(revision)
-            new_description = f"{description}\r\n- {new_pr_link}"
-            github_app.update_mr_description(infra_pr["url"], new_description)
+            if "body" in infra_pr:
+                description = infra_pr["body"]
+                if description == None:
+                    description = "Included PRs:"
+                new_pr_link = github_app.get_pr_url_from_sha(revision)
+                new_description = f"{description}\r\n- {new_pr_link}"
+                github_app.update_mr_description(infra_pr["url"], new_description)
+            else:
+                if "message" in infra_pr:
+                    print(infra_pr["message"])
+                raise Exception("PR not created or did not already exist")
 
         if __name__ == '__main__':
             main()


### PR DESCRIPTION
- add protection to prevent failures if there are no updated files.

```
Getting user token for application_id: 305606
{'message': 'Validation Failed', 'errors': [{'resource': 'PullRequest', 'code': 'custom', 'message': 'No commits between main and internal-services'}], 'documentation_url': 'https://docs.github.com/rest/pulls/pulls#create-a-pull-request'}
Traceback (most recent call last):
  File "/tekton/scripts/script-3-pvq8v", line 196, in <module>
    main()
  File "/tekton/scripts/script-3-pvq8v", line 188, in main
    description = infra_pr["body"]
TypeError: 'NoneType' object is not subscriptable
```