### PR TITLE
feat(RHTAPREL-729): add taskGitUrl and taskGitRevision params

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -13,6 +13,12 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+
+## Changes in 0.12.0
+- taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+- taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes since 0.10.0
 - Switch back to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.11.0"
+    app.kubernetes.io/version: "0.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -35,6 +35,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -47,9 +55,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -100,9 +108,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -155,9 +163,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -15,6 +15,12 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+
+## Changes in 0.3.0
+* taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+* taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes since 0.1.0
 * Switch to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,6 +36,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -48,9 +56,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -101,9 +109,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -4,17 +4,22 @@ Tekton release pipeline to interact with FBC Pipeline
 
 ## Parameters
 
-| Name                            | Description                                                                                              | Optional  | Default value                                   |
-|---------------------------------|----------------------------------------------------------------------------------------------------------|-----------|-------------------------------------------------|
-| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution   | No        | -                                               |
-| releaseplan                     | The namespaced name (namespace/name) of the releasePlan                                                  | No        | -                                               |
-| releaseplanadmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                         | No        | -                                               |
-| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                     | No        | -                                               |
-| enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                               |
-| enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key            |
-| verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                               |
-| postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                            |
+| Name                            | Description                                                                                              | Optional  | Default value                                                   |
+|---------------------------------|----------------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------------------------|
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution   | No        | -                                                               |
+| releaseplan                     | The namespaced name (namespace/name) of the releasePlan                                                  | No        | -                                                               |
+| releaseplanadmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                         | No        | -                                                               |
+| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                     | No        | -                                                               |
+| enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                                               |
+| enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key                            |
+| verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
+| postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | main                                                            |
 
+### Changes in 1.3.0
+- taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+- taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ### Changes since 1.1.0
 - update task definition `sign-index-image`

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -35,6 +35,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -60,9 +68,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -113,9 +121,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -139,9 +147,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/validate-single-component/validate-single-component.yaml
       params:
@@ -185,9 +193,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/get-ocp-version/get-ocp-version.yaml
       params:
@@ -203,9 +211,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/update-ocp-tag/update-ocp-tag.yaml
       params:
@@ -221,9 +229,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/add-fbc-contribution/add-fbc-contribution.yaml
       params:
@@ -242,9 +250,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -272,9 +280,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/sign-index-image/sign-index-image.yaml
       params:
@@ -298,9 +306,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/extract-index-image/extract-index-image.yaml
       params:
@@ -314,9 +322,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-internal-request/create-internal-request.yaml
       params:
@@ -351,9 +359,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -14,6 +14,12 @@ Tekton pipeline to push images to an external registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | Switch back to using bundle resolvers for the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+
+## Changes in 1.2.0
+- taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+- taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes since 1.1.0
 - Pass path to ReleasePlanAdmission to the apply-mapping task

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
   workspaces:
     - name: release-workspace
   tasks:
@@ -47,9 +55,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -100,9 +108,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -126,9 +134,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
@@ -176,9 +184,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
@@ -196,9 +204,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
@@ -214,9 +222,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-pyxis-image/create-pyxis-image.yaml
       params:
@@ -238,9 +246,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
       params:
@@ -269,9 +277,9 @@ spec:
         kind: Task
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/run-file-updates/run-file-updates.yaml
         resolver: git
@@ -284,9 +292,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/release/README.md
+++ b/pipelines/release/README.md
@@ -14,6 +14,12 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+
+## Changes in 1.2.0
+- taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+- taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes since 1.0.0
 - Switch back to using bundle resolvers for the verify-enterprise-contract task

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
   workspaces:
     - name: release-workspace
   tasks:
@@ -47,9 +55,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -100,9 +108,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -126,9 +134,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
@@ -174,9 +182,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
@@ -195,9 +203,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -14,7 +14,12 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
 
+## Changes in 1.7.0
+* taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+* taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes in 1.6.0
 * The publish-pyxis-repository task now has a dataPath parameter. It is used to set 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
   workspaces:
     - name: release-workspace
   tasks:
@@ -47,9 +55,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -100,9 +108,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -126,9 +134,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -153,9 +161,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
@@ -203,9 +211,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
@@ -223,9 +231,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
@@ -242,9 +250,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/rh-sign-image/rh-sign-image.yaml
       params:
@@ -264,9 +272,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-pyxis-image/create-pyxis-image.yaml
       params:
@@ -292,9 +300,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
       params:
@@ -317,9 +325,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
       params:
@@ -348,9 +356,9 @@ spec:
         kind: Task
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/run-file-updates/run-file-updates.yaml
         resolver: git
@@ -363,9 +371,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -16,6 +16,12 @@
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+
+## Changes in 1.3.0
+- taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+- taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
 
 ## Changes since 1.1.0
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,14 @@ spec:
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
   workspaces:
     - name: release-workspace
   tasks:
@@ -47,9 +55,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: hub/kubernetes-actions/kubernetes-actions.yaml
       params:
@@ -100,9 +108,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-data/collect-data.yaml
       params:
@@ -126,9 +134,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/apply-mapping/apply-mapping.yaml
       params:
@@ -176,9 +184,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
@@ -196,9 +204,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
@@ -214,9 +222,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/collect-slack-notification-params/collect-slack-notification-params.yaml
       params:
@@ -236,9 +244,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-pyxis-image/create-pyxis-image.yaml
       params:
@@ -260,9 +268,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
       params:
@@ -282,9 +290,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/update-infra-deployments/update-infra-deployments.yaml
       params:
@@ -306,9 +314,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/send-slack-notification/send-slack-notification.yaml
       workspaces:
@@ -331,9 +339,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/release-service-catalog.git
+            value: $(params.taskGitUrl)
           - name: revision
-            value: main
+            value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/cleanup-workspace/cleanup-workspace.yaml
       when:


### PR DESCRIPTION
This commit adds the taskGitUrl and taskGitRevision parameters to all of the pipelines. They are used to control the url and revision of the release-service-catalog repo that is used for their tasks.