### PR TITLE
chore(RHTAPREL-730): change branch reference in github workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,6 @@
 name: Linters
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches: ['main']
     types: ['opened', 'reopened', 'synchronize']
   workflow_dispatch:
 jobs:

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -2,7 +2,6 @@
 name: Tekton Task Tests
 on:
   pull_request:
-    branches: ['main']
     paths:
       - 'tasks/**'
 jobs:


### PR DESCRIPTION
Change the reference to the main branch to refer to the development branch in the github workflows as the development branch will take the place of main going forward.