### PR TITLE
fix(RHTAPREL-8834): skip when commontag null

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -21,6 +21,12 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.2.2
+- Added a `when` clause to the following tasks
+  `create-advisory`, and `check-data-keys`
+  to ensure they only execute when the `push-snapshot`
+  task result indicates that `commonTags` is not an empty string
+
 ## Changes in 0.2.1
 - Added a `when` clause to the following tasks
   `rh-sign-image`,

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -401,6 +401,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -422,6 +426,10 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: create-advisory
+      when:
+        - input: $(tasks.push-snapshot.results.commonTags)
+          operator: notin
+          values: [""]
       params:
         - name: releasePlanAdmissionPath
           value: "$(tasks.collect-data.results.releasePlanAdmission)"


### PR DESCRIPTION
 Added a `when` clause to the following tasks
 `create-advisory`, and `check-data-keys`
 to ensure they only execute when the `push-snapshot`
 task result indicates that `commonTags` is not an empty string