### PR TITLE
fix(RHTAPBUGS-919): update sbom task image for speed improvement

### DIFF
--- a/tasks/push-sbom-to-pyxis/README.md
+++ b/tasks/push-sbom-to-pyxis/README.md
@@ -11,6 +11,11 @@ Tekton task that extracts sboms from pull specs and pushes them to Pyxis.
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | server | The server type to use. Options are 'production' and 'stage' | Yes | production |
 
+## Changes since 0.3.0
+* Update image reference
+  - The new image includes performance optimizations which should increase the performance of pushing sbom
+    components to Pyxis by over 50 %
+
 ## Changes since 0.2
 * Update Tekton API to v1
 

--- a/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
+++ b/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-sbom-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,7 +36,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/hacbs-release/release-utils:de40e7e7b9d90de5cff5a4266d429f633bd1a1c2
+        quay.io/redhat-appstudio/release-service-utils:875ff0b302ff7a77330e902a017b6a945f15fdf5
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -68,7 +68,7 @@ spec:
 
     - name: push-sbom-files-to-pyxis
       image:
-        quay.io/hacbs-release/release-utils:de40e7e7b9d90de5cff5a4266d429f633bd1a1c2
+        quay.io/redhat-appstudio/release-service-utils:875ff0b302ff7a77330e902a017b6a945f15fdf5
       env:
         - name: pyxisCert
           valueFrom:


### PR DESCRIPTION
The new image includes performance optimizations which should increase the performance of pushing sbom components to Pyxis by over 50 %.

Here are the related changes that are included in the new image:
* https://github.com/redhat-appstudio/release-service-utils/pull/91
* https://github.com/redhat-appstudio/release-service-utils/pull/92