### PR TITLE
fix(RHTAPBUGS-940) make pushSourceContainer work as a data.images option

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -213,8 +213,6 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pushSourceContainer
-          value: "true"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -8,8 +8,10 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 |--------------------|---------------------------------------------------------------------------|----------|----------------------|
 | snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | mapped_snapshot.json |
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
-| pushSourceContainer| Push the source container to the mapped target                            | Yes      | false                |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes since 1.1.1
+* The pushSourceContainer parameter was removed in favor of reading it from the data.json
 
 ## Changes since 1.1.0
 * The source container source pullspec was updated to use a git sha tag instead of the image digest.

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -20,10 +20,6 @@ spec:
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
       default: "data.json"
-    - name: pushSourceContainer
-      type: string
-      description: Push the source container to the mapped target
-      default: "false"
     - name: retries
       description: Retry copy N times.
       type: string
@@ -138,14 +134,14 @@ spec:
               fi
             fi
             # Push the associated source container using the common tag
-            if [[ "$(params.pushSourceContainer)" == "true" ]] ; then # Default to false
+            if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
               # Calculate the source container image based on the provided container image
               sourceContainer="${containerImage%@sha256:*}:${git_sha}.src"
               # Check if the source container exists
               if ! skopeo inspect --no-tags "docker://${sourceContainer}" &>/dev/null; then
                 echo "Error: Source container ${sourceContainer} not found!"
                 exit 1
-              fi              
+              fi
               sourceTag="${prefixedTag}-source"
               push_image "${name}" "${sourceContainer}" "${repository}" "${sourceTag}"
             fi

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-push-snapshot-pushsourcecontainer
 spec:
   description: |
-    Run the push-snapshot task when pushSourceContainer is set to "true"
+    Run the push-snapshot task with pushSourceContainer enabled
   workspaces:
     - name: tests-workspace
   tasks:
@@ -49,6 +49,7 @@ spec:
                   "addGitShaTag": false,
                   "addTimestampTag": false,
                   "addSourceShaTag": false,
+                  "pushSourceContainer": true,
                   "tagPrefix": "testprefix"
                 }
               }
@@ -59,8 +60,6 @@ spec:
       params:
         - name: snapshotPath
           value: snapshot.json
-        - name: pushSourceContainer
-          value: "true"
         - name: retries
           value: 0
       workspaces:


### PR DESCRIPTION
This lets users configure whether it is turned on or off on an RPA by RPA basis.