### PR TITLE
fix(RHTAPREL-857): update release-utils image

### DIFF
--- a/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
+++ b/tasks/push-sbom-to-pyxis/push-sbom-to-pyxis.yaml
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+        quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -78,7 +78,7 @@ spec:
 
     - name: push-sbom-files-to-pyxis
       image:
-        quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+        quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-failure.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-urls-ids-mismatch.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis-urls-ids-mismatch.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis.yaml
+++ b/tasks/push-sbom-to-pyxis/tests/test-push-sbom-to-pyxis.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            image: quay.io/redhat-appstudio/release-service-utils:4d00a5731e96e341e0104ad2374792b985330c87
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
This PR updates the release-service-utils image to the latest that contains the fix for [RHTAPREL-857](https://issues.redhat.com//browse/RHTAPREL-857).

Signed-off-by: Leandro Mendes <lmendes@redhat.com>