### PR TITLE
fix(RHTAPBUGS-933): use digest for skopeo inspect in create-pyxis-image

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -21,6 +21,10 @@ by a new line.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
 
+## Changes since 1.1.1
+* Use the image digest when doing skopeo inspect
+  * Without a digest, the `latest` tag was assumed. But if it was missing, the command would fail
+
 ## Changes since 1.1.0
 * Update image used in the task
   * The new image contains fix for missing image_id field when creating the Pyxis Container Image object

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -108,10 +108,15 @@ spec:
         echo "${pyxisCert}" > /tmp/crt
         echo "${pyxisKey}" > /tmp/key
 
-        for containerImage in $(jq -r '.components[].repository' "${SNAPSHOT_SPEC_FILE}") ; do
-
-            MEDIA_TYPE=$(skopeo inspect --raw "docker://${containerImage}" | jq -r .mediaType)
-            skopeo inspect --no-tags "docker://${containerImage}" > /tmp/skopeo-inspect.json
+        COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
+        for (( i=0; i < $COMPONENTS; i++ )); do
+            CONTAINER_IMAGE=$(jq -r ".components[${i}].containerImage" "${SNAPSHOT_SPEC_FILE}")
+            REPOSITORY=$(jq -r ".components[${i}].repository" "${SNAPSHOT_SPEC_FILE}")
+            REPOSITORY=${REPOSITORY%:*} # strip tag just in case - it should not be there
+            DIGEST="${CONTAINER_IMAGE##*@}"
+            PULLSPEC="docker://${REPOSITORY}@${DIGEST}"
+            MEDIA_TYPE=$(skopeo inspect --raw "$PULLSPEC" | jq -r .mediaType)
+            skopeo inspect --no-tags "$PULLSPEC" > /tmp/skopeo-inspect.json
 
             PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
               --pyxis-url $PYXIS_URL \

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -16,6 +16,7 @@ function create_container_image() {
 }
 
 function skopeo() {
+  echo $* >> $(workspaces.data.path)/mock_skopeo.txt
   if [[ "$*" == "inspect --raw docker://"* ]]
   then
     echo '{"mediaType": "my_media_type"}'

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
@@ -29,7 +29,8 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "containerImage": "registry.io/image:tag"
+                    "containerImage": "source@mydigest",
+                    "repository": "registry.io/image"
                   }
                 ]
               }
@@ -90,5 +91,18 @@ spec:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
+                = "inspect --raw docker://registry.io/image@mydigest" ]
+
+              [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 2 | tail -n 1)" \
+                = "inspect --no-tags docker://registry.io/image@mydigest" ]
+
       runAfter:
         - run-task


### PR DESCRIPTION
Without the digest, the "latest" tag was assumed. Which would fail if there was no latest tag pushed for the repository. And even if it was, it was not safe - somebody else could have overriden latest in the meantime.

Note that the tests were wrong - they defined only `containerImage` in the snapshot, but the task was only using `repository` and they still passed. To get this ready quickly, I only fixed one test: `test-create-pyxis-image-one-containerimage` The rest will be fixed in a follow up PR.