### PR TITLE
fix(RHTAPBUGS-1019): support staged index use case

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -12,6 +12,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | binaryImage    | binaryImage value updated by update-ocp-tag task                          | No       |                      |
 | fromIndex      | fromIndex value updated by update-ocp-tag task                            | No       |                      |
 
+## changes in 1.3.1
+- add the possibility of setting a stagedIndex tag
+ 
 ## changes in 1.3.0
 - add the possibility of setting a hotfix tag
 - replace the `fbcOptIn` result with `mustSignIndexImage` and `mustPublishIndexImage`

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -74,6 +74,7 @@ spec:
         build_tags=$(jq '.fbc.buildTags // []' ${DATA_FILE})
         add_arches=$(jq '.fbc.addArches // []' ${DATA_FILE})
         hotfix=$(jq -r '.fbc.hotfix // "false"' ${DATA_FILE})
+        staged_index=$(jq -r '.fbc.stagedIndex // "false"' ${DATA_FILE})
         build_timeout_seconds=$(jq -r --arg build_timeout_seconds ${default_build_timeout_seconds} \
             '.fbc.buildTimeoutSeconds // $build_timeout_seconds' ${DATA_FILE})
         target_index=$(jq -r '.fbc.targetIndex' ${DATA_FILE})
@@ -107,6 +108,7 @@ spec:
             -p buildTags=${build_tags} \
             -p addArches=${add_arches} \
             -p hotfix=${hotfix} \
+            -p stagedIndex=${staged_index} \
             -t $(params.requestTimeout) |tee $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log
 
         internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log | xargs)

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-staged-index
+spec:
+  description: Test creating a internal request for the IIB pipeline
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "iibServiceConfigSecret": "test-iib-service-config-secret",
+                  "stagedIndex": true,
+                  "buildTimeoutSeconds": 420
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: binaryImage
+          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: fromIndex
+          value: "quay.io/scoheb/fbc-index-testing:latest"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              #
+              set -eux
+
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tac | tail -1)"
+
+              requestParams=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.stagedIndex' <<< "${requestParams}") != "true" ]
+              then
+                echo "stagedIndex does not match"
+                exit 1
+              fi
+
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
- when fbc_opt_in is set in pyxis for a bundle image, the staged index release use case still need to work.
- this will now allows us to force stagedIndex functionality to ensure there is no chance that a staged index get delivered to production.

Relates to https://github.com/hacbs-release/app-interface-deployments/pull/69