### PR TITLE
fix(RHTAPBUGS-946): push floating tag when tagPrefix is set

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -16,15 +16,21 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
 
+## Changes since 1.4.2
+* Move from commonTag to commonTags
+  - The result of push-snapshot was renamed to commonTags and now it contains both the fixed and floating
+    tags, e.g. tagprefix-timestamp and tagprefix. The consuming tasks (rh-sign-image and create-pyxis-image)
+    were also modified to take advantage of this
+
 ## Changes since 1.4.0
 * The parameter `pushSourceContainer` in the `push-snapshot` task
   was not added correctly in the previous version, the new version
   fixes the issue.
- 
+
 ## Changes since 1.3.0
 * add parameter `pushSourceContainer` to `push-snapshot`, this will
   enable push of the source container image and fail the pipeline if the
-  image is not available. 
+  image is not available.
 
 ## Changes since 1.2.0
 * Set rhPush and commonTag when calling create-pyxis-image task
@@ -42,4 +48,4 @@ Tekton pipeline to release content to registry.redhat.io registry.
 
 ## Changes since 0.1.0
 * Removed tagPrefix, timestampFormat, tag, addGitShaTag, addSourceShaTag, addTimestampTag parameters
-  * These are now provided in the data json that is collected in the collect-data task
+  - These are now provided in the data json that is collected in the collect-data task

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.4.2"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -253,8 +253,8 @@ spec:
           value: "$(context.pipelineRun.uid)/data.json"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
-        - name: commonTag
-          value: $(tasks.push-snapshot.results.commonTag)
+        - name: commonTags
+          value: $(tasks.push-snapshot.results.commonTags)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -275,8 +275,8 @@ spec:
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: rhPush
           value: "true"
-        - name: commonTag
-          value: $(tasks.push-snapshot.results.commonTag)
+        - name: commonTags
+          value: $(tasks.push-snapshot.results.commonTags)
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
         - name: dataPath

--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -16,9 +16,9 @@ by a new line.
 | certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
 | isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
 | rhPush | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes | false |
-| commonTag | If set, the 'tag' in the Pyxis Container Image object will be set to it | Yes | "" |
+| commonTags | Space separated list of common tags to be used when publishing. If set, these tags will be added to the Pyxis Container Image object. | Yes | "" |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
-| dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
+| dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | Yes | data.json |
 
 ## Changes since 1.2.0
 * Create a floating tag when tagPrefix is set

--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,12 @@ by a new line.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use. | Yes | data.json |
 
+## Changes since 1.2.0
+* Create a floating tag when tagPrefix is set
+  * This is in addition to the tag tagPrefix-timestamp a.k.a. commonTag that we create in Pyxis now
+* Update image used in the task
+  * The new image supports multiple tags in the create_pyxis_image Python script
+
 ## Changes since 1.1.2
 * Update image used in the task
   * When rhPush is true, now we'll create two entries in ContainerImage.repositories - one is the normal one and the other

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.2.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,9 +37,11 @@ spec:
         to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this
         repository entry will be marked as published.
       default: "false"
-    - name: commonTag
+    - name: commonTags
       type: string
-      description: If set, the 'tag' in the Pyxis Container Image object will be set to it
+      description: >
+        Space separated list of common tags to be used when publishing.
+        If set, these tags will be added to the Pyxis Container Image object.
       default: ""
     - name: snapshotPath
       type: string
@@ -48,7 +50,8 @@ spec:
     - name: dataPath
       type: string
       description: >
-        Path to the JSON string of the merged data to use in the data workspace
+        Path to the JSON string of the merged data to use in the data workspace.
+        Only required if commonTags is not set or empty.
       default: data.json
   workspaces:
     - name: data
@@ -92,15 +95,14 @@ spec:
             exit 1
         fi
 
-        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
-        if [ ! -f "${DATA_FILE}" ] ; then
-            echo "No data JSON was provided."
-            exit 1
-        fi
-
-        if [ -n "$(params.commonTag)" ]; then
-          TAGS="$(params.commonTag) $(jq -r '.images.tagPrefix' $DATA_FILE)"
+        if [ -n "$(params.commonTags)" ]; then
+          TAGS="$(params.commonTags)"
         else
+          DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+          if [ ! -f "${DATA_FILE}" ] ; then
+              echo "No data JSON was provided."
+              exit 1
+          fi
           TAGS=$(jq -r '.images.defaultTag' "${DATA_FILE}")
         fi
 

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,8 +48,7 @@ spec:
     - name: dataPath
       type: string
       description: >
