### PR TITLE
refactor(RELEASE-384): push-snapshot accepts tags per component

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -2,6 +2,12 @@
 
 Tekton task to push snapshot images to an image registry using `cosign copy`.
 
+This task supports variable expansion in tag values from the mapping. The currently supported variables are:
+* "{{ timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
+* "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
+* "{{ git_short_sha }}" -> The git sha reduced to 7 characters
+* "{{ digest_sha }}" -> The image digest of the respective component
+
 ## Parameters
 
 | Name               | Description                                                               | Optional | Default value        |
@@ -9,6 +15,14 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       |                      |
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | No       |                      |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes in 4.4.0
+* Added support for component specific tags
+  * Each component in the mapping can specify a tags array
+  * A defaults section can also be provided in the mapping
+  * The supported variables will be replaced in the passed tags
+  * The old functionality remains. The new tag functionality is only used if provided. In version 5.0.0, the old
+    functionality will be removed. The new tag functionality has priority over the old style.
 
 ## Changes in 4.3.0
 * When pushing source containers, the origin is now determined using `$repo:${digest}.src` instead of `$repo:${git_sha}.src`

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "4.3.0"
+    app.kubernetes.io/version: "4.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -64,6 +64,36 @@ spec:
           fi
         }
 
+        translate_tags () { # Expected arguments are [tags, timestamp, git sha, 7 character git sha, source sha]
+        # The tags argument is a json array
+            if [[ $1 == '' ]] ; then
+                echo ''
+                return
+            fi
+
+            SUPPORTED_VARIABLES='[
+                {"{{timestamp}}": "'$2'"},
+                {"{{ timestamp }}": "'$2'"},
+                {"{{git_sha}}": "'$3'"},
+                {"{{ git_sha }}": "'$3'"},
+                {"{{git_short_sha}}": "'$4'"},
+                {"{{ git_short_sha }}": "'$4'"},
+                {"{{digest_sha}}": "'$5'"},
+                {"{{ digest_sha }}": "'$5'"}
+            ]'
+            tags=$1
+
+            NUM_VARIABLES=$(jq 'length' <<< "${SUPPORTED_VARIABLES}")
+            for ((i = 0; i < $NUM_VARIABLES; i++)); do
+                variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
+                KEY=$(jq -r 'to_entries[] | .key' <<< $variable)
+                VALUE=$(jq -r 'to_entries[] | .value' <<< $variable)
+                tags=$(echo -n $tags | sed "s/$KEY/$VALUE/g")
+            done
+
+            echo -n $tags
+        }
+
         SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
             echo "No valid snapshot file was provided."
@@ -76,9 +106,12 @@ spec:
             exit 1
         fi
 
+        defaultTags=$(jq '.mapping.defaults.tags' $DATA_FILE)
+        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' $DATA_FILE)
         floatingTagsCount=$(jq '.images.floatingTags | length' $DATA_FILE)
-        timestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE)
-        timestamp="$(date "+$timestampFormat")"
+        oldTimestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE) # to be removed in v5.0.0
+        defaultTimestampFormat=$(jq -r '.mapping.defaults.timestampFormat // "%s"' $DATA_FILE)
+        timestamp="$(date "+$oldTimestampFormat")" # Here -> application= line to be removed in v5.0.0
         commonTags=""
         if [ $floatingTagsCount -gt 0 ]; then
             for floatingTag in $(jq -r '.images.floatingTags[]' $DATA_FILE) ; do
@@ -89,11 +122,14 @@ spec:
         echo -n $commonTags > $(results.commonTags.path)
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
+        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
-        for component in $(jq -rc '.components[]' "${SNAPSHOT_SPEC_FILE}")
+        for ((i = 0; i < $NUM_COMPONENTS; i++))
         do
+          component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
           containerImage=$(jq -r '.containerImage' <<< $component)
           repository=$(jq -r '.repository' <<< $component)
+          imageTags=$(jq '.tags' <<< $component)
 
           # Just read the first from the list of architectures
           read -r arch_json <<< $(get-image-architectures "${containerImage}")
@@ -101,11 +137,70 @@ spec:
 
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
+          build_sha=$(echo "${containerImage}" | cut -d ':' -f 2)
+          passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
+            '.timestampFormat // $default' <<< $component)
+          timestamp="$(date "+$passedTimestampFormat")"
+
+          allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
+            "$imageTags" '$defaults? + $imageTags? | unique')
+          tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
+            "${git_sha:0:7}" "${build_sha}")
+
           origin_digest=$(skopeo inspect \
             --override-arch "${arch}" \
             --no-tags \
             --format '{{.Digest}}' \
             "docker://${containerImage}" 2>/dev/null)
