### PR TITLE
fix: added title to gh release

### DIFF
--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -14,6 +14,9 @@ a `release` dir.
 | release_version | The version string to use creating the release | No | - |
 | content_directory | The directory inside the workspace to find files for release | No | - |
 
+## Changes in 1.0.2
+- Added title to the GitHub release creation
+
 ## Changes since 1.0.0
 - Added the `.sig` files to the release
 - Updated test with a `.sig` file

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,7 +41,8 @@ spec:
         cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
         set -o pipefail
         shopt -s failglob
-        gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS *.sig --repo $REPOSITORY | tee $(results.url.path)
+        gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS *.sig \
+          --repo $REPOSITORY --title "Release $RELEASE_VERSION" | tee $(results.url.path)
       env:
         - name: GH_TOKEN
           valueFrom:

--- a/tasks/create-github-release/tests/mocks.sh
+++ b/tasks/create-github-release/tests/mocks.sh
@@ -7,7 +7,7 @@ function gh() {
   echo "Mock gh called with: $*"
   echo "$*" >> $(workspaces.data.path)/mock_gh.txt
 
-  if [[ "$*" != "release create v1.2.3 foo.zip foo.json foo_SHA256SUMS foo_SHA256SUMS.sig --repo foo/bar" ]]
+  if [[ "$*" != "release create v1.2.3 foo.zip foo.json foo_SHA256SUMS foo_SHA256SUMS.sig --repo foo/bar --title Release 1.2.3" ]]
   then
     echo Error: Unexpected call
     exit 1


### PR DESCRIPTION
Github releases previously made with actions had a default title with the format `Release x.y.z` . If no title is set then release version is used as title resulting in `vx.y.z`.
Added the `--title`flag to the gh cli to create title releases in the original format `Release x.y.z`.