### PR TITLE
feat: add option to run single task tests

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -54,4 +54,4 @@ jobs:
         if: steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/test_tekton_tasks.sh
         env:
-          TASK_DIRS: ${{ steps.changed-dirs.outputs.all_changed_files }}
+          TEST_ITEMS: ${{ steps.changed-dirs.outputs.all_changed_files }}


### PR DESCRIPTION
When running task tests using the test_tekton_tasks.sh script, it will now be possible to provide either task dirs or single test yaml files. This will be useful for when you're working on a single test and want to try it out - until now you would always need to wait for all the other tests to run too (unless you temporarily renamed or deleted the other tests).