-        Path to the JSON string of the merged data to use in the data workspace.
-        The file is only needed if commonTag parameter is empty in which case it's used to determine the tag to use.
+        Path to the JSON string of the merged data to use in the data workspace
       default: data.json
   workspaces:
     - name: data
@@ -60,7 +59,7 @@ spec:
       description: IDs of the created entries in Pyxis, each on its own line
   steps:
     - name: create-pyxis-image
-      image: quay.io/hacbs-release/release-utils:0171e10da30c13f7ced47fb01b3ddb21cc642c16
+      image: quay.io/hacbs-release/release-utils:ddd3d43ef4bcb4ef5ab41c41228fcd2db2607ff7
       env:
         - name: pyxisCert
           valueFrom:
@@ -93,16 +92,16 @@ spec:
             exit 1
         fi
 
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
         if [ -n "$(params.commonTag)" ]; then
-          TAG="$(params.commonTag)"
+          TAGS="$(params.commonTag) $(jq -r '.images.tagPrefix' $DATA_FILE)"
         else
-          # DATA_FILE is only needed for defaultTag which is only needed if commonTag is empty
-          DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
-          if [ ! -f "${DATA_FILE}" ] ; then
-              echo "No data JSON was provided."
-              exit 1
-          fi
-          TAG=$(jq -r '.images.defaultTag' "${DATA_FILE}")
+          TAGS=$(jq -r '.images.defaultTag' "${DATA_FILE}")
         fi
 
         echo "${pyxisCert}" > /tmp/crt
@@ -121,7 +120,7 @@ spec:
             PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
               --pyxis-url $PYXIS_URL \
               --certified $(params.certified) \
-              --tag $TAG \
+              --tags "$TAGS" \
               --is-latest $(params.isLatest) \
               --verbose \
               --skopeo-result /tmp/skopeo-inspect.json \

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -7,7 +7,7 @@ function create_container_image() {
   echo $* >> $(workspaces.data.path)/mock_create_container_image.txt
   echo The image id is 0000
 
-  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tag "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --rh-push "* ]]
+  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --rh-push "* ]]
   then
     echo Error: Unexpected call
     echo Mock create_container_image called with: $*

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage.yaml
@@ -78,9 +78,9 @@ spec:
                 exit 1
               fi
 
-              if ! grep -- "--tag testtag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              if ! grep -- "--tags testtag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--tag testtag". Actual call:
+                echo Error: create_container_image call was expected to include "--tags testtag". Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -37,13 +37,6 @@ spec:
                 ]
               }
               EOF
-              cat > $(workspaces.data.path)/data.json << EOF
-              {
-                "images": {
-                  "tagPrefix": "myprefix"
-                }
-              }
-              EOF
     - name: run-task
       taskRef:
         name: create-pyxis-image
@@ -56,8 +49,8 @@ spec:
           value: data.json
         - name: rhPush
           value: "true"
-        - name: commonTag
-          value: myprefix-mytimestamp
+        - name: commonTags
+          value: "myprefix-mytimestamp myprefix"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -37,6 +37,13 @@ spec:
                 ]
               }
               EOF
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "tagPrefix": "myprefix"
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: create-pyxis-image
@@ -46,11 +53,11 @@ spec:
         - name: server
           value: stage
         - name: dataPath
-          value: mydata.json
+          value: data.json
         - name: rhPush
           value: "true"
         - name: commonTag
-          value: mycommontag
+          value: myprefix-mytimestamp
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -76,16 +83,19 @@ spec:
                 exit 1
               fi
 
-              if ! grep -- "--tag mycommontag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              if ! grep -- "--tags myprefix-mytimestamp myprefix" \
+                < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--tag mycommontag". Actual call:
+                echo Error: create_container_image call was expected to include "--tags myprefix-mytimestamp myprefix".
+                echo Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi
 
               if ! grep -- "--rh-push true" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--rh-push true". Actual call:
+                echo Error: create_container_image call was expected to include "--rh-push true".
+                echo Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -13,6 +13,7 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 ## Changes since 1.2.0
 * Push to floating tags when tagPrefix is set
   * In addition to pushing to $prefix-$timestamp, we now also push to $prefix
