### PR TITLE
fix(RHTAPREL-863): sign images for registry.access too

### DIFF
--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -11,6 +11,9 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 | commonTags   | Space separated list of common tags to be used when publishing       | No       | -             |
 
+## Changes in 1.0.1
+* Update task image and make changes to accomodate for new `translate-delivery-repo` funtionality
+
 ## Changes in 1.0.0
 * Task renamed from extract-release-notes-images to populate-release-notes-images
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,7 +26,7 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: populate-release-notes-images
-      image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+      image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -50,7 +50,7 @@ spec:
         for component in $(jq -c '.components[]' "${SNAPSHOT_FILE}")
         do
             repo=$(jq -r '.repository' <<< $component)
-            deliveryRepo=$(translate-delivery-repo $repo)
+            deliveryRepo=$(translate-delivery-repo $repo | jq -r '.[] | select(.repo=="redhat.io") | .url')
             image=$(jq -r '.containerImage' <<< $component)
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,6 +14,10 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.2.1
+* An InternalRequest is now created to sign the both the registry.redhat.io and registry.access.redhat.com references
+  * This change comes with a bump in the image used for the task
+
 ## Changes in 2.2.0
 * Support was added to handle the signing of multi-arch images 
 

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+      image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
       script: |
         #!/usr/bin/env sh
         #
@@ -76,10 +76,14 @@ spec:
 
             reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
 
-            # Translate direct quay.io reference to public facing registry reference
-            # quay.io/redhat-prod/product----repo -> registry.redhat.io/product/repo
-            # quay.io/redhat-pending/product----repo -> registry.stage.redhat.io/product/repo
-            reference=$(translate-delivery-repo $reference)
+            # Translate direct quay.io reference to public facing registry json
+            # quay.io/redhat-prod/product----repo ->
+            #   [{"repo":"redhat.io","url":registry.redhat.io/product/repo"},
+            #   {"repo":"access.redhat.com","url":"registry.access.redhat.com/product/repo"}]
+            # quay.io/redhat-pending/product----repo ->
+            #   [{"repo":"redhat.io","url":registry.stage.redhat.io/product/repo"},
+            #   {"repo":"access.redhat.com","url":"registry.access.stage.redhat.com/product/repo"}]
+            referenceJson=$(translate-delivery-repo $reference)
 
             # check if multi-arch
             RAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${referenceContainerImage})
@@ -91,26 +95,28 @@ spec:
 
             for manifest_digest in $manifest_digests; do
               for tag in $(params.commonTags); do
-                echo "Creating InternalRequest to sign image with tag ${tag}:"
-                echo "- reference=${reference}:${tag}"
-                echo "- manifest_digest=${manifest_digest}"
-                echo "- requester=$(params.requester)"
+                for registry_reference in $(jq -r '.[] | .url' <<< $referenceJson); do
+                  echo "Creating InternalRequest to sign image with tag ${tag}:"
+                  echo "- reference=${registry_reference}:${tag}"
+                  echo "- manifest_digest=${manifest_digest}"
+                  echo "- requester=$(params.requester)"
   
-                internal-request -r "${request}" \
-                    -p pipeline_image=${pipeline_image} \
-                    -p reference=${reference}:${tag} \
-                    -p manifest_digest=${manifest_digest} \
-                    -p requester=$(params.requester) \
-                    -p config_map_name=${config_map_name} \
-                    -l ${TASK_LABEL}=${TASK_ID} \
-                    -l ${PIPELINERUN_LABEL}=$(params.pipelineRunUid) \
-                    -s false
-                ((++count))
+                  internal-request -r "${request}" \
+                      -p pipeline_image=${pipeline_image} \
+                      -p reference=${registry_reference}:${tag} \
+                      -p manifest_digest=${manifest_digest} \
+                      -p requester=$(params.requester) \
+                      -p config_map_name=${config_map_name} \
+                      -l ${TASK_LABEL}=${TASK_ID} \
+                      -l ${PIPELINERUN_LABEL}=$(params.pipelineRunUid) \
+                      -s false
+                  ((++count))
   
-                if [ "$count" -eq "$N" ]; then
-                    wait-for-ir -l ${TASK_LABEL}=${TASK_ID} -t $(params.requestTimeout)
-                    count=0
-                fi
+                  if [ "$count" -eq "$N" ]; then
+                      wait-for-ir -l ${TASK_LABEL}=${TASK_ID} -t $(params.requestTimeout)
+                      count=0
+                  fi
+                done
               done        
             done
         done

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -85,17 +85,29 @@ spec:
 
               for((ir=0; ir<irsLength; ir++)); do
                 params=$(jq -r ".items[$ir].spec.params" <<< "${internalRequests}")
