### PR TITLE
feat(RHTAPREL-653): update pipeline to use json path from task result

### DIFF
--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -18,6 +18,10 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.5.0
+* Modified the pipeline to dynamically source the `snapshot_spec.json`
+  file from the results of the `collect-data` task.
+
 ## Changes in 0.4.1
 * The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
 

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -86,7 +86,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 1.9.0
+- modified the pipeline to dynamically source the `data.json` and `snapshot_spec.json`
+  files from the results of the `collect-data` task.
+
 ### Changes in 1.8.0
 - the task `add-fbc-contribution` now requires the `targetIndex` parameter set with the `updated-targetIndex`
   result from the task `update-ocp-tag`

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -153,7 +153,7 @@ spec:
             value: tasks/validate-single-component/validate-single-component.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -171,7 +171,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -217,7 +217,7 @@ spec:
             value: tasks/update-ocp-tag/update-ocp-tag.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
         - name: ocpVersion
           value: "$(tasks.get-ocp-version.results.stored-version)"
     - name: add-fbc-contribution-to-index-image
@@ -235,9 +235,9 @@ spec:
             value: tasks/add-fbc-contribution/add-fbc-contribution.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: binaryImage
           value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
         - name: fromIndex
@@ -290,7 +290,7 @@ spec:
             value: tasks/sign-index-image/sign-index-image.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
         - name: referenceImage
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestTargetIndex)
         - name: manifestDigestImage
@@ -334,7 +334,7 @@ spec:
             value: tasks/publish-index-image/publish-index-image.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
         - name: sourceIndex
           value: $(tasks.extract-index-image.results.indexImageResolved)
         - name: targetIndex

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -17,6 +17,10 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 2.2.0
+- Modified the pipeline to dynamically source the `data.json`, `snapshot_spec.json` and
+  `release_plan_admission.json` files from the results of the `collect-data` task.
+
 ## Changes in 2.1.1
 - The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.1.1"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -142,9 +142,9 @@ spec:
         - name: failOnEmptyResult
           value: "true"
         - name: releasePlanAdmissionPath
-          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: config
           workspace: release-workspace
@@ -162,7 +162,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -190,9 +190,9 @@ spec:
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.2.0
+- Modified the pipeline to dynamically source the `snapshot_spec.json`
+  file from the results of the `collect-data` task.
+
 ## Changes in 1.1.1
 - Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
 

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -141,7 +141,7 @@ spec:
             value: tasks/validate-single-component/validate-single-component.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -159,7 +159,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -220,7 +220,7 @@ spec:
         - name: subdirectory
           value: $(context.pipelineRun.uid)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       runAfter:
         - validate-single-component
     - name: base64-encode-checksum

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -17,6 +17,10 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 2.2.0
+- Modified the pipeline to dynamically source the `data.json`, `snapshot_spec.json` and
+  `release_plan_admission.json` files from the results of the `collect-data` task.
+
 ## Changes in 2.1.1
 - Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "2.1.1"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -142,9 +142,9 @@ spec:
         - name: failOnEmptyResult
           value: "true"
         - name: releasePlanAdmissionPath
-          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: config
           workspace: release-workspace
@@ -162,7 +162,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -190,9 +190,9 @@ spec:
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -210,7 +210,7 @@ spec:
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -232,9 +232,9 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -258,18 +258,18 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
       params:
         - name: fileUpdatesPath
-          value: $(context.pipelineRun.uid)/data.json
+          value: $(tasks.collect-data.results.data)
         - name: jsonKey
           value: ".fileUpdates"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -17,6 +17,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.9.0
+* Modified the pipeline to dynamically source the `data.json`, `snapshot_spec.json` and
+  `release_plan_admission.json` files from the results of the `collect-data` task.
+
 ## Changes in 1.8.1
 * Tasks that interact with InternalRequests now have a pipelineRunUid parameter added to them to help with cleanup
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/version: "1.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -169,9 +169,9 @@ spec:
         - name: failOnEmptyResult
           value: "true"
         - name: releasePlanAdmissionPath
-          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: config
           workspace: release-workspace
@@ -189,7 +189,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -217,9 +217,9 @@ spec:
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -237,7 +237,7 @@ spec:
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -256,9 +256,9 @@ spec:
             value: tasks/rh-sign-image/rh-sign-image.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: commonTags
@@ -288,9 +288,9 @@ spec:
         - name: commonTags
           value: $(tasks.push-snapshot.results.commonTags)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -312,9 +312,9 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -339,18 +339,18 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
       params:
         - name: fileUpdatesPath
-          value: $(context.pipelineRun.uid)/data.json
+          value: $(tasks.collect-data.results.data)
         - name: jsonKey
           value: ".fileUpdates"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -19,6 +19,10 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.5.0
+- Modified the pipeline to dynamically source the `data.json`, `snapshot_spec.json` and
+  `release_plan_admission.json` files from the results of the `collect-data` task.
+
 ## Changes in 1.4.1
 - The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -142,9 +142,9 @@ spec:
         - name: failOnEmptyResult
           value: "true"
         - name: releasePlanAdmissionPath
-          value: "$(context.pipelineRun.uid)/release_plan_admission.json"
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: config
           workspace: release-workspace
@@ -162,7 +162,7 @@ spec:
             value: verify-enterprise-contract
       params:
         - name: IMAGES
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -190,9 +190,9 @@ spec:
             value: tasks/push-snapshot/push-snapshot.yaml
       params:
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -210,7 +210,7 @@ spec:
             value: tasks/collect-pyxis-params/collect-pyxis-params.yaml
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -254,9 +254,9 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: "$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -280,7 +280,7 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
         - name: data
           workspace: release-workspace
@@ -299,9 +299,9 @@ spec:
           value: >-
             quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
         - name: snapshotPath
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
         - name: dataJsonPath
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/data.json"
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.data)"
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
- modified the pipeline to dynamically source the `data.json`,
  `snapshot_spec.json` and `release_plan_admission` files from
  the results of the `collect-data` task.