### PR TITLE
feat(RHTAPREL-815): create-advisory-internal-request passes repo

### DIFF
--- a/tasks/create-advisory-internal-request/README.md
+++ b/tasks/create-advisory-internal-request/README.md
@@ -9,11 +9,16 @@ the ReleasePlanAdmission and Application from the Snapshot are also used. The ad
 |--------------------------|-------------------------------------------------------------------------------------------|----------|-----------------------------|
 | jsonKey                  | The json key containing the advisory data                                                 | Yes      | .releaseNotes               |
 | releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the data workspace                   | Yes      | release_plan_admission.json |
+| releaseServiceConfigPath | Path to the JSON file of the ReleaseServiceConfig in the data workspace                   | No       |                             |
 | snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | Yes      | snapshot_spec.json          |
 | dataPath                 | Path to data JSON in the data workspace                                                   | Yes      | data.json                   |
 | request                  | Type of request to be created                                                             | Yes      | create-advisory             |
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |
+
+## Changes in 2.0.0
+- The path to the ReleaseServiceConfig in the data workspace is now passed as a parameter
+  - The advisory repo will be fetched from the ReleaseServiceConfig json
 
 ## Changes in 1.2.0
 - The sign.configMapName is passed to the internal request so the signing key can be added to the advisory yaml

--- a/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-internal-request
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -20,6 +20,9 @@ spec:
       type: string
       description: Path to the JSON string of the ReleasePlanAdmission in the data workspace
       default: "release_plan_admission.json"
+    - name: releaseServiceConfigPath
+      type: string
+      description: Path to the JSON string of the ReleaseServiceConfig in the data workspace
     - name: snapshotPath
       type: string
       description: Path to the JSON string of the Snapshot spec in the data workspace
@@ -57,6 +60,9 @@ spec:
         # Obtain origin workspace from releasePlanAdmission
         origin=$(jq -rc '.spec.origin' $(workspaces.data.path)/$(params.releasePlanAdmissionPath))
 
+        # Obtain the advisory repo from releaseServiceConfig
+        repo=$(jq -er '.spec.advisoryRepo' $(workspaces.data.path)/$(params.releaseServiceConfigPath))
+
         # Extract the advisory key and signing configMap name from the data JSON file
         advisoryData=$(jq -c "$(params.jsonKey)" $(workspaces.data.path)/$(params.dataPath))
         configMapName=$(jq -er '.sign.configMapName' $(workspaces.data.path)/$(params.dataPath))
@@ -67,6 +73,7 @@ spec:
         internal-request -r "$(params.request)" \
                          -p application="${application}" \
                          -p origin="${origin}" \
+                         -p repo="${repo}" \
                          -p advisory_json="${advisoryData}" \
                          -p config_map_name="${configMapName}" \
                          -s "$(params.synchronously)" \

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-data.yaml
@@ -33,25 +33,41 @@ spec:
                     "app"
                   ],
                   "policy": "policy",
-                  "pipelineRef": {
-                    "resolver": "git",
-                    "params": [
-                      {
-                        "name": "url",
-                        "value": "github.com"
-                      },
-                      {
-                        "name": "revision",
-                        "value": "main"
-                      },
-                      {
-                        "name": "pathInRepo",
-                        "value": "pipeline.yaml"
-                      }
-                    ]
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
                   },
-                  "serviceAccount": "sa",
                   "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/test_release_service_config.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleaseServiceConfig",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "advisoryRepo": "github.com/repo"
                 }
               }
               EOF
@@ -76,6 +92,8 @@ spec:
       params:
         - name: releasePlanAdmissionPath
           value: "test_release_plan_admission.json"
+        - name: releaseServiceConfigPath
+          value: "test_release_service_config.json"
         - name: snapshotPath
           value: "test_snapshot_spec.json"
         - name: dataPath

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rpa.yaml
@@ -19,6 +19,20 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              cat > $(workspaces.data.path)/test_release_service_config.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleaseServiceConfig",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "advisoryRepo": "github.com/repo"
+                }
+              }
+              EOF
               
               cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
               {
@@ -51,6 +65,8 @@ spec:
       params:
         - name: releasePlanAdmissionPath
           value: "test_release_plan_admission.json"
+        - name: releaseServiceConfigPath
+          value: "test_release_service_config.json"
         - name: snapshotPath
           value: "test_snapshot_spec.json"
         - name: dataPath

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rsc.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request-fail-no-rsc.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-advisory-internal-request-fail-no-snapshot
+  name: test-create-advisory-internal-request-fail-no-rsc
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the create-advisory-internal-request task with no Snapshot and verify the taks fails as expected
+    Run the create-advisory-internal-request task with no ReleaseServiceConfig and verify the taks fails as expected
   workspaces:
     - name: tests-workspace
   tasks:
@@ -58,17 +58,15 @@ spec:
               }
               EOF
 
-              cat > $(workspaces.data.path)/test_release_service_config.json << EOF
+              cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
               {
-                "apiVersion": "appstudio.redhat.com/v1alpha1",
-                "kind": "ReleaseServiceConfig",
-                "metadata": {
-                  "name": "test",
-                  "namespace": "default"
-                },
-                "spec": {
-                  "advisoryRepo": "github.com/repo"
-                }
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "repo"
+                  }
+                ]
               }
               EOF
 

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
@@ -31,25 +31,41 @@ spec:
                     "app"
                   ],
                   "policy": "policy",
-                  "pipelineRef": {
-                    "resolver": "git",
-                    "params": [
-                      {
-                        "name": "url",
-                        "value": "github.com"
-                      },
-                      {
-                        "name": "revision",
-                        "value": "main"
-                      },
-                      {
-                        "name": "pathInRepo",
-                        "value": "pipeline.yaml"
-                      }
-                    ]
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
                   },
-                  "serviceAccount": "sa",
                   "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/test_release_service_config.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleaseServiceConfig",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "advisoryRepo": "github.com/repo"
                 }
               }
               EOF
@@ -85,6 +101,8 @@ spec:
       params:
         - name: releasePlanAdmissionPath
           value: "test_release_plan_admission.json"
+        - name: releaseServiceConfigPath
+          value: "test_release_service_config.json"
         - name: snapshotPath
           value: "test_snapshot_spec.json"
         - name: dataPath
@@ -140,6 +158,12 @@ spec:
               # Check the origin parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.origin' )" != "dev" ]; then
                 echo "InternalRequest has the wrong origin parameter"
+                exit 1
+              fi
+
+              # Check the repo parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.repo' )" != "github.com/repo" ]; then
+                echo "InternalRequest has the wrong repo parameter"
                 exit 1
               fi
 


### PR DESCRIPTION
This commit modifies the create-advisory-internal-request task to require a parameter providing the path to the ReleaseServiceConfig json in the data workspace. The json is then read to fetch the advisoryRepo and that is passed to the InternalRequest as a parameter.