### PR TITLE
feat(RHTAPREL-619): add prepare-fbc-release task to support-multi-comp

### DIFF
--- a/tasks/prepare-fbc-release/README.md
+++ b/tasks/prepare-fbc-release/README.md
@@ -1,0 +1,15 @@
+# prepare-fbc-release
+
+A tekton task to prepare FBC Release by collecting a valid
+OCP version for each component from given
+containerImage(fbcFragment) in the snapshot, and update
+the fromIndex, targetIndex and binaryImage with collected
+OCP version and store updated values to snapshot respective
+to each component, so other task can use them.
+
+## Parameters
+
+| Name         | Description                                                             | Optional | Default value      |
+|--------------|-------------------------------------------------------------------------|----------|--------------------|
+| snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace      | Yes      | snapshot_spec.json |
+| dataPath     | Path to the JSON string of the merged data to use in the data workspace | Yes      | data.json          |

--- a/tasks/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/prepare-fbc-release.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: prepare-fbc-release
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    A tekton task to prepare FBC Release by collecting a valid
+    OCP version for each component from given
+    containerImage(fbcFragment) in the snapshot, and update
+    the fromIndex, targetIndex and binaryImage with collected
+    OCP version and store updated values to snapshot respective
+    to each component, so other task can use them.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      type: string
+      default: "snapshot_spec.json"
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+      default: "data.json"
+  workspaces:
+    - name: data
+      description: Workspace where the snapshot and data json is stored
+  steps:
+    - name: prepare-fbc-release
+      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
+        if [ ! -f "${SNAPSHOT_PATH}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi        
+        
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi        
+
+        pattern="^v[0-9]+\.[0-9]+$"
+
+        # Read components and initial values
+        components=$(jq -c '.components[]' "$SNAPSHOT_PATH")
+        fromIndex=$(jq -r '.fbc.fromIndex' "$DATA_FILE")
+        targetIndex=$(jq -r '.fbc.targetIndex' "$DATA_FILE")
+        binaryImage=$(jq -r '.fbc.binaryImage' "$DATA_FILE")
+
+        # Print initial values
+        echo "Initial fromIndex: $fromIndex"
+        echo "Initial targetIndex: $targetIndex"
+        echo "Initial binaryImage: $binaryImage"
+        echo
+
+        # Get the number of components
+        num_components=$(jq '.components | length' "$SNAPSHOT_PATH")
+        echo "Found $num_components components"
+
+        # Function to replace tag in an image
+        replace_tag() {
+            local updatedImage="${1%:*}:${2}"
+            echo "$updatedImage"
+        }
+
+        # Iterate over component indices
+        for ((i=0; i<num_components; i++)); do
+            component=$(jq -c ".components[$i]" "$SNAPSHOT_PATH")
+            containerImage=$(jq -r '.containerImage' <<< "$component")
+            componentName=$(jq -r '.name' <<< "$component")
+
+            # Extract OCP version from container image using Skopeo.
+            # This command retrieves the 'org.opencontainers.image.base.name' annotation,
+            # which includes the OCP version, formatted as "registry:version".
+            # Example: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+            # The script then isolates the version part (e.g., "v4.12") from this string.
+            ocpVersion=$(skopeo inspect --raw docker://"$containerImage" \
+                | jq -r '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2)
+
+            # Check if the version matches the pattern
+            if ! [[ "$ocpVersion" =~ $pattern ]]; then
+                echo "Invalid format for image $containerImage."
+                exit 1
+            fi
+
+            # Compute updated values
+            updatedFromIndex=$(replace_tag "$fromIndex" "$ocpVersion")
+            updatedTargetIndex=$(replace_tag "$targetIndex" "$ocpVersion")
+            updatedBinaryImage=$(replace_tag "$binaryImage" "$ocpVersion")
+
+            # Print updated values
+            echo "Component: $componentName"
+            echo "ocpVersion: $ocpVersion"
+            echo "Updated fromIndex for $componentName: $updatedFromIndex"
+            echo "Updated targetIndex for $componentName: $updatedTargetIndex"
+            echo "Updated binaryImage for $componentName: $updatedBinaryImage"
+            echo
+
+            # Apply each update directly
+            jq ".components[$i].ocpVersion |= \"$ocpVersion\"" \
+              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+            jq ".components[$i].updatedFromIndex |= \"$updatedFromIndex\"" \
+              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+            jq ".components[$i].updatedTargetIndex |= \"$updatedTargetIndex\"" \
+              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+            jq ".components[$i].updatedBinaryImage |= \"$updatedBinaryImage\"" \
+              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+        done

--- a/tasks/prepare-fbc-release/samples/sample_prepare-fbc-release_TaskRun.yaml
+++ b/tasks/prepare-fbc-release/samples/sample_prepare-fbc-release_TaskRun.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: prepare-fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshotPath
+      value: ""
+    - name: dataPath
+      value: "data.json"
+  taskRef:
+    resolver: "git"
+    params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/prepare-fbc-release/prepare-fbc-release.yaml

--- a/tasks/prepare-fbc-release/tests/mocks.sh
+++ b/tasks/prepare-fbc-release/tests/mocks.sh
@@ -1,0 +1,20 @@
+# mocks to be injected into task step scripts
+
+#!/bin/sh -ex
+
+function skopeo() {
+  echo "Mock skopeo called with: $*" >&2
+  
+  # Append call information to mock_skopeo.txt
+  echo "$*" >> $(workspaces.data.path)/mock_skopeo.txt
+
+ 
+  if [[ "$*" == "inspect --raw docker://quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297" ]]; then
+    echo '{"annotations":{"org.opencontainers.image.base.name":"registry.redhat.io/openshift4/ose-operator-registry:v4.12"}}'
+    return
+  fi
+
+  # If the command is not the expected inspect --raw, output an error and exit
+  echo Error: Unexpected call of skopeo
+  exit 1
+}

--- a/tasks/prepare-fbc-release/tests/pre-apply-task-hook.sh
+++ b/tasks/prepare-fbc-release/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../prepare-fbc-release.yaml

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-release-fail-no-data
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the prepare-fbc-release task with no data file and verify the task fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "registry.io/image0@sha256:0000",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }
+                  ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-release
+      params:
+        - name: dataPath
+          value: data.json
+        - name: snapshotPath
+          value: snapshot_spec.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-snapshot.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-snapshot.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-release-fail-no-snapshot-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the prepare-fbc-release task with no snapshot file present in the path specified by
+    snapshotPath. The task should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-release
+      params:
+        - name: snapshotPath
+          value: missing
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-release 
+spec:
+  description: |
+    Run the prepare-fbc-release task and verify
+    that the task succesfully update the snapshot
+    with the ocpVersion, fromIndex, targetIndex,
+    and binaryImage for all the component in snapshot  
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: add-snapshot
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.09",
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.10",
+                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.11"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                  "application": "foo-app",
+                  "artifacts": {},
+                  "components": [
+                      {
+                          "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
+                          "name": "test-container-foo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      },
+                      {
+                       "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
+                          "name": "test-container-boo",
+                          "source": {
+                              "git": {
+                                  "context": "./",
+                                  "dockerfileUrl": "build/Dockerfile",
+                                  "revision": "foo",
+                                  "url": "https://github.com/foo/bar"
+                              }
+                          },
+                          "repository": "test/foo/bar"
+                      }
+                      ]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-release
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: snapshotPath
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi


### PR DESCRIPTION
This task introduced to support multi-component release for FBC. In this task, we fetch `containerImage` from the snapshot and collect a valid OCP tag to be used, and update `fromIndex`, `targetIndex` and `binaryImage` with the found OCP tag from containerImage and also adds the value to snapshot respective to components so that other tasks can use this for multiple component FBC release.

Also, this task will result in removing get-ocp-version, update-ocp-tag and validate-single-component once we have the compatibility for multicomponent support.(soon)