### PR TITLE
feat(RELEASE-500): update release service catalog reference to konflux-ci

### DIFF
--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -16,8 +16,12 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 2.1.0
+* update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 2.0.0
 * releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -15,8 +15,12 @@ Tekton release pipeline to interact with FBC Pipeline
 | enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key                            |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
-| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
+
+### Changes in 3.2.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ### Changes in 3.1.0
 - add a new `check-fbc-packages` task to support operator package name uniqueness constraints

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "3.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,7 +41,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -15,8 +15,12 @@ Tekton pipeline to release Snapshots to an external registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 4.2.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 4.0.1
 - Added `when` clause to `push-snapshot` task in the pipeline to ensure it only executes when

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.0.1"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -15,8 +15,12 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.1.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 3.0.0
 - releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,7 +46,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -18,8 +18,12 @@ the rh-push-to-registry-redhat-io pipeline.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 0.4.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 0.3.1
 - Added `when` clause to `push-snapshot` task in the pipeline

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.3.1"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -15,8 +15,12 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 4.2.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 4.1.1
 - Added `when` clause to 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.1.1"
+    app.kubernetes.io/version: "4.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -15,8 +15,12 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.2.0
+- Update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 3.1.2
 * Added `when` clause to `push-snapshot` task in the pipeline

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.1.2"
+    app.kubernetes.io/version: "3.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -17,8 +17,12 @@
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
-| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
+| taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 3.2.0
+- update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
 
 ## Changes in 3.1.1
 - Added `when` clause to

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.1.1"
+    app.kubernetes.io/version: "3.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/redhat-appstudio/release-service-catalog.git
+      default: https://github.com/konflux-ci/release-service-catalog.git
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used

--- a/tasks/base64-encode-checksum/tests/run.yaml
+++ b/tasks/base64-encode-checksum/tests/run.yaml
@@ -13,7 +13,7 @@ spec:
     resolver: "git"
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: main
       - name: pathInRepo

--- a/tasks/create-internal-request/tests/run.yaml
+++ b/tasks/create-internal-request/tests/run.yaml
@@ -23,7 +23,7 @@ spec:
     resolver: "git"
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: main
       - name: pathInRepo

--- a/tasks/prepare-validation/tests/run.yaml
+++ b/tasks/prepare-validation/tests/run.yaml
@@ -11,7 +11,7 @@ spec:
     resolver: "git"
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: main
       - name: pathInRepo

--- a/tasks/slack-webhook-notification/tests/run.yaml
+++ b/tasks/slack-webhook-notification/tests/run.yaml
@@ -15,7 +15,7 @@ spec:
     resolver: "git"
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: main
       - name: pathInRepo

--- a/tasks/update-infra-deployments/tests/run.yaml
+++ b/tasks/update-infra-deployments/tests/run.yaml
@@ -25,7 +25,7 @@ spec:
     resolver: "git"
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: main
       - name: pathInRepo


### PR DESCRIPTION
 This commit updates the `release-service catalog` reference
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800