### PR TITLE
fix(RHTAP-193): update default image for blob signing task

### DIFF
--- a/tasks/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/sign-base64-blob.yaml
@@ -53,7 +53,7 @@ spec:
         fi
 
         request=$(jq -r '.sign.request // "$(params.request)"' ${DATA_FILE})
-        default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
+        default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3"
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' ${DATA_FILE})

--- a/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -81,7 +81,7 @@ spec:
               fi
 
               if [ $(jq -r '.pipeline_image' <<< "${params}") != \
-                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
+                 "quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3" ]
               then
                 echo "pipeline_image does not match"
                 exit 1


### PR DESCRIPTION
The image by default should be the correct one. The `released` tag doesn't have the required script