### PR TITLE
feat(RHTAPREL-774): collect-data performs content validation

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -13,6 +13,9 @@ operator passes them as lowercase.
 A task result is returned for each resource with the relative path to the stored JSON for it in the workspace. There is
 also a task result for the fbcFragment extracted from the snapshot's first component.
 
+Finally, the task checks that the keys from the correct resource (a key that should come from the ReleasePlanAdmission
+should not be present in the Release data section).
+
 ## Parameters
 
 | Name                 | Description                                        | Optional | Default value |
@@ -22,6 +25,11 @@ also a task result for the fbcFragment extracted from the snapshot's first compo
 | releaseplanadmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
+
+## Changes in 2.0.0
+  * A second step was added to the task
+    * The step lists keys that are disallowed for each of the three release resources
+    * If any of the disallowed keys are found in the corresponding resource, the check will fail the task
 
 ## Changes since 1.0.1
   * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,13 +4,14 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task to collect data from release resources and optionally save CRs to a workspace
+    Tekton task to collect data from release resources and verify that they do not contain any
+    disallowed fields
   params:
     - name: release
       type: string
@@ -106,3 +107,41 @@ spec:
         DATA_PATH=$(params.subdirectory)/data.json
         echo -n $DATA_PATH > $(results.data.path)
         echo "$merged_output" > $(workspaces.data.path)/$DATA_PATH
+    - name: check-data-key-sources
+      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      script: |
+        #!/usr/bin/env sh
+        set -ex
+
+        DISALLOWED_KEYS_JSON='{
+            "Release": [
+                "releaseNotes.product_id",
+                "releaseNotes.cpe",
+                "releaseNotes.type"
+            ],
+            "ReleasePlan": [
+                "releaseNotes.product_id",
+                "releaseNotes.cpe",
+                "releaseNotes.type"
+            ],
+            "ReleasePlanAdmission": [
+            ]
+        }'
+
+        RC=0
+
+        check_source () { # Expected arguments are [CRD from DISALLOWED_KEYS_JSON, file]
+            for KEY in $(jq -r ".$1[]" <<< $DISALLOWED_KEYS_JSON) ; do
+                if [[ $(jq ".spec.data.$KEY" "$2") != "null" ]] ; then
+                    echo "Found disallowed key: $KEY in resource $1"
+                    RC=1
+                fi
+            done
+        }
+
+        check_source "Release" "$(workspaces.data.path)/$(params.subdirectory)/release.json"
+        check_source "ReleasePlan" "$(workspaces.data.path)/$(params.subdirectory)/release_plan.json"
+        check_source "ReleasePlanAdmission" \
+            "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json"
+
+        exit $RC

--- a/tasks/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -2,17 +2,24 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-with-data
+  name: test-collect-data-fail-disallowed-release
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-data task and verify that data task result is accurate.
+    Run the collect-data task with the disallowed key product_id in the Release data.
   workspaces:
     - name: tests-workspace
   tasks:
     - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
+        workspaces:
+          - name: data
         steps:
-          - name: create-crs
+          - name: setup
             image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
             script: |
               #!/usr/bin/env sh
@@ -22,14 +29,19 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
-                name: release-with-data-sample
+                name: release-disallowed-release-sample
                 namespace: default
               spec:
                 snapshot: foo
                 releasePlan: foo
                 data:
-                  rkey: rvalue
-                  foo: shouldGetOverwritten
+                  releaseNotes:
+                    issues:
+                      - id: issue1
+                        source: github.com
+                      - id: issue2
+                        source: github.com
+                    product_id: 123
               EOF
               kubectl apply -f release
 
@@ -37,14 +49,14 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
               metadata:
-                name: releaseplan-with-data-sample
+                name: releaseplan-disallowed-release-sample
                 namespace: default
               spec:
                 application: foo
                 target: foo
                 data:
-                  foo: bar
-                  one: one
+                  releaseNotes:
+                    synopsis: some text field
               EOF
               kubectl apply -f releaseplan
 
@@ -52,18 +64,12 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlanAdmission
               metadata:
