### PR TITLE
fix(RHTAPBUGS-972): pass source-container-enabled to pyxis

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,9 @@ by a new line.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | mapped_snapshot.json |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | Yes | data.json |
 
+## Changes in 2.2.0
+* `source-container-enabled` flag set to true if `pushSourceContainer` is set to true in the data file's `images` key
+
 ## Changes since 2.0.0
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
 

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,7 +62,7 @@ spec:
       description: IDs of the created entries in Pyxis, each on its own line
   steps:
     - name: create-pyxis-image
-      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c # needs update once other PR merges
       env:
         - name: pyxisCert
           valueFrom:
@@ -127,7 +127,9 @@ spec:
               --verbose \
               --skopeo-result /tmp/skopeo-inspect.json \
               --media-type "$MEDIA_TYPE" \
-              --rh-push $(params.rhPush) | tee /tmp/output
+              --rh-push $(params.rhPush) \
+              --source-container-enabled $(jq -r '.images.pushSourceContainer // "false"' ${DATA_FILE}) \
+              | tee /tmp/output
 
             grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageIDs.path)
         done

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -7,7 +7,7 @@ function create_container_image() {
   echo $* >> $(workspaces.data.path)/mock_create_container_image.txt
   echo The image id is 0000
 
-  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --rh-push "* ]]
+  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --rh-push "*" --source-container-enabled "* ]]
   then
     echo Error: Unexpected call
     echo Mock create_container_image called with: $*

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-source-container-enabled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-source-container-enabled.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-one-containerimage
+  name: test-create-pyxis-image-source-container-enabled
 spec:
   description: |
-    Run the create-pyxis-image task with a single containerImage in the snapshot.
+    Run the create-pyxis-image task with a single containerImage in the snapshot and
+    pushSourceContainer set to true in the data json so source-container-enabled is passed as true.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -39,7 +40,8 @@ spec:
               cat > $(workspaces.data.path)/mydata.json << EOF
               {
                 "images": {
-                  "defaultTag": "testtag"
+                  "defaultTag": "testtag",
+                  "pushSourceContainer": "true"
                 }
               }
               EOF
@@ -92,11 +94,11 @@ spec:
                 exit 1
               fi
 
-              if ! grep -- "--source-container-enabled false" \
+              if ! grep -- "--source-container-enabled true" \
                 < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
                 echo Error: create_container_image call was expected to \
-                  include "--source-container-image false". Actual call:
+                  include "--source-container-image true". Actual call:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi


### PR DESCRIPTION
If images.pushSourceContainer is set to true in the data json, pass --source-container-enabled true when calling create_container_image in the create-pyxis-image task.