### PR TITLE
feat(RHTAP-1932): add extract-binaries-from-image task

### DIFF
--- a/tasks/extract-binaries-from-image/README.md
+++ b/tasks/extract-binaries-from-image/README.md
@@ -1,0 +1,14 @@
+# extract-binaries-from-image
+
+Tekton task that extracts binaries to be released on github.com from an image.
+
+The path to the directory inside the provided workspace where the binaries were
+saved is provided as a result.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| image_binaries_path | Path inside the image where the binaries to extract are stored | Yes | /releases |
+| snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes | snapshot.json |
+| subdirectory | Subdirectory inside the workspace to be used for storing the binaries | Yes | "" |

--- a/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-binaries-from-image
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that extracts binaries to be released on github.com from an image
+  params:
+    - name: image_binaries_path
+      type: string
+      description: Path inside the image where the binaries to extract are stored
+      default: "releases"
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+      default: snapshot.json
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used for storing the binaries
+      type: string
+      default: ""
+  results:
+    - name: binaries_path
+      type: string
+      description: The directory inside the workspace where the binaries are stored
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot is stored. The extracted binaries will be stored here as well.
+  steps:
+    - name: extract-binaries-from-image
+      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      script: |
+        #!/bin/sh -ex
+
+        SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "Error: No valid snapshot file was provided."
+            exit 1
+        fi
+        IMAGE_URL=$(jq -r '.components[0].containerImage // ""' "${SNAPSHOT_SPEC_FILE}")
+        if [ -z "${IMAGE_URL}" ] ; then
+            echo "Error: Unable to get image url from snapshot."
+            exit 1
+        fi
+
+        BINARIES_DIR=binaries
+        BINARIES_PATH=$(workspaces.data.path)/$(params.subdirectory)/$BINARIES_DIR
+        mkdir -p $BINARIES_PATH
+
+        TMP_DIR=$(mktemp -d)
+        skopeo copy docker://$IMAGE_URL dir:$TMP_DIR
+
+        cd $TMP_DIR
+
+        for DIGEST in $(jq -r ".layers[].digest" manifest.json)
+        do
+            FILE=${DIGEST#sha256:}
+            tar -xzvf $FILE
+        done
+
+        cp "$IMAGE_PATH"/* $BINARIES_PATH/
+
+        echo -n $(params.subdirectory)/$BINARIES_DIR | tee $(results.binaries_path.path)
+      env:
+        - name: "IMAGE_PATH"
+          value: "$(params.image_binaries_path)"

--- a/tasks/extract-binaries-from-image/tests/mocks.sh
+++ b/tasks/extract-binaries-from-image/tests/mocks.sh
@@ -1,0 +1,16 @@
+# mocks to be injected into task step scripts
+
+#!/bin/sh -ex
+
+function skopeo() {
+  echo "Mock skopeo called with: $*"
+  echo "$*" >> $(workspaces.data.path)/mock_skopeo.txt
+
+  if [[ "$*" != "copy docker://registry.io/image:tag dir:/"* ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  cp $(workspaces.data.path)/image_data/* $TMP_DIR/
+}

--- a/tasks/extract-binaries-from-image/tests/pre-apply-task-hook.sh
+++ b/tasks/extract-binaries-from-image/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../extract-binaries-from-image.yaml

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-binaries-from-image
+spec:
+  description: |
+    Run the extract-binaries-from-image task
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-snapshot
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag"
+                  }
+                ]
+              }
+              EOF
+
+              mkdir -p $(workspaces.data.path)/image_data
+              cd $(workspaces.data.path)/image_data
+
+              cat > manifest.json <<EOF
+              {
+                "layers": [
+                  {"digest": "sha256:1111"},
+                  {"digest": "sha256:2222"}
+                ]
+              }
+              EOF
+
+              TAR_IN1=$(mktemp -d)
+              TAR_IN2=$(mktemp -d)
+
+              mkdir -p $TAR_IN1/my-binaries-path
+              echo text1 > $TAR_IN1/my-binaries-path/file1.txt
+              tar czf 1111 -C $TAR_IN1 my-binaries-path
+
+              mkdir -p $TAR_IN2/my-binaries-path
+              echo text2 > $TAR_IN2/my-binaries-path/file2.txt
+              tar czf 2222 -C $TAR_IN2 my-binaries-path
+    - name: run-task
+      taskRef:
+        name: extract-binaries-from-image
+      params:
+        - name: image_binaries_path
+          value: my-binaries-path
+        - name: snapshotPath
+          value: snapshot.json
+        - name: subdirectory
+          value: my-subdir
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: binaries_path
+          value: $(tasks.run-task.results.binaries_path)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: binaries_path
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              if [ "$(params.binaries_path)" != "my-subdir/binaries" ]; then
+                  echo Error: Unexpected binaries_path result
+                  exit 1
+              fi
+
+              cd $(workspaces.data.path)/$(params.binaries_path)
+
+              test "$(< file1.txt)" = "text1"
+              test "$(< file2.txt)" = "text2"
+      runAfter:
+        - run-task


### PR DESCRIPTION
Modify extract-binaries-from-image task from PR #229 

- Make clearer the difference between the binaries path in the data
  workspace and the releases path in the image
- Solve issue that extracting anything out of the /releases folder from
  the image will give an error and exit the script