### PR TITLE
feat(RHTAPREL-618): add rhPush and commonTag to create-pyxis-image

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -15,8 +15,19 @@ by a new line.
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
 | isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
+| rhPush | If set to true, the registry and repository entries in the Pyxis Container Image object will be converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, the image
+        will be marked as published. | Yes | false |
+| commonTag | If set, the 'tag' in the Pyxis Container Image object will be set to it | Yes | "" |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
-| dataPath | Path to the JSON string of the merged data to use in the data workspace | Yes | data.json |
+| dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
+
+## Changes since 1.0.0
+* Add optional `rhPush` parameter
+  * This will be used in the `rh-push-to-registry-redhat-io` to use the proper `registry` and `repository` values when
+    creating the Container Image object in Pyxis. Also, the image will be marked as published.
+* Add optional `commonTag` parameter
+  * If set, the `tag` in the Pyxis Container Image object will be set to it
+
 
 ## Changes since 0.5
 * The tag parameter is removed

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,13 +28,28 @@ spec:
       type: string
       description: If set to true, the images will have a latest tag added with their Pyxis entries
       default: "false"
+    - name: rhPush
+      type: string
+      description: >
+        If set to true, the registry and repository entries in the Pyxis Container Image object will be
+        converted to use Red Hat's official registry. E.g. a mapped repository of
+        "quay.io/redhat-pending/product---my-image" will be converted to use registry
+        "registry.access.redhat.com" and repository "product/my-image". Also, the image will be
+        marked as published.
+      default: "false"
+    - name: commonTag
+      type: string
+      description: If set, the 'tag' in the Pyxis Container Image object will be set to it
+      default: ""
     - name: snapshotPath
       type: string
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
       default: mapped_snapshot.json
     - name: dataPath
       type: string
-      description: Path to the JSON string of the merged data to use in the data workspace
+      description: >
+        Path to the JSON string of the merged data to use in the data workspace.
+        The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use.
       default: data.json
   workspaces:
     - name: data
@@ -45,8 +60,7 @@ spec:
       description: IDs of the created entries in Pyxis, each on its own line
   steps:
     - name: create-pyxis-image
-      image:
-        quay.io/hacbs-release/release-utils:b198ed78e14490f194f69cc33137900abe07b848
+      image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
       env:
         - name: pyxisCert
           valueFrom:
@@ -79,10 +93,16 @@ spec:
             exit 1
         fi
 
-        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
-        if [ ! -f "${DATA_FILE}" ] ; then
-            echo "No data JSON was provided."
-            exit 1
+        if [ -n "$(params.commonTag)" ]; then
+          TAG="$(params.commonTag)"
+        else
+          # DATA_FILE is only needed for defaultTag which is only needed if commonTag is empty
+          DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+          if [ ! -f "${DATA_FILE}" ] ; then
+              echo "No data JSON was provided."
+              exit 1
+          fi
+          TAG=$(jq -r '.images.defaultTag' "${DATA_FILE}")
         fi
 
         echo "${pyxisCert}" > /tmp/crt
@@ -96,11 +116,12 @@ spec:
             PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
               --pyxis-url $PYXIS_URL \
               --certified $(params.certified) \
-              --tag $(jq -r '.images.defaultTag' "${DATA_FILE}") \
+              --tag $TAG \
               --is-latest $(params.isLatest) \
               --verbose \
               --skopeo-result /tmp/skopeo-inspect.json \
-              --media-type "$MEDIA_TYPE" | tee /tmp/output
+              --media-type "$MEDIA_TYPE" \
+              --rh-push $(params.rhPush) | tee /tmp/output
 
             grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageIDs.path)
         done

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -4,10 +4,10 @@ set -eux
 # mocks to be injected into task step scripts
 
 function create_container_image() {
-  echo Mock create_container_image called with: $* >> $(workspaces.data.path)/mock_create_container_image.txt
+  echo $* >> $(workspaces.data.path)/mock_create_container_image.txt
   echo The image id is 0000
 
-  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tag testtag --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type" ]]
+  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tag "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --rh-push "* ]]
   then
     echo Error: Unexpected call
     echo Mock create_container_image called with: $*

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multiple-containerimages.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multiple-containerimages.yaml
@@ -68,7 +68,7 @@ spec:
         - name: data
           workspace: tests-workspace
       taskSpec:
-        workspaces: 
+        workspaces:
           - name: data
         steps:
           - name: check-result
@@ -77,10 +77,9 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | \
-                  grep 'Mock create_container_image' | wc -l) != 3 ]; then
+              if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 3 ]; then
                 echo Error: create_container_image was expected to be called 3 times. Actual calls:
-                cat $(workspaces.data.path)/mock_create_container_image.txt | grep 'Mock create_container_image'
+                cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi
       runAfter:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -2,10 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-one-containerimage
+  name: test-create-pyxis-image-rhpush-and-commontag
 spec:
-  description: |
-    Run the create-pyxis-image task with a single containerImage in the snapshot.
+  description: >
+    Run the create-pyxis-image task with a single containerImage in the snapshot and set rhPush to true.
+    Also set the commonTag value.
+    Check that both values are propagated to the create_pyxis_image call.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -34,14 +36,6 @@ spec:
                 ]
               }
               EOF
-
-              cat > $(workspaces.data.path)/mydata.json << EOF
-              {
-                "images": {
-                  "defaultTag": "testtag"
-                }
-              }
-              EOF
     - name: run-task
       taskRef:
         name: create-pyxis-image
@@ -52,6 +46,10 @@ spec:
           value: stage
         - name: dataPath
           value: mydata.json
+        - name: rhPush
+          value: "true"
+        - name: commonTag
+          value: mycommontag
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -77,16 +75,16 @@ spec:
                 exit 1
               fi
 
-              if ! grep -- "--tag testtag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              if ! grep -- "--tag mycommontag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--tag testtag". Actual call:
+                echo Error: create_container_image call was expected to include "--tag mycommontag". Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi
 
-              if ! grep -- "--rh-push false" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              if ! grep -- "--rh-push true" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--rh-push false". Actual call:
+                echo Error: create_container_image call was expected to include "--rh-push true". Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi


### PR DESCRIPTION
These new parameters will be used in the
rh-push-to-registry-redhat-io pipeline.

rhPush, if set to true, will set the proper
`registry` and `repository` values when creating the Container Image object in Pyxis. Also, the image will be marked as published.

commonTag, if set, will be used for the `tag` value in the Container Image object in Pyxis.

This change depends on
https://github.com/redhat-appstudio/release-service-utils/pull/76