### PR TITLE
feat(RHTAPREL-815): pass releaseServiceConfig to pipelines

### DIFF
--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -10,6 +10,7 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -17,6 +18,9 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 2.0.0
+* releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 1.0.0
 * Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,6 +23,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -67,6 +70,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -9,6 +9,7 @@ Tekton release pipeline to interact with FBC Pipeline
 | release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution   | No        | -                                                               |
 | releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                  | No        | -                                                               |
 | releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                         | No        | -                                                               |
+| releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                         | No        | -                                                               |
 | snapshot                        | The namespaced name (namespace/name) of the snapshot                                                     | No        | -                                                               |
 | enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                                               |
 | enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key                            |
@@ -16,6 +17,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
+
+## Changes in 3.0.0
+- releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 2.0.0
 - Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -80,16 +83,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -97,6 +104,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -105,6 +113,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"
@@ -132,6 +141,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -9,6 +9,7 @@ Tekton pipeline to release Snapshots to an external registry.
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -16,6 +17,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 4.0.0
+- releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 3.0.0
 - Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -67,16 +70,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -84,6 +91,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -92,6 +100,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"
@@ -119,6 +128,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -9,6 +9,7 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -16,6 +17,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.0.0
+- releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 2.0.0
 - Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,6 +23,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -68,16 +71,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -85,6 +92,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -93,6 +101,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"
@@ -120,6 +129,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -9,6 +9,7 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -16,6 +17,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 4.0.0
+- releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 3.0.0
 - Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -67,16 +70,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -84,6 +91,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -92,6 +100,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"
@@ -119,6 +128,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -9,6 +9,7 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -16,6 +17,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.0.0
+* releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 2.0.0
 * Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -67,16 +70,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -84,6 +91,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -92,6 +100,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"
@@ -119,6 +128,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -11,6 +11,7 @@
 | release | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan | The namespaced name (namespace/name) of the releasePlan | No | - |
 | releasePlanAdmission | The namespaced name (namespace/name) of the releasePlanAdmission | No | - |
+| releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
@@ -18,6 +19,9 @@
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.0.0
+- releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 
 ## Changes in 2.0.0
 - Parameters supplied by the Release Service operator now use camelCase format

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
     - name: snapshot
       type: string
       description: The namespaced name (namespace/name) of the snapshot
@@ -67,16 +70,20 @@ spec:
           value: |
             ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
             TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
 
             RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
             RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
             RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
             SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
 
             CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
                 -n ${TARGET_NAMESPACE})
+            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+                -n ${RSC_NAMESPACE})
             CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
             CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
 
@@ -84,6 +91,7 @@ spec:
             echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
             echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
             echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
             echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
             echo ""
             echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
@@ -92,6 +100,7 @@ spec:
             if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
                 [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
+                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
                 [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
                 [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
               echo "Error: Cannot read or create required Release resources!"


### PR DESCRIPTION
This commit updates all the pipelines to have a releaseServiceConfig parameter for the namespaced name of the ReleaseServiceConfig. It also updates the verify-access-to-resources task to check that the ReleaseServiceConfig can be read.