### PR TITLE
feat(RELEASE-537): add option to skip pyxis repo publishing

### DIFF
--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -22,6 +22,9 @@ does not publish the repository.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       |                    |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                           | No       |                    |
 
+## Changes in 0.4.0
+* Add option to skip publishing via `skipRepoPublishing` flag in the data file
+
 ## Changes in 0.3.0
 * remove `dataPath` and `snapshotPath` default values
 

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -84,9 +84,16 @@ spec:
             exit 1
         fi
 
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+
+        # Default to false
+        if [[ -f "${DATA_FILE}" && $(jq -r ".pyxis.skipRepoPublishing" "${DATA_FILE}") == "true" ]] ; then
+            echo "skipRepoPublishing is set to true, exiting..."
+            exit
+        fi
+
         PAYLOAD='{"published":true}'
 
-        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [[ -f "${DATA_FILE}" && $(jq -r '.images.pushSourceContainer' ${DATA_FILE}) == "true" ]] ; then
             PAYLOAD=$(jq -c '. += {"source_container_image_enabled":true}' <<< $PAYLOAD)
         fi
@@ -101,7 +108,7 @@ spec:
             PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
             PYXIS_REPOSITORY_JSON=$(curl --retry 5 --key /tmp/key --cert /tmp/crt \
                 "${PYXIS_URL}/v1/repositories/registry/${PYXIS_REGISTRY}/repository/${PYXIS_REPOSITORY}" -X GET)
-        
+
             PYXIS_REPOSITORY_ID=$(jq -r '._id // ""' <<< $PYXIS_REPOSITORY_JSON)
             if [ -z "$PYXIS_REPOSITORY_ID" ]; then
                 echo Error: Unable to get Container Repository object id from Pyxis
@@ -118,7 +125,7 @@ spec:
               echo "Skipping the setting of the published flag."
               continue
             fi
-        
+
             curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
                 -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
         done

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-skip-publishing
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a single component and skipRepoPublishing
+    set to true in the data JSON. The task will stop right at the start.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "pyxis": {
+                  "skipRepoPublishing": "true"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ -f $(workspaces.data.path)/mock_curl.txt ]; then
+                  echo Error: curl was not expected to be called. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+      runAfter:
+        - run-task


### PR DESCRIPTION
If pyxis.skipRepoPublishing is set to true in the data file, the publishing of the repo in Pyxis will be skipped.