### PR TITLE
feat(RHTAPREL-618): add publish-pyxis-repository task

### DIFF
--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -1,0 +1,17 @@
+# publish-pyxis-repository
+
+Tekton task to mark all repositories in the mapped snapshot as published in Pyxis.
+This is currently only meant to be used in the rh-push-to-registry-redhat-io pipeline,
+so it will convert the values to the ones used for registry.redhat.io releases.
+E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted to use
+registry "registry.access.redhat.com" and repository "my-product/my-image" to identify
+the right Container Registry object in Pyxis.
+
+
+## Parameters
+
+| Name         | Description                                                                                       | Optional | Default value      |
+|--------------|---------------------------------------------------------------------------------------------------|----------|--------------------|
+| server       | The server type to use. Options are 'production' and 'stage'                                      | Yes      | production         |
+| pyxisSecret  | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No       | -                  |
+| snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | Yes      | snapshot_spec.json |

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-pyxis-repository
+  labels:
+    app.kubernetes.io/version: "0.0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >
+    Tekton task to mark all repositories in the mapped snapshot as published in Pyxis.
+    This is currently only intended for the rh-push-to-registry-redhat-io pipeline,
+    so it will convert the values to the ones used for registry.redhat.io releases.
+    E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted
+    to use registry "registry.access.redhat.com" and repository "my-product/my-image"
+    to identify the right Container Registry object in Pyxis.
+  params:
+    - name: server
+      type: string
+      description: The server type to use. Options are 'production' and 'stage'
+      default: production
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: snapshotPath
+      description: Path to the JSON file containing the mapped Snapshot spec in the data workspace
+      type: string
+      default: "snapshot_spec.json"
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  steps:
+    - name: publish-pyxis-repository
+      image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
+      env:
+        - name: pyxisCert
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: cert
+        - name: pyxisKey
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: key
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        PYXIS_REGISTRY=registry.access.redhat.com
+
+        if [[ "$(params.server)" == "production" ]]
+        then
+            PYXIS_URL="https://pyxis.api.redhat.com"
+        elif [[ "$(params.server)" == "stage" ]]
+        then
+            PYXIS_URL="https://pyxis.preprod.api.redhat.com"
+        else
+            echo "Invalid server parameter. Only 'production' and 'stage' are allowed."
+            exit 1
+        fi
+
+        echo "${pyxisCert}" > /tmp/crt
+        echo "${pyxisKey}" > /tmp/key
+
+        SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi
+
+        application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
+        printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
+
+        for REPOSITORY in $(jq -r '.components[].repository' "${SNAPSHOT_SPEC_FILE}")
+        do
+            PYXIS_REPOSITORY=${REPOSITORY##*/}
+            # Replace "----" with "/"
+            PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
+            PYXIS_REPOSITORY_JSON=$(curl --retry 5 --key /tmp/key --cert /tmp/crt \
+                "${PYXIS_URL}/v1/repositories/registry/${PYXIS_REGISTRY}/repository/${PYXIS_REPOSITORY}" -X GET)
+            PYXIS_REPOSITORY_ID=$(jq -r '._id // ""' <<< $PYXIS_REPOSITORY_JSON)
+            if [ -z "$PYXIS_REPOSITORY_ID" ]; then
+                echo Error: Unable to get Container Repository object id from Pyxis
+                echo Pyxis response:
+                echo $PYXIS_REPOSITORY_JSON
+                exit 1
+            fi
+            curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
+                -X PATCH -H 'Content-Type: application/json' --data-binary '{"published": true}'
+        done
+
+        printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/publish-pyxis-repository/samples/sample_publish-pyxis-repository_TaskRun.yaml
+++ b/tasks/publish-pyxis-repository/samples/sample_publish-pyxis-repository_TaskRun.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: publish-pyxis-repository-run-empty-params
+spec:
+  params:
+    - name: pyxisSecret
+      value: ""
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/publish-pyxis-repository/publish-pyxis-repository.yaml

--- a/tasks/publish-pyxis-repository/tests/pre-apply-task-hook.sh
+++ b/tasks/publish-pyxis-repository/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../publish-pyxis-repository.yaml
+
+# Create a dummy pyxis secret (and delete it first if it exists)
+kubectl delete secret test-publish-pyxis-repository-cert --ignore-not-found
+kubectl create secret generic test-publish-pyxis-repository-cert --from-literal=cert=mycert --from-literal=key=mykey

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-missing-pyxis-repository
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-pyxis-repository task. This will simulate a failure where
+    the Container Repository object does not exist in Pyxis. The task will fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image9"
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-missing-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-pyxis-repository task without a valid snapshot spec file.
+    It should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-wrong-server
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-pyxis-repository task with an invalid pyxis server.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+        - name: server
+          value: qa
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository
+spec:
+  description: |
+    Run the publish-pyxis-repository task with multiple components.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                  },
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image2"
+                  },
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image3"
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 6 ]; then
+                  echo Error: curl was expected to be called 6 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 2 | tail -n 1) \
+                  == *"/id/1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 3 | tail -n 1) \
+                  == *"/my-product/my-image2 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 4 | tail -n 1) \
+                  == *"/id/3 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 5 | tail -n 1) \
+                  == *"/my-product/my-image3 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 6 | tail -n 1) \
+                  == *"/id/5 "* ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
This task will go over components in mapped snapshot and mark each corresponding Container Repository object in Pyxis as published.

This will be used in the rh-push-to-registry-redhat-io pipeline.