### PR TITLE
feat(RHTAPREL-793): create-advisory task passes signing CM

### DIFF
--- a/tasks/create-advisory-internal-request/README.md
+++ b/tasks/create-advisory-internal-request/README.md
@@ -15,6 +15,9 @@ the ReleasePlanAdmission and Application from the Snapshot are also used. The ad
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |
 
+## Changes in 1.2.0
+- The sign.configMapName is passed to the internal request so the signing key can be added to the advisory yaml
+
 ## Changes in 1.1.0
 - The default value of jsonKey changed from .advisory to .releaseNotes
 

--- a/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-internal-request
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -57,8 +57,9 @@ spec:
         # Obtain origin workspace from releasePlanAdmission
         origin=$(jq -rc '.spec.origin' $(workspaces.data.path)/$(params.releasePlanAdmissionPath))
 
-        # Extract the advisory key from the data JSON file
+        # Extract the advisory key and signing configMap name from the data JSON file
         advisoryData=$(jq -c "$(params.jsonKey)" $(workspaces.data.path)/$(params.dataPath))
+        configMapName=$(jq -er '.sign.configMapName' $(workspaces.data.path)/$(params.dataPath))
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
@@ -67,6 +68,7 @@ spec:
                          -p application="${application}" \
                          -p origin="${origin}" \
                          -p advisory_json="${advisoryData}" \
+                         -p config_map_name="${configMapName}" \
                          -s "$(params.synchronously)" \
                          -l ${pipelinerun_label}=$(params.pipelineRunUid) \
                          > $(workspaces.data.path)/ir-result.txt || \

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
@@ -70,6 +70,9 @@ spec:
               {
                 "releaseNotes": {
                   "foo": "bar"
+                },
+                "sign": {
+                  "configMapName": "cm"
                 }
               }
               EOF
@@ -144,5 +147,11 @@ spec:
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_json' )" != \
               '{"foo":"bar"}' ]; then
                 echo "InternalRequest has the wrong advisory_json parameter"
+                exit 1
+              fi
+
+              # Check the config_map_name parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.config_map_name' )" != "cm" ]; then
+                echo "InternalRequest has the wrong config_map_name parameter"
                 exit 1
               fi


### PR DESCRIPTION
This commit changes the create-advisory-internal-request task to pass the sign.configMapName value from the data.json to the internal request so that the signing key can be added to the advisory yaml.