### PR TITLE
fix: up the taskrun timeout for sbom pushing

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -310,7 +310,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: push-sbom-to-pyxis
-      timeout: "2h00m0s"
+      timeout: "4h00m0s"
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -237,6 +237,7 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
+      timeout: "2h00m0s"
       taskRef:
         resolver: "git"
         params:
@@ -309,6 +310,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: push-sbom-to-pyxis
+      timeout: "2h00m0s"
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
This reverts https://github.com/redhat-appstudio/release-service-catalog/pull/288 which reverted https://github.com/redhat-appstudio/release-service-catalog/pull/284

Also, increase the sbom timeout significantly.