### PR TITLE
feat(RHTAP-1934): Add sign-base64-blob task to release-to-github pipeline

### DIFF
--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -15,4 +15,4 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -47,7 +47,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: main
+      default: development
   workspaces:
     - name: release-workspace
   tasks:
@@ -241,6 +241,31 @@ spec:
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
       runAfter: 
         - extract-binaries-from-image
+    - name: sign-base64-blob
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/sign-base64-blob/sign-base64-blob.yaml
+      params:
+        - name: dataPath
+          value: $(tasks.collect-data.results.data)
+        - name: blob
+          value: $(tasks.base64-encode-checksum.results.blob)
+        - name: requester
+          value: $(tasks.extract-requester-from-release.results.output-result)
+        - name: binariesPath
+          value: $(tasks.extract-binaries-from-image.results.binaries_path)
+      runAfter:
+        - base64-encode-checksum
+        - extract-requester-from-release
     - name: collect-gh-params
       workspaces:
         - name: data
@@ -287,6 +312,7 @@ spec:
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
       runAfter: 
         - collect-gh-params
+        - sign-base64-blob
   finally:
     - name: cleanup
       taskRef:

--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -14,6 +14,10 @@ a `release` dir.
 | release_version | The version string to use creating the release | No | - |
 | content_directory | The directory inside the workspace to find files for release | No | - |
 
+## Changes since 1.0.0
+- Added the `.sig` files to the release
+- Updated test with a `.sig` file
+
 ## Changes since 0.2.0
 - Removed the installation of the `gh` CLI, since it is now part of the release image
 - Changed way to send the results, piping from the `gh` command to make it cleaner

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,9 +40,8 @@ spec:
         
         cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
         set -o pipefail
-        gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS --repo $REPOSITORY | tee $(results.url.path)
-        # We will add .sig file when we have the sigining step is done
-        #gh release create v$RELEASE_VERSION *.zip *.json *.sig --repo $REPOSITORY 
+        shopt -s failglob
+        gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS *.sig --repo $REPOSITORY | tee $(results.url.path)
       env:
         - name: GH_TOKEN
           valueFrom:

