### PR TITLE
feat(RHTAPREL-889): populate-release-notes keeps CVEs

### DIFF
--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -11,6 +11,11 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 | commonTags   | Space separated list of common tags to be used when publishing       | No       | -             |
 
+## Changes in 1.1.0
+* Existing CVE data is present in the resulting releaseNotes key instead of overwritten
+* Update task image for fix in get-image-architectures script
+  * util now outputs compact json
+
 ## Changes in 1.0.2
 * Absorb change in refactored get-image-architectures script
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,7 +26,7 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: populate-release-notes-images
-      image: quay.io/redhat-appstudio/release-service-utils:b3059c67d4bdb6c9cf1739fdfb2c0cb595fe0f86
+      image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -49,6 +49,7 @@ spec:
 
         for component in $(jq -c '.components[]' "${SNAPSHOT_FILE}")
         do
+            name=$(jq -r '.name' <<< $component)
             repo=$(jq -r '.repository' <<< $component)
             deliveryRepo=$(translate-delivery-repo $repo | jq -r '.[] | select(.repo=="redhat.io") | .url')
             image=$(jq -r '.containerImage' <<< $component)
@@ -64,6 +65,15 @@ spec:
             repository=$(echo ${containerImage} | cut -d '/' -f 2- | cut -d '@' -f 1)
             # purl should be pkg:oci/foo@sha256:abcde?repository_url=registry.redhat.io/foo/bar
             purl="pkg:oci/$(echo $repository | cut -d '/' -f 1)@sha256:${sha}?repository_url=${deliveryRepo}"
+            # Construct CVE json
+            CVEsJson='{"cves":{"fixed":{}}}'
+            for cve in $(jq -c '.releaseNotes.cves[] | select(.component=="'$name'")' ${DATA_FILE}) ; do
+                cveJson=$(jq -n \
+                    --arg id $(jq -r '.key' <<< $cve) \
+                    --argjson packages $(jq -c '.packages' <<< $cve) \
+                    '{($id): {"components": $packages}}')
+                CVEsJson=$(jq --argjson cve "$cveJson" '.cves.fixed += $cve' <<< $CVEsJson)
+            done
             # Add one entry per arch (amd64 for example)
             get-image-architectures "${image}" | while IFS= read -r arch_json;
             do
@@ -76,6 +86,9 @@ spec:
                     --argjson tags "$tags" \
                     '{"architecture": $arch, "containerImage":$containerImage,
                     "purl": $purl, "repository": $repository, "tags": $tags}')
+                if [ $(jq '.cves.fixed | length' <<< $CVEsJson) -gt 0 ]; then
+                    jsonString=$(jq --argjson cves "$CVEsJson" '. += $cves' <<< $jsonString)
+                fi
                 # Inject JSON into data.json
                 jq --argjson image "$jsonString" '.releaseNotes.content.images += [$image]' ${DATA_FILE} > \
                     /tmp/data.tmp && mv /tmp/data.tmp ${DATA_FILE}

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-populate-release-notes-images-single-image
+  name: test-populate-release-notes-images-cves-added
 spec:
   description: |
-    Run the populate-release-notes-images task with a single image in the snapshot JSON and verify
-    the data JSON has the proper content
+    Run the populate-release-notes-images task and ensure CVE information present in the data.json
+    is properly included in the releaseNotes.content.images.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -27,6 +27,29 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "releaseNotes": {
+                  "cves": [
+                    {
+                      "component": "comp",
+                      "packages": [
+                        "pkg1",
+                        "pkg2"
+                      ],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp",
+                      "packages": [
+                        "pkg3"
+                      ],
+                      "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
                   "product_id": 123,
                   "product_name": "Red Hat Openstack Product",
                   "product_version": "123",
@@ -96,20 +119,9 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
-              test $(jq -r '.architecture' <<< $imagearch1) == "amd64"
-              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:123456"
-              test $(jq -r '.purl' <<< $imagearch1) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch1) == "product/repo"
-              test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
-
-              imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
-              test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
-              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:123456"
-              test $(jq -r '.purl' <<< $imagearch2) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch2) == "product/repo"
-              test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
+              # The CVEs should be present in the comp image section
+              test $(jq '.releaseNotes.content.images[0].cves.fixed | length' "$(workspaces.data.path)/data.json") == 2
+              test "$(jq -jr '.releaseNotes.content.images[0].cves.fixed | keys[]' $(workspaces.data.path)/data.json)" \
+                == "CVE-123CVE-456"
       runAfter:
         - run-task

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-snapshot.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-snapshot.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -96,7 +96,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -98,7 +98,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
This commit modifies the populate-release-notes-images task to preserve CVE data that already exists in the data.json and add it to the image entries it creates.