### PR TITLE
feat(RHTAPREL-618): update rh-push-to-registry-redhat-io pipeline

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 
+## Changes since 1.2.0
+* Set rhPush and commonTag when calling create-pyxis-image task
+* Add publish-pyxis-repository task
+
 ## Changes since 1.1.1
 * Add tasks extract-requester-from-release and rh-sign-image so the pipeline can sign
   component images using the requester username

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -287,6 +287,10 @@ spec:
           value: $(tasks.collect-pyxis-params.results.server)
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
+        - name: rhPush
+          value: "true"
+        - name: commonTag
+          value: $(tasks.push-snapshot.results.commonTag)
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: dataPath
@@ -296,6 +300,28 @@ spec:
           workspace: release-workspace
       runAfter:
         - rh-sign-image
+    - name: publish-pyxis-repository
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/release-service-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+      params:
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - create-pyxis-image
     - name: push-sbom-to-pyxis
       taskRef:
         resolver: "git"


### PR DESCRIPTION
These changes are necessary to make the released images pullable from registry.redhat.io.

* Set rhPush to true and set commonTag when calling create-pyxis-image task
* Add publish-pyxis-repository task which will set the published flag in Pyxis to true for each Container Repository object

This requires these PRs to be merged first:
* https://github.com/redhat-appstudio/release-service-catalog/pull/264
* https://github.com/redhat-appstudio/release-service-catalog/pull/265