### PR TITLE
fix: wrong test name and mock check

### DIFF
--- a/tasks/send-slack-notification/README.md
+++ b/tasks/send-slack-notification/README.md
@@ -7,7 +7,7 @@ Sends message to Slack using postMessage API
 |-----------------|------------------------------------------------------------|----------|---------------------------|
 | message         | Message to be sent                                         | No       |                           |
 | tasksStatus     | status of tasks execution                                  | No       |                           |
-| secretName      | Name of secret which contains authentication token for app | Yes      | slack-notification-secret |
+| secretName      | Name of secret which contains authentication token for app | No       |                           |
 | secretKeyName   | Name of key within secret which contains webhook URL       | No       |                           |
 
 ## Changes in 1.1.1

--- a/tasks/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-send-slack-notification
+  name: test-send-slack-notification-no-secret
 spec:
   description: |
     Run the send-slack-notification task and verify the results
@@ -38,8 +38,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 0 ]; then
-                echo Error: curl was expected to be called 0 times. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_curl.txt ]; then
+                echo Error: curl was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_curl.txt
                 exit 1
               fi


### PR DESCRIPTION
The test name should match the filename.

In the check-result task, the check for 0 calls
was not working properly - with 0 calls of the mock there will be no mock_curl.txt.

Also, the readme said the secretName parameter was optional, but it's mandatory.

This is related to https://github.com/redhat-appstudio/release-service-catalog/pull/329