### PR TITLE
feat(KFLUXBUGS-1115): add push-rpm-manifests task

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -21,6 +21,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.5.0
+- Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
+
 ## Changes in 0.4.0
 - update the taskGitUrl default value due to migration
   to konflux-ci GitHub org

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -401,6 +401,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - create-pyxis-image
+    - name: push-rpm-manifests-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+      params:
+        - name: pyxisJsonPath
+          value: $(tasks.create-pyxis-image.results.pyxisDataPath)
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
     - name: run-file-updates
       when:
         - input: $(tasks.push-snapshot.results.commonTags)
@@ -416,7 +436,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - push-snapshot
+        - push-rpm-manifests-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -18,6 +18,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.3.0
+- Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
+
 ## Changes in 4.2.0
 - update the taskGitUrl default value due to migration
   to konflux-ci GitHub org

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.2.0"
+    app.kubernetes.io/version: "4.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -263,6 +263,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-snapshot
+    - name: push-rpm-manifests-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+      params:
+        - name: pyxisJsonPath
+          value: $(tasks.create-pyxis-image.results.pyxisDataPath)
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
     - name: run-file-updates
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -278,7 +298,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - push-snapshot
+        - push-rpm-manifests-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -18,8 +18,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.3.0
+* Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
+
 ## Changes in 3.2.0
-- Update the taskGitUrl default value due to migration
+* Update the taskGitUrl default value due to migration
   to konflux-ci GitHub org
 
 ## Changes in 3.1.2

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -347,6 +347,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - create-pyxis-image
+    - name: push-rpm-manifests-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+      params:
+        - name: pyxisJsonPath
+          value: $(tasks.create-pyxis-image.results.pyxisDataPath)
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
     - name: run-file-updates
       when:
         - input: $(tasks.push-snapshot.results.commonTags)
@@ -362,7 +382,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - create-pyxis-image
+        - push-rpm-manifests-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -20,6 +20,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.3.0
+- Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
+
 ## Changes in 3.2.0
 - update the taskGitUrl default value due to migration
   to konflux-ci GitHub org

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -285,6 +285,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-snapshot
+    - name: push-rpm-manifests-to-pyxis
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+      params:
+        - name: pyxisJsonPath
+          value: $(tasks.create-pyxis-image.results.pyxisDataPath)
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+      workspaces:
+        - name: data
+          workspace: release-workspace
     - name: infra-deployments-pr
       taskRef:
         resolver: "git"
@@ -307,7 +327,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-snapshot
+        - push-rpm-manifests-to-pyxis
   finally:
     - name: send-slack-notification
       taskRef:

