### PR TITLE
fix(RHTAPREL-842): FBC should error when preGA & hotfix both set

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -13,6 +13,10 @@ Task to create a internalrequest to add fbc contributions to index images
 | pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       |                      |
 
+## changes in 2.3.2
+- add check to fail the task if `fbc.preGA` and `fbc.hotfix` were both set in the `ReleasePlanAdmission` data and
+  test for the failing scenario
+
 ## changes in 2.3.1
 - fix the error message for the empty value of `issueId`, `productName` and `productVersion`
   with the old format, the backticks caused the string inside (e.g. fbc.issueId) to be executed as a command

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "2.3.1"
+    app.kubernetes.io/version: "2.3.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -97,6 +97,11 @@ spec:
 
         # default target_index
         target_index=$(params.targetIndex)
+
+        if [ "${hotfix}" == "true" ] && [ "${pre_ga}" == "true" ]; then
+          echo "fbc.preGA and fbc.hotfix are mutually exclusive. Please set just one in the ReleasePlanAdmission"
+          exit 1
+        fi
 
         # the target_index is modified when the pipelinerun is a for `hotfix` or a `pre-GA` release
         if [ "${hotfix}" == "true" ]; then

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-pre-ga-and-hotfix-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test the add-fbc-contribution task InternalRequest creation using
+    pre-GA data.fbc parameters
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "iibServiceConfigSecret": "test-iib-service-config-secret",
+                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "preGA": "true",
+                  "hotfix": "true",
+                  "productName": "pre-ga-product",
+                  "productVersion": "v2",
+                  "buildTimeoutSeconds": 420
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: binaryImage
+          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: fromIndex
+          value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: targetIndex
+          value: "quay.io/scoheb/fbc-target-index-testing:v4.12"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup


### PR DESCRIPTION
This commit adds a check to make sure fbc.preGA and fbc.hotfix can not be both set at once

Signed-off-by: Leandro Mendes <lmendes@redhat.com>