+  * Rename result commonTag to commonTags and save both tags in it
 
 ## Changes since 1.1.1
 * The pushSourceContainer parameter was removed in favor of reading it from the data.json

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -10,6 +10,10 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
 
+## Changes since 1.2.0
+* Push to floating tags when tagPrefix is set
+  * In addition to pushing to $prefix-$timestamp, we now also push to $prefix
+
 ## Changes since 1.1.1
 * The pushSourceContainer parameter was removed in favor of reading it from the data.json
 
@@ -19,7 +23,7 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 ## Changes since 1.0.1
 * The new functionality is added to publish source containers to a given target
   * A new parameter exists called pushSourceContainer to enable/disable the source container push,
-    the value is set to false by default 
+    the value is set to false by default
   * a new tag `sourceTag = <prefix>-<integer timestamp>-source` is added for source container push
 
 ## Changes since 1.0.0

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -69,7 +69,7 @@ spec:
         if [ -n $tagPrefix ]; then
             echo -n "${tagPrefix}-${timestamp}" > $(results.commonTag.path)
         else
-          echo -n "" > $(results.commonTag.path)
+            echo -n "" > $(results.commonTag.path)
         fi
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "1.2.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,9 +25,11 @@ spec:
       type: string
       default: "0"
   results:
-    - name: commonTag
+    - name: commonTags
       type: string
-      description: Common tag for downstream tasks. Only set if tagPrefix length in the data JSON is nonzero
+      description: >
+        Space separated list of common tags for downstream tasks.
+        Only set if tagPrefix length in the data JSON is nonzero
   workspaces:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
@@ -67,9 +69,9 @@ spec:
         timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
         timestamp="$(date "+$timestampFormat")"
         if [ -n $tagPrefix ]; then
-            echo -n "${tagPrefix}-${timestamp}" > $(results.commonTag.path)
+            echo -n "${tagPrefix}-${timestamp} ${tagPrefix}" > $(results.commonTags.path)
         else
-            echo -n "" > $(results.commonTag.path)
+            echo -n "" > $(results.commonTags.path)
         fi
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -33,8 +33,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
-      image:
-        quay.io/hacbs-release/release-utils@sha256:fbe973077b00242eeb3d25101def1be286c621436c5a003527736eabb48f0398
+      image: quay.io/hacbs-release/release-utils@sha256:fbe973077b00242eeb3d25101def1be286c621436c5a003527736eabb48f0398
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -64,12 +63,14 @@ spec:
             exit 1
         fi
 
-        prefixedTag=""
+        tagPrefix=$(jq -r '.images.tagPrefix // ""' $DATA_FILE)
         timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
-        if [ $(jq '.images | has("tagPrefix")' $DATA_FILE) == true ]; then
-            prefixedTag="$(jq -r '.images.tagPrefix' $DATA_FILE)-$(date "+$timestampFormat")"
+        timestamp="$(date "+$timestampFormat")"
+        if [ -n $tagPrefix ]; then
+            echo -n "${tagPrefix}-${timestamp}" > $(results.commonTag.path)
+        else
+          echo -n "" > $(results.commonTag.path)
         fi
-        echo -n "${prefixedTag}" > $(results.commonTag.path)
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
@@ -82,18 +83,16 @@ spec:
           #
           # The tag is determined as follows:
           #
-          # If the value of the task parameter `tagPrefix` has a non-zero length, the tag value is built by
-          # the task in `<prefix>-<timestamp>` format, where prefix is the value of `tagPrefix` and `timestamp`
-          # is the output of the date command using the value of `timestampFormat` as argument.
+          # If `tagPrefix` is non-empty, we push to $tagPrefix and $tagPrefix-$timestamp.
           #
           # Otherwise the tag used is the one existent in the component or in case it is absent, it uses
           # the value set for the task parameter `tag`.
           #
-          if [ -n "${prefixedTag}" ] ; then
-              tag="${prefixedTag}"
+          if [ -n "${tagPrefix}" ] ; then
+              tag="${tagPrefix}-${timestamp}"
           else
               defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
