### PR TITLE
chore(RHTAPREL-790): remove default taskGitRevision

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -14,10 +14,11 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 0.13.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 0.12.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.12.0"
+    app.kubernetes.io/version: "0.13.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -16,10 +16,11 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 0.4.0
+* taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 0.3.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -43,7 +43,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -15,10 +15,11 @@ Tekton release pipeline to interact with FBC Pipeline
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | See Note Below                                                  |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+### Changes in 1.7.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ### Changes in 1.6.0
 - add new parameter `buildTimestamp` when calling the `publish-index-image` task

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -15,10 +15,11 @@ Tekton pipeline to release Snapshots to an external registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 2.1.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 2.0.0
 - Pipeline renamed from `release` to `push-to-external-registry`

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -15,10 +15,11 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 1.1.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 1.0.1
 - Fixed bug where pipeline execution didn't wait for verify-enterprise-contract task to succeed

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,7 +47,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -15,10 +15,11 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 2.1.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 2.0.0
 - Renamed pipeline from `push-to-external-registry` to `rh-push-to-external-registry`

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -15,10 +15,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 1.8.0
+* taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 1.7.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -17,10 +17,11 @@
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | See Note Below |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-* Note: The default taskGitRevision value is taken from whatever branch of release-service-catalog the file is in. It is not maintained
-  in the README, but it can be found by looking in the pipeline yaml definition.
+## Changes in 1.4.0
+- taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
 
 ## Changes in 1.3.1
 - `send-slack-notification` task is only called if slack notification secret is set in data file

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
   workspaces:
     - name: release-workspace
   tasks:


### PR DESCRIPTION
This commit removes the default taskGitRevision value from the pipeline yaml definitions. The value will come from the operator instead. This allows us to keep the development, staging, and production branches more closely in sync.