### PR TITLE
fix(RHTAPREL-815): releaseServiceConfig was not passed to collect-data

### DIFF
--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -20,6 +20,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.0.1
+- releaseServiceConfig was not passed to the collect-data task - now it is
+
 ## Changes in 3.0.0
 - releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -128,6 +128,8 @@ spec:
           value: $(params.releasePlan)
         - name: releasePlanAdmission
           value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
         - name: subdirectory


### PR DESCRIPTION
This was missed when the new parameter was added to all the pipelines in this PR:
https://github.com/redhat-appstudio/release-service-catalog/pull/368