### PR TITLE
refactor(RHTAPREL-816): use util for delivery repo translation

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,6 +14,10 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.1.0
+* Use the translate-delivery-repo util for translating the reference variable
+  * This change comes with a bump in the image used for the task
+
 ## Changes in 2.0.0
 * The internalrequest CRs are created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
   * This change comes with a bump in the image used for the task

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
+      image: quay.io/redhat-appstudio/release-service-utils:cc80f80ba26c89c4979644e2bc7d8ccbbae7eaa1
       script: |
         #!/usr/bin/env sh
         #
@@ -79,9 +79,7 @@ spec:
             # Translate direct quay.io reference to public facing registry reference
             # quay.io/redhat-prod/product----repo -> registry.redhat.io/product/repo
             # quay.io/redhat-pending/product----repo -> registry.stage.redhat.io/product/repo
-            reference=${reference/quay.io\/redhat-prod/registry.redhat.io}
-            reference=${reference/quay.io\/redhat-pending/registry.stage.redhat.io}
-            reference=${reference//----//}
+            reference=$(translate-delivery-repo $reference)
 
             manifest_digest="${referenceContainerImage#*@}"
 

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -27,6 +27,10 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 2.1.0
+- Use the translate-delivery-repo util for translating the reference_image variable
+  - This change comes with a bump in the image used for the task
+
 ## Changes in 2.0.0
 - The internalrequest CR is created with a label specifying the pipelinerun uid with the new pipelineRunUid parameter
   - This change comes with a bump in the image used for the task

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -43,7 +43,7 @@ spec:
   steps:
     - name: sign-index-image
       image:
-        quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
+        quay.io/redhat-appstudio/release-service-utils:cc80f80ba26c89c4979644e2bc7d8ccbbae7eaa1
       script: |
         #!/usr/bin/env sh
         set -e
@@ -70,8 +70,7 @@ spec:
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
-        reference_image=${reference_image/quay.io\/redhat/registry.redhat.io}
-        reference_image=${reference_image//----//}
+        reference_image=$(translate-delivery-repo $reference_image)
 
         echo "Creating InternalRequest to sign image:"
         echo "- reference=${reference_image}"


### PR DESCRIPTION
This commit refactors the rh-sign-image and sign-index-image tasks to use the translate-delivery-repo util from release-service-utils to translate the quay repo into the delivery repo. This comes with a bump in the base image used in each task.