### PR TITLE
feat(RELEASE-266): use digest-based tag for source container origin

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -10,6 +10,13 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | No       |                      |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
 
+## Changes in 4.3.0
+* When pushing source containers, the origin is now determined using `$repo:${digest}.src` instead of `$repo:${git_sha}.src`
+  that was used previously. This follows a change in the build service.
+  * We also added a new push of the source container to `$repo:${digest}.src`.
+* Fixed a bug when pushing source containers where previously we would never skip a push even if the destination container
+  already existed, because we were comparing the binary image digest instead of the source container one.
+
 ## Changes in 4.2.0
 * remove `dataPath` and `snapshotPath` default values
 

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "4.2.0"
+    app.kubernetes.io/version: "4.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
-        push_image () { # Expected arguments are [source_digest, name, containerImage, repository, tag, arch]
+        push_image () { # Expected arguments are [origin_digest, name, containerImage, repository, tag, arch]
           # note: Inspection might fail on empty repos, hence `|| true`
           destination_digest=$(
             skopeo inspect \
@@ -101,7 +101,7 @@ spec:
 
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
-          source_digest=$(skopeo inspect \
+          origin_digest=$(skopeo inspect \
             --override-arch "${arch}" \
             --no-tags \
             --format '{{.Digest}}' \
@@ -116,24 +116,24 @@ spec:
           if [ $floatingTagsCount -gt 0 ]; then
             for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
               # Push the container image
-              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${floatingTag}" \
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${floatingTag}" \
               "${arch}"
-              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" \
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" \
               "${floatingTag}-${timestamp}" "${arch}"
             done
           else
             defaultTag=$(jq -r '.images.defaultTag // "latest"' "${DATA_FILE}")
             tag=$(jq -r --arg defaultTag $defaultTag '.tag // $defaultTag' <<< $component)
-            push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${tag}" "${arch}"
+            push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${tag}" "${arch}"
           fi
           if [[ $(jq -r ".images.addTimestampTag" "${DATA_FILE}") == "true" ]] ; then # Default to false
             timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
-            push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "$timestamp" "${arch}"
+            push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "$timestamp" "${arch}"
           fi
           if [[ $(jq -r ".images.addGitShaTag" "${DATA_FILE}") != "false" ]] ; then # Default to true
             if [ "${git_sha}" != "null" ] ; then
-              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha:0:7}" "${arch}"
-              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha}" "${arch}"
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha:0:7}" "${arch}"
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${git_sha}" "${arch}"
             else
               printf 'Asked to create git sha based tag, but no git sha found in %s\n' "${component}"
               exit 1
@@ -143,7 +143,7 @@ spec:
             if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
             then
               sha=$(echo "${containerImage}" | cut -d ':' -f 2)
-              push_image "${source_digest}" "${name}" "${containerImage}" "${repository}" "${sha}" "${arch}"
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${sha}" "${arch}"
             else
               printf 'Asked to create source sha based tag, but no sha found in %s\n' "${containerImage}"
               exit 1
@@ -151,11 +151,18 @@ spec:
           fi
           # Push the associated source container using the common tags
           if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
+            source_repo=${containerImage%%@sha256:*}
+            source_tag=${origin_digest/:/-}.src
             # Calculate the source container image based on the provided container image
-            sourceContainer="${containerImage%@sha256:*}:${git_sha}.src"
+            sourceContainer="${source_repo}:${source_tag}"
             # Check if the source container exists
-            skopeo inspect --override-arch "${arch}" --no-tags "docker://${sourceContainer}" >/dev/null
-            if [ $? != 0 ] ; then
+            source_container_digest=$(skopeo inspect \
+              --override-arch "${arch}" \
+              --no-tags \
+              --format '{{.Digest}}' \
+              "docker://${sourceContainer}" 2>/dev/null)
+
+            if [ -z "$source_container_digest" ] ; then
               echo "Error: Source container ${sourceContainer} not found!"
               exit 1
             fi
@@ -163,11 +170,13 @@ spec:
               echo "Error: at least one tag must exist in floatingTags when pushing source containers"
               exit 1
             fi
+            push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
+              "${repository}" "${source_tag}" "${arch}"
             for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
-              push_image "${source_digest}" "${name}" "${sourceContainer}" \
-                "${repository}" "${floatingTag}-${timestamp}-source" "${arch}"
-              push_image "${source_digest}" "${name}" "${sourceContainer}" \
+              push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
                 "${repository}" "${floatingTag}-source" "${arch}"
+              push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
+                "${repository}" "${floatingTag}-${timestamp}-source" "${arch}"
             done
           fi
         done

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -25,11 +25,20 @@ function cosign() {
 }
 
 function skopeo() {
-  echo Mock skopeo called with: $*
+  echo Mock skopeo called with: $* >&2
   echo $* >> $(workspaces.data.path)/mock_skopeo.txt
 
   if [[ "$*" == "inspect --override-arch "*" --no-tags --format {{.Digest}} docker://"* ]]; then
-    echo $5
+    # test scenarios where we want to skip the push because the image already exists
+    if [[ "$7" == *skip-image*.src || "$7" == *skip-image*-source ]]; then
+      echo "sha256:000000"
+    elif [[ "$7" == *skip-image* ]]; then
+      echo "sha256:111111"
+    else
+      # echo the shasum computed from the pull spec so the task knows if two images are the same
+      echo -n "sha256:"
+      echo $7 | sha256sum | cut -d ' ' -f 1
+    fi
     return
   fi
   if [[ "$*" == "inspect --override-arch "*" --no-tags docker://"* ]]; then

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-skip-existing
+spec:
+  description: |
+    Run the push-snapshot task including source container push.
+    Test the scenario where the destination image already exists (both binary and source).
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/skip-image:tag",
+                    "repository": "prod-registry.io/skip-image"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false,
+                  "pushSourceContainer": true,
+                  "floatingTags": [
+                    "testtag"
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: retries
+          value: 0
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ -f $(workspaces.data.path)/mock_cosign.txt ]; then
+                echo Error: cosign was not expected to be called. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 7 ]; then
+                echo Error: skopeo was expected to be called 7 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -96,27 +96,31 @@ spec:
                 exit 1
               fi
 
+              # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
+              # from the origin image pull spec - see mocks.sh
               cat > $(workspaces.data.path)/cosign_expected_calls.txt << EOF
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag-$epoch
               copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
-               prod-registry.io/prod-location:testtag-$epoch-source
-              copy -f registry.io/image:a51005b614c359b17a24317fdb264d76b2706a5a.src\
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag-$epoch
+              copy -f registry.io/image:sha256-570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e.src\
+               prod-registry.io/prod-location:sha256-570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e.src
+              copy -f registry.io/image:sha256-570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e.src\
                prod-registry.io/prod-location:testtag-source
+              copy -f registry.io/image:sha256-570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e.src\
+               prod-registry.io/prod-location:testtag-$epoch-source
               EOF
 
-              if [ $(cat $(workspaces.data.path)/cosign_expected_calls.txt | md5sum)
-                != $(cat $(workspaces.data.path)/mock_cosign.txt | md5sum) ]; then
+              if [ "$(cat $(workspaces.data.path)/cosign_expected_calls.txt | md5sum)" \
+                != "$(cat $(workspaces.data.path)/mock_cosign.txt | md5sum)" ]; then
                 echo Error: Expected cosign calls do not match actual calls
                 echo Actual calls:
-                cat cat $(workspaces.data.path)/mock_cosign.txt
+                cat $(workspaces.data.path)/mock_cosign.txt
                 echo Expected calls:
                 cat $(workspaces.data.path)/cosign_expected_calls.txt
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 6 ]; then
-                echo Error: skopeo was expected to be called 6 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 7 ]; then
+                echo Error: skopeo was expected to be called 7 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,8 +14,14 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.4.0
+* When pushing source containers, the origin is now determined using `$repo:${digest}.src` instead of `$repo:${git_sha}.src`
+  that was used previously. This follows a change in the build service.
+  * We now also push this new tag, so sign it as well.
+
+
 ## Changes in 2.3.0
