### PR TITLE
fix: set longer timeout on the longer release pipeline

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -237,6 +237,7 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
+      timeout: "2h00m0s"
       taskRef:
         resolver: "git"
         params:
@@ -309,6 +310,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: push-sbom-to-pyxis
+      timeout: "2h00m0s"
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
For a release with 20 images, this takes over an hour currently.