### PR TITLE
chore(RHTAPREL-335): add scoped tag to pre-GA images

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 1.8.0
+- the task `add-fbc-contribution` now requires the `targetIndex` parameter set with the `updated-targetIndex`
+  result from the task `update-ocp-tag`
+
 ### Changes in 1.7.1
 - tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -242,6 +242,8 @@ spec:
           value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
         - name: fromIndex
           value: "$(tasks.update-ocp-tag.results.updated-fromIndex)"
+        - name: targetIndex
+          value: "$(tasks.update-ocp-tag.results.updated-targetIndex)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -12,6 +12,11 @@ Task to create a internalrequest to add fbc contributions to index images
 | binaryImage    | binaryImage value updated by update-ocp-tag task                                          | No       |                      |
 | fromIndex      | fromIndex value updated by update-ocp-tag task                                            | No       |                      |
 | pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
+| targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       |                      |
+
+## changes in 2.1.0
+- add the parameter `targetIndex` to receive the `updated-targetIndex` result from
+  the task `update-ocp-tag` as input
 
 ## changes in 2.0.0
 - The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,6 +26,9 @@ spec:
     - name: fromIndex
       type: string
       description: fromIndex value updated by update-ocp-tag task
+    - name: targetIndex
+      type: string
+      description: targetIndex value updated by update-ocp-tag task
     - name: requestTimeout
       type: string
       default: "180"
@@ -79,24 +82,38 @@ spec:
         build_tags=$(jq '.fbc.buildTags // []' ${DATA_FILE})
         add_arches=$(jq '.fbc.addArches // []' ${DATA_FILE})
         hotfix=$(jq -r '.fbc.hotfix // "false"' ${DATA_FILE})
+        pre_ga=$(jq -r '.fbc.preGA // "false"' ${DATA_FILE})
         staged_index=$(jq -r '.fbc.stagedIndex // "false"' ${DATA_FILE})
+        product_name=$(jq -r '.fbc.productName // ""' ${DATA_FILE})
+        product_version=$(jq -r '.fbc.productVersion // ""' ${DATA_FILE})
         build_timeout_seconds=$(jq -r --arg build_timeout_seconds ${default_build_timeout_seconds} \
             '.fbc.buildTimeoutSeconds // $build_timeout_seconds' ${DATA_FILE})
-        target_index=$(jq -r '.fbc.targetIndex' ${DATA_FILE})
         fbc_fragment=$(jq -cr '.components[0].containerImage' ${SNAPSHOT_PATH})
 
         timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' ${DATA_FILE})
         timestamp=$(date "+${timestamp_format}")
 
+        # default target_index
+        target_index=$(params.targetIndex)
+
+        # the target_index is modified when the pipelinerun is a for `hotfix` or a `pre-GA` release
         if [ "${hotfix}" == "true" ]; then
           issue_id=$(jq -r '.fbc.issueId // empty' ${DATA_FILE})
           if [ -z "${issue_id}" ]; then
-            echo "Hotfix releases requires the issue id."
+            echo "Hotfix releases requires the issue id set in the `fbc.issueId` key of the ReleasePlanAdmission " \
+                 "spec.data field"
             exit 1
           fi
-          tag="${issue_id}-${timestamp}"
-          target_index="${target_index}-${tag}"
+          target_index="${target_index}-${issue_id}-${timestamp}"
+        elif [ "${pre_ga}" == "true" ]; then
+          if [ -z "${product_name}" -o -z "${product_version}" ]; then
+            echo "Pre-GA releases require `fbc.productName` and `fbc.productVersion` set in the ReleasePlanAdmission " \
+                 "`spec.data` field"
+            exit 1
+          fi
+          target_index="${target_index}-${product_name}-${product_version}-${timestamp}"
         fi
+
         echo -n $timestamp > $(results.buildTimestamp.path)
         echo -n $target_index > $(results.requestTargetIndex.path)
 

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -41,7 +41,6 @@ spec:
                   "iibServiceConfigSecret": "test-iib-service-config-secret",
                   "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
-                  "targetIndex": "quay.io/scoheb/fbc-target-index-testing:latest",
                   "hotfix": true,
                   "issueId": "bz123456",
                   "buildTimeoutSeconds": 420
@@ -56,6 +55,8 @@ spec:
           value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: targetIndex
+          value: "quay.io/scoheb/fbc-target-index-testing:v4.12"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:
@@ -125,7 +126,7 @@ spec:
 
               TS=1696946200 # ts set in the mocked `date`
               value=$(jq -r '.targetIndex' <<< "${requestParams}")
-              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:latest-bz123456-${TS}" ]; then
+              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:v4.12-bz123456-${TS}" ]; then
                 echo "targetIndex does not match"
                 exit 1
               fi

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -2,9 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-add-fbc-contribution
+  name: test-add-fbc-contribution-pre-ga
 spec:
-  description: Test creating a internal request for the IIB pipeline
+  description: Test the add-fbc-contribution task InternalRequest creation using
+    pre-GA data.fbc parameters
   workspaces:
     - name: tests-workspace
   tasks:
@@ -41,6 +42,9 @@ spec:
                   "iibServiceConfigSecret": "test-iib-service-config-secret",
                   "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "preGA": "true",
+                  "productName": "pre-ga-product",
+                  "productVersion": "v2",
                   "buildTimeoutSeconds": 420
                 }
               }
@@ -92,12 +96,6 @@ spec:
                 exit 1
               fi
 
-              if [ $(jq -r '.targetIndex' <<< "${requestParams}") != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]
-              then
-                echo "targetIndex does not match"
-                exit 1
-              fi
-
               if [ $(jq -r '.fromIndex' <<< "${requestParams}") != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"
                 exit 1
@@ -121,6 +119,13 @@ spec:
                 echo "fbcFragment does not match"
                 exit 1
               fi
+
+              TS=1696946200 # ts set in the mocked `date`
+              value=$(jq -r '.targetIndex' <<< "${requestParams}")
+              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:v4.12-pre-ga-product-v2-${TS}" ]; then
+                echo "targetIndex does not match"
+                exit 1
+              fi
       runAfter:
         - run-task
   finally:
@@ -132,5 +137,5 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -52,6 +52,8 @@ spec:
           value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: targetIndex
+          value: "quay.io/scoheb/fbc-index-testing:v4.12"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:


### PR DESCRIPTION
This PR modify the task add-fbc-contribution to allow scoped tags
for pre-GA builds. With this change the releasePlanAdmission for
pre-GA builds should also contain the parameters `fbc.productName`
and `fbc.productVersion`.