--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -1,0 +1,12 @@
+# push-rpm-manifests-to-pyxis
+
+Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an RPM Manifest.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| pyxisJsonPath | Path to the JSON string of the saved Pyxis data in the data workspace | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
+| server | The server type to use. Options are 'production' and 'stage' | Yes | production |
+| concurrentLimit | The maximum number of images to be processed at once | Yes | 4 |

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-rpm-manifests-to-pyxis
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an RPM Manifest.
+  params:
+    - name: pyxisJsonPath
+      description: Path to the JSON string of the saved Pyxis data in the data workspace
+      type: string
+    - name: pyxisSecret
+      type: string
+      description: |
+        The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: server
+      type: string
+      description: The server type to use. Options are 'production' and 'stage'
+      default: production
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be processed at once
+      default: 4
+  workspaces:
+    - name: data
+      description: The workspace where the pyxis data json file resides
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  steps:
+    - name: download-sbom-files
+      image:
+        quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+      volumeMounts:
+        - mountPath: /workdir
+          name: workdir
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        PYXIS_FILE="$(workspaces.data.path)/$(params.pyxisJsonPath)"
+        if [ ! -f "${PYXIS_FILE}" ] ; then
+            echo "No valid pyxis file was provided."
+            exit 1
+        fi
+
+        IMAGEURLS=($(cat "${PYXIS_FILE}" | jq -r '.components[].pyxisImages[].containerImage' | sort | uniq))
+
+        mkdir /workdir/sboms
+        cd /workdir/sboms
+
+        for i in ${!IMAGEURLS[@]}; do
+          echo "Fetching sbom for image: ${IMAGEURLS[$i]}"
+          FILE="$(echo ${IMAGEURLS[$i]} | tr "/@:" ---).json"
+          cosign download sbom --output-file "${FILE}" "${IMAGEURLS[$i]}"
+        done
+
+        SBOM_COUNT=$(ls *.json | wc -l )
+        if [ $SBOM_COUNT != ${#IMAGEURLS[@]} ]; then
+          echo "ERROR: Expected to fetch sbom for ${#IMAGEURLS[@]} images, but only $SBOM_COUNT were saved"
+          exit 1
+        fi
+
+    - name: push-rpm-manifests-to-pyxis
+      image:
+        quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+      env:
+        - name: pyxisCert
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: cert
+        - name: pyxisKey
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: key
+      volumeMounts:
+        - mountPath: /workdir
+          name: workdir
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [[ "$(params.server)" == "production" ]]
+        then
+          export PYXIS_GRAPHQL_API="https://graphql-pyxis.api.redhat.com/graphql/"
+        elif [[ "$(params.server)" == "stage" ]]
+        then
+          export PYXIS_GRAPHQL_API="https://graphql-pyxis.preprod.api.redhat.com/graphql/"
+        else
+          echo "Invalid server parameter. Only 'production' and 'stage' are allowed."
+          exit 1
+        fi
+
+        export PYXIS_CERT_PATH=/tmp/crt
+        export PYXIS_KEY_PATH=/tmp/key
+        echo "${pyxisCert}" > $PYXIS_CERT_PATH
+        echo "${pyxisKey}" > $PYXIS_KEY_PATH
+
+        PYXIS_FILE="$(workspaces.data.path)/$(params.pyxisJsonPath)"
+
+        cd /workdir/sboms
+
+        N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
+        declare -a jobs=()
+        declare -a files=()
+        total=$(jq '[.components[].pyxisImages | length] | add' "${PYXIS_FILE}")
+        count=0
+        success=true
+        echo "Starting RPM Manifest upload for $total files in total. " \
+          "Up to $N files will be uploaded at once..."
+
+        # Loop through all components then all images in case there is a space
+        # in one of the keys or values, which would break jq looping
+        NUM_COMPONENTS=$(jq '.components | length' "${PYXIS_FILE}")
+        for ((i = 0; i < $NUM_COMPONENTS; i++)); do
+          COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
+          NUM_IMAGES=$(jq '.pyxisImages | length' <<< $COMPONENT)
+          for ((j = 0; j < $NUM_IMAGES; j++)); do
+            IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< $COMPONENT)
+            IMAGEID=$(jq -r '.imageId' <<< $IMAGE)
+            SBOM="$(jq -r '.containerImage' <<< $IMAGE | tr "/@:" ---).json"
+            echo Uploading RPM Manifest to Pyxis for IMAGE: $IMAGEID with SBOM: $SBOM
+            upload_rpm_manifest --retry --image-id $IMAGEID --sbom-path $SBOM > ${IMAGEID}.out 2>&1 &
+
+            jobs+=($!)  # Save the background process ID
+            images+=($IMAGEID)
+            ((++count))
+
+            if [ $((count%N)) -eq 0 -o $((count)) -eq $total ]; then
+              echo Waiting for the current batch of background processes to finish
+              for job_id in "${!jobs[@]}"; do
+                if ! wait ${jobs[job_id]}; then
+                  echo "Error: upload of ${IMAGE} failed"
+                  success=false
+                fi
+              done
+
+              echo
+              echo Printing outputs for current upload_rpm_manifest script runs
+              for img in ${images[@]}; do
+                echo "=== $img ==="
+                cat "${img}.out"
+                echo
+              done
+
+              if [ $success != "true" ]; then
+                echo ERROR: At least one upload in the last batch failed
+                exit 1
+              fi
+
+              # Reset job and files arrays for the next batch
+              jobs=()
+              images=()
+            fi
+          done
+        done

--- a/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function cosign() {
+  echo Mock cosign called with: $*
+  echo $* >> $(workspaces.data.path)/mock_cosign.txt
+
+  if [[ "$*" != "download sbom --output-file imageurl"[1-5]*".json imageurl"[1-5] && \
+     "$*" != "download sbom --output-file quay.io-org-repo-sha256-0123456abcdef.json quay.io/org/repo@sha256:0123456abcdef" ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  touch /workdir/sboms/${4}
+}
+
+function upload_rpm_manifest() {
+  echo Mock upload_rpm_manifest called with: $*
+  echo $* >> $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+
+  if [[ "$*" != "--retry --image-id "*" --sbom-path "*".json" ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  if [[ "$3" == myImageID1Failing ]]
+  then
+    echo "Simulating a failing RPM Manifest push..."
+    return 1
+  fi
+
+  if [[ "$3" == myImageID?Parallel ]]
+  then
+    LOCK_FILE=$(workspaces.data.path)/${3}.lock
+    touch $LOCK_FILE
+    sleep 2
+    LOCK_FILE_COUNT=$(ls $(workspaces.data.path)/*.lock | wc -l)
+    echo $LOCK_FILE_COUNT > $(workspaces.data.path)/${3}.count
+    sleep 2
+    rm $LOCK_FILE
+  fi
+}

--- a/tasks/push-rpm-manifests-to-pyxis/tests/pre-apply-task-hook.sh
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Create a dummy pyxis secret (and delete it first if it exists)
+kubectl delete secret test-push-rpm-manifests-to-pyxis-cert --ignore-not-found
+kubectl create secret generic test-push-rpm-manifests-to-pyxis-cert --from-literal=cert=mycert --from-literal=key=mykey
+
+# Add mocks to the beginning of scripts
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpm-manifests-to-pyxis-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-rpm-manifests-to-pyxis task with required parameters.
+    The first image will fail. The second image will still have a rpm manifest pushed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/pyxis.json << EOF
+              {
+                "components": [
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID1Failing",
+                        "digest": "mydigest1",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl1"
+                      }
+                    ]
+                  },
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID2",
+                        "digest": "mydigest2",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl2"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-rpm-manifests-to-pyxis
+      params:
+        - name: pyxisJsonPath
+          value: pyxis.json
+        - name: pyxisSecret
+          value: test-push-rpm-manifests-to-pyxis-cert
+        - name: server
+          value: production
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-no-pyxis-file.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpm-manifests-to-pyxis-no-pyxis-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-rpm-manifests-to-pyxis task with no pyxis file provided in the workspace.
+    This should result in a failure.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-rpm-manifests-to-pyxis
+      params:
+        - name: pyxisJsonPath
+          value: missing.json
+        - name: pyxisSecret
+          value: test-push-rpm-manifests-to-pyxis-cert
+        - name: server
+          value: production
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpm-manifests-to-pyxis-parallel
+spec:
+  description: |
+    Run the push-rpm-manifests-to-pyxis task with required parameters with multiple images
+    processed in parallel.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/pyxis.json << EOF
+              {
+                "components": [
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID1Parallel",
+                        "digest": "mydigest2",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl1"
+                      },
+                      {
+                        "arch": "ppc64le",
+                        "imageId": "myImageID2Parallel",
+                        "digest": "mydigest2",
+                        "arch_digest": "deadbeef",
+                        "containerImage": "imageurl1"
+                      }
+                    ]
+                  },
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID3Parallel",
+                        "digest": "mydigest3",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl2"
+                      },
+                      {
+                        "arch": "ppc64le",
+                        "imageId": "myImageID4Parallel",
+                        "digest": "mydigest4",
+                        "arch_digest": "deadbeef",
+                        "containerImage": "imageurl2"
+                      }
+                    ]
+                  },
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID5Parallel",
+                        "digest": "mydigest5",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl3"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-rpm-manifests-to-pyxis
+      params:
+        - name: pyxisJsonPath
+          value: pyxis.json
+        - name: pyxisSecret
+          value: test-push-rpm-manifests-to-pyxis-cert
+        - name: server
+          value: production
+        - name: concurrentLimit
+          value: 4
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 3 ]; then
+                echo Error: cosign was expected to be called 3 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 5 ]; then
+                echo Error: upload_rpm_manifest was expected to be called 5 times. Actual calls:
+                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+                exit 1
+              fi
+
+              # Check that multiple instances of upload_rpm_manifest were running in parallel - up to 4 at once
+              if ! cat $(workspaces.data.path)/myImageID[1234]Parallel.count | grep 4; then
+                echo Error: Expected to see 4 parallel runs of upload_rpm_manifest at some point.
+                echo Actual counts:
+                cat $(workspaces.data.path)/myImageID[1234]Parallel.count
+                exit 1
+              fi
+              # The last instance of upload_rpm_manifest was in a new batch - it ran alone
+              test $(wc -l < $(workspaces.data.path)/myImageID5Parallel.count) -eq 1
+      runAfter:
+        - run-task

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpm-manifests-to-pyxis
+spec:
+  description: |
+    Run the push-rpm-manifests-to-pyxis task with required parameters - a happy path scenario.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/pyxis_data.json << EOF
+              {
+                "components": [
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID1",
+                        "digest": "mydigest1",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "imageurl1"
+                      },
+                      {
+                        "arch": "ppc64le",
+                        "imageId": "myImageID2",
+                        "digest": "mydigest1",
+                        "arch_digest": "deadbeef",
+                        "containerImage": "imageurl1"
+                      }
+                    ]
+                  },
+                  {
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID3",
+                        "digest": "mydigest2",
+                        "arch_digest": "abcdefg",
+                        "containerImage": "quay.io/org/repo@sha256:0123456abcdef"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-rpm-manifests-to-pyxis
+      params:
+        - name: pyxisJsonPath
+          value: pyxis_data.json
+        - name: pyxisSecret
+          value: test-push-rpm-manifests-to-pyxis-cert
+        - name: server
+          value: production
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
+                echo Error: cosign was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 3 ]; then
+                echo Error: upload_rpm_manifest was expected to be called 3 times. Actual calls:
+                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit adds a new task `push-rpm-manifests-to-pyxis` and adds it to all the pipelines that interact with pyxis. This task is needed so that the package list for containers in RHEC is properly populated.