### PR TITLE
fix(RHTAPBUGS-1017): only call slack task when secret name is set

### DIFF
--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -19,6 +19,10 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
 
+## Changes in 1.3.1
+- `send-slack-notification` task is only called if slack notification secret is set in data file
+  - the taskrun would fail to start with an empty `secretName` parameter
+
 ## Changes in 1.3.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
 - taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -319,6 +319,10 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/send-slack-notification/send-slack-notification.yaml
+      when:
+        - input: $(tasks.collect-slack-notification-params.results.slack-notification-secret)
+          operator: notin
+          values: [""]
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
The task mounts the secret as a volume. It has the "optional" flag so it works even if that secret does not exists. But it does not work if the secret name is an empty string. So this task shouldn't even be called in such case.