### PR TITLE
fix(KFLUXBUGS-1161): rh-sign-image does not fail when signing internal requests timeout

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,6 +14,10 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.2.3
+* Add `set -e` to the task script, so it can fail if the `wait-for-ir` script exits with a non-zero status code, when at
+  least one of the InternalRequests has not succeeded
+
 ## Changes in 2.2.2
 * An InternalRequest is now created to sign source containers
 

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.2.2"
+    app.kubernetes.io/version: "2.2.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,6 +46,8 @@ spec:
       script: |
         #!/usr/bin/env sh
         #
+        set -e
+
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         RUNDIR="$(workspaces.data.path)/$(context.taskRun.uid)"
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"


### PR DESCRIPTION
This commit add `set -e` to the task script so the task will fail when the `wait-for-ir` script exits with a non-zero code.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>