### PR TITLE
fix: generate a non-ascii binary signature

### DIFF
--- a/tasks/sign-base64-blob/README.md
+++ b/tasks/sign-base64-blob/README.md
@@ -25,6 +25,8 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+## Changes in 1.0.2
+- Save the `.sig` file as a non-ASCII armored GPG binary instead of clear ASCII GPG signature
 
 ## Changes in 1.0.1
 - Now the task decodes the payload from base64 before creating the `.sig` file

--- a/tasks/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -78,5 +78,7 @@ spec:
         decoded_payload=$(echo -n $payload | base64 -d)
 
         # Build .sig file
-        checksum_file_name=$(ls $(workspaces.data.path)/$(params.binariesPath) | grep SHA256SUMS) 
-        echo -n $decoded_payload | tee $(workspaces.data.path)/$(params.binariesPath)/${checksum_file_name}.sig
+        checksum_file_name=$(ls $(workspaces.data.path)/$(params.binariesPath) | grep SHA256SUMS)
+        echo -n "$decoded_payload" \
+        | gpg --dearmor \
+        | tee "$(workspaces.data.path)/$(params.binariesPath)/${checksum_file_name}.sig"

--- a/tasks/sign-base64-blob/tests/mocks.sh
+++ b/tasks/sign-base64-blob/tests/mocks.sh
@@ -23,3 +23,7 @@ function kubectl() {
 
   echo -n "dummy-payload" | base64
 }
+
+function gpg() {
+  echo -n "dummy-payload" 	
+}


### PR DESCRIPTION
GPG signature needed should be a non-ASCII binary file as generated in a `gpg --detach-sign` command. Now we are getting a clear ASCII GPG signature file.

More context:
https://issues.redhat.com/browse/ISV-4394
https://developer.hashicorp.com/terraform/registry/providers/publishing#manually-preparing-a-release

/cc @ernesgonzalez33 @ralphbean 