### PR TITLE
fix(RHTAPBUGS-972): set source_container_image_enabled in pyxis

### DIFF
--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -16,6 +16,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 
 
+## Changes in 1.6.0
+* The publish-pyxis-repository task now has a dataPath parameter. It is used to set 
+  source_container_image_enabled if `pushSourceContainer` is present in the data `images` key
+  and set to true
+
 ## Changes since 1.4.2
 * Move from commonTag to commonTags
   - The result of push-snapshot was renamed to commonTags and now it contains both the fixed and floating

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.5.0"
+    app.kubernetes.io/version: "1.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -304,6 +304,8 @@ spec:
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -5,7 +5,9 @@ This is currently only meant to be used in the rh-push-to-registry-redhat-io pip
 so it will convert the values to the ones used for registry.redhat.io releases.
 E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted to use
 registry "registry.access.redhat.com" and repository "my-product/my-image" to identify
-the right Container Registry object in Pyxis.
+the right Container Registry object in Pyxis. The task also optionally
+marks the repositories as source_container_image_enabled true if pushSourceContainer
+is true in the data JSON. 
 
 
 ## Parameters
@@ -15,6 +17,11 @@ the right Container Registry object in Pyxis.
 | server       | The server type to use. Options are 'production' and 'stage'                                      | Yes      | production         |
 | pyxisSecret  | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No       | -                  |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | Yes      | snapshot_spec.json |
+| dataPath     | Path to the JSON string of the merged data to use in the data workspace                           | Yes      | data.json          |
+
+## Changes in 0.2.0
+* If a data JSON is provided and images.pushSourceContainer is set to true inside it, a call is made
+  to mark the repository as source_container_image_enabled true
 
 ## Changes since 0.0.2
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -15,7 +15,9 @@ spec:
     so it will convert the values to the ones used for registry.redhat.io releases.
     E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted
     to use registry "registry.access.redhat.com" and repository "my-product/my-image"
-    to identify the right Container Registry object in Pyxis.
+    to identify the right Container Registry object in Pyxis. The task also optionally
+    marks the repositories as source_container_image_enabled true if pushSourceContainer
+    is true in the data JSON.
   params:
     - name: server
       type: string
@@ -29,6 +31,10 @@ spec:
       description: Path to the JSON file containing the mapped Snapshot spec in the data workspace
       type: string
       default: "snapshot_spec.json"
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+      default: "data.json"
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -72,6 +78,13 @@ spec:
             exit 1
         fi
 
+        PAYLOAD='{"published":true}'
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [[ -f "${DATA_FILE}" && $(jq -r '.images.pushSourceContainer' ${DATA_FILE}) == "true" ]] ; then
+            PAYLOAD=$(jq -c '. += {"source_container_image_enabled":true}' <<< $PAYLOAD)
+        fi
+
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
 
@@ -90,7 +103,7 @@ spec:
                 exit 1
             fi
             curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
-                -X PATCH -H 'Content-Type: application/json' --data-binary '{"published": true}'
+                -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
         done
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/publish-pyxis-repository/tests/mocks.sh
+++ b/tasks/publish-pyxis-repository/tests/mocks.sh
@@ -17,7 +17,10 @@ function curl() {
     else
       echo '{"_id": "'$CALL_ID'"}'
     fi
-  elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published": true}' ]]
+  elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published":true}' ]]
+  then
+    : # no-op - do nothing
+  elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published":true,"source_container_image_enabled":true}' ]]
   then
     : # no-op - do nothing
   else

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-no-data-json
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a single component and no data JSON.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  == *"/id/1 "* ]]
+      runAfter:
+        - run-task

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-source-container-false
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a single component and pushSourceContainer
+    set to false in the data JSON.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "pushSourceContainer": "false"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  == *"/id/1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  != *'{"source_container_image_enabled":true}' ]]
+      runAfter:
+        - run-task

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-source-container-true
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a single component and pushSourceContainer
+    set to true in the data JSON. A curl call should be executed to set the
+    source_container_image_enabled to true for the component.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/mydata.json << EOF
+              {
+                "images": {
+                  "pushSourceContainer": "true"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+        - name: dataPath
+          value: mydata.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  == *'"source_container_image_enabled":true}' ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
If images.pushSourceContainer is set to true in the data json, the publish-pyxis-repository task will set this in the ContainerRepository object.