-              tag=$(jq -r --arg tag $defaultTag '.tag // $tag' <<< $component)
+              tag=$(jq -r --arg defaultTag $defaultTag '.tag // $defaultTag' <<< $component)
           fi
 
           source_digest=$(skopeo inspect \
@@ -110,6 +109,9 @@ spec:
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
             # Push the container image
             push_image "${name}" "${containerImage}" "${repository}" "${tag}"
+            if [ -n "${tagPrefix}" ] ; then
+              push_image "${name}" "${containerImage}" "${repository}" "${tagPrefix}"
+            fi
             if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
               timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
               push_image "${name}" "${containerImage}" "${repository}" "$timestamp"
@@ -142,8 +144,11 @@ spec:
                 echo "Error: Source container ${sourceContainer} not found!"
                 exit 1
               fi
-              sourceTag="${prefixedTag}-source"
-              push_image "${name}" "${sourceContainer}" "${repository}" "${sourceTag}"
+              if [ -z "$tagPrefix" ]; then
+                echo "Error: tagPrefix needs to be set when pushing source containers"
+                exit 1
+              fi
+              push_image "${name}" "${sourceContainer}" "${repository}" "${tagPrefix}-${timestamp}-source"
             fi
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -69,14 +69,14 @@ spec:
         - setup
     - name: check-result
       params:
-        - name: commonTag
-          value: $(tasks.run-task.results.commonTag)
+        - name: commonTags
+          value: $(tasks.run-task.results.commonTags)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
         params:
-          - name: commonTag
+          - name: commonTags
         workspaces:
           - name: data
         steps:
@@ -115,6 +115,7 @@ spec:
                 exit 1
               fi
 
-              [[ "$(params.commonTag)" ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt)" ]]
+              [[ "$(params.commonTags)" \
+                ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testprefix" ]]
       runAfter:
         - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -86,9 +86,26 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
-                echo Error: cosign was expected to be called 2 times. Actual calls:
-                cat $(workspaces.data.path)/mock_cosign.txt
+              epoch=$(cat $(workspaces.data.path)/mock_date_epoch.txt)
+              if [ -z $epoch ]; then
+                echo Error: Epoch was expected to be written to $(workspaces.data.path)/mock_date_epoch.txt
+                exit 1
+              fi
+
+              cat > $(workspaces.data.path)/cosign_expected_calls.txt << EOF
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testprefix-$epoch
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testprefix
+              copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
+               prod-registry.io/prod-location:testprefix-$epoch-source
+              EOF
+
+              if [ $(cat $(workspaces.data.path)/cosign_expected_calls.txt | md5sum)
+                != $(cat $(workspaces.data.path)/mock_cosign.txt | md5sum) ]; then
+                echo Error: Expected cosign calls do not match actual calls
+                echo Actual calls:
+                cat cat $(workspaces.data.path)/mock_cosign.txt
+                echo Expected calls:
+                cat $(workspaces.data.path)/cosign_expected_calls.txt
                 exit 1
               fi
 

--- a/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
@@ -79,7 +79,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 1 ]; then
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
                 echo Error: cosign was expected to be called 1 times. Actual calls:
                 cat $(workspaces.data.path)/mock_cosign.txt
                 exit 1

--- a/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tagprefix.yaml
@@ -62,14 +62,14 @@ spec:
         - setup
     - name: check-result
       params:
-        - name: commonTag
-          value: $(tasks.run-task.results.commonTag)
+        - name: commonTags
+          value: $(tasks.run-task.results.commonTags)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
         params:
-          - name: commonTag
+          - name: commonTags
         workspaces:
           - name: data
         steps:
@@ -91,6 +91,7 @@ spec:
                 exit 1
               fi
 
-              [[ "$(params.commonTag)" ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt)" ]]
+              [[ "$(params.commonTags)" \
+                ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testprefix" ]]
       runAfter:
         - run-task

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -11,3 +11,8 @@ Task to create internalrequests to sign snapshot components
 | requester      | Name of the user that requested the signing, for auditing purpose         | No       |                      |
 | commonTag      | Common tag to be used when publishing                                     | No       |                      |
 | requestTimeout | InternalRequest timeout                                                   | Yes      | 180                  |
+
+## Changes since 0.1.0
+* Also sign floating tag
+  * In addition to pushing $tagPrefix-$timestamp tag, we now also push
+    $tagPrefix tag a.k.a. commonTag, so this needs to be signed as well

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -9,10 +9,11 @@ Task to create internalrequests to sign snapshot components
 | snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
 | dataPath       | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
 | requester      | Name of the user that requested the signing, for auditing purpose         | No       |                      |
-| commonTag      | Common tag to be used when publishing                                     | No       |                      |
+| commonTags      | Space separated list of common tags to be used when publishing           | No       |                      |
 | requestTimeout | InternalRequest timeout                                                   | Yes      | 180                  |
 
 ## Changes since 0.1.0
 * Also sign floating tag
-  * In addition to pushing $tagPrefix-$timestamp tag, we now also push
+  - In addition to pushing $tagPrefix-$timestamp tag, we now also push
     $tagPrefix tag a.k.a. commonTag, so this needs to be signed as well
+  - Rename parameter commonTag to commonTags which will contain both tags to sign

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,9 +23,9 @@ spec:
     - name: requester
       type: string
       description: Name of the user that requested the signing, for auditing purposes
-    - name: commonTag
+    - name: commonTags
       type: string
-      description: Common tag to be used when publishing
+      description: Space separated list of common tags to be used when publishing
     - name: requestTimeout
       type: string
       default: "180"
@@ -62,37 +62,23 @@ spec:
 
             referenceContainerImage=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
 
-            tagPrefix=$(jq -r '.images.tagPrefix' $DATA_FILE)
             reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
-            referenceFixed=${reference}:$(params.commonTag)
-            referenceFloating=${reference}:$tagPrefix
             manifest_digest="${referenceContainerImage#*@}"
 
-            echo "Creating InternalRequest to sign image with fixed tag:"
-            echo "- reference=${referenceFixed}"
-            echo "- manifest_digest=${manifest_digest}"
-            echo "- requester=$(params.requester)"
+            for tag in $(params.commonTags); do
+              echo "Creating InternalRequest to sign image with tag ${tag}:"
+              echo "- reference=${reference}:${tag}"
+              echo "- manifest_digest=${manifest_digest}"
+              echo "- requester=$(params.requester)"
 
-            internal-request -r "${request}" \
-                -p pipeline_image=${pipeline_image} \
-                -p reference=${referenceFixed} \
-                -p manifest_digest=${manifest_digest} \
-                -p requester=$(params.requester) \
-                -p config_map_name=${config_map_name} \
-                -t $(params.requestTimeout)
-
-            echo "Creating InternalRequest to sign image with floating tag:"
-            echo "- reference=${referenceFloating}"
-            echo "- manifest_digest=${manifest_digest}"
-            echo "- requester=$(params.requester)"
-
-            internal-request -r "${request}" \
-                -p pipeline_image=${pipeline_image} \
-                -p reference=${referenceFloating} \
-                -p manifest_digest=${manifest_digest} \
-                -p requester=$(params.requester) \
-                -p config_map_name=${config_map_name} \
-                -t $(params.requestTimeout)
+              internal-request -r "${request}" \
+                  -p pipeline_image=${pipeline_image} \
+                  -p reference=${reference}:${tag} \
+                  -p manifest_digest=${manifest_digest} \
+                  -p requester=$(params.requester) \
+                  -p config_map_name=${config_map_name} \
+                  -t $(params.requestTimeout)
+            done
 
             echo "done"
         done

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,20 +62,37 @@ spec:
 
             referenceContainerImage=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
 
-            reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH}):$(params.commonTag)
+            tagPrefix=$(jq -r '.images.tagPrefix' $DATA_FILE)
+            reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
+            referenceFixed=${reference}:$(params.commonTag)
+            referenceFloating=${reference}:$tagPrefix
             manifest_digest="${referenceContainerImage#*@}"
 
-            echo "Creating InternalRequest to sign image:"
-            echo "- reference=${reference}"
+            echo "Creating InternalRequest to sign image with fixed tag:"
+            echo "- reference=${referenceFixed}"
             echo "- manifest_digest=${manifest_digest}"
             echo "- requester=$(params.requester)"
 
             internal-request -r "${request}" \
                 -p pipeline_image=${pipeline_image} \
-                -p reference=${reference} \
+                -p reference=${referenceFixed} \
                 -p manifest_digest=${manifest_digest} \
                 -p requester=$(params.requester) \
                 -p config_map_name=${config_map_name} \
                 -t $(params.requestTimeout)
+
+            echo "Creating InternalRequest to sign image with floating tag:"
+            echo "- reference=${referenceFloating}"
+            echo "- manifest_digest=${manifest_digest}"
+            echo "- requester=$(params.requester)"
+
+            internal-request -r "${request}" \
+                -p pipeline_image=${pipeline_image} \
+                -p reference=${referenceFloating} \
+                -p manifest_digest=${manifest_digest} \
+                -p requester=$(params.requester) \
+                -p config_map_name=${config_map_name} \
+                -t $(params.requestTimeout)
+
             echo "done"
         done

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -50,9 +50,6 @@ spec:
                 "sign": {
                   "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
-                },
-                "images": {
-                  "tagPrefix": "myprefix"
                 }
               }
               EOF
@@ -62,8 +59,8 @@ spec:
       params:
         - name: requester
           value: testuser-multiple
-        - name: commonTag
-          value: some-product-12345
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -89,13 +86,13 @@ spec:
                 i=$((ir/2))
                 if [ $((ir%2)) -eq 0 ]; then
                   if [ $(jq -r '.reference' <<< "${params}") \
-                      != "prod-registry.io/prod-location${i}:some-product-12345" ]; then
+                      != "prod-registry.io/prod-location${i}:some-prefix-12345" ]; then
                     echo "fixed tag reference does not match"
                     exit 1
                   fi
                 else
                   if [ $(jq -r '.reference' <<< "${params}") \
-                      != "prod-registry.io/prod-location${i}:myprefix" ]; then
+                      != "prod-registry.io/prod-location${i}:some-prefix" ]; then
                     echo "floating tag reference does not match"
                     exit 1
                   fi

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -50,6 +50,9 @@ spec:
                 "sign": {
                   "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
+                },
+                "images": {
+                  "tagPrefix": "myprefix"
                 }
               }
               EOF
