### PR TITLE
fix: task should fail on internalrequest failure

### DIFF
--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -52,7 +52,7 @@ spec:
       script: |
         #!/usr/bin/env sh
         #
-        set -e
+        set -eo pipefail
 
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"


### PR DESCRIPTION
This PR fixes the case when the internal-request script fails the task keeps running

Signed-off-by: Leandro Mendes <lmendes@redhat.com>