### PR TITLE
feat(RHTAPREL-618): update image in create-pyxis-image task

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -15,11 +15,15 @@ by a new line.
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
 | isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
-| rhPush | If set to true, the registry and repository entries in the Pyxis Container Image object will be converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, the image
-        will be marked as published. | Yes | false |
+| rhPush | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes | false |
 | commonTag | If set, the 'tag' in the Pyxis Container Image object will be set to it | Yes | "" |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
+
+## Changes since 1.1.2
+* Update image used in the task
+  * When rhPush is true, now we'll create two entries in ContainerImage.repositories - one is the normal one and the other
+    is the special one with registry="registry.access.redhat.com"
 
 ## Changes since 1.1.1
 * Use the image digest when doing skopeo inspect

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,11 +31,11 @@ spec:
     - name: rhPush
       type: string
       description: >
-        If set to true, the registry and repository entries in the Pyxis Container Image object will be
-        converted to use Red Hat's official registry. E.g. a mapped repository of
-        "quay.io/redhat-pending/product---my-image" will be converted to use registry
-        "registry.access.redhat.com" and repository "product/my-image". Also, the image will be
-        marked as published.
+        If set to true, an additional entry will be created in ContainerImage.repositories with
+        the registry and repository fields converted to use Red Hat's official registry.
+        E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted
+        to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this
+        repository entry will be marked as published.
       default: "false"
     - name: commonTag
       type: string
@@ -60,7 +60,7 @@ spec:
       description: IDs of the created entries in Pyxis, each on its own line
   steps:
     - name: create-pyxis-image
-      image: quay.io/hacbs-release/release-utils:b596085a18c7d02007acf3ebbe340a4e4da2a9f4
+      image: quay.io/hacbs-release/release-utils:0171e10da30c13f7ced47fb01b3ddb21cc642c16
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
When rhPush is true, now we'll create two entries in ContainerImage.repositories - one is the normal one and the other is the special one with registry="registry.access.redhat.com"

This is the related PR for the utils image: https://github.com/redhat-appstudio/release-service-utils/pull/80