### PR TITLE
refactor(RHTAPBUGS-946): rename tagPrefix to floatingTag

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -10,6 +10,10 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
 
+## Changes since 2.0.0
+* Rename tagPrefix to floatingTag
+  * The optional parameter provided in RPA's data.images changes its name to clarify its meaning
+
 ## Changes since 1.2.0
 * Push to floating tags when tagPrefix is set
   * In addition to pushing to $prefix-$timestamp, we now also push to $prefix

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,7 +29,7 @@ spec:
       type: string
       description: >
         Space separated list of common tags for downstream tasks.
-        Only set if tagPrefix length in the data JSON is nonzero
+        Only set if floatingTag length in the data JSON is nonzero
   workspaces:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
@@ -65,11 +65,11 @@ spec:
             exit 1
         fi
 
-        tagPrefix=$(jq -r '.images.tagPrefix // ""' $DATA_FILE)
+        floatingTag=$(jq -r '.images.floatingTag // ""' $DATA_FILE)
         timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
         timestamp="$(date "+$timestampFormat")"
-        if [ -n $tagPrefix ]; then
-            echo -n "${tagPrefix}-${timestamp} ${tagPrefix}" > $(results.commonTags.path)
+        if [ -n $floatingTag ]; then
+            echo -n "${floatingTag}-${timestamp} ${floatingTag}" > $(results.commonTags.path)
         else
             echo -n "" > $(results.commonTags.path)
         fi
@@ -85,13 +85,13 @@ spec:
           #
           # The tag is determined as follows:
           #
-          # If `tagPrefix` is non-empty, we push to $tagPrefix and $tagPrefix-$timestamp.
+          # If `floatingTag` is non-empty, we push to $floatingTag and $floatingTag-$timestamp.
           #
           # Otherwise the tag used is the one existent in the component or in case it is absent, it uses
           # the value set for the task parameter `tag`.
           #
-          if [ -n "${tagPrefix}" ] ; then
-              tag="${tagPrefix}-${timestamp}"
+          if [ -n "${floatingTag}" ] ; then
+              tag="${floatingTag}-${timestamp}"
           else
               defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
               tag=$(jq -r --arg defaultTag $defaultTag '.tag // $defaultTag' <<< $component)
@@ -111,8 +111,8 @@ spec:
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
             # Push the container image
             push_image "${name}" "${containerImage}" "${repository}" "${tag}"
-            if [ -n "${tagPrefix}" ] ; then
-              push_image "${name}" "${containerImage}" "${repository}" "${tagPrefix}"
+            if [ -n "${floatingTag}" ] ; then
+              push_image "${name}" "${containerImage}" "${repository}" "${floatingTag}"
             fi
             if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
               timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
@@ -146,11 +146,11 @@ spec:
                 echo "Error: Source container ${sourceContainer} not found!"
                 exit 1
               fi
-              if [ -z "$tagPrefix" ]; then
-                echo "Error: tagPrefix needs to be set when pushing source containers"
+              if [ -z "$floatingTag" ]; then
+                echo "Error: floatingTag needs to be set when pushing source containers"
                 exit 1
               fi
-              push_image "${name}" "${sourceContainer}" "${repository}" "${tagPrefix}-${timestamp}-source"
+              push_image "${name}" "${sourceContainer}" "${repository}" "${floatingTag}-${timestamp}-source"
             fi
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \

--- a/tasks/push-snapshot/tests/test-push-snapshot-floatingtag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-floatingtag.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-tagprefix
+  name: test-push-snapshot-floatingtag
 spec:
   description: |
-    Run the push-snapshot task with tagPrefix set
+    Run the push-snapshot task with floatingTag set
   workspaces:
     - name: tests-workspace
   tasks:
@@ -43,7 +43,7 @@ spec:
                   "addGitShaTag": false,
                   "addTimestampTag": false,
                   "addSourceShaTag": false,
-                  "tagPrefix": "testprefix"
+                  "floatingTag": "testtag"
                 }
               }
               EOF
@@ -92,6 +92,6 @@ spec:
               fi
 
               [[ "$(params.commonTags)" \
-                ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testprefix" ]]
+                ==  "testtag-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testtag" ]]
       runAfter:
         - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -50,7 +50,7 @@ spec:
                   "addTimestampTag": false,
                   "addSourceShaTag": false,
                   "pushSourceContainer": true,
-                  "tagPrefix": "testprefix"
+                  "floatingTag": "testtag"
                 }
               }
               EOF
@@ -93,10 +93,10 @@ spec:
               fi
 
               cat > $(workspaces.data.path)/cosign_expected_calls.txt << EOF
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testprefix-$epoch
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testprefix
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag-$epoch
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
               copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
-               prod-registry.io/prod-location:testprefix-$epoch-source
+               prod-registry.io/prod-location:testtag-$epoch-source
               EOF
 
               if [ $(cat $(workspaces.data.path)/cosign_expected_calls.txt | md5sum)
@@ -116,6 +116,6 @@ spec:
               fi
 
               [[ "$(params.commonTags)" \
-                ==  "testprefix-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testprefix" ]]
+                ==  "testtag-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testtag" ]]
       runAfter:
         - run-task


### PR DESCRIPTION
This parameter is set in RPA's data.images. Renaming it to floatingTag makes it a bit more obvious what it is for.

E.g. if it's set to 1.0.0.beta1 we will push to that tag plus 1.0.0.beta1-$timestamp (where timestamp is configurable and defaults to epoch).

Note that this will also be changed in all places where RPAs are stored and I will coordinate the changes to minimize downtime (time when things are broken). Here's the related change to the releng repo: https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/55