### PR TITLE
feat(RHTAPREL-624): rh-push-to-registry-redhat-io push source container

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_git_pathInRepo | The location of the verify-enterprise-contract task in its repo | No | - |
 
 
+## Changes since 1.3.0
+* add component `pushSourceContainer` to `push-snapshot`, this will
+  enable push of the source container image and fail the pipeline if the
+  image is not available. 
+
 ## Changes since 1.2.0
 * Set rhPush and commonTag when calling create-pyxis-image task
 * Add publish-pyxis-repository task

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -222,6 +222,8 @@ spec:
             value: main
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
+          - name: pushSourceContainer
+            value: "true"
       params:
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"


### PR DESCRIPTION
This Commit will add a component `pushSourceContainer` to `push-snapshot`, this will enable push of the source container image and fail the pipeline if the built source image is not available.