### PR TITLE
fix: pipeline version rh-push-to-registry-redhat-io

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,7 +20,7 @@ Tekton pipeline to release content to registry.redhat.io registry.
 
 
 ## Changes since 1.3.0
-* add component `pushSourceContainer` to `push-snapshot`, this will
+* add parameter `pushSourceContainer` to `push-snapshot`, this will
   enable push of the source container image and fail the pipeline if the
   image is not available. 
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release


### PR DESCRIPTION
The previous change(#267) was not a bug fix, but a new feature, 
so the minor version should have been updated.