### PR TITLE
fix: correct the pushsourcecontainer parameter call

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -16,6 +16,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
 
+## Changes since 1.4.0
+* The parameter `pushSourceContainer` in the `push-snapshot` task
+  was not added correctly in the previous version, the new version
+  fixes the issue.
+ 
 ## Changes since 1.3.0
 * add parameter `pushSourceContainer` to `push-snapshot`, this will
   enable push of the source container image and fail the pipeline if the

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -208,13 +208,13 @@ spec:
             value: main
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
-          - name: pushSourceContainer
-            value: "true"
       params:
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
+        - name: pushSourceContainer
+          value: "true"
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
The parameter `pushSourceContainer` in the
`push-snapshot` task was not added correctly
in the previous version, the new version fixes the issue.