### PR TITLE
feat(RHTAPREL-793): add extract-release-notes-images task

### DIFF
--- a/tasks/extract-release-notes-images/README.md
+++ b/tasks/extract-release-notes-images/README.md
@@ -1,0 +1,12 @@
+# extract-release-notes-images
+
+Tekton task to populate the releaseNotes.content.images key in the data.json file. It will update the data.json
+in place so that downstream tasks relying on the releaseNotes data can use it.
+
+## Parameters
+
+| Name         | Description                                                          | Optional | Default value |
+|--------------|----------------------------------------------------------------------|----------|---------------|
+| dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
+| snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
+| commonTags   | Space separated list of common tags to be used when publishing       | No       | -             |

--- a/tasks/extract-release-notes-images/extract-release-notes-images.yaml
+++ b/tasks/extract-release-notes-images/extract-release-notes-images.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-release-notes-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to populate the releaseNotes.content.images key in the data.json file
+  params:
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use
+      type: string
+    - name: snapshotPath
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+      type: string
+    - name: commonTags
+      type: string
+      description: Space separated list of common tags to be used when publishing
+  workspaces:
+    - name: data
+      description: The workspace where the data JSON file resides
+  steps:
+    - name: extract-release-notes-images
+      image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        SNAPSHOT_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_FILE}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi
+
+        # Common vars
+        # Convert space separated list of common tags into an array
+        tags=$(jq -cn --arg tags "$(params.commonTags)" '$tags|split(" ")')
+
+        for component in $(jq -c '.components[]' "${SNAPSHOT_FILE}")
+        do
+            repo=$(jq -r '.repository' <<< $component)
+            deliveryRepo=$(translate-delivery-repo $repo)
+            image=$(jq -r '.containerImage' <<< $component)
+            if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
+                echo "Failed to extract sha256 tag from ${image}. Exiting with failure"
+                exit 1
+            fi
+            sha=$(echo "${image}" | cut -d ':' -f 2)
+            # containerImage should be of the form registry.redhat.io/foo/bar@sha256:abcde
+            # This value will be used as the basis for the example values that follow
+            containerImage="${deliveryRepo}@sha256:${sha}"
+            # repository should be foo/bar
+            repository=$(echo ${containerImage} | cut -d '/' -f 2- | cut -d '@' -f 1)
+            # purl should be pkg:oci/foo@sha256:abcde?repository_url=registry.redhat.io/foo/bar
+            purl="pkg:oci/$(echo $repository | cut -d '/' -f 1)@sha256:${sha}?repository_url=${deliveryRepo}"
+            # Add one entry per arch (amd64 for example)
+            for arch in $(get-image-architectures ${image})
+            do
+                jsonString=$(jq -cn \
+                    --arg arch "$arch" \
+                    --arg containerImage "$containerImage" \
+                    --arg purl "$purl" \
+                    --arg repository "$repository" \
+                    --argjson tags "$tags" \
+                    '{"architecture": $arch, "containerImage":$containerImage,
+                    "purl": $purl, "repository": $repository, "tags": $tags}')
+                # Inject JSON into data.json
+                jq --argjson image "$jsonString" '.releaseNotes.content.images += [$image]' ${DATA_FILE} > data.tmp \
+                    && mv data.tmp ${DATA_FILE}
+            done
+        done

--- a/tasks/extract-release-notes-images/tests/mocks.sh
+++ b/tasks/extract-release-notes-images/tests/mocks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+
+function get-image-architectures() {
+    echo amd64
+    echo s390x
+}

