### PR TITLE
feat(RHTAPREL-382): enable building hotfixes in fbc-releases

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | main                                                            |
 
+### Changes in 1.4.0
+- rename task results accordingly to the changes contained in the task
+  `add-fbc-contribution`
+
 ### Changes in 1.3.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
 - taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -295,9 +295,9 @@ spec:
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
       when:
-        - input: "$(tasks.add-fbc-contribution-to-index-image.results.fbcOptIn)"
+        - input: "$(tasks.add-fbc-contribution-to-index-image.results.mustSignIndexImage)"
           operator: in
-          values: ["fbc_opt_in=true"]
+          values: ["true"]
     - name: extract-index-image
       workspaces:
         - name: data
@@ -334,8 +334,6 @@ spec:
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
         - name: request
           value: "publish-index-image-pipeline"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: internalRequestParams
@@ -348,9 +346,9 @@ spec:
             - name: retries
               value: "0"
       when:
-        - input: "$(tasks.add-fbc-contribution-to-index-image.results.fbcOptIn)"
+        - input: $(tasks.add-fbc-contribution-to-index-image.results.mustPublishIndexImage)
           operator: in
-          values: ["fbc_opt_in=true"]
+          values: ["true"]
       runAfter:
         - sign-index-image
   finally:

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -12,6 +12,11 @@ Task to create a internalrequest to add fbc contributions to index images
 | binaryImage    | binaryImage value updated by update-ocp-tag task                          | No       |                      |
 | fromIndex      | fromIndex value updated by update-ocp-tag task                            | No       |                      |
 
+## changes in 1.3.0
+- add the possibility of setting a hotfix tag
+- replace the `fbcOptIn` result with `mustSignIndexImage` and `mustPublishIndexImage`
+  to control the pipeline flow
+
 ## changes in 1.2.0
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
 

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,8 +31,10 @@ spec:
       default: "180"
       description: InternalRequest timeout
   results:
-    - name: fbcOptIn
-      description: Result to set weather the contribution is FBC opt in
+    - name: mustSignIndexImage
+      description: Whether the index image should be signed
+    - name: mustPublishIndexImage
+      description: Whether the index image should be published
     - name: requestTargetIndex
       description: The targetIndex used in this request
     - name: requestResultsFile
@@ -71,12 +73,23 @@ spec:
         iib_service_account_secret=$(jq -r '.fbc.iibServiceAccountSecret // "iib-service-account"' ${DATA_FILE})
         build_tags=$(jq '.fbc.buildTags // []' ${DATA_FILE})
         add_arches=$(jq '.fbc.addArches // []' ${DATA_FILE})
+        hotfix=$(jq -r '.fbc.hotfix // "false"' ${DATA_FILE})
         build_timeout_seconds=$(jq -r --arg build_timeout_seconds ${default_build_timeout_seconds} \
             '.fbc.buildTimeoutSeconds // $build_timeout_seconds' ${DATA_FILE})
         target_index=$(jq -r '.fbc.targetIndex' ${DATA_FILE})
         fbc_fragment=$(jq -cr '.components[0].containerImage' ${SNAPSHOT_PATH})
 
-        # saves the target index required to sign
+        if [ "${hotfix}" == "true" ]; then
+          timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' ${DATA_FILE})
+          timestamp=$(date "+${timestamp_format}")
+          issue_id=$(jq -r '.fbc.issueId // empty' ${DATA_FILE})
+          if [ -z "${issue_id}" ]; then
+            echo "Hotfix releases requires the issue id."
+            exit 1
+          fi
+          tag="${issue_id}-${timestamp}"
+          target_index="${target_index}-${tag}"
+        fi
         echo -n $target_index > $(results.requestTargetIndex.path)
 
         # The internal-request script will create the InternalRequest and wait until it finishes to get its status
@@ -93,6 +106,7 @@ spec:
             -p buildTimeoutSeconds=${build_timeout_seconds} \
             -p buildTags=${build_tags} \
             -p addArches=${add_arches} \
