### PR TITLE
feat: use a copy when adding mocks to task files

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -88,14 +88,20 @@ do
     continue
   fi
 
+  # Use a copy of the task file to prevent modifying to original task file
+  TASK_COPY=$(mktemp)
+  cp "$TASK_PATH" "$TASK_COPY"
+
   if [ -f ${TESTS_DIR}/pre-apply-task-hook.sh ]
   then
     echo Found pre-apply-task-hook.sh file in dir: $TESTS_DIR. Executing...
-    ${TESTS_DIR}/pre-apply-task-hook.sh
+    ${TESTS_DIR}/pre-apply-task-hook.sh "$TASK_COPY"
   fi
 
   echo "  Installing task"
-  kubectl apply -f $TASK_PATH
+  kubectl apply -f "$TASK_COPY"
+
+  rm -f "$TASK_COPY"
 
   for TEST_PATH in ${TEST_PATHS[@]}
   do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,10 +213,11 @@ For reference implementation, check [push-sbom-to-pyxis/tests/](/tasks/push-sbom
     ```sh
     #!/usr/bin/env sh
 
+    TASK_PATH=$1
     SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-    yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../push-sbom-to-pyxis.yaml
-    yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $SCRIPT_DIR/../push-sbom-to-pyxis.yaml
+    yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $TASK_PATH
+    yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $TASK_PATH
     ```
 
     In this case we inject the file to both steps in the task under test. This will depend on
@@ -259,3 +260,12 @@ as arguments, e.g.
 ```
 
 This will install the task and run all test pipelines matching `tests/test*.yaml`.
+
+Another option is to run one or more tests directly:
+
+```
+./.github/scripts/test_tekton_tasks.sh tasks/apply-mapping/tests/test-apply-mapping.yaml
+```
+
+This will still install the task and run `pre-apply-task-hook.sh` if present, but it will then
+run only the specified test pipeline.

--- a/tasks/add-fbc-contribution/tests/pre-apply-task-hook.sh
+++ b/tasks/add-fbc-contribution/tests/pre-apply-task-hook.sh
@@ -10,5 +10,6 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 kubectl delete internalrequests --all -A
 
 # Add mocks to the beginning of task step script
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../add-fbc-contribution.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
+++ b/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../cleanup-workspace.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/create-advisory-internal-request/tests/pre-apply-task-hook.sh
+++ b/tasks/create-advisory-internal-request/tests/pre-apply-task-hook.sh
@@ -9,7 +9,8 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 # delete old InternalRequests
 kubectl delete internalrequests --all -A
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../create-advisory-internal-request.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/create-github-release/tests/pre-apply-task-hook.sh
+++ b/tasks/create-github-release/tests/pre-apply-task-hook.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../create-github-release.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy github secret (and delete it first if it exists)
 kubectl delete secret test-create-github-release-token --ignore-not-found

--- a/tasks/create-pyxis-image/tests/pre-apply-task-hook.sh
+++ b/tasks/create-pyxis-image/tests/pre-apply-task-hook.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../create-pyxis-image.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-create-pyxis-image-cert --ignore-not-found

--- a/tasks/extract-binaries-from-image/tests/pre-apply-task-hook.sh
+++ b/tasks/extract-binaries-from-image/tests/pre-apply-task-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../extract-binaries-from-image.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/prepare-fbc-release/tests/pre-apply-task-hook.sh
+++ b/tasks/prepare-fbc-release/tests/pre-apply-task-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../prepare-fbc-release.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/publish-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/publish-index-image/tests/pre-apply-task-hook.sh
@@ -10,5 +10,6 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 kubectl delete internalrequests --all -A
 
 # Add mocks to the beginning of task step script
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../publish-index-image.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/publish-pyxis-repository/tests/pre-apply-task-hook.sh
+++ b/tasks/publish-pyxis-repository/tests/pre-apply-task-hook.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../publish-pyxis-repository.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-publish-pyxis-repository-cert --ignore-not-found

--- a/tasks/push-sbom-to-pyxis/tests/pre-apply-task-hook.sh
+++ b/tasks/push-sbom-to-pyxis/tests/pre-apply-task-hook.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Create a dummy pyxis secret (and delete it first if it exists)
@@ -7,5 +8,5 @@ kubectl delete secret test-push-sbom-to-pyxis-cert --ignore-not-found
 kubectl create secret generic test-push-sbom-to-pyxis-cert --from-literal=cert=mycert --from-literal=key=mykey
 
 # Add mocks to the beginning of scripts
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../push-sbom-to-pyxis.yaml
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $SCRIPT_DIR/../push-sbom-to-pyxis.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/push-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/push-snapshot/tests/pre-apply-task-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../push-snapshot.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/rh-sign-image/tests/pre-apply-task-hook.sh
+++ b/tasks/rh-sign-image/tests/pre-apply-task-hook.sh
@@ -10,5 +10,6 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 kubectl delete internalrequests --all -A
 
 # Add mocks to the beginning of task step script
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../rh-sign-image.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/send-slack-notification/tests/pre-apply-task-hook.sh
+++ b/tasks/send-slack-notification/tests/pre-apply-task-hook.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 set -x
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../send-slack-notification.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy slack-notification-secret secret (and delete it first if it exists)
 kubectl delete secret my-secret --ignore-not-found

--- a/tasks/sign-base64-blob/tests/pre-apply-task-hook.sh
+++ b/tasks/sign-base64-blob/tests/pre-apply-task-hook.sh
@@ -10,5 +10,6 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 kubectl delete internalrequests --all -A
 
 # Add mocks to the beginning of task step script
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../sign-base64-blob.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/sign-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/sign-index-image/tests/pre-apply-task-hook.sh
@@ -10,5 +10,6 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 kubectl delete internalrequests --all -A
 
 # Add mocks to the beginning of task step script
+TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $SCRIPT_DIR/../sign-index-image.yaml
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"


### PR DESCRIPTION
This will make local task testing more convenient.

Until now, whenever you ran task tests that added mocks to a task, you would end up with a modified task file and had to restore the file manually.

With this change, each task file will be copied to a temp location before modifying it. Afterwards, the temp file will be deleted.

If you need to test if your mock replacement works, you can still run the pre-apply-task-hook.sh script manually, supplying the task file path as a cli argument.