### PR TITLE
refactor(KFLUXBUGS-1115): modify create-pyxis-image results

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -4,8 +4,8 @@ Tekton task that pushes metadata to Pyxis for all container images contained in 
 result of the `apply-mapping` task. It first extracts the containerImages from the snapshot, then runs
 `skopeo inspect` on each, before finally pushing metadata to Pyxis.
 
-The IDs of the created `containerImage` Pyxis objects are stored as a task result with each ID separated
-by a new line.
+The relative path of the pyxis.json file in the data workspace is output as a task result named
+`pyxisDataPath`.
 
 ## Parameters
 
@@ -19,6 +19,11 @@ by a new line.
 | commonTags | Space separated list of common tags to be used when publishing. If set, these tags will be added to the Pyxis Container Image object. | Yes | "" |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
+
+## Changes in 2.4.0
+* containerImageIDs result is removed as the data is present in pyxis.json that is written to the workspace
+* the containerImage is now saved in the pyxis.json entries
+* the pyxis.json file is saved in the same subdirectory as the passed snapshot file
 
 ## Changes in 2.3.0
 * remove `dataPath` and `snapshotPath` default values

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.3.0"
+    app.kubernetes.io/version: "2.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -55,9 +55,8 @@ spec:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
   results:
-    - name: containerImageIDs
-      type: string
-      description: IDs of the created entries in Pyxis, each on its own line
+    - name: pyxisDataPath
+      description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
       image: quay.io/redhat-appstudio/release-service-utils:b3059c67d4bdb6c9cf1739fdfb2c0cb595fe0f86
@@ -98,6 +97,9 @@ spec:
             echo "No valid snapshot file was provided."
             exit 1
         fi
+
+        PYXIS_DATA_PATH="$(dirname $(params.snapshotPath))/pyxis.json"
+        echo -n "${PYXIS_DATA_PATH}" > $(results.pyxisDataPath.path)
 
         if [ -n "$(params.commonTags)" ]; then
           TAGS="$(params.commonTags)"
@@ -145,18 +147,19 @@ spec:
                   --media-type "$MEDIA_TYPE" \
                   --architecture-digest "$ARCH_DIGEST" \
                   --rh-push $(params.rhPush) | tee "/tmp/output"
+                # The rh-push-to-external-registry e2e test depends on this line being in the task log
                 IMAGEID=$(awk '/The image id is/{print $NF}' /tmp/output)
                 JSON_OUTPUT=$(jq --argjson component_index $i --argjson arch_index $index \
                   --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \
-                  --arg arch_digest "${ARCH_DIGEST}" \
+                  --arg arch_digest "${ARCH_DIGEST}" --arg containerImage "${CONTAINER_IMAGE}" \
                     '.components[$component_index].pyxisImages[$arch_index] += {
                       "arch": $arch,
                       "imageId": $imageId,
                       "digest": $digest,
-                      "arch_digest": $arch_digest}' <<< "$JSON_OUTPUT")
+                      "arch_digest": $arch_digest,
+                      "containerImage": $containerImage}' <<< "$JSON_OUTPUT")
 
-                echo $IMAGEID >> $(results.containerImageIDs.path)
                 index=$((index + 1))
             done <<< $(get-image-architectures "${PULLSPEC}" | jq -c)
         done
-        echo "$JSON_OUTPUT" | tee $(workspaces.data.path)/pyxis.json
+        echo "$JSON_OUTPUT" | tee "$(workspaces.data.path)/${PYXIS_DATA_PATH}"

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -72,10 +72,16 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pyxisDataPath
+            type: string
         workspaces:
           - name: data
         steps:
@@ -121,24 +127,24 @@ spec:
                 exit 1
               fi
 
-              # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )' \
-                $(workspaces.data.path)/pyxis.json
+              # check if the correct arch, image id, and containerImage are set in the json file
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
+                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )
+                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[1].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0004" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[1].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0004" )
+                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0005" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0005" )
+                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[2].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0006" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[2].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0006" )
+                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -72,10 +72,16 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:   
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pyxisDataPath
+            type: string
         workspaces:
           - name: data
         steps:
@@ -113,14 +119,14 @@ spec:
               fi
 
               # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )
+                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )
+                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -62,10 +62,16 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:   
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pyxisDataPath
+            type: string
         workspaces:
           - name: data
         steps:
@@ -109,11 +115,11 @@ spec:
               docker://registry.io/multi-arch-image@mydigest" ]
 
               # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
+                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -61,10 +61,16 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:   
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pyxisDataPath
+            type: string
         workspaces:
           - name: data
         steps:
@@ -107,8 +113,8 @@ spec:
                 = "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/image@mydigest" ]
 
               # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )' \
-                $(workspaces.data.path)/pyxis.json
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task


### PR DESCRIPTION
This commit modifies the create-pyxis-image task to no longer have containerImageIDs as a result. These are stored in the pyxis.json file it now creates and no pipeline is using them. It also update the pyxis.json to include the containerImage value in each entry.