### PR TITLE
fix(KFLUXBUGS-1116): support signing all manifest digests

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 1.10.0
+- the task `sign-index-image` now requires the `manifestListDigests` parameter set with the `indexImageDigests`
+  result from the task `extract-index-image`
+
 ### Changes in 1.9.0
 - modified the pipeline to dynamically source the `data.json` and `snapshot_spec.json`
   files from the results of the `collect-data` task.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.9.0"
+    app.kubernetes.io/version: "1.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -295,6 +295,8 @@ spec:
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestTargetIndex)
         - name: manifestDigestImage
           value: $(tasks.extract-index-image.results.indexImageResolved)
+        - name: manifestListDigests
+          value: $(tasks.extract-index-image.results.indexImageDigests)
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: pipelineRunUid

--- a/tasks/extract-index-image/README.md
+++ b/tasks/extract-index-image/README.md
@@ -11,6 +11,11 @@ the workspace name for this task *must* be input.
 |------|-------------|----------|---------------|
 | inputDataFile | File to read json data from | No | - |
 
+
+## Changes in 0.4.0
+- This version now produces a result that contains the list of digests found in the manifest list for each arch
+- This result is called `indexImageDigests`
+
 ## Changes since 0.2.0
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
 

--- a/tasks/extract-index-image/extract-index-image.yaml
+++ b/tasks/extract-index-image/extract-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-index-image
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,8 @@ spec:
       type: string
     - name: indexImageResolved
       type: string
+    - name: indexImageDigests
+      type: string
   steps:
     - name: extract-index-image
       image: >-
@@ -37,3 +39,10 @@ spec:
 
         indexImageResolved=`echo $jsonBuildInfo | jq -cr .index_image_resolved`
         echo -n $indexImageResolved > $(results.indexImageResolved.path)
+
+        indexImageCopy=`echo $jsonBuildInfo | jq -cr  .internal_index_image_copy`
+        # Use this to obtain the manifest digests for each arch in manifest list
+        indexImageDigestsRaw=$(skopeo inspect --raw docker://$indexImageCopy)
+        indexImageDigests=$(echo ${indexImageDigestsRaw} | \
+           jq -r '.manifests[] | select(.mediaType=="application/vnd.docker.distribution.manifest.v2+json") | .digest')
+        echo -n $indexImageDigests > $(results.indexImageDigests.path)

--- a/tasks/extract-index-image/tests/mocks.sh
+++ b/tasks/extract-index-image/tests/mocks.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+
+function skopeo() {
+  echo "Mock skopeo called with: $*" >&2
+
+  # Append call information to mock_skopeo.txt
+  echo "$*" >> $(workspaces.data.path)/mock_skopeo.txt
+
+  echo '
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1253,
+      "digest": "sha256:406a",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1252,
+      "digest": "sha256:4bfe",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1252,
+      "digest": "sha256:6f9",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1253,
+      "digest": "sha256:71e1",
+      "platform": {
+        "architecture": "s390x",
+        "os": "linux"
+      }
+    }
+  ]
+}'
+
+}

--- a/tasks/extract-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/extract-index-image/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image.yaml
@@ -77,11 +77,15 @@ spec:
           value: $(tasks.run-task.results.indexImage)
         - name: indexImageResolved
           value: $(tasks.run-task.results.indexImageResolved)
+        - name: indexImageDigests
+          value: $(tasks.run-task.results.indexImageDigests)
       taskSpec:
         params:
           - name: indexImage
             type: string
           - name: indexImageResolved
+            type: string
+          - name: indexImageDigests
             type: string
         steps:
           - name: check-result
@@ -95,5 +99,8 @@ spec:
 
               echo Test the indexImageResolved result was properly set
               test $(echo $(params.indexImageResolved)) == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+
+              echo Test the indexImageDigests result was properly set
+              test "$(echo $(params.indexImageDigests))" == "sha256:406a sha256:4bfe sha256:6f9 sha256:71e1"
       runAfter:
         - run-task

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -9,7 +9,7 @@ Creates an InternalRequest to sign an index image
 | dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json              |
 | request              | Signing pipeline name to handle this request                                              | Yes      | hacbs-signing-pipeline |
 | referenceImage       | The image to be signed                                                                    | No       |                        |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                     |
+| manifestListDigests  | The manifest digests for each arch in manifest list                                       | No       |                        |
 | requester            | Name of the user that requested the signing, for auditing purposes                        | No       |                        |
 | requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
 | pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                        |
@@ -26,6 +26,9 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 3.0.0
+- This task now requires a list of digests to use in the signing request via the parameter `manifestListDigests`
 
 ## Changes in 2.1.0
 - Use the translate-delivery-repo util for translating the reference_image variable

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,10 +23,9 @@ spec:
     - name: referenceImage
       type: string
       description: The image to be signed.
-    - name: manifestDigestImage
+    - name: manifestListDigests
       type: string
