### PR TITLE
feat(RHTAPREL-762): support multiple floating tags

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -10,6 +10,17 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
 
+## Changes in 4.0.0
+* floatingTag is replaced by floatingTags in the RPA's data.images field
+  * A list of floating tags is accepted instead of a single string. The logic remains unchanged, with each
+    provided floating tag treated as the single one was previously
+* Digest checking behavior was modified
+  * Previously, a push only happened if the containerImage did not exist at $repository:$tag. This is flawed
+    as we push to multiple tags (git, sha, timestamp...) yet we only checked against the default tag. Now,
+    every push_image call has a check to see if the image already exists at the destination digest
+* For source containers, an image is now pushed to $floatingTag-source as well as the existing
+  $floatingTag-$timestamp-source location
+
 ## Changes since 3.0.0
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
 

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,7 +29,7 @@ spec:
       type: string
       description: >
         Space separated list of common tags for downstream tasks.
-        Only set if floatingTag length in the data JSON is nonzero
+        Only set if floatingTags length in the data JSON is nonzero
   workspaces:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
@@ -40,16 +40,28 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
-        push_image () { # Expected arguments are [name, containerImage, repository, tag]
-          printf '* Pushing component: %s to %s:%s\n' "$1" "$3" "$4"
-          attempt=0
-          until [ "$attempt" -gt "$(params.retries)" ] ; do # 0 retries by default which will execute this once
-            cosign copy -f "$2" "$3:$4" && break
-            attempt=$((attempt+1))
-          done
-          if [ "$attempt" -gt "$(params.retries)" ] ; then
-            echo "Max retries exceeded."
-            exit 1
+        push_image () { # Expected arguments are [source_digest, name, containerImage, repository, tag]
+          # note: Inspection might fail on empty repos, hence `|| true`
+          destination_digest=$(
+            skopeo inspect \
+            --no-tags \
+            --format '{{.Digest}}' \
+            "docker://$4:$5" 2>/dev/null || true)
+
+          if [[ "$destination_digest" != "$1" || -z "$destination_digest" ]]; then
+            printf '* Pushing component: %s to %s:%s\n' "$2" "$4" "$5"
+            attempt=0
+            until [ "$attempt" -gt "$(params.retries)" ] ; do # 0 retries by default which will execute this once
+              cosign copy -f "$3" "$4:$5" && break
+              attempt=$((attempt+1))
+            done
+            if [ "$attempt" -gt "$(params.retries)" ] ; then
+              echo "Max retries exceeded."
+              exit 1
+            fi
+          else
+            printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
+              "$2" "$3"
           fi
         }
 
@@ -65,14 +77,17 @@ spec:
             exit 1
         fi
 
-        floatingTag=$(jq -r '.images.floatingTag // ""' $DATA_FILE)
+        floatingTagsCount=$(jq '.images.floatingTags | length' $DATA_FILE)
         timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
         timestamp="$(date "+$timestampFormat")"
-        if [ -n $floatingTag ]; then
-            echo -n "${floatingTag}-${timestamp} ${floatingTag}" > $(results.commonTags.path)
-        else
-            echo -n "" > $(results.commonTags.path)
+        commonTags=""
+        if [ $floatingTagsCount -gt 0 ]; then
+            for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
+                commonTags="${commonTags}${floatingTag}-${timestamp} ${floatingTag} "
+            done
+            commonTags=${commonTags% }
         fi
+        echo -n $commonTags > $(results.commonTags.path)
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
@@ -82,79 +97,70 @@ spec:
           repository=$(jq -r '.repository' <<< $component)
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
-          #
-          # The tag is determined as follows:
-          #
-          # If `floatingTag` is non-empty, we push to $floatingTag and $floatingTag-$timestamp.
-          #
-          # Otherwise the tag used is the one existent in the component or in case it is absent, it uses
-          # the value set for the task parameter `tag`.
-          #
-          if [ -n "${floatingTag}" ] ; then
-              tag="${floatingTag}-${timestamp}"
-          else
-              defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
-              tag=$(jq -r --arg defaultTag $defaultTag '.tag // $defaultTag' <<< $component)
-          fi
-
           source_digest=$(skopeo inspect \
             --no-tags \
             --format '{{.Digest}}' \
             "docker://${containerImage}" 2>/dev/null)
-          # note: Inspection might fail on empty repos, hence `|| true`
-          destination_digest=$(
-            skopeo inspect \
-            --no-tags \
-            --format '{{.Digest}}' \
-            "docker://${repository}:${tag}" 2>/dev/null || true)
 
-          if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
-            # Push the container image
-            push_image "${name}" "${containerImage}" "${repository}" "${tag}"
-            if [ -n "${floatingTag}" ] ; then
-              push_image "${name}" "${containerImage}" "${repository}" "${floatingTag}"
-            fi
-            if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
-              timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
-              push_image "${name}" "${containerImage}" "${repository}" "$timestamp"
-            fi
-            if [[ $(jq -r ".images.addGitShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
-              if [ "${git_sha}" != "null" ] ; then
-                push_image "${name}" "${containerImage}" "${repository}" "${git_sha:0:7}"
-                push_image "${name}" "${containerImage}" "${repository}" "${git_sha}"
-              else
-                printf 'Asked to create git sha based tag, but no git sha found in %s\n' "${component}"
-                exit 1
-              fi
-            fi
-            if [[ $(jq -r ".images.addSourceShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
-              if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
-              then
-                sha=$(echo "${containerImage}" | cut -d ':' -f 2)
-                push_image "${name}" "${containerImage}" "${repository}" "${sha}"
-              else
-                printf 'Asked to create source sha based tag, but no sha found in %s\n' "${containerImage}"
-                exit 1
-              fi
-            fi
-            # Push the associated source container using the common tag
-            if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
-              # Calculate the source container image based on the provided container image
-              sourceContainer="${containerImage%@sha256:*}:${git_sha}.src"
-              # Check if the source container exists
-              if ! skopeo inspect --no-tags "docker://${sourceContainer}" &>/dev/null; then
-                echo "Error: Source container ${sourceContainer} not found!"
-                exit 1
-              fi
-              if [ -z "$floatingTag" ]; then
-                echo "Error: floatingTag needs to be set when pushing source containers"
-                exit 1
-              fi
-              push_image "${name}" "${sourceContainer}" "${repository}" "${floatingTag}-${timestamp}-source"
-            fi
+          # If `floatingTags` is non-empty, for each of the `floatingTags` we push each image to
+          # $floatingTag and $floatingTag-$timestamp.
+          #
+          # Otherwise the tag used is the one existent in the component or in case it is absent, it uses
+          # the value set for the task parameter `tag`.
+          #
+          if [ $floatingTagsCount -gt 0 ]; then
+            for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
+              # Push the container image
+              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "{floatingTag}"
+              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "{floatingTag}-${timestamp}"
+            done
           else
-            printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
-              "${name}" "$source_digest"
+            defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
+            tag=$(jq -r --arg defaultTag $defaultTag '.tag // $defaultTag' <<< $component)
+            push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${tag}"
+          fi
+          if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
+            timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
+            push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "$timestamp"
+          fi
+          if [[ $(jq -r ".images.addGitShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
+            if [ "${git_sha}" != "null" ] ; then
+              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha:0:7}"
+              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha}"
+            else
+              printf 'Asked to create git sha based tag, but no git sha found in %s\n' "${component}"
+              exit 1
+            fi
+          fi
+          if [[ $(jq -r ".images.addSourceShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
+            if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
+            then
+              sha=$(echo "${containerImage}" | cut -d ':' -f 2)
+              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${sha}"
+            else
+              printf 'Asked to create source sha based tag, but no sha found in %s\n' "${containerImage}"
+              exit 1
+            fi
+          fi
+          # Push the associated source container using the common tags
+          if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
+            # Calculate the source container image based on the provided container image
+            sourceContainer="${containerImage%@sha256:*}:${git_sha}.src"
+            # Check if the source container exists
+            if ! skopeo inspect --no-tags "docker://${sourceContainer}" &>/dev/null; then
+              echo "Error: Source container ${sourceContainer} not found!"
+              exit 1
+            fi
+            if [ $floatingTagsCount -eq 0 ]; then
+              echo "Error: at least one tag must exist in floatingTags when pushing source containers"
+              exit 1
+            fi
+            for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
+              push_image "${source_digest}" "${name}" "${sourceContainer}" \
+                "${repository}" "${floatingTag}-${timestamp}-source"
+              push_image "${source_digest}" "${name}" "${sourceContainer}" \
+                "${repository}" "${floatingTag}-source"
+            done
           fi
         done
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
@@ -78,8 +78,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
-                echo Error: skopeo was expected to be called 2 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 4 ]; then
+                echo Error: skopeo was expected to be called 4 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi

--- a/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
@@ -73,8 +73,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
-                echo Error: skopeo was expected to be called 2 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 3 ]; then
+                echo Error: skopeo was expected to be called 3 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi

--- a/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
@@ -73,8 +73,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
-                echo Error: skopeo was expected to be called 2 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 3 ]; then
+                echo Error: skopeo was expected to be called 3 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi

--- a/tasks/push-snapshot/tests/test-push-snapshot-floatingtags.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-floatingtags.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-floatingtag
+  name: test-push-snapshot-floatingtags
 spec:
   description: |
-    Run the push-snapshot task with floatingTag set
+    Run the push-snapshot task with floatingTags set
   workspaces:
     - name: tests-workspace
   tasks:
@@ -43,7 +43,10 @@ spec:
                   "addGitShaTag": false,
                   "addTimestampTag": false,
                   "addSourceShaTag": false,
-                  "floatingTag": "testtag"
+                  "floatingTags": [
+                    "testtag",
+                    "testtag2"
+                  ]
                 }
               }
               EOF
@@ -79,19 +82,20 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
-                echo Error: cosign was expected to be called 1 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 4 ]; then
+                echo Error: cosign was expected to be called 4 times. Actual calls:
                 cat $(workspaces.data.path)/mock_cosign.txt
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
-                echo Error: skopeo was expected to be called 2 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 5 ]; then
+                echo Error: skopeo was expected to be called 5 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi
 
+              timestamp=$(cat $(workspaces.data.path)/mock_date_epoch.txt)
               [[ "$(params.commonTags)" \
-                ==  "testtag-$(cat $(workspaces.data.path)/mock_date_epoch.txt) testtag" ]]
+                ==  "testtag-$timestamp testtag testtag2-$timestamp testtag2" ]]
       runAfter:
         - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -50,7 +50,9 @@ spec:
                   "addTimestampTag": false,
                   "addSourceShaTag": false,
                   "pushSourceContainer": true,
-                  "floatingTag": "testtag"
+                  "floatingTags": [
+                    "testtag"
+                  ]
                 }
               }
               EOF
@@ -97,6 +99,8 @@ spec:
               copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
               copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
                prod-registry.io/prod-location:testtag-$epoch-source
+              copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
+               prod-registry.io/prod-location:testtag-source
               EOF
 
               if [ $(cat $(workspaces.data.path)/cosign_expected_calls.txt | md5sum)
@@ -109,8 +113,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 3 ]; then
-                echo Error: skopeo was expected to be called 3 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 6 ]; then
+                echo Error: skopeo was expected to be called 6 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi


### PR DESCRIPTION
This commit modifies the push-snapshot task to accept a list of floatingTags in the data.images key of the RPA instead of just a single floatingTag string.