### PR TITLE
feat(RHTAPBUGS-1077): add pipelinerun uids to IR labels

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -16,6 +16,9 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.13.1
+- The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
+
 ## Changes in 0.13.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: deploy-release
   labels:
-    app.kubernetes.io/version: "0.13.0"
+    app.kubernetes.io/version: "0.13.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -174,6 +174,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -18,6 +18,9 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.4.1
+* The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
+
 ## Changes in 0.4.0
 * taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -120,6 +120,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 1.7.1
+- tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
+
 ### Changes in 1.7.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.7.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -242,6 +242,8 @@ spec:
           value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
         - name: fromIndex
           value: "$(tasks.update-ocp-tag.results.updated-fromIndex)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - verify-enterprise-contract
     - name: extract-requester-from-release
@@ -293,6 +295,8 @@ spec:
           value: $(tasks.extract-index-image.results.indexImageResolved)
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       when:
         - input: "$(tasks.add-fbc-contribution-to-index-image.results.mustSignIndexImage)"
           operator: in
@@ -337,6 +341,8 @@ spec:
           value: $(tasks.add-fbc-contribution-to-index-image.results.buildTimestamp)
         - name: retries
           value: "3"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       when:
         - input: $(tasks.add-fbc-contribution-to-index-image.results.mustPublishIndexImage)
           operator: in
@@ -361,6 +367,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -17,6 +17,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 2.1.1
+- The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
+
 ## Changes in 2.1.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -216,6 +216,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -17,6 +17,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.1.1
+- Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
+
 ## Changes in 1.1.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -263,6 +263,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: binariesPath
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - base64-encode-checksum
         - extract-requester-from-release
@@ -331,6 +333,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -17,6 +17,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 2.1.1
+- Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
+
 ## Changes in 2.1.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -270,6 +270,8 @@ spec:
           value: ".fileUpdates"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - push-sbom-to-pyxis
       taskRef:
@@ -303,6 +305,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -17,6 +17,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.8.1
+* Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
+
 ## Changes in 1.8.0
 * taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.8.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -263,6 +263,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: commonTags
           value: $(tasks.push-snapshot.results.commonTags)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -349,6 +351,8 @@ spec:
           value: ".fileUpdates"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - push-sbom-to-pyxis
       taskRef:
@@ -382,6 +386,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -19,6 +19,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.4.1
+- The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
+
 ## Changes in 1.4.0
 - taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
   the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -354,6 +354,8 @@ spec:
       params:
         - name: subdirectory
           value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: input
           workspace: release-workspace

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -4,13 +4,18 @@ Task to create a internalrequest to add fbc contributions to index images
 
 ## Parameters
 
-| Name           | Description                                                               | Optional | Default value        |
-|----------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
-| dataPath       | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
-| requestTimeout | InternalRequest timeout                                                   | Yes      | 180                  |
-| binaryImage    | binaryImage value updated by update-ocp-tag task                          | No       |                      |
-| fromIndex      | fromIndex value updated by update-ocp-tag task                            | No       |                      |
+| Name           | Description                                                                               | Optional | Default value        |
+|----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | Yes      | snapshot_spec.json   |
+| dataPath       | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json            |
+| requestTimeout | InternalRequest timeout                                                                   | Yes      | 180                  |
+| binaryImage    | binaryImage value updated by update-ocp-tag task                                          | No       |                      |
+| fromIndex      | fromIndex value updated by update-ocp-tag task                                            | No       |                      |
+| pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
+
+## changes in 2.0.0
+- The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
 
 ## changes in 1.5.0
 - add the result `buildTimestamp` to be used in the downstream tasks

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "1.5.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,6 +30,9 @@ spec:
       type: string
       default: "180"
       description: InternalRequest timeout
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   results:
     - name: buildTimestamp
       description: Build timestamp used in the tag
@@ -50,7 +53,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: add-contribution
-      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/usr/bin/env sh
         #
@@ -97,6 +100,8 @@ spec:
         echo -n $timestamp > $(results.buildTimestamp.path)
         echo -n $target_index > $(results.requestTargetIndex.path)
 
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
         # The internal-request script will create the InternalRequest and wait until it finishes to get its status
         # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
         echo "Creating InternalRequest to add FBC contribution to index image:"
@@ -113,6 +118,7 @@ spec:
             -p addArches=${add_arches} \
             -p hotfix=${hotfix} \
             -p stagedIndex=${staged_index} \
