### PR TITLE
fix(RHTAPBUGS-959): run internal requests in parallel in rh-sign-image

### DIFF
--- a/.github/resources/crd_rbac.yaml
+++ b/.github/resources/crd_rbac.yaml
@@ -9,6 +9,7 @@ rules:
       - appstudio.redhat.com
     resources:
       - internalrequests
+      - internalrequests/status
       - releases
       - releaseplans
       - releaseplanadmissions
@@ -20,6 +21,7 @@ rules:
       - get
       - list
       - watch
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -4,13 +4,18 @@ Task to create internalrequests to sign snapshot components
 
 ## Parameters
 
-| Name           | Description                                                               | Optional | Default value        |
-|----------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
-| dataPath       | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
-| requester      | Name of the user that requested the signing, for auditing purpose         | No       |                      |
-| commonTags      | Space separated list of common tags to be used when publishing           | No       |                      |
-| requestTimeout | InternalRequest timeout                                                   | Yes      | 180                  |
+| Name            | Description                                                               | Optional | Default value        |
+|-----------------|---------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
+| dataPath        | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
+| requester       | Name of the user that requested the signing, for auditing purpose         | No       |                      |
+| commonTags      | Space separated list of common tags to be used when publishing            | No       |                      |
+| requestTimeout  | InternalRequest timeout                                                   | Yes      | 180                  |
+| concurrentLimit | The maximum number of images to be processed at once                      | Yes      | 4                    |
+
+## Changes in 1.2.0
+* Optimize the task to process multiple images in parallel. This will improve the performance of the task.
+* Add a new `concurrentLimit` parameter that controls the number of images to be processed in parallel
 
 ## Changes since 1.0.1
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,17 +30,22 @@ spec:
       type: string
       default: "180"
       description: InternalRequest timeout
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be processed at once
+      default: 4
   workspaces:
     - name: data
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
       script: |
         #!/usr/bin/env sh
         #
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         RUNDIR="$(workspaces.data.path)/$(context.taskRun.uid)"
+        IDENTIFIER=$(context.taskRun.uid)
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -57,6 +62,8 @@ spec:
             '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' ${DATA_FILE})
 
+        N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
+        count=0
         COMPONENTS_LENGTH=$(jq '.components |length' ${SNAPSHOT_PATH})
         for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
 
@@ -85,8 +92,15 @@ spec:
                   -p manifest_digest=${manifest_digest} \
                   -p requester=$(params.requester) \
                   -p config_map_name=${config_map_name} \
-                  -t $(params.requestTimeout)
-            done
+                  -i $IDENTIFIER \
+                  -s false
+              ((++count))
 
-            echo "done"
+              if [ "$count" -eq "$N" ]; then
+                  wait-for-ir -i $IDENTIFIER -t $(params.requestTimeout)
+                  count=0
+              fi
+            done
         done
+        wait-for-ir -i $IDENTIFIER -t $(params.requestTimeout)
+        echo "done"

--- a/tasks/rh-sign-image/tests/mocks.sh
+++ b/tasks/rh-sign-image/tests/mocks.sh
@@ -6,10 +6,47 @@ function internal-request() {
   echo Mock internal-request called with: $*
   echo $* >> $(workspaces.data.path)/mock_internal-request.txt
 
-  # set to async
-  /home/utils/internal-request $@ -s false
+  /home/utils/internal-request $@
 
-  # mimic the sync output
-  echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
-  sleep 2
+  sleep 1
+  NAME=$(kubectl get internalrequest --no-headers -o custom-columns=":metadata.name" \
+      --sort-by=.metadata.creationTimestamp | tail -1)
+  if [ -z $NAME ]; then
+      echo Error: Unable to get IR name
+      echo Internal requests:
+      kubectl get internalrequest --no-headers -o custom-columns=":metadata.name" \
+          --sort-by=.metadata.creationTimestamp
+      exit 1
+  fi
+
+  if [[ "$*" == *"requester=testuser-failure"* ]]; then
+      set_ir_status $NAME Failure 3 &
+  else
+      set_ir_status $NAME Succeeded 10 &
+  fi
+}
+
+function set_ir_status() {
+    NAME=$1
+    REASON=$2
+    DELAY=$3
+    echo Setting status of $NAME to reason $REASON in $DELAY seconds... >&2
+    sleep $DELAY
+    PATCH_FILE=$(workspaces.data.path)/${NAME}-patch.json
+    cat > $PATCH_FILE << EOF
+{
+  "status": {
+    "conditions": [
+      {
+        "reason": "${REASON}",
+        "lastTransitionTime": "2023-12-06T15:22:45Z",
+        "message": "my message",
+        "status": "True",
+        "type": "merge"
+      }
+    ]
+  }
+}
+EOF
+    kubectl patch internalrequest $NAME --type=merge --subresource status --patch-file $PATCH_FILE
 }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-ir-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test a scenario when the internalRequests fail
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct----myrepo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-failure
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -129,7 +129,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -119,7 +119,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-timeout
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: >
+    Test a scenario when the IR processing times out. The timeout happens
+    because the requestTimeout parameter of the task is set to 1 and this
+    is passed to the wait-for-ir call. So the mock would mark the IR as passed
+    in 10 seconds, but it will time out before that happens.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct----myrepo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-single
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
+        - name: requestTimeout
+          value: 1
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
Up to 4 IRs will run in parallel. This will improve the performance of the task.

Note that this depends on https://github.com/redhat-appstudio/release-service-utils/pull/98