### PR TITLE
fix(RHTAPBUGS-927): update image in create-pyxis-image task

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -21,6 +21,10 @@ by a new line.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
 
+## Changes since 1.1.0
+* Update image used in the task
+  * The new image contains fix for missing image_id field when creating the Pyxis Container Image object
+
 ## Changes since 1.0.0
 * Add optional `rhPush` parameter
   * This will be used in the `rh-push-to-registry-redhat-io` to use the proper `registry` and `repository` values when

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -60,7 +60,7 @@ spec:
       description: IDs of the created entries in Pyxis, each on its own line
   steps:
     - name: create-pyxis-image
-      image: quay.io/hacbs-release/release-utils:3f444c112061fc224bc414d3f5e78b5e654729ae
+      image: quay.io/hacbs-release/release-utils:b596085a18c7d02007acf3ebbe340a4e4da2a9f4
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
This new image contains a fix for missing image_id field when creating the Pyxis Container Image object:
https://github.com/redhat-appstudio/release-service-utils/pull/77