--- a/tasks/create-github-release/tests/mocks.sh
+++ b/tasks/create-github-release/tests/mocks.sh
@@ -7,7 +7,7 @@ function gh() {
   echo "Mock gh called with: $*"
   echo "$*" >> $(workspaces.data.path)/mock_gh.txt
 
-  if [[ "$*" != "release create v1.2.3 foo.zip foo.json foo_SHA256SUMS --repo foo/bar" ]]
+  if [[ "$*" != "release create v1.2.3 foo.zip foo.json foo_SHA256SUMS foo_SHA256SUMS.sig --repo foo/bar" ]]
   then
     echo Error: Unexpected call
     exit 1

--- a/tasks/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-release.yaml
@@ -29,6 +29,7 @@ spec:
               EOF
               touch $(workspaces.data.path)/release/foo.zip
               touch $(workspaces.data.path)/release/foo_SHA256SUMS
+              touch $(workspaces.data.path)/release/foo_SHA256SUMS.sig
     - name: run-task
       taskRef:
         name: create-github-release

--- a/tasks/sign-base64-blob/README.md
+++ b/tasks/sign-base64-blob/README.md
@@ -1,0 +1,27 @@
+# sign-base64-blob
+
+Creates an InternalRequest to sign a base64 encoded blob
+
+## Parameters
+
+| Name                 | Description                                                             | Optional | Default value          |
+|----------------------|-------------------------------------------------------------------------|----------|------------------------|
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace | Yes      | data.json              |
+| request              | Signing pipeline name to handle this request                            | Yes      | hacbs-signing-pipeline |
+| referenceImage       | The image to be signed                                                  | No       |                        |
+| manifestDigestImage  | Manifest Digest Image used to extract the SHA                           | Yes      | ""                     |
+| requester            | Name of the user that requested the signing, for auditing purposes      | No       |                        |
+| requestTimeout       | InternalRequest timeout                                                 | Yes      | 180                    |
+| binariesPath         | The directory inside the workspace where the binaries are stored        | Yes      | binaries               |
+
+## Signing data parameters
+
+ The signing configuration should be set as `data.sign` in the _releasePlanAdmission_. The data should be set in the _ReleasePlanAdmission_ as follows:
+
+```
+data:
+    sign:
+        request: <signing pipeline name>
+        pipelineImage: <image pullspec>
+        configMapName: <configmap name>
+```

--- a/tasks/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/sign-base64-blob.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sign-base64-blob
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Task to create an internalrequest to sign a base64 encoded blob.
+  params:
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+      default: "data.json"
+    - name: request
+      type: string
+      description: Signing pipeline name to handle this request
+      default: "blob-signing-pipeline"
+    - name: blob
+      type: string
+      description: The base64 encoded blob to be signed.
+    - name: requester
+      type: string
+      description: Name of the user that requested the signing, for auditing purposes
+    - name: requestTimeout
+      type: string
+      default: "180"
+      description: InternalRequest timeout
+    - name: binariesPath
+      type: string
+      description: The directory inside the workspace where the binaries are stored
+      default: binaries
+  workspaces:
+    - name: data
+      description: workspace to read and save files
+  steps:
+    - name: sign-base64-blob
+      image:
+        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      script: |
+        #!/usr/bin/env sh
+        set -ex
+        set -o pipefail
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No valid data file was provided."
+            exit 1
+        fi
+
+        request=$(jq -r '.sign.request // "$(params.request)"' ${DATA_FILE})
+        default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
+        pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
+            '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
+        config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' ${DATA_FILE})
+
+        echo "Creating InternalRequest to sign blob:"
+        echo "- blob=$(params.blob)"
+        echo "- requester=$(params.requester)"
+
+        internal-request -r "${request}" \
+            -p pipeline_image=${pipeline_image} \
+            -p blob=$(params.blob) \
+            -p requester=$(params.requester) \
+            -p config_map_name=${config_map_name} \
+            -t $(params.requestTimeout) \
+            > $(workspaces.data.path)/ir-result.txt || \
+            (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
+          
+        internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
+        echo "done (${internalRequest})"
+        
+        payload=$(kubectl get internalrequest $internalRequest -o=jsonpath='{.status.results.signed_payload}')
+
+        # Build .sig file
+        checksum_file_name=$(ls $(workspaces.data.path)/$(params.binariesPath) | grep SHA256SUMS) 
+        echo -n $payload | tee $(workspaces.data.path)/$(params.binariesPath)/${checksum_file_name}.sig

--- a/tasks/sign-base64-blob/tests/mocks.sh
+++ b/tasks/sign-base64-blob/tests/mocks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function internal-request() {
+  echo Mock internal-request called with: $*
+  echo $* >> $(workspaces.data.path)/mock_internal-request.txt
+
+  # set to async
+  /home/utils/internal-request $@ -s false
+
+  # mimic the sync output
+  echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
+  sleep 2
+}
+
+function kubectl() {
+  if [ $* != "get internalrequest internal-request -o=jsonpath='{.status.results.signed_payload}'" ]
+  then
+    echo "Unexpected call to kubectl"
+    exit 1
+  fi
+
+  echo "dummy-payload"
+}

--- a/tasks/sign-base64-blob/tests/pre-apply-task-hook.sh
+++ b/tasks/sign-base64-blob/tests/pre-apply-task-hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+# Add mocks to the beginning of task step script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../sign-base64-blob.yaml

--- a/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sign-base64-blob
+spec:
+  description: Test creating a internal request to sign a blob
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "sign": {
+                  "request": "blob-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+
+              mkdir -p $(workspaces.data.path)/binaries
+              touch $(workspaces.data.path)/binaries/foo_SHA256SUMS
+    - name: run-task
+      taskRef:
+        name: sign-base64-blob
+      params:
+        - name: requester
+          value: testuser
+        - name: blob
+          value: test-blob
+        - name: binariesPath
+          value: binaries
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.blob' <<< "${params}") != "test-blob" ]; then
+                echo "blob does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
+              then
+                echo "config_map_name does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
+              then
+                echo "requester does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.pipeline_image' <<< "${params}") != \
+                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
+              then
+                echo "pipeline_image does not match"
+                exit 1
+              fi
+
+              binaries_path=$(workspaces.data.path)/binaries
+              created_file=$(ls $binaries_path | grep sig)
+              if [ $created_file != "foo_SHA256SUMS.sig" ]
+              then
+                echo "Unexpected filename for the signed file"
+                exit 1
+              fi
+
+              file_content=$(cat $binaries_path/foo_SHA256SUMS.sig)
+              if [ $file_content != "dummy-payload" ]
+              then
+                echo "Payload is not correct"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
- Add new sign-base64-blob task with its tests, to sign a base64 encoded blob using the internal request script. Creating a .sig file
- Update release-to-github pipeline to use this new task and release the .sig file as well