@@ -82,15 +85,23 @@ spec:
               irsLength=$(jq ".items | length" <<< "${internalRequests}" )
 
               for((ir=0; ir<irsLength; ir++)); do
-                internalRequestName=$(jq -r ".items[$ir].metadata.name" <<< "${internalRequests}")
                 params=$(jq -r ".items[$ir].spec.params" <<< "${internalRequests}")
-                if [ $(jq -r '.reference' <<< "${params}") \
-                    != "prod-registry.io/prod-location${ir}:some-product-12345" ]; then
-                  echo "reference does not match"
-                  exit 1
+                i=$((ir/2))
+                if [ $((ir%2)) -eq 0 ]; then
+                  if [ $(jq -r '.reference' <<< "${params}") \
+                      != "prod-registry.io/prod-location${i}:some-product-12345" ]; then
+                    echo "fixed tag reference does not match"
+                    exit 1
+                  fi
+                else
+                  if [ $(jq -r '.reference' <<< "${params}") \
+                      != "prod-registry.io/prod-location${i}:myprefix" ]; then
+                    echo "floating tag reference does not match"
+                    exit 1
+                  fi
                 fi
 
-                if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:000${ir}" ]; then
+                if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:000${i}" ]; then
                   echo "manifest_digest does not match"
                   exit 1
                 fi