-                i=$((ir/2))
-                if [ $((ir%2)) -eq 0 ]; then
+                i=$((ir/4))
+                if [ $((ir%4)) -eq 0 ]; then
                   if [ $(jq -r '.reference' <<< "${params}") \
                       != "registry.stage.redhat.io/prod/repo${i}:some-prefix-12345" ]; then
-                    echo "fixed tag reference does not match"
+                    echo "fixed tag redhat.io reference does not match"
+                    exit 1
+                  fi
+                elif [ $((ir%4)) -eq 1 ]; then
+                  if [ $(jq -r '.reference' <<< "${params}") \
+                      != "registry.access.stage.redhat.com/prod/repo${i}:some-prefix-12345" ]; then
+                    echo "fixed tag access.redhat.com reference does not match"
+                    exit 1
+                  fi
+                elif [ $((ir%4)) -eq 2 ]; then
+                  if [ $(jq -r '.reference' <<< "${params}") \
+                      != "registry.stage.redhat.io/prod/repo${i}:some-prefix" ]; then
+                    echo "floating tag redhat.io reference does not match"
                     exit 1
                   fi
                 else
                   if [ $(jq -r '.reference' <<< "${params}") \
-                      != "registry.stage.redhat.io/prod/repo${i}:some-prefix" ]; then
-                    echo "floating tag reference does not match"
+                      != "registry.access.stage.redhat.com/prod/repo${i}:some-prefix" ]; then
+                    echo "floating tag access.redhat.com reference does not match"
                     exit 1
                   fi
                 fi

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -71,18 +71,24 @@ spec:
               set -eux
 
               counter=0
-              # first 2 are for the 1st arch
-              # last 2 are for  the 2nd arch
+              # first 2 are for the 1st arch and registry.redhat.io
+              # 3-4 are for the 1st arch and registry.access.redhat.com
+              # 5-6 are for the 2nd arch and registry.redhat.io
+              # last 2 are for the 2nd arch and registry.access.redhat.com
               testValues=('sha256:6f9a420f660e73a' \
                           'sha256:6f9a420f660e73a' \
+                          'sha256:6f9a420f660e73a' \
+                          'sha256:6f9a420f660e73a' \
+                          'sha256:6f9a420f660e73b' \
+                          'sha256:6f9a420f660e73b' \
                           'sha256:6f9a420f660e73b' \
                           'sha256:6f9a420f660e73b')
 
               internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
               internalRequestsCount=$(echo $internalRequests | wc -w)
 
-              if [ $internalRequestsCount != "4" ] ; then
-                echo "incorrect number of internalRequests created. Expected 4"
+              if [ $internalRequestsCount != "8" ] ; then
+                echo "incorrect number of internalRequests created. Expected 8"
                 exit 1
               fi
 

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -70,9 +70,9 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              # First internal request with fixed tag
+              # First internal request with fixed tag and registry.redhat.io
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tail -2 | head -1)"
+                tail -4 | head -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") \
@@ -81,12 +81,34 @@ spec:
                 exit 1
               fi
 
-              # Second internal request with floating tag
+              # Second internal request with fixed tag and registry.access.redhat.com
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tail -3 | head -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix-12345" ]; then
+                echo "fixed tag reference does not match"
+                exit 1
+              fi
+
+              # Third internal request with floating tag and registry.redhat.io
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tail -2 | head -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
+                echo "floating tag reference does not match"
+                exit 1
+              fi
+
+              # Fourth internal request with floating tag and registry.access.redhat.com
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
                 tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
-              if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix" ]; then
                 echo "floating tag reference does not match"
                 exit 1
               fi

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -27,6 +27,9 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 3.0.1
+- Update task image and make changes to accomodate for new `translate-delivery-repo` funtionality
+
 ## Changes in 3.0.0
 - This task now requires a list of digests to use in the signing request via the parameter `manifestListDigests`
 - The `manifestDigestImage` parameter has been removed.

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
   steps:
     - name: sign-index-image
       image:
-        quay.io/redhat-appstudio/release-service-utils:cc80f80ba26c89c4979644e2bc7d8ccbbae7eaa1
+        quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
       script: |
         #!/usr/bin/env sh
         set -e
@@ -64,7 +64,7 @@ spec:
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
-        reference_image=$(translate-delivery-repo $reference_image)
+        reference_image=$(translate-delivery-repo $reference_image | jq -r '.[] | select(.repo=="redhat.io") | .url')
 
         # get all digests from manifest list
         for manifest_digest in $(params.manifestListDigests)


### PR DESCRIPTION
Amend the rh-sign-image task to sign both the registry.redhat.io location as well as the registry.access.redhat.com location. This commit also adjusts some other tasks that use translate-delivery-repo to account for these changes.