+            -l ${pipelinerun_label}=$(params.pipelineRunUid) \
             -t $(params.requestTimeout) |tee $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log
 
         internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-$(context.taskRun.uid)-output.log | xargs)

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -56,6 +56,8 @@ spec:
           value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -52,6 +52,8 @@ spec:
           value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -54,6 +54,8 @@ spec:
           value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/create-advisory-internal-request/README.md
+++ b/tasks/create-advisory-internal-request/README.md
@@ -5,14 +5,19 @@ the ReleasePlanAdmission and Application from the Snapshot are also used. The ad
 
 ## Parameters
 
-| Name                     | Description                                                             | Optional | Default value               |
-|--------------------------|-------------------------------------------------------------------------|----------|-----------------------------|
-| jsonKey                  | The json key containing the advisory data                               | Yes      | .advisory                   |
-| releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the data workspace | Yes      | release_plan_admission.json |
-| snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace        | Yes      | snapshot_spec.json          |
-| dataPath                 | Path to data JSON in the data workspace                                 | Yes      | data.json                   |
-| request                  | Type of request to be created                                           | Yes      | create-advisory             |
-| synchronously            | Whether the task should wait for InternalRequests to complete           | Yes      | true                        |
+| Name                     | Description                                                                               | Optional | Default value               |
+|--------------------------|-------------------------------------------------------------------------------------------|----------|-----------------------------|
+| jsonKey                  | The json key containing the advisory data                                                 | Yes      | .advisory                   |
+| releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the data workspace                   | Yes      | release_plan_admission.json |
+| snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | Yes      | snapshot_spec.json          |
+| dataPath                 | Path to data JSON in the data workspace                                                   | Yes      | data.json                   |
+| request                  | Type of request to be created                                                             | Yes      | create-advisory             |
+| synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |
+
+## Changes in 1.0.0
+- The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
 
 ## Changes since 0.1.0
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-internal-request
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,12 +36,15 @@ spec:
       type: string
       description: Whether the task should wait for InternalRequests to complete
       default: "true"
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: Workspace where the json files are stored
   steps:
     - name: run-script
-      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/bin/sh
         #
@@ -57,12 +60,15 @@ spec:
         # Extract the advisory key from the data JSON file
         advisoryData=$(jq -c "$(params.jsonKey)" $(workspaces.data.path)/$(params.dataPath))
 
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
         echo "Creating InternalRequest to create advisory..."
         internal-request -r "$(params.request)" \
                          -p application="${application}" \
                          -p origin="${origin}" \
                          -p advisory_json="${advisoryData}" \
                          -s "$(params.synchronously)" \
