### PR TITLE
feat(RHTAPREL-812): create-advisory returns advisory_url

### DIFF
--- a/tasks/create-advisory-internal-request/README.md
+++ b/tasks/create-advisory-internal-request/README.md
@@ -16,6 +16,10 @@ the ReleasePlanAdmission and Application from the Snapshot are also used. The ad
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |
 
+## Changes in 2.1.0
+- The advisory_url is reported as task result
+  - If the advisory was not created, the result will instead be the empty string
+
 ## Changes in 2.0.0
 - The path to the ReleaseServiceConfig in the data workspace is now passed as a parameter
   - The advisory repo will be fetched from the ReleaseServiceConfig json

--- a/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/create-advisory-internal-request.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-internal-request
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,6 +45,9 @@ spec:
   workspaces:
     - name: data
       description: Workspace where the json files are stored
+  results:
+    - name: advisory_url
+      description: The advisory url if one was created
   steps:
     - name: run-script
       image: quay.io/redhat-appstudio/release-service-utils:305541d8b8c2670dea4b50bd8c56858c365ca11e
@@ -84,6 +87,7 @@ spec:
         internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
         echo "done (${internalRequest})"
 
+        echo -n "" > $(results.advisory_url.path)
         results=$(kubectl get internalrequest $internalRequest -o=jsonpath='{.status.results}')
         if [[ "$(echo ${results} | jq -r '.result')" == "Success" ]]; then
           echo "Advisory created"
@@ -92,3 +96,5 @@ spec:
           echo "$results"
           exit 1
         fi
+
+        echo -n "$(echo ${results} | jq -r '.advisory_url // ""')" | tee $(results.advisory_url.path)

--- a/tasks/create-advisory-internal-request/tests/mocks.sh
+++ b/tasks/create-advisory-internal-request/tests/mocks.sh
@@ -7,7 +7,7 @@ function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
   then
-    echo '{"result":"Success"}'
+    echo '{"result":"Success","advisory_url":"https://github.com/org/repo/advisory"}'
   else
     kubectl $*
   fi

--- a/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
+++ b/tasks/create-advisory-internal-request/tests/test-create-advisory-internal-request.yaml
@@ -117,12 +117,18 @@ spec:
         - name: data
           workspace: tests-workspace
     - name: check-result
+      params:
+        - name: advisory_url
+          value: $(tasks.run-task.results.advisory_url)
       workspaces:
         - name: data
           workspace: tests-workspace
       runAfter:
         - run-task
       taskSpec:
+        params:
+          - name: advisory_url
+            type: string
         workspaces:
           - name: data
         steps:
@@ -179,3 +185,6 @@ spec:
                 echo "InternalRequest has the wrong config_map_name parameter"
                 exit 1
               fi
+
+              echo Test that the advisory_url result was properly set
+              test "$(echo $(params.advisory_url))" == "https://github.com/org/repo/advisory"


### PR DESCRIPTION
This commit modifies the create-advisory-internal-request task to store the advisory_url from the InternalRequest results as a task result.