### PR TITLE
refactor(RELEASE-384): rh-sign-image looks at mapping

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,11 +14,15 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.5.0
+* Add support for checking the `mapping` key for `pushSourceContainer`
+  * Can be per component or in the `mapping.defaults` section
+  * The legacy location of `images.pushSourceContainer` will be removed in a future version
+
 ## Changes in 2.4.0
 * When pushing source containers, the origin is now determined using `$repo:${digest}.src` instead of `$repo:${git_sha}.src`
   that was used previously. This follows a change in the build service.
   * We now also push this new tag, so sign it as well.
-
 
 ## Changes in 2.3.0
 * remove `dataPath` and `snapshotPath` default values

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.4.0"
+    app.kubernetes.io/version: "2.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -66,6 +66,7 @@ spec:
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' ${DATA_FILE})
+        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' ${DATA_FILE})
 
         N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
         count=0
@@ -96,7 +97,13 @@ spec:
             fi
 
             sourceContainerDigest=
-            if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] ; then # Default to false
+            if [[ $(jq -r ".images.pushSourceContainer" "${DATA_FILE}") == "true" ]] || \
+              # Push source container if the component has pushSourceContainer: true or if the
+              # pushSourceContainer key is missing from the component and the defaults has
+              # pushSourceContainer: true
+              [[ $(jq -r ".components[$COMPONENTS_INDEX].pushSourceContainer" ${SNAPSHOT_PATH}) == "true" ]] || \
+              [[ $(jq ".components[$COMPONENTS_INDEX] | has(\"pushSourceContainer\")" ${SNAPSHOT_PATH}) == "false" && \
+                ${defaultPushSourceContainer} == "true" ]] ; then
               source_repo=${referenceContainerImage%%@sha256:*}
               source_reference_tag=sha256-${referenceContainerImage#*@sha256:}.src
               # Calculate the source container image based on the provided container image

--- a/tasks/rh-sign-image/tests/mocks.sh
+++ b/tasks/rh-sign-image/tests/mocks.sh
@@ -125,7 +125,7 @@ function skopeo() {
                 }
             '
         else
-          if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image0:sha256-0000.src"* ]]
+          if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
           then
             echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
           else

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container-in-mapping.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container-in-mapping.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-push-source-container-in-mapping
+spec:
+  description: |
+    Test creating a internal request to sign an image with the pushSourceContainer
+    values set in the mapping instead of images section of the data file
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "source": {
+                      "git": {
+                        "revision": "deadbeef"
+                      }
+                    },
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct0----myrepo0",
+                    "pushSourceContainer": true
+                  },
+                  {
+                    "name": "comp1",
+                    "source": {
+                      "git": {
+                        "revision": "alivebeef"
+                      }
+                    },
+                    "containerImage": "registry.io/image1@sha256:1111",
+                    "repository": "quay.io/redhat-prod/myproduct1----myrepo1",
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "source": {
+                      "git": {
+                        "revision": "deaderbeef"
+                      }
+                    },
+                    "containerImage": "registry.io/image2@sha256:2222",
+                    "repository": "quay.io/redhat-prod/myproduct2----myrepo2"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "true"
+                  }
+                },
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-single
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Just checking source container IRs because the others are checked in the single
+              # component test. There should be 8 IRs for the first component (two tags * one for
+              # registry.access.redhat.com and one for registry.redhat.io, * one for the image, one for
+              # the source image), 4 for the second component (same 4 as above but only half as 
+              # pushSourceContainer is false), and 8 for the final (same as first component).
+              #
+              # Just checking the first source one for each (IRs 5 and 17, but also ensuring IR
+              # 13 isn't for the comp1 source container. These will use registry.redhat.io and the
+              # first commonTag which is some-prefix-12345
+
+              # source container internal request for component 0
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -5 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.redhat.io/myproduct0/myrepo0:some-prefix-12345-source" ]; then
+                echo "floating tag reference does not match for source container comp0 IR"
+                exit 1
+              fi
+
+              # Ensure IR13 is not for a source container for comp1 as comp1 has pushSourceContainer false
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -13 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                == "registry.redhat.io/myproduct1/myrepo1:some-prefix-12345-source" ]; then
+                echo "Incorrectly signed source container for comp1"
+                exit 1
+              fi
+
+              # source container internal request for component 2
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -17 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.redhat.io/myproduct2/myrepo2:some-prefix-12345-source" ]; then
+                echo "floating tag reference does not match for source container comp2 IR"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-images-key-priority.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-images-key-priority.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-single-component-images-key-priority
+spec:
+  description: |
+    Test creating a internal request to sign an image with pushSourceContainer set in
+    both the images key and the mapping key. The value in images should be used. This
+    test will be removed once the legacy functionality is removed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+
+                    "source": {
+                      "git": {
+                        "revision": "deadbeef"
+                      }
+                    },
+
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct----myrepo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "images": {
+                  "pushSourceContainer": "true",
+                  "floatingTags": [
+                    "1.0.0"
+                  ]
+                },
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "false"
+                  }
+                },
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-single
+        - name: commonTags
+          value: "some-prefix-12345 some-prefix"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # First internal request with fixed tag and registry.redhat.io
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -1 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.redhat.io/myproduct/myrepo:some-prefix-12345" ]; then
+                echo "fixed tag reference does not match for first IR"
+                exit 1
+              fi
+
+              # Second internal request with fixed tag and registry.access.redhat.com
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -2 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix-12345" ]; then
+                echo "fixed tag reference does not match for second IR"
+                exit 1
+              fi
+
+              # Third internal request with floating tag and registry.redhat.io
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -3 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
+                echo "floating tag reference does not match for third IR"
+                exit 1
+              fi
+
+              # Fourth internal request with floating tag and registry.access.redhat.com
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -4 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix" ]; then
+                echo "floating tag reference does not match for fourth IR"
+                exit 1
+              fi
+
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
+                echo "manifest_digest does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
+              then
+                echo "config_map_name does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.requester' <<< "${params}") != "testuser-single" ]
+              then
+                echo "requester does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.pipeline_image' <<< "${params}") != \
+                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
+              then
+                echo "pipeline_image does not match"
+                exit 1
+              fi
+
+              # last internal request for source container check
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix-source" ]; then
+                echo "floating tag reference does not match for source container IR"
+                exit 1
+              fi
+
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != \
+                  "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1" ]; then
+                echo "manifest_digest does not match for source container IR"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit changes the rh-sign-image task to take the pushSourceContainer values from mapping.components and mapping.defaults into account. If a value exists in mapping.components for the component being processed, that value is used. Otherwise, it looks at mapping.defaults. Neither is considered, however, if it is set in the normal spot of images.pushSourceContainer. The
images.pushSourceContainer support will be removed in a future commit.