### PR TITLE
fix(RHTAPBUGS-1024): publish-index-image should also create a timestamp-based tag

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | main                                                            |
 
+### Changes in 1.6.0
+- modify the task `publish-index-image` to accept the new parameter `buildTimestamp` used
+  to append to the publishing image tag
+
 ### Changes in 1.5.0
 - modify the task `publish-index-image` to use a dedicated task instead of using the `create-internal-request` task
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.5.0"
+    app.kubernetes.io/version: "1.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -334,6 +334,8 @@ spec:
           value: $(tasks.extract-index-image.results.indexImageResolved)
         - name: targetIndex
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestTargetIndex)
+        - name: buildTimestamp
+          value: $(tasks.add-fbc-contribution-to-index-image.results.buildTimestamp)
         - name: retries
           value: "3"
       when:

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -12,6 +12,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | binaryImage    | binaryImage value updated by update-ocp-tag task                          | No       |                      |
 | fromIndex      | fromIndex value updated by update-ocp-tag task                            | No       |                      |
 
+## changes in 1.5.0
+- add the result `buildTimestamp` to be used in the downstream tasks
+
 ## changes in 1.4.0
 - add the possibility of setting a stagedIndex tag
  

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,6 +31,8 @@ spec:
       default: "180"
       description: InternalRequest timeout
   results:
+    - name: buildTimestamp
+      description: Build timestamp used in the tag
     - name: mustSignIndexImage
       description: Whether the index image should be signed
     - name: mustPublishIndexImage
@@ -80,9 +82,10 @@ spec:
         target_index=$(jq -r '.fbc.targetIndex' ${DATA_FILE})
         fbc_fragment=$(jq -cr '.components[0].containerImage' ${SNAPSHOT_PATH})
 
+        timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' ${DATA_FILE})
+        timestamp=$(date "+${timestamp_format}")
+
         if [ "${hotfix}" == "true" ]; then
-          timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' ${DATA_FILE})
-          timestamp=$(date "+${timestamp_format}")
           issue_id=$(jq -r '.fbc.issueId // empty' ${DATA_FILE})
           if [ -z "${issue_id}" ]; then
             echo "Hotfix releases requires the issue id."
@@ -91,6 +94,7 @@ spec:
           tag="${issue_id}-${timestamp}"
           target_index="${target_index}-${tag}"
         fi
+        echo -n $timestamp > $(results.buildTimestamp.path)
         echo -n $target_index > $(results.requestTargetIndex.path)
 
         # The internal-request script will create the InternalRequest and wait until it finishes to get its status

--- a/tasks/publish-index-image/README.md
+++ b/tasks/publish-index-image/README.md
@@ -11,8 +11,12 @@ Publish a built FBC index image using skopeo
 | targetIndex    | Pullspec to push the image to                                           | No       |               |
 | retries        | Number of skopeo retries                                                | Yes      | 0             |
 | requestTimeout | Max seconds waiting for the status update                               | Yes      | 360           |
+| buildTimestamp | Build timestamp for the publishing image                                | No       |               |
 
 ## Changelog
+
+### Changes in 2.0.0
+- Add the parameter `buildTimestamp` to push also a timestamp-based tag
 
 ### Changes in 1.0.0
 - Refactor to use the `internal-request` script

--- a/tasks/publish-index-image/publish-index-image.yaml
+++ b/tasks/publish-index-image/publish-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-index-image
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,6 +30,9 @@ spec:
       type: string
       default: "360"
       description: Max seconds waiting for the status update
+    - name: buildTimestamp
+      type: string
+      description: Build timestamp for the publishing image
   workspaces:
     - name: data
       description: Workspace to store the params and responses for the internalRequest
@@ -53,14 +56,25 @@ spec:
         request="publish-index-image-pipeline"
         credentials=$(jq -r '.fbc.publishingCredentials' $DATA_FILE)
 
