### PR TITLE
fix(KFLUXBUGS-1116): support signing all manifest digests

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -17,6 +17,11 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 1.10.0
+- the task `sign-index-image` now requires the `manifestListDigests` parameter set with the `indexImageDigests`
+  result from the task `add-fbc-contribution-to-index-image`.
+- the `manifestDigestImage` parameter was removed from `sign-index-image` task
+
 ### Changes in 1.9.0
 - modified the pipeline to dynamically source the `data.json` and `snapshot_spec.json`
   files from the results of the `collect-data` task.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "1.9.0"
+    app.kubernetes.io/version: "1.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -293,8 +293,8 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: referenceImage
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestTargetIndex)
-        - name: manifestDigestImage
-          value: $(tasks.extract-index-image.results.indexImageResolved)
+        - name: manifestListDigests
+          value: $(tasks.add-fbc-contribution-to-index-image.results.indexImageDigests)
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: pipelineRunUid

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -13,6 +13,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       |                      |
 
+## changes in 2.3.0
+- add new result called `indexImageDigests`
+
 ## changes in 2.2.0
 - remove requestTimeout parameter and use values defined in RP/RPA
 - default build and request timeouts are now 1500 seconds

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,6 +47,8 @@ spec:
       description: Internal Request message
     - name: requestReason
       description: Internal Request reason
+    - name: indexImageDigests
+      description: list of manifest digests for each arch from manifest list in index image
   workspaces:
     - name: data
       description: workspace to read and save files
@@ -155,3 +157,5 @@ spec:
 
         jq '.reason // "Unset"'  <<< "${conditions}" | tee $(results.requestReason.path)
         jq '.message // "Unset"' <<< "${conditions}" | tee $(results.requestMessage.path)
+
+        jq -r '.indexImageDigests' <<< "${results}" |  tee $(results.indexImageDigests.path)

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -9,7 +9,7 @@ Creates an InternalRequest to sign an index image
 | dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | Yes      | data.json              |
 | request              | Signing pipeline name to handle this request                                              | Yes      | hacbs-signing-pipeline |
 | referenceImage       | The image to be signed                                                                    | No       |                        |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                     |
+| manifestListDigests  | The manifest digests for each arch in manifest list                                       | No       |                        |
 | requester            | Name of the user that requested the signing, for auditing purposes                        | No       |                        |
 | requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
 | pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                        |
@@ -26,6 +26,10 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 3.0.0
+- This task now requires a list of digests to use in the signing request via the parameter `manifestListDigests`
+- The `manifestDigestImage` parameter has been removed.
 
 ## Changes in 2.1.0
 - Use the translate-delivery-repo util for translating the reference_image variable

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,10 +23,9 @@ spec:
     - name: referenceImage
       type: string
       description: The image to be signed.
-    - name: manifestDigestImage
+    - name: manifestListDigests
       type: string
-      default: ""
-      description: Manifest Digest Image used to extract the SHA
+      description: The manifest digests for each arch in manifest list
     - name: requester
       type: string
       description: Name of the user that requested the signing, for auditing purposes
@@ -60,29 +59,28 @@ spec:
             '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' ${DATA_FILE})
         reference_image=$(params.referenceImage)
-        if [ -n "$(params.manifestDigestImage)" ]; then
-          manifestDigestImage="$(params.manifestDigestImage)"
-          manifest_digest="${manifestDigestImage#*@}"
-        else
-          manifest_digest="${reference_image#*@}"
-        fi
+
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
         reference_image=$(translate-delivery-repo $reference_image)
 
-        echo "Creating InternalRequest to sign image:"
-        echo "- reference=${reference_image}"
-        echo "- manifest_digest=${manifest_digest}"
-        echo "- requester=$(params.requester)"
+        # get all digests from manifest list
+        for manifest_digest in $(params.manifestListDigests)
+        do
+          echo "Creating InternalRequest to sign image:"
+          echo "- reference=${reference_image}"
+          echo "- manifest_digest=${manifest_digest}"
+          echo "- requester=$(params.requester)"
 