+                         -l ${pipelinerun_label}=$(params.pipelineRunUid) \
                          > $(workspaces.data.path)/ir-result.txt || \
                          (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
         

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
@@ -82,6 +82,8 @@ spec:
           value: "data.json"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
@@ -57,6 +57,8 @@ spec:
           value: "data.json"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-snapshot.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-snapshot.yaml
@@ -81,6 +81,8 @@ spec:
           value: "data.json"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
@@ -91,6 +91,8 @@ spec:
           value: "data.json"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:

--- a/tasks/publish-index-image/README.md
+++ b/tasks/publish-index-image/README.md
@@ -4,16 +4,21 @@ Publish a built FBC index image using skopeo
 
 ## Parameters
 
-| Name           | Description                                                             | Optional | Default value |
-|----------------|-------------------------------------------------------------------------|----------|---------------|
-| dataPath       | Path to the JSON string of the merged data to use in the data workspace | Yes      | data.json     |
-| sourceIndex    | Pullspec to pull the image from                                         | No       |               |
-| targetIndex    | Pullspec to push the image to                                           | No       |               |
-| retries        | Number of skopeo retries                                                | Yes      | 0             |
-| requestTimeout | Max seconds waiting for the status update                               | Yes      | 360           |
-| buildTimestamp | Build timestamp for the publishing image                                | No       |               |
+| Name           | Description                                                                               | Optional | Default value |
+|----------------|-------------------------------------------------------------------------------------------|----------|---------------|
+| dataPath       | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json     |
+| sourceIndex    | Pullspec to pull the image from                                                           | No       |               |
+| targetIndex    | Pullspec to push the image to                                                             | No       |               |
+| retries        | Number of skopeo retries                                                                  | Yes      | 0             |
+| requestTimeout | Max seconds waiting for the status update                                                 | Yes      | 360           |
+| buildTimestamp | Build timestamp for the publishing image                                                  | No       |               |
+| pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |               |
 
 ## Changelog
+
+### Changes in 3.0.0
+- The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
 
 ### Changes in 2.0.0
 - Add the parameter `buildTimestamp` to push also a timestamp-based tag

--- a/tasks/publish-index-image/publish-index-image.yaml
+++ b/tasks/publish-index-image/publish-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-index-image
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -33,6 +33,9 @@ spec:
     - name: buildTimestamp
       type: string
       description: Build timestamp for the publishing image
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: Workspace to store the params and responses for the internalRequest
@@ -42,7 +45,7 @@ spec:
   steps:
     - name: publish-index-image
       image: >-
-        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+        quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/usr/bin/env sh
         set -e
@@ -55,6 +58,7 @@ spec:
 
         request="publish-index-image-pipeline"
         credentials=$(jq -r '.fbc.publishingCredentials' $DATA_FILE)
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         publishingImages=($(params.targetIndex))
         # only publish the extra timestamp-based tag if the targetIndex does not have it already
@@ -73,7 +77,8 @@ spec:
                 -p targetIndex=${publishingImages[$i]} \
                 -p publishingCredentials=${credentials} \
                 -p retries=$(params.retries) \
-                -t $(params.requestTimeout)
+                -t $(params.requestTimeout) \
+                -l ${pipelinerun_label}=$(params.pipelineRunUid)
             echo "=== done"
             echo ""
             echo ""

--- a/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -41,6 +41,8 @@ spec:
           value: 11111111111
         - name: retries
           value: 2
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/publish-index-image/tests/test-publish-index-image.yaml
@@ -41,6 +41,8 @@ spec:
           value: 11111111111
         - name: retries
           value: 2
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -4,14 +4,19 @@ Task to create internalrequests to sign snapshot components
 
 ## Parameters
 
-| Name            | Description                                                               | Optional | Default value        |
-|-----------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
-| dataPath        | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
-| requester       | Name of the user that requested the signing, for auditing purpose         | No       |                      |
-| commonTags      | Space separated list of common tags to be used when publishing            | No       |                      |
-| requestTimeout  | InternalRequest timeout                                                   | Yes      | 180                  |
-| concurrentLimit | The maximum number of images to be processed at once                      | Yes      | 4                    |
+| Name            | Description                                                                               | Optional | Default value        |
+|-----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | Yes      | snapshot_spec.json   |
+| dataPath        | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json            |
+| requester       | Name of the user that requested the signing, for auditing purpose                         | No       |                      |
+| commonTags      | Space separated list of common tags to be used when publishing                            | No       |                      |
+| requestTimeout  | InternalRequest timeout                                                                   | Yes      | 180                  |
+| concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
+| pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
+
+## Changes in 2.0.0
+* The internalrequest CRs are created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  * This change comes with a bump in the image used for the task
 
 ## Changes in 1.2.0
 * Optimize the task to process multiple images in parallel. This will improve the performance of the task.

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,18 +34,23 @@ spec:
       type: string
       description: The maximum number of images to be processed at once
       default: 4
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/redhat-appstudio/release-service-utils:4713b58df57b06e5ca248f1c8227a8493ceb5b01
+      image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/usr/bin/env sh
         #
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         RUNDIR="$(workspaces.data.path)/$(context.taskRun.uid)"
-        IDENTIFIER=$(context.taskRun.uid)
+        TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
+        TASK_ID=$(context.taskRun.uid)
+        PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -92,15 +97,16 @@ spec:
                   -p manifest_digest=${manifest_digest} \
                   -p requester=$(params.requester) \
                   -p config_map_name=${config_map_name} \
-                  -i $IDENTIFIER \
+                  -l ${TASK_LABEL}=${TASK_ID} \
+                  -l ${PIPELINERUN_LABEL}=$(params.pipelineRunUid) \
                   -s false
               ((++count))
 
               if [ "$count" -eq "$N" ]; then
-                  wait-for-ir -i $IDENTIFIER -t $(params.requestTimeout)
+                  wait-for-ir -l ${TASK_LABEL}=${TASK_ID} -t $(params.requestTimeout)
                   count=0
               fi
             done
         done
-        wait-for-ir -i $IDENTIFIER -t $(params.requestTimeout)
+        wait-for-ir -l ${TASK_LABEL}=${TASK_ID} -t $(params.requestTimeout)
         echo "done"

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -53,6 +53,8 @@ spec:
           value: testuser-failure
         - name: commonTags
           value: "some-prefix-12345 some-prefix"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -61,6 +61,8 @@ spec:
           value: testuser-multiple
         - name: commonTags
           value: "some-prefix-12345 some-prefix"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -51,6 +51,8 @@ spec:
           value: testuser-single
         - name: commonTags
           value: "some-prefix-12345 some-prefix"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -59,6 +59,8 @@ spec:
           value: "some-prefix-12345 some-prefix"
         - name: requestTimeout
           value: 1
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/run-file-updates/README.md
+++ b/tasks/run-file-updates/README.md
@@ -5,15 +5,20 @@ the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 
 ## Parameters
 
-| Name            | Description                                                        | Optional | Default value            |
-|-----------------|--------------------------------------------------------------------|----------|--------------------------|
-| jsonKey         | JSON key where the information is defined                          | Yes      | .spec.data.fileUpdates[] |
-| fileUpdatesPath | Path to the JSON file containing the key                           | No       |                          |
-| snapshotPath    | Path to the JSON string of the Snapshot spec in the data workspace | No       | snapshot_spec.json       |
-| request         | Type of request to be created                                      | Yes      | file-updates             |
-| synchronously   | Whether the task should wait for InternalRequests to complete      | Yes      | true                     |
+| Name            | Description                                                                               | Optional | Default value            |
+|-----------------|-------------------------------------------------------------------------------------------|----------|--------------------------|
+| jsonKey         | JSON key where the information is defined                                                 | Yes      | .spec.data.fileUpdates[] |
+| fileUpdatesPath | Path to the JSON file containing the key                                                  | No       |                          |
+| snapshotPath    | Path to the JSON string of the Snapshot spec in the data workspace                        | No       | snapshot_spec.json       |
+| request         | Type of request to be created                                                             | Yes      | file-updates             |
+| synchronously   | Whether the task should wait for InternalRequests to complete                             | Yes      | true                     |
+| pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                          |
 
 ## Changelog
+
+## Changes in 1.0.0
+- The internalrequest CRs are created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
 
 ## Changes since 0.5.0
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/run-file-updates/run-file-updates.yaml
+++ b/tasks/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,12 +31,15 @@ spec:
       type: string
       description: Whether to run synchronously or not
       default: "true"
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: Workspace where the file updates to apply are defined
   steps:
     - name: run-script
-      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/bin/sh
         #
@@ -48,6 +51,8 @@ spec:
         
         # Extract the key from the JSON file
         fileUpdates=$(jq -rc "$(params.jsonKey)" $(workspaces.data.path)/$(params.fileUpdatesPath))
+
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
   
         # Iterate over the extracted array and call the script
         fileUpdatesLength=$(jq '. | length' <<< "${fileUpdates}")
@@ -73,6 +78,7 @@ spec:
                            -p paths="${updatedPaths}" \
                            -p application=${application} \
                            -s "$(params.synchronously)" \
+                           -l ${pipelinerun_label}=$(params.pipelineRunUid) \
                            > $(workspaces.data.path)/ir-result.txt || \
                            (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
           

--- a/tasks/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/run-file-updates/tests/test-run-file-updates.yaml
@@ -81,6 +81,8 @@ spec:
           value: "rpa.json"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:

--- a/tasks/sign-base64-blob/README.md
+++ b/tasks/sign-base64-blob/README.md
@@ -4,15 +4,16 @@ Creates an InternalRequest to sign a base64 encoded blob
 
 ## Parameters
 
-| Name                 | Description                                                             | Optional | Default value          |
-|----------------------|-------------------------------------------------------------------------|----------|------------------------|
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace | Yes      | data.json              |
-| request              | Signing pipeline name to handle this request                            | Yes      | hacbs-signing-pipeline |
-| referenceImage       | The image to be signed                                                  | No       |                        |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                           | Yes      | ""                     |
-| requester            | Name of the user that requested the signing, for auditing purposes      | No       |                        |
-| requestTimeout       | InternalRequest timeout                                                 | Yes      | 180                    |
-| binariesPath         | The directory inside the workspace where the binaries are stored        | Yes      | binaries               |
+| Name                 | Description                                                                               | Optional | Default value          |
+|----------------------|-------------------------------------------------------------------------------------------|----------|------------------------|
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json              |
+| request              | Signing pipeline name to handle this request                                              | Yes      | hacbs-signing-pipeline |
+| referenceImage       | The image to be signed                                                                    | No       |                        |
+| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                     |
+| requester            | Name of the user that requested the signing, for auditing purposes                        | No       |                        |
+| requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
+| binariesPath         | The directory inside the workspace where the binaries are stored                          | Yes      | binaries               |
+| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                        |
 
 ## Signing data parameters
 
@@ -25,6 +26,10 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+## Changes in 2.0.0
+- The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
+
 ## Changes in 1.0.2
 - Save the `.sig` file as a non-ASCII armored GPG binary instead of clear ASCII GPG signature
 

--- a/tasks/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,13 +34,16 @@ spec:
       type: string
       description: The directory inside the workspace where the binaries are stored
       default: binaries
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: workspace to read and save files
   steps:
     - name: sign-base64-blob
       image:
-        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+        quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/usr/bin/env sh
         set -ex
@@ -57,6 +60,7 @@ spec:
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' ${DATA_FILE})
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         echo "Creating InternalRequest to sign blob:"
         echo "- blob=$(params.blob)"
@@ -68,6 +72,7 @@ spec:
             -p requester=$(params.requester) \
             -p config_map_name=${config_map_name} \
             -t $(params.requestTimeout) \
+            -l ${pipelinerun_label}=$(params.pipelineRunUid) \
             > $(workspaces.data.path)/ir-result.txt || \
             (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
           

--- a/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -43,6 +43,8 @@ spec:
           value: test-blob
         - name: binariesPath
           value: binaries
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -4,14 +4,15 @@ Creates an InternalRequest to sign an index image
 
 ## Parameters
 
-| Name                 | Description                                                             | Optional | Default value          |
-|----------------------|-------------------------------------------------------------------------|----------|------------------------|
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace | Yes      | data.json              |
-| request              | Signing pipeline name to handle this request                            | Yes      | hacbs-signing-pipeline |
-| referenceImage       | The image to be signed                                                  | No       |                        |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                           | Yes      | ""                     |
-| requester            | Name of the user that requested the signing, for auditing purposes      | No       |                        |
-| requestTimeout       | InternalRequest timeout                                                 | Yes      | 180                    |
+| Name                 | Description                                                                               | Optional | Default value          |
+|----------------------|-------------------------------------------------------------------------------------------|----------|------------------------|
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json              |
+| request              | Signing pipeline name to handle this request                                              | Yes      | hacbs-signing-pipeline |
+| referenceImage       | The image to be signed                                                                    | No       |                        |
+| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                     |
+| requester            | Name of the user that requested the signing, for auditing purposes                        | No       |                        |
+| requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
+| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                        |
 
 ## Signing data parameters
 
@@ -25,6 +26,10 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 2.0.0
+- The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
+  - This change comes with a bump in the image used for the task
 
 ## Changes in 1.2.1
 - add image pullspec rewriting

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "1.2.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,13 +34,16 @@ spec:
       type: string
       default: "180"
       description: InternalRequest timeout
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
   workspaces:
     - name: data
       description: workspace to read and save files
   steps:
     - name: sign-index-image
       image:
-        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+        quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
       script: |
         #!/usr/bin/env sh
         set -e
@@ -63,6 +66,7 @@ spec:
         else
           manifest_digest="${reference_image#*@}"
         fi
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
@@ -80,5 +84,6 @@ spec:
             -p manifest_digest=${manifest_digest} \
             -p requester=$(params.requester) \
             -p config_map_name=${config_map_name} \
-            -t $(params.requestTimeout)
+            -t $(params.requestTimeout) \
+            -l ${pipelinerun_label}=$(params.pipelineRunUid)
         echo "done"

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -40,6 +40,8 @@ spec:
           value: quay.io/redhat/redhat----testimage:tag
         - name: manifestDigestImage
           value: quay.io/redhat/redhat----testimage@sha256:0000
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image.yaml
@@ -40,6 +40,8 @@ spec:
           value: quay.io/testrepo/testimage:tag
         - name: manifestDigestImage
           value: quay.io/testrepo/testimage@sha256:0000
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
All tasks that create internalrequests will now add a label that specifies the pipelinerun uid. We can use these to clean them up at the end of the pipelinerun. The change also required a new image for each task using internalrequests.