### PR TITLE
feat(EC-272) check that operator package name is allowed

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -18,6 +18,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 3.1.0
+- add a new `check-fbc-packages` task to support operator package name uniqueness constraints
+
 ## Changes in 3.0.0
 - releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -231,6 +231,26 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: ocpVersion
           value: "$(tasks.get-ocp-version.results.stored-version)"
+    - name: check-fbc-packages
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-fbc-packages/check-fbc-packages.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+      runAfter:
+        - verify-enterprise-contract
     - name: add-fbc-contribution-to-index-image
       workspaces:
         - name: data
@@ -258,6 +278,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
+        - check-fbc-packages
         - verify-enterprise-contract
     - name: extract-requester-from-release
       taskRef:

--- a/tasks/check-fbc-packages/README.md
+++ b/tasks/check-fbc-packages/README.md
@@ -1,0 +1,10 @@
+# check-fbc-packages
+
+Task to check that the packages being shipped in an fbc contribution are in the allow list provided in the dataPath.
+
+## Parameters
+
+| Name           | Description                                                               | Optional | Default value        |
+|----------------|---------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | Yes      | snapshot_spec.json   |
+| dataPath       | Path to the JSON string of the merged data to use in the data workspace   | Yes      | data.json            |

--- a/tasks/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/check-fbc-packages/check-fbc-packages.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-fbc-packages
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Task to check that the packages being shipped in an fbc contribution are in the allow list provided in the dataPath.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+      type: string
+      default: "snapshot_spec.json"
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+      default: "data.json"
+  workspaces:
+    - name: data
+      description: workspace to read and save files
+  steps:
+    - name: check-contribution
+      image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+      script: |
+        #!/usr/bin/env sh
+        #
+        set -e
+
+        SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No valid data file was provided."
+            exit 1
+        fi
+
+        fbc_fragment=$(jq -cr '.components[0].containerImage' ${SNAPSHOT_PATH})
+
+        allowed_packages=$(jq -r '.fbc.allowedPackages[]' ${DATA_FILE})
+
+        echo "Inspecting fbc fragment ${fbc_fragment} with opm render"
+        actual_packages=$(opm render ${fbc_fragment} | jq -r 'select(.schema=="olm.package") | .name')
+
+        RC=0
+        for package in ${actual_packages}; do
+          if jq -e --arg pkg $package '.fbc.allowedPackages | index($pkg)' ${DATA_FILE}
+          then
+            echo "${package} is one of the allowedPackages: ${allowed_packages}"
+          else
+            echo "${package} is not one of the allowedPackages: ${allowed_packages}"
+            RC=1
+          fi
+        done
+        exit $RC

--- a/tasks/check-fbc-packages/tests/mocks.sh
+++ b/tasks/check-fbc-packages/tests/mocks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eux
+
+function opm() {
+  echo $* >> $(workspaces.data.path)/mock_opm.txt
+  if [[ "$*" == "render "* ]]
+  then
+    echo '{"schema": "olm.package","name": "test-package-1"}'
+  else
+    echo Mock opm called with: $*
+    if [[ "$*" != "render "* ]]
+    then
+      echo Error: Unexpected call
+      exit 1
+    fi
+  fi
+}

--- a/tasks/check-fbc-packages/tests/pre-apply-task-hook.sh
+++ b/tasks/check-fbc-packages/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
+++ b/tasks/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-fbc-packages-negative
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test checking fbc allowedPackages when the packages do not match; task should fail as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "allowedPackages": ["test-package-2"]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: check-fbc-packages
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
+++ b/tasks/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-fbc-packages-positive
+spec:
+  description: Test checking fbc allowedPackages when the packages match; task should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "allowedPackages": ["test-package-1"]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: check-fbc-packages
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup


### PR DESCRIPTION
This checks that the FBC pipeline can only publish operator packages which are declared explicitly on the ReleasePlanAdmission.

The purpose of this change is to prevent two different teams from publishing the same operator package name to the same index, stomping on each other. That uniqueness requirement is enforced elsewhere, where we ensure that all RPAs in a managed workspace have no conflicting allowedPackages values.

See also https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/209