### PR TITLE
fix(RHTAPREL-834): add condition to check commontags is not null

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -21,5 +21,15 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.2.1
+- Added a `when` clause to the following tasks
+  `rh-sign-image`,
+  `populate-release-notes-images`,
+  `create-pyxis-image`,
+  `collect-pyxis-params` and
+  `run-file-updates`
+  to ensure they only execute when the `push-snapshot`
+  task result indicates that `commonTags` is not an empty string
+
 ## Changes in 0.2.0
 - Remove push-sbom-to-pyxis. It has been replaced by manifest-box.

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -241,6 +241,10 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: populate-release-notes-images
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -261,6 +265,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: collect-pyxis-params
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -279,6 +287,10 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       timeout: "2h00m0s"
       taskRef:
         resolver: "git"
@@ -304,6 +316,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: create-pyxis-image
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -356,6 +372,10 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: run-file-updates
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -18,8 +18,17 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.1.1
+* Added a `when` clause to the following tasks
+  `rh-sign-image`,
+  `create-pyxis-image`
+  `collect-pyxis-params` and
+  `run-file-updates`
+  to ensure they only execute when the `push-snapshot`
+  task result indicates that `commonTags` is not an empty string
+
 ## Changes in 3.1.0
-- Remove push-sbom-to-pyxis. It has been replaced by manifest-box.
+* Remove push-sbom-to-pyxis. It has been replaced by manifest-box.
 
 ## Changes in 3.0.0
 * releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "3.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -237,6 +237,10 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: collect-pyxis-params
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -265,6 +269,10 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/rh-sign-image/rh-sign-image.yaml
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
@@ -289,6 +297,10 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-pyxis-image/create-pyxis-image.yaml
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: server
           value: $(tasks.collect-pyxis-params.results.server)
@@ -332,6 +344,10 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: run-file-updates
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)


### PR DESCRIPTION
* Added `when` clause to `rh-sign-image` and `create-pyxis-image` task in the pipeline to ensure it only executes when the `push-snapshot` task result indicates that `commonTags` is not an empty string