-      default: ""
-      description: Manifest Digest Image used to extract the SHA
+      description: The manifest digests for each arch in manifest list
     - name: requester
       type: string
       description: Name of the user that requested the signing, for auditing purposes
@@ -60,29 +59,28 @@ spec:
             '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' ${DATA_FILE})
         reference_image=$(params.referenceImage)
-        if [ -n "$(params.manifestDigestImage)" ]; then
-          manifestDigestImage="$(params.manifestDigestImage)"
-          manifest_digest="${manifestDigestImage#*@}"
-        else
-          manifest_digest="${reference_image#*@}"
-        fi
+
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
         reference_image=$(translate-delivery-repo $reference_image)
 
-        echo "Creating InternalRequest to sign image:"
-        echo "- reference=${reference_image}"
-        echo "- manifest_digest=${manifest_digest}"
-        echo "- requester=$(params.requester)"
+        # get all digests from manifest list
+        for manifest_digest in $(params.manifestListDigests)
+        do
+          echo "Creating InternalRequest to sign image:"
+          echo "- reference=${reference_image}"
+          echo "- manifest_digest=${manifest_digest}"
+          echo "- requester=$(params.requester)"
 
-        internal-request -r "${request}" \
-            -p pipeline_image=${pipeline_image} \
-            -p reference=${reference_image} \
-            -p manifest_digest=${manifest_digest} \
-            -p requester=$(params.requester) \
-            -p config_map_name=${config_map_name} \
-            -t $(params.requestTimeout) \
-            -l ${pipelinerun_label}=$(params.pipelineRunUid)
-        echo "done"
+          internal-request -r "${request}" \
+              -p pipeline_image=${pipeline_image} \
+              -p reference=${reference_image} \
+              -p manifest_digest=${manifest_digest} \
+              -p requester=$(params.requester) \
+              -p config_map_name=${config_map_name} \
+              -t $(params.requestTimeout) \
+              -l ${pipelinerun_label}=$(params.pipelineRunUid)
+          echo "done"
+        done

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -38,10 +38,8 @@ spec:
           value: testuser
         - name: referenceImage
           value: quay.io/redhat/redhat----testimage:tag
-        - name: manifestDigestImage
-          value: quay.io/redhat/redhat----testimage@sha256:0000
-        - name: pipelineRunUid
-          value: $(context.pipelineRun.uid)
+        - name: manifestListDigests
+          value: "sha256:6f9a420f660e73b"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -67,7 +65,7 @@ spec:
                 exit 1
               fi
 
-              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:6f9a420f660e73b" ]; then
                 echo "manifest_digest does not match"
                 exit 1
               fi

--- a/tasks/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image.yaml
@@ -38,8 +38,8 @@ spec:
           value: testuser
         - name: referenceImage
           value: quay.io/testrepo/testimage:tag
-        - name: manifestDigestImage
-          value: quay.io/testrepo/testimage@sha256:0000
+        - name: manifestListDigests
+          value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:
@@ -59,37 +59,52 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
-              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+              counter=0
+              testValues=('sha256:6f9a420f660e73a' \
+                          'sha256:6f9a420f660e73b')
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
+              internalRequestsCount=$(echo $internalRequests | wc -w)
 
-              if [ $(jq -r '.reference' <<< "${params}") != "quay.io/testrepo/testimage:tag" ]; then
-                echo "reference image does not match"
+              if [ $internalRequestsCount != "2" ] ; then
+                echo "incorrect number of internalRequests created. Expected 2"
                 exit 1
               fi
 
-              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
-                echo "manifest_digest does not match"
-                exit 1
-              fi
+              for internalRequest in ${internalRequests};
+              do
+                params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
-              then
-                echo "config_map_name does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.reference' <<< "${params}") != "quay.io/testrepo/testimage:tag" ]; then
+                  echo "reference image does not match"
+                  exit 1
+                fi
 
-              if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
-              then
-                echo "requester does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.manifest_digest' <<< "${params}") != "${testValues[$counter]}" ]; then
+                  echo "manifest_digest does not match"
+                  exit 1
+                fi
 
-              if [ $(jq -r '.pipeline_image' <<< "${params}") != \
-                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
-              then
-                echo "pipeline_image does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
+                then
+                  echo "config_map_name does not match"
+                  exit 1
+                fi
+
+                if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
+                then
+                  echo "requester does not match"
+                  exit 1
+                fi
+
+                if [ $(jq -r '.pipeline_image' <<< "${params}") != \
+                   "quay.io/redhat-isv/operator-pipelines-images:released" ]
+                then
+                  echo "pipeline_image does not match"
+                  exit 1
+                fi
+
+                counter=$((counter+1))
+              done
       runAfter:
         - run-task
   finally:


### PR DESCRIPTION
- `extract-index-image` now produces a result of the digests for each arch found in the manifest list
- `sign-index-image` now consumes this list and creates an `InternalRequest` for each digest.
- `fbc-release` updated to specify new parameter for sign-index-image