### PR TITLE
chore(RHTAPREL-788): remove taskGitRevision default from READMEs

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -14,7 +14,10 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 0.12.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -16,7 +16,10 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 0.3.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -15,7 +15,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | development                                                            |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | See Note Below                                                  |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ### Changes in 1.6.0
 - add new parameter `buildTimestamp` when calling the `publish-index-image` task

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -15,7 +15,10 @@ Tekton pipeline to release Snapshots to an external registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 2.0.0
 - Pipeline renamed from `release` to `push-to-external-registry`

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -15,7 +15,10 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 1.0.1
 - Fixed bug where pipeline execution didn't wait for verify-enterprise-contract task to succeed

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -15,7 +15,10 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | main |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 2.0.0
 - Renamed pipeline from `push-to-external-registry` to `rh-push-to-external-registry`

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -15,7 +15,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 1.7.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -17,7 +17,10 @@
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+
+* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
+  in the README, but it can be found by looking in the pipeline yaml definition.
 
 ## Changes in 1.3.1
 - `send-slack-notification` task is only called if slack notification secret is set in data file


### PR DESCRIPTION
Remove the taskGitRevision default value from the pipeline READMEs. This commit also adds a note explaining that the value comes from the current branch and that it can be found in the pipeline yaml definition.