### PR TITLE
feat(RHTAPREL-663): add task to check for embargoes

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -21,6 +21,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.3.0
+- Add task `embargo-check` to end execution early if any passed issues or CVEs are embargoed.
+
 ## Changes in 0.2.2
 - Added a `when` clause to the following tasks
   `create-advisory`, and `check-data-keys`

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -264,6 +264,30 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+    - name: embargo-check
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/embargo-check/embargo-check.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - populate-release-notes-images
     - name: collect-pyxis-params
       when:
         - input: $(tasks.push-snapshot.results.commonTags)
@@ -315,6 +339,8 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+      runAfter:
+        - embargo-check
     - name: create-pyxis-image
       when:
         - input: $(tasks.push-snapshot.results.commonTags)
@@ -455,6 +481,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - check-data-keys
+        - embargo-check
   finally:
     - name: cleanup
       taskRef:

--- a/tasks/embargo-check/README.md
+++ b/tasks/embargo-check/README.md
@@ -1,0 +1,12 @@
+# embargo-check
+
+Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json are embargoed. It checks the issues
+by server using curl and checks the CVEs via an InternalRequest. If any issue or CVE is embargoed, the task will fail.
+
+## Parameters
+
+| Name                     | Description                                                                               | Optional | Default value               |
+|--------------------------|-------------------------------------------------------------------------------------------|----------|-----------------------------|
+| dataPath                 | Path to data JSON in the data workspace                                                   | Yes      | data.json                   |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180                         |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |

--- a/tasks/embargo-check/embargo-check.yaml
+++ b/tasks/embargo-check/embargo-check.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: embargo-check
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >
+    Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json
+    are embargoed. It checks the issues by server using curl and checks the CVEs via an
+    InternalRequest. If any issue or CVE is embargoed, the task will fail.
+  params:
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+      default: "data.json"
+    - name: requestTimeout
+      type: string
+      default: "180"
+      description: InternalRequest timeout
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  steps:
+    - name: check-issues
+      image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+      script: |
+        #!/usr/bin/env bash
+        set -x
+
+        SUPPORTED_ISSUE_TRACKERS='{
+            "Jira": {
+                "api": "rest/api/2/issue",
+                "servers": [
+                    "issues.redhat.com",
+                    "jira.atlassian.com"
+                ]
+            },
+            "bugzilla": {
+                "api": "rest/bug",
+                "servers": [
+                    "bugzilla.redhat.com"
+                ]
+            }
+        }'
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        RC=0
+
+        for issue in $(jq -cr '.releaseNotes.issues.fixed[]?' "${DATA_FILE}") ; do
+            server=$(jq -r '.source' <<< $issue)
+            API=$(jq -r '.[] | select(.servers[] | contains("'$server'")) | .api' <<< $SUPPORTED_ISSUE_TRACKERS)
+            API_URL="https://$(jq -r '.source' <<< $issue)/${API}/$(jq -r '.id' <<< $issue)"
+            curl --fail --output /dev/null ${API_URL}
+            if [ $? -ne 0 ] ; then
+                echo "${issue} is not publicly visible. Assuming it is embargoed and stopping pipelineRun execution."
+                RC=1
+            fi
+        done
+
+        exit $RC
+    - name: check-cves
+      image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+      script: |
+        #!/usr/bin/env bash
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+        CVES=$(jq -r '.releaseNotes.content.images[].cves.fixed
+            | to_entries[] | .key' "${DATA_FILE}" | sort -u | tr "\n" " ")
+
+        if [[ ${CVES} == "" ]] ; then
+            echo "No CVEs found to check"
+            exit 0
+        fi
+
+        echo "Checking the following CVEs: ${CVES}"
+
+        internal-request -r "check-embargoed-cves" \
+            -p cves="${CVES}" \
+            -l ${PIPELINERUN_LABEL}=$(params.pipelineRunUid) \
+            -t $(params.requestTimeout) \
+            -s true \
+            > $(workspaces.data.path)/ir-result.txt || \
+            (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
+        
+        internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
+        echo "done (${internalRequest})"
+
+        results=$(kubectl get internalrequest $internalRequest -o=jsonpath='{.status.results}')
+        if [[ "$(echo ${results} | jq -r '.result')" == "Success" ]]; then
+          echo "No embargoed CVEs found"
+        else
+          echo "The following CVEs are marked as embargoed:"
+          echo "$(echo ${results} | jq -cr '.embargoed_cves')"
+          exit 1
+        fi

--- a/tasks/embargo-check/tests/mocks.sh
+++ b/tasks/embargo-check/tests/mocks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function curl() {
+  echo Mock curl called with: $* >&2
+  echo $* >> $(workspaces.data.path)/mock_curl.txt
+
+  if [[ "$*" == "--fail --output /dev/null https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
+  then
+    :
+  elif [[ "$*" == "--fail --output /dev/null https://bugzilla.redhat.com/rest/bug/12345" ]]
+  then
+    :
+  elif [[ "$*" == "--fail --output /dev/null https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
+  then
+    exit 1
+  else
+    echo Error: Unexpected call
+    exit 1
+  fi
+}
+
+function internal-request() {
+  if [[ "$*" == *"CVE-999"* ]]; then
+    echo "Name: embargo-ir"
+  elif [[ "$*" == *"CVE-FAIL-555"* ]]; then
+    exit 1
+  else
+    echo "Name: success-ir"
+  fi
+}
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == *"get internalrequest success-ir"* ]]
+  then
+    echo '{"result":"Success","embargoed_cves":""}'
+  # Mock an IR with embargoed CVEs
+  elif [[ "$*" == *"get internalrequest embargo-ir"* ]]
+  then
+    echo '{"result":"Failure","embargoed_cves":"CVE-999"}'
+  else
+    kubectl $*
+  fi
+}

--- a/tasks/embargo-check/tests/pre-apply-task-hook.sh
+++ b/tasks/embargo-check/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-embargoed-cve
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test with an embargoed CVE
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "containerImage": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-999": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-embargoed-issue
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test for embargo-check where an issue is embargoed
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "EMBARGOED-987",
+                        "source": "jira.atlassian.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-embargoed-fail-no-data-json
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test for embargo-check where there is no data JSON
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-ir-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test with the InternalRequest failing to ensure task fails
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "containerImage": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-FAIL-555": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-no-release-notes
+spec:
+  description: Test for embargo-check where the data JSON has no releaseNotes key
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "foo": "bar"
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-public-cves
+spec:
+  description: Test with no embargoed CVEs
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "containerImage": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-345": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-public-issues
+spec:
+  description: Test for embargo-check where all issues are public
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "ISSUE-123",
+                        "source": "jira.atlassian.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:c6989496ce3326ae2556bd5afb992da13e94d3ea
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"ISSUE-123"* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 2 | tail -n 1) \
+                  == *"12345"* ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
Add a new tekton task that checks for embargoed issues and CVEs. It is added to the rh-advisories pipeline.