### PR TITLE
fix(RHTAPBUGS-919): run sbom uploads in parallel

### DIFF
--- a/tasks/push-sbom-to-pyxis/README.md
+++ b/tasks/push-sbom-to-pyxis/README.md
@@ -10,6 +10,11 @@ Tekton task that extracts sboms from pull specs and pushes them to Pyxis.
 | containerImageIDs | Space separated list of Pyxis image IDs | No | - |
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | server | The server type to use. Options are 'production' and 'stage' | Yes | production |
+| concurrentLimit | The maximum number of images to be processed at once | Yes | 4 |
+
+## Changes since 0.4.0
+* Optimize the task to process multiple images in parallel. This will improve the performance of the task.
+* Add a new `concurrentLimit` parameter that controls the number of images to be processed in parallel
 
 ## Changes since 0.3.1
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
+++ b/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-sbom-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -27,6 +27,10 @@ spec:
       type: string
       description: The server type to use. Options are 'production' and 'stage'
       default: production
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be processed at once
+      default: 4
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -65,6 +69,12 @@ spec:
           echo "Fetching sbom for image: ${IMAGEURLS[$i]}"
           cosign download sbom --output-file "${IMAGEIDS[$i]}.json" "${IMAGEURLS[$i]}"
         done
+
+        SBOM_COUNT=$(ls *.json | wc -l )
+        if [ $SBOM_COUNT != ${#IMAGEURLS[@]} ]; then
+          echo "ERROR: Expected to fetch sbom for ${#IMAGEURLS[@]} images, but only $SBOM_COUNT were saved"
+          exit 1
+        fi
 
     - name: push-sbom-files-to-pyxis
       image:
@@ -105,7 +115,47 @@ spec:
 
         cd /workdir/sboms
 
+        N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
+        declare -a jobs=()
+        declare -a files=()
+        total=$(ls *.json | wc -l )
+        count=0
+        success=true
+        echo "Starting sbom upload for $total files in total. " \
+          "Up to $N files will be uploaded at once..."
+
         for FILE in *.json; do
           echo Uploading sbom to Pyxis: $FILE
-          upload_sbom --retry --sbom-path $FILE
+          upload_sbom --retry --sbom-path $FILE > ${FILE}.out 2>&1 &
+
+          jobs+=($!)  # Save the background process ID
+          files+=($FILE)
+          ((++count))
+
+          if [ $((count%N)) -eq 0 -o $((count)) -eq $total ]; then
+            echo Waiting for the current batch of background processes to finish
+            for i in "${!jobs[@]}"; do
+              if ! wait ${jobs[i]}; then
+                echo "Error: upload of ${files[i]} failed"
+                success=false
+              fi
+            done
+
+            echo
+            echo Printing outputs for current upload_sbom script runs
+            for FILE in ${files[@]}; do
+              echo "=== $FILE ==="
+              cat "${FILE}.out"
+              echo
+            done
+
+            if [ $success != "true" ]; then
+              echo ERROR: At least one upload in the last batch failed
+              exit 1
+            fi
+
+            # Reset job and files arrays for the next batch
+            jobs=()
+            files=()
+          fi
         done

--- a/tasks/push-sbom-to-pyxis/tests/mocks.sh
+++ b/tasks/push-sbom-to-pyxis/tests/mocks.sh
@@ -7,7 +7,7 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> $(workspaces.data.path)/mock_cosign.txt
 
-  if [[ "$*" != "download sbom --output-file myImageID"[12]".json imageurl"[12] ]]
+  if [[ "$*" != "download sbom --output-file myImageID"*".json imageurl"[1-5] ]]
   then
     echo Error: Unexpected call
     exit 1
@@ -24,5 +24,17 @@ function upload_sbom() {
   then
     echo Error: Unexpected call
     exit 1
+  fi
+
+  if [[ "$3" == myImageID1Failing.json ]]
+  then
+    echo "Simulating a failing sbom push..."
+    return 1
+  fi
+
+  if [[ "$3" == myImageID?Parallel.json ]]
+  then
+    echo "Adding a small sleep"
+    sleep 0.3
   fi
 }

--- a/tasks/push-sbom-to-pyxis/tests/mocks.sh
+++ b/tasks/push-sbom-to-pyxis/tests/mocks.sh
@@ -34,7 +34,12 @@ function upload_sbom() {
 
   if [[ "$3" == myImageID?Parallel.json ]]
   then
-    echo "Adding a small sleep"
-    sleep 0.3
+    LOCK_FILE=$(workspaces.data.path)/${3}.lock
+    touch $LOCK_FILE
+    sleep 1
+    LOCK_FILE_COUNT=$(ls $(workspaces.data.path)/*.lock | wc -l)
+    echo $LOCK_FILE_COUNT > $(workspaces.data.path)/${3}.count
+    sleep 1
+    rm $LOCK_FILE
   fi
 }

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-failure.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-failure.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-sbom-to-pyxis-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-sbom-to-pyxis task with required parameters.
+    The first image will fail. The second image will still be pushed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "containerImage": "imageurl1"
+                  },
+                  {
+                    "containerImage": "imageurl2"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-sbom-to-pyxis
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: containerImageIDs
+          value: myImageID1Failing myImageID2
+        - name: pyxisSecret
+          value: test-push-sbom-to-pyxis-cert
+        - name: server
+          value: production
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
@@ -60,7 +60,7 @@ spec:
         - name: server
           value: production
         - name: concurrentLimit
-          value: 2
+          value: 4
       runAfter:
         - setup
       workspaces:
@@ -91,5 +91,15 @@ spec:
                 cat $(workspaces.data.path)/mock_upload_sbom.txt
                 exit 1
               fi
+
+              # Check that multiple instances of upload_sbom were running in parallel - up to 4 at once
+              if ! cat $(workspaces.data.path)/myImageID[1234]Parallel.json.count | grep 4; then
+                echo Error: Expected to see 4 parallel runs of upload_sbom at some point.
+                echo Actual counts:
+                cat $(workspaces.data.path)/myImageID[1234]Parallel.json.count
+                exit 1
+              fi
+              # The last instance of upload_sbom was in a new batch - it ran alone
+              test $(wc -l < $(workspaces.data.path)/myImageID5Parallel.json.count) -eq 1
       runAfter:
         - run-task

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-sbom-to-pyxis-parallel
+spec:
+  description: |
+    Run the push-sbom-to-pyxis task with required parameters with multiple images
+    processed in parallel.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "containerImage": "imageurl1"
+                  },
+                  {
+                    "containerImage": "imageurl2"
+                  },
+                  {
+                    "containerImage": "imageurl3"
+                  },
+                  {
+                    "containerImage": "imageurl4"
+                  },
+                  {
+                    "containerImage": "imageurl5"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-sbom-to-pyxis
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: containerImageIDs
+          value:
+            myImageID1Parallel myImageID2Parallel myImageID3Parallel myImageID4Parallel myImageID5Parallel
+        - name: pyxisSecret
+          value: test-push-sbom-to-pyxis-cert
+        - name: server
+          value: production
+        - name: concurrentLimit
+          value: 2
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_upload_sbom.txt | wc -l) != 5 ]; then
+                echo Error: upload_sbom was expected to be called 5 times. Actual calls:
+                cat $(workspaces.data.path)/mock_upload_sbom.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
Up to 4 sbom uploads will run in parallel. This will improve the performance of the task.