### PR TITLE
fix(KFLUXBUGS-1156): only publish when publish flag is true

### DIFF
--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -7,7 +7,10 @@ E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted t
 registry "registry.access.redhat.com" and repository "my-product/my-image" to identify
 the right Container Registry object in Pyxis. The task also optionally
 marks the repositories as source_container_image_enabled true if pushSourceContainer
-is true in the data JSON. 
+is true in the data JSON.
+Additionally, this task respects the `publish-on-push` flag. If `false`, then the task
+does not publish the repository.
+
 
 
 ## Parameters
@@ -18,6 +21,10 @@ is true in the data JSON.
 | pyxisSecret  | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No       | -                  |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | Yes      | snapshot_spec.json |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                           | Yes      | data.json          |
+
+## Changes in 0.2.1
+The task now respects the `publish-on-push` flag. If `false`, then the task
+does not publish the repository.
 
 ## Changes in 0.2.0
 * If a data JSON is provided and images.pushSourceContainer is set to true inside it, a call is made

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -18,6 +18,8 @@ spec:
     to identify the right Container Registry object in Pyxis. The task also optionally
     marks the repositories as source_container_image_enabled true if pushSourceContainer
     is true in the data JSON.
+    Additionally, this task respects the `publish-on-push` flag. If `false`, then the task
+    does not publish the repository.
   params:
     - name: server
       type: string
@@ -95,6 +97,7 @@ spec:
             PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
             PYXIS_REPOSITORY_JSON=$(curl --retry 5 --key /tmp/key --cert /tmp/crt \
                 "${PYXIS_URL}/v1/repositories/registry/${PYXIS_REGISTRY}/repository/${PYXIS_REPOSITORY}" -X GET)
+        
             PYXIS_REPOSITORY_ID=$(jq -r '._id // ""' <<< $PYXIS_REPOSITORY_JSON)
             if [ -z "$PYXIS_REPOSITORY_ID" ]; then
                 echo Error: Unable to get Container Repository object id from Pyxis
@@ -102,6 +105,16 @@ spec:
                 echo $PYXIS_REPOSITORY_JSON
                 exit 1
             fi
+
+            # verify that publish_on_push is set to true.
+            # otherwise, do not publish the image.
+            PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< $PYXIS_REPOSITORY_JSON)
+            if [ "${PYXIS_REPOSITORY_PUBLISH_ON_PUSH}" != "true" ] ; then
+              echo "WARNING: repository ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY} is marked as publish_on_push = false"
+              echo "Skipping the setting of the published flag."
+              continue
+            fi
+        
             curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
                 -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
         done

--- a/tasks/publish-pyxis-repository/tests/mocks.sh
+++ b/tasks/publish-pyxis-repository/tests/mocks.sh
@@ -15,7 +15,11 @@ function curl() {
     if [[ "$*" == *"my-image9"* ]]; then
       echo '{"detail": "Document in containerRepository not found.", "status": 404, "title": "Not Found", "type": "about:blank", "trace_id": "0x4d7be17d142d24c5f2b10b5f1745cc89"}'
     else
-      echo '{"_id": "'$CALL_ID'"}'
+      if [[ "$*" == *"my-image0"* ]]; then
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": "false"}'
+      else
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": "true"}'
+      fi
     fi
   elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published":true}' ]]
   then

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-marked-as-not-pub-on-push
+spec:
+  description: |
+    Run the publish-pyxis-repository task for a repo that is
+    marked as publish-on-push: false
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image0"
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:447ea0580a2cdd48b4091e1df86fab5c3f86d01c
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 1 ]; then
+                  echo Error: curl was expected to be called 1 time. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image0 "* ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
- we first need to inspect the publish-on-push flag before we actually try to publish the image.
- this gives Product Owners the ability to hide content.