@@ -125,5 +136,5 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -40,9 +40,6 @@ spec:
                 "sign": {
                   "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
-                },
-                "images": {
-                  "tagPrefix": "myprefix"
                 }
               }
               EOF
@@ -52,8 +49,8 @@ spec:
       params:
         - name: requester
           value: testuser-single
-        - name: commonTag
-          value: some-product-12345
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -76,7 +73,7 @@ spec:
                 tail -2 | head -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-product-12345" ]; then
+              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-prefix-12345" ]; then
                 echo "fixed tag reference does not match"
                 exit 1
               fi
@@ -86,7 +83,7 @@ spec:
                 tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:myprefix" ]; then
+              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-prefix" ]; then
                 echo "floating tag reference does not match"
                 exit 1
               fi

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -40,6 +40,9 @@ spec:
                 "sign": {
                   "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
+                },
+                "images": {
+                  "tagPrefix": "myprefix"
                 }
               }
               EOF
@@ -68,12 +71,23 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              # First internal request with fixed tag
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tac | tail -1)"
+                tail -2 | head -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-product-12345" ]; then
-                echo "reference does not match"
+                echo "fixed tag reference does not match"
+                exit 1
+              fi
+
+              # Second internal request with floating tag
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:myprefix" ]; then
+                echo "floating tag reference does not match"
                 exit 1
               fi
 
@@ -111,5 +125,5 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all


### PR DESCRIPTION
When tagPrefix is set, in addition to the tagPrefix-timestamp tag, we also push the tagPrefix floating tag. This additional tag will also be created in Pyxis.

This depends on https://github.com/redhat-appstudio/release-service-utils/pull/86