### PR TITLE
feat(RHTAPBUGS-1077): cleanup-workspace removes IRs

### DIFF
--- a/tasks/cleanup-workspace/README.md
+++ b/tasks/cleanup-workspace/README.md
@@ -1,31 +1,17 @@
 # cleanup-workspace
 
-Tekton task to delete a given directory in a passed workspace.
+Tekton task to delete a given directory in a passed workspace and cleanup InternalRequests related to the current PipelineRun.
 
 ## Parameters
 
-| Name         | Description                                                                                                      | Optional | Default value |
-|--------------|------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| subdirectory | The directory to remove within the workspace                                                                     | No       | -             |
-| delay        | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
+| Name           | Description                                                                                                      | Optional | Default value |
+|----------------|------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| subdirectory   | The directory to remove within the workspace                                                                     | No       | -             |
+| delay          | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
+| pipelineRunUid | The uid of the current pipelineRun. It is only available at the pipeline level                                   | Yes      | ""            |
 
-## Example usage
-
-This is an example usage of the `cleanup-workpace` task:
-
-```
----
-tasks:
-  - name: cleanup-workspace
-    taskRef:
-      name: cleanup-workspace
-    params:
-      - name: subdirectory
-        value: "some/directory"
-    workspaces:
-      - name: input
-        workspace: input_workspace
-```
+## Changes in 0.6.0
+* The task now removes all internalrequest CRs for the current pipelinerun via the pipelineRunUid parameter
 
 ## Changes since 0.4.0
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/cleanup-workspace/cleanup-workspace.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: cleanup-workspace
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -19,6 +19,10 @@ spec:
       type: string
       default: 60
       description: Time in seconds to delay the cleanup action
+    - name: pipelineRunUid
+      type: string
+      default: ""
+      description: The uid of the current pipelineRun. It is only available at the pipeline level
   workspaces:
     - name: input
       description: Workspace where the directory to cleanup exists
@@ -28,6 +32,12 @@ spec:
       script: |
         #!/usr/bin/env sh
         set -eux
+
+        if [ -n "$(params.pipelineRunUid)" ] ; then
+            # Cleanup all internalrequests
+            kubectl delete internalrequest \
+                -l internal-services.appstudio.openshift.io/pipelinerun-uid=$(params.pipelineRunUid)
+        fi
 
         if [ -z "$(params.subdirectory)" ] ; then
             echo "The empty string is not a valid subdirectory"

--- a/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
+++ b/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get internalrequests
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
 
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-cleanup-workspace-internalrequests
+spec:
+  description: |
+    Run the cleanup-workspace task with internalrequests created
+    to ensure the proper ones are cleaned up
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      params:
+        - name: uid
+          value: $(context.pipelineRun.uid)
+      taskSpec:
+        params:
+          - name: uid
+            type: string
+        steps:
+          - name: create-crs
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > irs << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: InternalRequest
+              metadata:
+                name: ir-1
+              spec:
+                request: foo
+              ---
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: InternalRequest
+              metadata:
+                name: ir-2
+                labels:
+                  internal-services.appstudio.openshift.io/pipelinerun-uid: $(params.uid)
+              spec:
+                request: foo
+              EOF
+              kubectl apply -f irs
+    - name: run-task
+      taskRef:
+        name: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: ""
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: input
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/bin/sh
+              set -ex
+
+              # Make sure ir-1 was not deleted
+              if ! kubectl get internalrequest ir-1 ; then
+                  echo "InternalRequest ir-1 was deleted and should not have been"
+                  exit 1
+              fi
+
+              # Make sure ir-2 was deleted
+              if kubectl get internalrequest ir-2 ; then
+                  echo "InternalRequest ir-2 was not deleted and should have been"
+                  exit 1
+              fi
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit modifies the cleanup-workspace task to remove all InternalRequests that have a label specifying the current pipelineRun uid.