-        internal-request -r "${request}" \
-            -p pipeline_image=${pipeline_image} \
-            -p reference=${reference_image} \
-            -p manifest_digest=${manifest_digest} \
-            -p requester=$(params.requester) \
-            -p config_map_name=${config_map_name} \
-            -t $(params.requestTimeout) \
-            -l ${pipelinerun_label}=$(params.pipelineRunUid)
-        echo "done"
+          internal-request -r "${request}" \
+              -p pipeline_image=${pipeline_image} \
+              -p reference=${reference_image} \
+              -p manifest_digest=${manifest_digest} \
+              -p requester=$(params.requester) \
+              -p config_map_name=${config_map_name} \
+              -t $(params.requestTimeout) \
+              -l ${pipelinerun_label}=$(params.pipelineRunUid)
+          echo "done"
+        done

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -38,8 +38,8 @@ spec:
           value: testuser
         - name: referenceImage
           value: quay.io/redhat/redhat----testimage:tag
-        - name: manifestDigestImage
-          value: quay.io/redhat/redhat----testimage@sha256:0000
+        - name: manifestListDigests
+          value: "sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:
@@ -67,7 +67,7 @@ spec:
                 exit 1
               fi
 
-              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:6f9a420f660e73b" ]; then
                 echo "manifest_digest does not match"
                 exit 1
               fi

--- a/tasks/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image.yaml
@@ -38,8 +38,8 @@ spec:
           value: testuser
         - name: referenceImage
           value: quay.io/testrepo/testimage:tag
-        - name: manifestDigestImage
-          value: quay.io/testrepo/testimage@sha256:0000
+        - name: manifestListDigests
+          value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:
@@ -59,37 +59,52 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
-              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+              counter=0
+              testValues=('sha256:6f9a420f660e73a' \
+                          'sha256:6f9a420f660e73b')
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
+              internalRequestsCount=$(echo $internalRequests | wc -w)
 
-              if [ $(jq -r '.reference' <<< "${params}") != "quay.io/testrepo/testimage:tag" ]; then
-                echo "reference image does not match"
+              if [ $internalRequestsCount != "2" ] ; then
+                echo "incorrect number of internalRequests created. Expected 2"
                 exit 1
               fi
 
-              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
-                echo "manifest_digest does not match"
-                exit 1
-              fi
+              for internalRequest in ${internalRequests};
+              do
+                params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
-              then
-                echo "config_map_name does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.reference' <<< "${params}") != "quay.io/testrepo/testimage:tag" ]; then
+                  echo "reference image does not match"
+                  exit 1
+                fi
 
-              if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
-              then
-                echo "requester does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.manifest_digest' <<< "${params}") != "${testValues[$counter]}" ]; then
+                  echo "manifest_digest does not match"
+                  exit 1
+                fi
 
-              if [ $(jq -r '.pipeline_image' <<< "${params}") != \
-                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
-              then
-                echo "pipeline_image does not match"
-                exit 1
-              fi
+                if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
+                then
+                  echo "config_map_name does not match"
+                  exit 1
+                fi
+
+                if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
+                then
+                  echo "requester does not match"
+                  exit 1
+                fi
+
+                if [ $(jq -r '.pipeline_image' <<< "${params}") != \
+                   "quay.io/redhat-isv/operator-pipelines-images:released" ]
+                then
+                  echo "pipeline_image does not match"
+                  exit 1
+                fi
+
+                counter=$((counter+1))
+              done
       runAfter:
         - run-task
   finally:


### PR DESCRIPTION
- add-fbc-contribution now produces a result of the digests for each arch found in the manifest list
- sign-index-image now consumes this list and creates an InternalRequest for each digest.
- fbc-release updated to specify new parameter for sign-index-image

Requires https://github.com/hacbs-release/app-interface-deployments/pull/74