-        echo "Creating internal request to publish image:"
-        echo "- from: $(params.sourceIndex)"
-        echo "- to: $(params.targetIndex)"
+        publishingImages=($(params.targetIndex))
+        # only publish the extra timestamp-based tag if the targetIndex does not have it already
+        if [[ ! "$(params.targetIndex)" =~ .*$(params.buildTimestamp)$ ]]; then
+          publishingImages+=("$(params.targetIndex)-$(params.buildTimestamp)")
+        fi
 
-        internal-request -r "${request}" \
-            -p sourceIndex=$(params.sourceIndex) \
-            -p targetIndex=$(params.targetIndex) \
-            -p publishingCredentials=${credentials} \
-            -p retries=$(params.retries) \
-            -t $(params.requestTimeout)
-        echo "done"
+        for((i=0; i<${#publishingImages[@]}; i++ )); do
+            echo "=== Creating internal request to publish image:"
+            echo ""
+            echo "- from: $(params.sourceIndex)"
+            echo "- to: ${publishingImages[$i]}"
+
+            internal-request -r "${request}" \
+                -p sourceIndex=$(params.sourceIndex) \
+                -p targetIndex=${publishingImages[$i]} \
+                -p publishingCredentials=${credentials} \
+                -p retries=$(params.retries) \
+                -t $(params.requestTimeout)
+            echo "=== done"
+            echo ""
+            echo ""
+        done

--- a/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -36,7 +36,7 @@ spec:
         - name: sourceIndex
           value: "quay.io/test/sourceIndex:tag"
         - name: targetIndex
-          value: "quay.io/test/targetIndex:tag"
+          value: "quay.io/test/targetIndex:tag-abc-11111111111"
         - name: buildTimestamp
           value: 11111111111
         - name: retries
@@ -58,43 +58,30 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
-              | tr "\n" " ")"
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
+              request=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.request}")
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              read -r -a ir <<< "${internalRequests}"
-              for((i=0; i<${#ir[@]}; i++)); do
+              if [ "$request" != "publish-index-image-pipeline" ]; then
+                echo "request pipeline does not match"
+                exit 1
+              fi
 
-                  request=$(kubectl get internalrequest ${ir[$i]} -o jsonpath="{.spec.request}")
-                  params=$(kubectl get internalrequest ${ir[$i]} -o jsonpath="{.spec.params}")
+              if [ $(jq -r '.retries' <<< "${params}") != "2" ]; then
+                echo "number of retries does not match"
+                exit 1
+              fi
 
-                  if [ "$request" != "publish-index-image-pipeline" ]; then
-                    echo "request pipeline does not match"
-                    exit 1
-                  fi
+              if [ $(jq -r '.sourceIndex' <<< "${params}") != "quay.io/test/sourceIndex:tag" ]; then
+                echo "sourceIndex image does not match"
+                exit 1
+              fi
 
-                  if [ $(jq -r '.retries' <<< "${params}") != "2" ]; then
-                    echo "number of retries does not match"
-                    exit 1
-                  fi
-
-                  if [ $(jq -r '.sourceIndex' <<< "${params}") != "quay.io/test/sourceIndex:tag" ]; then
-                    echo "sourceIndex image does not match"
-                    exit 1
-                  fi
-
-                  targetIndex=$(jq -r '.targetIndex' <<< "${params}")
-                  if [ $i = 0 ]; then
-                      if [ $targetIndex != "quay.io/test/targetIndex:tag" ]; then
-                        echo "targetIndex image does not match"
-                        exit 1
-                      fi
-                  else
-                      if [ $targetIndex != "quay.io/test/targetIndex:tag-11111111111" ]; then
-                        echo "targetIndex image does not match"
-                        exit 1
-                      fi
-                  fi
-              done
+              targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+              if [ $targetIndex != "quay.io/test/targetIndex:tag-abc-11111111111" ]; then
+                echo "targetIndex image does not match"
+                exit 1
+              fi
       runAfter:
         - run-task
   finally:


### PR DESCRIPTION
This PR change the task publish-index-image to push
also a timestamp-based tag in addition of the ocp
versioned one.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>