+
+          # Push source container if the component has pushSourceContainer: true or if the
+          # pushSourceContainer key is missing from the component and the defaults has
+          # pushSourceContainer: true
+          if [[ $(jq -r '.pushSourceContainer' <<< $component) == "true" ]] \
+            || [[ $(jq 'has("pushSourceContainer")' <<< $component) == "false" && \
+                  ${defaultPushSourceContainer} == "true" ]] ; then
+
+            source_repo=${containerImage%%@sha256:*}
+            source_tag=${origin_digest/:/-}.src
+            # Calculate the source container image based on the provided container image
+            sourceContainer="${source_repo}:${source_tag}"
+            # Check if the source container exists
+            source_container_digest=$(skopeo inspect \
+              --override-arch "${arch}" \
+              --no-tags \
+              --format '{{.Digest}}' \
+              "docker://${sourceContainer}" 2>/dev/null)
+
+            if [ -z "$source_container_digest" ] ; then
+              echo "Error: Source container ${sourceContainer} not found!"
+              exit 1
+            fi
+            # Push the source image with the source tag here. The source image will be
+            # pushed with the provided tags below in the loop
+            push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
+              "${repository}" "${source_tag}" "${arch}"
+          fi
+
+          if [[ $(jq 'length' <<< $tags) -ne 0 ]] ; then
+            commonTags="" # To move out of if statement in v5.0.0
+            for tag in $(jq -r '.[]' <<< $tags) ; do
+              commonTags="${commonTags}${tag} "
+              # Push the container image
+              push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${tag}" \
+              "${arch}"
+
+              # This variable will only exist if the above logic determined the source container should
+              # be pushed for this component
+              if [ -n "${source_container_digest-}" ] ; then
+                push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
+                  "${repository}" "${tag}-source" "${arch}"
+              fi
+            done
+            commonTags=${commonTags% }
+            echo -n $commonTags > $(results.commonTags.path) # To move out of if in v5.0.0
+            continue
+          fi
+          # all code below this line will be removed once all teams are using the new tag format
 
           # If `floatingTags` is non-empty, for each of the `floatingTags` we push each image to
           # $floatingTag and $floatingTag-$timestamp.

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -60,6 +60,12 @@ function date() {
       "+%s")
           echo "1696946200" | tee $(workspaces.data.path)/mock_date_epoch.txt
           ;;
+      "+%Y-%m-%d")
+          echo "1980-01-01"
+          ;;
+      "+%Y-%m")
+          echo "1980-01"
+          ;;
       "*")
           echo Error: Unexpected call
           exit 1

--- a/tasks/push-snapshot/tests/test-push-snapshot-both.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-both.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-both
+spec:
+  description: |
+    Run the push-snapshot task with both tagging formats used. Only the new one
+    should be run. This test will be removed when the legacy format is removed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag",
+                    "repository": "prod-registry.io/prod-location",
+                    "tags": [
+                      "not-latest"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "defaultTag": "latest",
+                  "addGitShaTag": false,
+                  "addTimestampTag": false,
+                  "addSourceShaTag": false
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: retries
+          value: 0
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Ensure cosign called with the not-latest tag only
+              [[ $(cat $(workspaces.data.path)/mock_cosign.txt) == *"not-latest" ]]
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-tags
+spec:
+  description: |
+    Run the push-snapshot task with various components and tags.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repository": "prod-registry.io/prod-location1",
+                    "tags": [
+                      "tag1-{{timestamp}}",
+                      "tag2-{{ timestamp }}",
+                      "{{git_sha}}",
+                      "{{ git_sha }}-abc",
+                      "{{git_short_sha}}",
+                      "{{ git_short_sha }}-bar",
+                      "foo-{{digest_sha}}",
+                      "{{ digest_sha }}"
+                    ],
+                    "pushSourceContainer": false,
+                    "source": {
+                      "git": {
+                        "revision": "testrevision"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repository": "prod-registry.io/prod-location2",
+                    "tags": [
+                      "{{timestamp}}"
+                    ],
+                    "timestampFormat": "%Y-%m"
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image3:tag3",
+                    "repository": "prod-registry.io/prod-location3"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true,
+                    "timestampFormat": "%Y-%m-%d",
+                    "tags": [
+                      "defaultTag"
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: retries
+          value: 0
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # 9 for comp1 (the 8 provided tags + default)
+              # 5 for comp2 (provided tag + default, once for image, once for source container, + once for source tag)
+              # 3 for comp3 (default tag, once for the image, once for the source container + once for source tag)
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 17 ]; then
+                echo Error: cosign was expected to be called 17 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              # 10 for comp1 (same 9 as cosign + 1 for origin digest
+              # 7 for comp2 (same 5 as cosign + 1 for origin digest + 1 for source container digest
+              # 5 for comp3 ( same 3 as cosign + 1 for origin digest + 1 for source container digest
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 22 ]; then
+                echo Error: skopeo was expected to be called 22 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit refactors the push-snapshot task to accept tags in each individual component in the mapping. It also accepts a defaults section in the mapping that will be added to each individual component's list of tags.

The legacy code using data.images.floatingTags and things like data.images.addSourceShaTag is left in the task with this commit. It will continue to be used if no tags are provided in data.mapping.components or defaults. Once all users are migrated, the legacy code will be removed.