--- a/tasks/extract-release-notes-images/tests/pre-apply-task-hook.sh
+++ b/tasks/extract-release-notes-images/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-fail-missing-data.yaml
+++ b/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-fail-missing-data.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-release-notes-images-fail-missing-data
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the extract-release-notes-images task without a data JSON and verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "prod-registry.io/prod-location"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: extract-release-notes-images
+      params:
+        - name: dataPath
+          value: "missing.json"
+        - name: snapshotPath
+          value: "snapshot.json"
+        - name: commonTags
+          value: "foo bar"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-fail-missing-snapshot.yaml
+++ b/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-fail-missing-snapshot.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-release-notes-images-fail-missing-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the extract-release-notes-images task without a snapshot JSON and verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: extract-release-notes-images
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: snapshotPath
+          value: "missing.json"
+        - name: commonTags
+          value: "foo bar"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-multiple-images.yaml
+++ b/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-multiple-images.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-release-notes-images-multiple-images
+spec:
+  description: |
+    Run the extract-release-notes-images task with mulitple images in the snapshot JSON and verify
+    the data JSON has the proper content
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/product----repo"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2@sha256:abcde",
+                    "repository": "quay.io/redhat-pending/product2----repo2"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: extract-release-notes-images
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: snapshotPath
+          value: "snapshot.json"
+        - name: commonTags
+          value: "foo bar"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              image1arch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $image1arch1) == "amd64"
+              test $(jq -r '.containerImage' <<< $image1arch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $image1arch1) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $image1arch1) == "product/repo"
+              test $(jq -rc '.tags' <<< $image1arch1) == '["foo","bar"]'
+
+              image1arch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $image1arch2) == "s390x"
+              test $(jq -r '.containerImage' <<< $image1arch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $image1arch2) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $image1arch2) == "product/repo"
+              test $(jq -rc '.tags' <<< $image1arch2) == '["foo","bar"]'
+
+              image2arch1=$(jq '.releaseNotes.content.images[2]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $image2arch1) == "amd64"
+              test $(jq -r '.containerImage' <<< $image2arch1) == "registry.stage.redhat.io/product2/repo2@sha256:abcde"
+              test $(jq -r '.purl' <<< $image2arch1) == \
+                "pkg:oci/product2@sha256:abcde?repository_url=registry.stage.redhat.io/product2/repo2"
+              test $(jq -r '.repository' <<< $image2arch1) == "product2/repo2"
+              test $(jq -rc '.tags' <<< $image2arch1) == '["foo","bar"]'
+
+              image2arch2=$(jq '.releaseNotes.content.images[3]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $image2arch2) == "s390x"
+              test $(jq -r '.containerImage' <<< $image2arch2) == "registry.stage.redhat.io/product2/repo2@sha256:abcde"
+              test $(jq -r '.purl' <<< $image2arch2) == \
+                "pkg:oci/product2@sha256:abcde?repository_url=registry.stage.redhat.io/product2/repo2"
+              test $(jq -r '.repository' <<< $image2arch2) == "product2/repo2"
+              test $(jq -rc '.tags' <<< $image2arch2) == '["foo","bar"]'
+      runAfter:
+        - run-task

--- a/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-no-overwrite.yaml
+++ b/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-no-overwrite.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-release-notes-images-no-overwrite
+spec:
+  description: |
+    Run the extract-release-notes-images task and ensure existing information in the
+    releaseNotes.content.images section of the data JSON is not overwritten
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "one": "two"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/product----repo"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: extract-release-notes-images
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: snapshotPath
+          value: "snapshot.json"
+        - name: commonTags
+          value: "foo bar"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # The existing image should be there + 2 new ones (one image, two architectures in it per mocks.sh)
+              test $(jq '.releaseNotes.content.images | length' "$(workspaces.data.path)/data.json") == 3
+      runAfter:
+        - run-task

--- a/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-single-image.yaml
+++ b/tasks/extract-release-notes-images/tests/test-extract-release-notes-images-single-image.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-release-notes-images-single-image
+spec:
+  description: |
+    Run the extract-release-notes-images task with a single image in the snapshot JSON and verify
+    the data JSON has the proper content
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/product----repo"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: extract-release-notes-images
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: snapshotPath
+          value: "snapshot.json"
+        - name: commonTags
+          value: "foo bar"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:eb694b1a87f5129838929e0f79697eb40251a754
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $imagearch1) == "amd64"
+              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $imagearch1) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $imagearch1) == "product/repo"
+              test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
+
+              imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
+              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $imagearch2) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $imagearch2) == "product/repo"
+              test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
+      runAfter:
+        - run-task


### PR DESCRIPTION
This new task is for adding the releaseNotes content.images information to the data.json based on the content of the snapshot JSON