### PR TITLE
fix: check enterprise contract before pushing to github

### DIFF
--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -16,3 +16,6 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+
+## Changes in 1.0.1
+- Fixed bug where pipeline execution didn't wait for verify-enterprise-contract task to succeed

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -203,6 +203,7 @@ spec:
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:
         - verify-access-to-resources
+        - verify-enterprise-contract
     - name: extract-binaries-from-image
       workspaces:
         - name: data


### PR DESCRIPTION
Before this, the github release pipeline would check enterprise contract, but it didn't actually gate the release actions to github. This change should make the pipeline wait until contract validation completes successfully before proceeding.