### PR TITLE
fix(RELEASE-1): issues in output of "create-pyxis-image" task

### DIFF
--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -159,6 +159,6 @@ spec:
 
                 echo $IMAGEID >> $(results.containerImageIDs.path)
                 index=$((index + 1))
-            done <<< $(get-image-architectures "${PULLSPEC}")
+            done <<< $(get-image-architectures "${PULLSPEC}" | jq -c)
         done
         echo "$JSON_OUTPUT" | tee $(workspaces.data.path)/pyxis.json


### PR DESCRIPTION
This PR fixes the task create-pyxis-image breaking when
reading the output of the `get-image-architectures` command.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>