### PR TITLE
feat(RELEASE-500): update ref to konflux ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @redhat-appstudio/konflux-release-team will be requested for
+# @konflux-ci/release-service-maintainers will be requested for
 # review when someone opens a pull request.
-*       @redhat-appstudio/konflux-release-team
+*       @konflux-ci/release-service-maintainers

--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -16,13 +16,13 @@
 #
 # Prerequisities:
 #   - An environment variable GITHUB_TOKEN is defined that provides access to the user's account. See
-#     https://github.com/redhat-appstudio/release-service-utils/blob/main/ci/promote-overlay/README.md#setup for help.
+#     https://github.com/konflux-ci/release-service-utils/blob/main/ci/promote-overlay/README.md#setup for help.
 #   - curl, git and jq installed.
 
 set -e
 
 # GitHub repository details
-ORG="redhat-appstudio"
+ORG="konflux-ci"
 REPO="release-service-catalog"
 
 OPTIONS=$(getopt --long "target-branch:,force-to-staging:,override:,dry-run:,help" -o "tgt:,h" -- "$@")


### PR DESCRIPTION
This commit updates CODEOWNER and promote_branch
script to point konflux-ci GitHub org due to
migration from redhat-appstudio.
more details parent EPIC:
https://issues.redhat.com/browse/RHTAPREL-800