### PR TITLE
feat(RHTAPREL-818): add new releaseNotes keys

### DIFF
--- a/tasks/check-data-keys/README.md
+++ b/tasks/check-data-keys/README.md
@@ -15,6 +15,9 @@ Currently, `releaseNotes` is the only supported system.
 | dataPath | Path to the JSON string of the merged data to use       | Yes      | data.json     |
 | systems  | The systems to check that all data keys are present for | Yes      | []            |
 
+## Changes in 0.4.0
+- Add releaseNotes.product_name and releaseNotes.product_version to required keys
+
 ## Changes in 0.3.0
 - Replace advisory.spec references with releaseNotes key
 

--- a/tasks/check-data-keys/check-data-keys.yaml
+++ b/tasks/check-data-keys/check-data-keys.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-data-keys
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,8 @@ spec:
         KEYS_JSON='{
             "releaseNotes": [
                 "product_id",
+                "product_name",
+                "product_version",
                 "cpe",
                 "type",
                 "content.images",

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -29,6 +29,8 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
                   "content": {

--- a/tasks/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys.yaml
@@ -27,6 +27,8 @@ spec:
               {
                 "releaseNotes": {
                   "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
                   "issues": {

--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -26,6 +26,9 @@ should not be present in the Release data section).
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
+## Changes in 2.1.0
+  * product_name and product_version were added as disallowed keys in Release and ReleasePlan CRs
+
 ## Changes in 2.0.0
   * A second step was added to the task
     * The step lists keys that are disallowed for each of the three release resources

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,11 +116,15 @@ spec:
         DISALLOWED_KEYS_JSON='{
             "Release": [
                 "releaseNotes.product_id",
+                "releaseNotes.product_name",
+                "releaseNotes.product_version",
                 "releaseNotes.cpe",
                 "releaseNotes.type"
             ],
             "ReleasePlan": [
                 "releaseNotes.product_id",
+                "releaseNotes.product_name",
+                "releaseNotes.product_version",
                 "releaseNotes.cpe",
                 "releaseNotes.type"
             ],


### PR DESCRIPTION
This commit adds the releaseNotes.product_name and releaseNotes.product_version keys. They are both required, so check-data-keys was modified to check for them. Also, they must come from the ReleasePlanAdmission, so collect-data was modified to ensure they are not present in the Release or ReleasePlan.