+            -p hotfix=${hotfix} \
             -t $(params.requestTimeout) |tee $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log
 
         internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log | xargs)
@@ -105,6 +119,10 @@ spec:
         conditions=$(kubectl get internalrequest ${internalRequest} \
           -o jsonpath='{.status.conditions[?(@.type=="Succeeded")]}')
 
-        jq '.genericResult' <<< "${results}" | tee $(results.fbcOptIn.path)
+        jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.sign_index_image' |tr -d "\n" \
+            | tee $(results.mustSignIndexImage.path)
+        jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.publish_index_image' |tr -d "\n" \
+            | tee $(results.mustPublishIndexImage.path)
+
         jq '.reason // "Unset"'  <<< "${conditions}" | tee $(results.requestReason.path)
         jq '.message // "Unset"' <<< "${conditions}" | tee $(results.requestMessage.path)

--- a/tasks/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/add-fbc-contribution/tests/mocks.sh
@@ -12,3 +12,20 @@ function internal-request() {
   echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
   sleep 2
 }
+
+function date() {
+  echo $* >> $(workspaces.data.path)/mock_date.txt
+
+  case "$*" in
+      "+%Y-%m-%dT%H:%M:%SZ")
+          echo "2023-10-10T15:00:00Z" |tee $(workspaces.data.path)/mock_date_iso_format.txt
+          ;;
+      "+%s")
+          echo "1696946200" | tee $(workspaces.data.path)/mock_date_epoch.txt
+          ;;
+      "*")
+          echo Error: Unexpected call
+          exit 1
+          ;;
+  esac
+}

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-hotfix
+spec:
+  description: Test creating a internal request for the IIB pipeline
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "iibServiceConfigSecret": "test-iib-service-config-secret",
+                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "targetIndex": "quay.io/scoheb/fbc-target-index-testing:latest",
+                  "hotfix": true,
+                  "issueId": "bz123456",
+                  "buildTimeoutSeconds": 420
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: binaryImage
+          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: fromIndex
+          value: "quay.io/scoheb/fbc-index-testing:latest"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              #
+              set -eux
+
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tac | tail -1)"
+
+              requestParams=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.iibServiceConfigSecret' <<< "${requestParams}") != "test-iib-service-config-secret" ]; then
+                echo "iibServiceConfigSecret does not match"
+                exit 1
+              fi
+
+              value=$(jq -r '.iibOverwriteFromIndexCredential' <<< "${requestParams}")
+              if [ "${value}" != "test-iib-overwrite-fromindex-credential" ]
+              then
+                echo "iibOverwriteFromIndexCredential does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.fromIndex' <<< "${requestParams}") != "quay.io/scoheb/fbc-index-testing:latest" ]; then
+                echo "fromIndex does not match"
+                exit 1
+              fi
+
+              value=$(jq -r '.binaryImage' <<< "${requestParams}")
+              if [ "${value}" != "registry.redhat.io/openshift4/ose-operator-registry:v4.12" ]
+              then
+                echo "binaryImage does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.buildTimeoutSeconds' <<< "${requestParams}") != "420" ]
+              then
+                echo "buildTimeoutSeconds does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.fbcFragment' <<< "${requestParams}") != "registry.io/image0@sha256:0000" ]
+              then
+                echo "fbcFragment does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.hotfix' <<< "${requestParams}") != "true" ]
+              then
+                echo "hotfix does not match"
+                exit 1
+              fi
+
+              TS=1696946200 # ts set in the mocked `date`
+              value=$(jq -r '.targetIndex' <<< "${requestParams}")
+              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:latest-bz123456-${TS}" ]; then
+                echo "targetIndex does not match"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This PR enable building and publishing FBC hotfixes with a
scoped static tag in `<ocp-version>-<bug-fixes>-<timestamp>`
format. It also add/rename results to control the pipeline flow.

Depends on: https://github.com/hacbs-release/app-interface-deployments/pull/61

Signed-off-by: Leandro Mendes <lmendes@redhat.com>