### PR TITLE
fix(RHTAPBUGS-973): translate image references when signing rh images

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -12,6 +12,14 @@ Task to create internalrequests to sign snapshot components
 | commonTags      | Space separated list of common tags to be used when publishing           | No       |                      |
 | requestTimeout | InternalRequest timeout                                                   | Yes      | 180                  |
 
+## Changes since 1.0.0
+* Translate docker-reference when signing images
+  - Before this change, signing request would be sent with the actual quay location of the image. Instead, the reference
+    need to be translated to the public facing reference.
+    - E.g. quay.io/redhat-prod/rhtas-tech-preview----tuf-server-rhel9:1.0.beta needs to be translated to
+      registry.redhat.io/rhtas-tech-preview/tuf-server-rhel9:1.0.beta. Similarly, quay.io/redhat-pending references
+      need to be translated to registry.stage.redhat.io.
+
 ## Changes since 0.1.0
 * Also sign floating tag
   - In addition to pushing $tagPrefix-$timestamp tag, we now also push

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -63,6 +63,14 @@ spec:
             referenceContainerImage=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
 
             reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
+
+            # Translate direct quay.io reference to public facing registry reference
+            # quay.io/redhat-prod/product----repo -> registry.redhat.io/product/repo
+            # quay.io/redhat-pending/product----repo -> registry.stage.redhat.io/product/repo
+            reference=${reference/quay.io\/redhat-prod/registry.redhat.io}
+            reference=${reference/quay.io\/redhat-pending/registry.stage.redhat.io}
+            reference=${reference//----//}
+
             manifest_digest="${referenceContainerImage#*@}"
 
             for tag in $(params.commonTags); do

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -29,17 +29,17 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
-                    "repository": "prod-registry.io/prod-location0"
+                    "repository": "quay.io/redhat-pending/prod----repo0"
                   },
                   {
                     "name": "comp1",
                     "containerImage": "registry.io/image1@sha256:0001",
-                    "repository": "prod-registry.io/prod-location1"
+                    "repository": "quay.io/redhat-pending/prod----repo1"
                   },
                   {
                     "name": "comp2",
                     "containerImage": "registry.io/image2@sha256:0002",
-                    "repository": "prod-registry.io/prod-location2"
+                    "repository": "quay.io/redhat-pending/prod----repo2"
                   }
                 ]
               }
@@ -86,13 +86,13 @@ spec:
                 i=$((ir/2))
                 if [ $((ir%2)) -eq 0 ]; then
                   if [ $(jq -r '.reference' <<< "${params}") \
-                      != "prod-registry.io/prod-location${i}:some-prefix-12345" ]; then
+                      != "registry.stage.redhat.io/prod/repo${i}:some-prefix-12345" ]; then
                     echo "fixed tag reference does not match"
                     exit 1
                   fi
                 else
                   if [ $(jq -r '.reference' <<< "${params}") \
-                      != "prod-registry.io/prod-location${i}:some-prefix" ]; then
+                      != "registry.stage.redhat.io/prod/repo${i}:some-prefix" ]; then
                     echo "floating tag reference does not match"
                     exit 1
                   fi

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -29,7 +29,7 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
-                    "repository": "prod-registry.io/prod-location0"
+                    "repository": "quay.io/redhat-prod/myproduct----myrepo"
                   }
                 ]
               }
@@ -73,7 +73,8 @@ spec:
                 tail -2 | head -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-prefix-12345" ]; then
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.redhat.io/myproduct/myrepo:some-prefix-12345" ]; then
                 echo "fixed tag reference does not match"
                 exit 1
               fi
@@ -83,7 +84,7 @@ spec:
                 tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.reference' <<< "${params}") != "prod-registry.io/prod-location0:some-prefix" ]; then
+              if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
                 echo "floating tag reference does not match"
                 exit 1
               fi


### PR DESCRIPTION
When creating a signing request, the image reference needs to be translated to the public facing one
which will be used for pulling of the image.

Before this change, the signatures would be requested for the actual quay.io references. Now they will use registry.redhat.io or registry.stage.redhat.io references.