-                name: releaseplanadmission-with-data-sample
+                name: releaseplanadmission-disallowed-release-sample
                 namespace: default
               spec:
                 applications:
                   - foo
                 origin: foo
-                data:
-                  one:
-                    two: three
-                    four:
-                      - five
-                      - six
                 policy: foo
                 pipeline:
                   pipelineRef:
@@ -75,6 +81,9 @@ spec:
                         value: default
                       - name: kind
                         value: pipeline
+                data:
+                  releaseNotes:
+                    product_id: 123
               EOF
               kubectl apply -f releaseplanadmission
 
@@ -82,10 +91,13 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
-                name: snapshot-with-data-sample
+                name: snapshot-disallowed-release-sample
                 namespace: default
               spec:
                 application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
               EOF
               kubectl apply -f snapshot
     - name: run-task
@@ -93,54 +105,17 @@ spec:
         name: collect-data
       params:
         - name: release
-          value: default/release-with-data-sample
+          value: default/release-disallowed-release-sample
         - name: releaseplan
-          value: default/releaseplan-with-data-sample
+          value: default/releaseplan-disallowed-release-sample
         - name: releaseplanadmission
-          value: default/releaseplanadmission-with-data-sample
+          value: default/releaseplanadmission-disallowed-release-sample
         - name: snapshot
-          value: default/snapshot-with-data-sample
+          value: default/snapshot-disallowed-release-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-    - name: check-result
-      params:
-        - name: data
-          value: $(tasks.run-task.results.data)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      runAfter:
-        - run-task
-      taskSpec:
-        params:
-          - name: data
-            type: string
-        steps:
-          - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
-            script: |
-              #!/usr/bin/env sh
-              set -eux
-
-              echo Test that data result was set properly
-              test $(cat "$(workspaces.data.path)/$(params.data)") \
-                == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"}}'
-  finally:
-    - name: cleanup
-      taskSpec:
-        steps:
-          - name: delete-crs
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
-            script: |
-              #!/usr/bin/env sh
-              set -eux
-
-              kubectl delete release release-with-data-sample
-              kubectl delete releaseplan releaseplan-with-data-sample
-              kubectl delete releaseplanadmission releaseplanadmission-with-data-sample
-              kubectl delete snapshot snapshot-with-data-sample

--- a/tasks/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -2,17 +2,24 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-with-data
+  name: test-collect-data-fail-disallowed-releaseplan
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-data task and verify that data task result is accurate.
+    Run the collect-data task with the disallowed key product_id in the ReleasePlan data.
   workspaces:
     - name: tests-workspace
   tasks:
     - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
+        workspaces:
+          - name: data
         steps:
-          - name: create-crs
+          - name: setup
             image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
             script: |
               #!/usr/bin/env sh
@@ -22,14 +29,18 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
-                name: release-with-data-sample
+                name: release-disallowed-rp-sample
                 namespace: default
               spec:
                 snapshot: foo
                 releasePlan: foo
                 data:
-                  rkey: rvalue
-                  foo: shouldGetOverwritten
+                  releaseNotes:
+                    issues:
+                      - id: issue1
+                        source: github.com
+                      - id: issue2
+                        source: github.com
               EOF
               kubectl apply -f release
 
@@ -37,14 +48,15 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
               metadata:
-                name: releaseplan-with-data-sample
+                name: releaseplan-disallowed-rp-sample
                 namespace: default
               spec:
                 application: foo
                 target: foo
                 data:
-                  foo: bar
-                  one: one
+                  releaseNotes:
+                    synopsis: some text field
+                    product_id: 123
               EOF
               kubectl apply -f releaseplan
 
@@ -52,18 +64,12 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlanAdmission
               metadata:
-                name: releaseplanadmission-with-data-sample
+                name: releaseplanadmission-disallowed-rp-sample
                 namespace: default
               spec:
                 applications:
                   - foo
                 origin: foo
-                data:
-                  one:
-                    two: three
-                    four:
-                      - five
-                      - six
                 policy: foo
                 pipeline:
                   pipelineRef:
@@ -75,6 +81,9 @@ spec:
                         value: default
                       - name: kind
                         value: pipeline
+                data:
+                  releaseNotes:
+                    product_id: 123
               EOF
               kubectl apply -f releaseplanadmission
 
@@ -82,10 +91,13 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
-                name: snapshot-with-data-sample
+                name: snapshot-disallowed-rp-sample
                 namespace: default
               spec:
                 application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
               EOF
               kubectl apply -f snapshot
     - name: run-task
@@ -93,54 +105,17 @@ spec:
         name: collect-data
       params:
         - name: release
-          value: default/release-with-data-sample
+          value: default/release-disallowed-rp-sample
         - name: releaseplan
-          value: default/releaseplan-with-data-sample
+          value: default/releaseplan-disallowed-rp-sample
         - name: releaseplanadmission
-          value: default/releaseplanadmission-with-data-sample
+          value: default/releaseplanadmission-disallowed-rp-sample
         - name: snapshot
-          value: default/snapshot-with-data-sample
+          value: default/snapshot-disallowed-rp-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-    - name: check-result
-      params:
-        - name: data
-          value: $(tasks.run-task.results.data)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      runAfter:
-        - run-task
-      taskSpec:
-        params:
-          - name: data
-            type: string
-        steps:
-          - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
-            script: |
-              #!/usr/bin/env sh
-              set -eux
-
-              echo Test that data result was set properly
-              test $(cat "$(workspaces.data.path)/$(params.data)") \
-                == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"}}'
-  finally:
-    - name: cleanup
-      taskSpec:
-        steps:
-          - name: delete-crs
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
-            script: |
-              #!/usr/bin/env sh
-              set -eux
-
-              kubectl delete release release-with-data-sample
-              kubectl delete releaseplan releaseplan-with-data-sample
-              kubectl delete releaseplanadmission releaseplanadmission-with-data-sample
-              kubectl delete snapshot snapshot-with-data-sample

--- a/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -27,7 +27,7 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
-                name: release-sample
+                name: release-missing-cr-sample
                 namespace: default
               spec:
                 snapshot: foo
@@ -39,7 +39,7 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
               metadata:
-                name: releaseplan-sample
+                name: releaseplan-missing-cr-sample
                 namespace: default
               spec:
                 application: foo
@@ -51,7 +51,7 @@ spec:
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
-                name: snapshot-sample
+                name: snapshot-missing-cr-sample
                 namespace: default
               spec:
                 application: foo
@@ -65,13 +65,13 @@ spec:
         name: collect-data
       params:
         - name: release
-          value: default/release-sample
+          value: default/release-missing-cr-sample
         - name: releaseplan
-          value: default/releaseplan-sample
+          value: default/releaseplan-missing-cr-sample
         - name: releaseplanadmission
-          value: default/releaseplanadmission-sample
+          value: default/releaseplanadmission-missing-cr-sample
         - name: snapshot
-          value: default/snapshot-sample
+          value: default/snapshot-missing-cr-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
       runAfter:
@@ -89,6 +89,6 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              kubectl delete release release-sample
-              kubectl delete releaseplan releaseplan-sample
-              kubectl delete snapshot snapshot-sample
+              kubectl delete release release-missing-cr-sample
+              kubectl delete releaseplan releaseplan-missing-cr-sample
+              kubectl delete snapshot snapshot-missing-cr-sample

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -53,15 +53,16 @@ spec:
                   - foo
                 origin: foo
                 policy: foo
-                pipelineRef:
-                  resolver: cluster
-                  params:
-                    - name: name
-                      value: release-pipeline
-                    - name: namespace
-                      value: default
-                    - name: kind
-                      value: pipeline
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                      - name: name
+                        value: release-pipeline
+                      - name: namespace
+                        value: default
+                      - name: kind
+                        value: pipeline
               EOF
               kubectl apply -f releaseplanadmission
 


### PR DESCRIPTION
This commit adds a step to the check-data-keys task to inspect the release, releaseplan, and releaseplanadmission jsons to ensure that none of them contain any data keys that are disallowed. This is to check that some keys in the data json are coming from the expected resource.