-- remove `dataPath` and `snapshotPath` default values
+* remove `dataPath` and `snapshotPath` default values
 
 ## Changes in 2.2.3
 * Add `set -e` to the task script, so it can fail if the `wait-for-ir` script exits with a non-zero status code, when at
@@ -29,7 +35,7 @@ Task to create internalrequests to sign snapshot components
   * This change comes with a bump in the image used for the task
 
 ## Changes in 2.2.0
-* Support was added to handle the signing of multi-arch images 
+* Support was added to handle the signing of multi-arch images
 
 ## Changes in 2.1.0
 * Use the translate-delivery-repo util for translating the reference variable

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.3.0"
+    app.kubernetes.io/version: "2.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -97,8 +97,11 @@ spec:
 
             sourceContainerDigest=
             if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
+              source_repo=${referenceContainerImage%%@sha256:*}
+              source_reference_tag=sha256-${referenceContainerImage#*@sha256:}.src
               # Calculate the source container image based on the provided container image
-              sourceContainer="${referenceContainerImage%@sha256:*}:${git_sha}.src"
+              sourceContainer="${source_repo}:${source_reference_tag}"
+
               sourceContainerDigest=$(skopeo inspect \
                 --no-tags \
                 --format '{{.Digest}}' \
@@ -112,7 +115,7 @@ spec:
                   echo "- reference=${registry_reference}:${tag}"
                   echo "- manifest_digest=${manifest_digest}"
                   echo "- requester=$(params.requester)"
-  
+
                   internal-request -r "${request}" \
                       -p pipeline_image=${pipeline_image} \
                       -p reference=${registry_reference}:${tag} \
@@ -123,13 +126,13 @@ spec:
                       -l ${PIPELINERUN_LABEL}=$(params.pipelineRunUid) \
                       -s false
                   ((++count))
-  
+
                   if [ "$count" -eq "$N" ]; then
                       wait-for-ir -l ${TASK_LABEL}=${TASK_ID} -t $(params.requestTimeout)
                       count=0
                   fi
                 done
-              done        
+              done
             done
 
             if [ "${sourceContainerDigest}" != "" ] ; then

--- a/tasks/rh-sign-image/tests/mocks.sh
+++ b/tasks/rh-sign-image/tests/mocks.sh
@@ -21,8 +21,11 @@ function internal-request() {
 
   if [[ "$*" == *"requester=testuser-failure"* ]]; then
       set_ir_status $NAME Failure 3 &
-  else
+  elif [[ "$*" == *"requester=testuser-timeout"* ]]; then
+      # The interval in wait-for-ir is 5 sec, so increase the ir delay to timeout for sure
       set_ir_status $NAME Succeeded 10 &
+  else
+      set_ir_status $NAME Succeeded 5 &
   fi
 }
 
@@ -122,7 +125,7 @@ function skopeo() {
                 }
             '
         else
-          if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image0:deadbeef.src"* ]]
+          if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image0:sha256-0000.src"* ]]
           then
             echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
           else

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -90,7 +90,7 @@ spec:
 
               # First internal request with fixed tag and registry.redhat.io
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tail -8 | head -1)"
+                head -1 | tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") \
@@ -101,7 +101,7 @@ spec:
 
               # Second internal request with fixed tag and registry.access.redhat.com
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tail -7 | head -1)"
+                head -2 | tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") \
@@ -112,7 +112,7 @@ spec:
 
               # Third internal request with floating tag and registry.redhat.io
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tail -6 | head -1)"
+                head -3 | tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
@@ -122,7 +122,7 @@ spec:
 
               # Fourth internal request with floating tag and registry.access.redhat.com
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tail -5 | head -1)"
+                head -4 | tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
 
               if [ $(jq -r '.reference' <<< "${params}") \

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -54,7 +54,7 @@ spec:
         name: rh-sign-image
       params:
         - name: requester
-          value: testuser-single
+          value: testuser-timeout
         - name: commonTags
           value: "some-prefix-12345 some-prefix"
         - name: requestTimeout


### PR DESCRIPTION
The build service is switching to a new tag for the source container, so we need to use the new one which is based on the binary image digest. (For now they push both.)

Also, push this new digest-based tag to the destination repo as well.

Also, fix a bug where the digest comparison was wrong when pushing source containers, so the push would happen even if the destination already had the image.