### PR TITLE
refactor(RELEASE-384): publish-pyxis-repository looks at mapping

### DIFF
--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -22,6 +22,11 @@ does not publish the repository.
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       |                    |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                           | No       |                    |
 
+## Changes in 0.5.0
+* Add support for checking the `mapping` key for `pushSourceContainer`
+  * Can be per component or in the `mapping.defaults` section
+  * The legacy location of `images.pushSourceContainer` will be removed in a future version
+
 ## Changes in 0.4.0
 * Add option to skip publishing via `skipRepoPublishing` flag in the data file
 

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -94,15 +94,21 @@ spec:
 
         PAYLOAD='{"published":true}'
 
-        if [[ -f "${DATA_FILE}" && $(jq -r '.images.pushSourceContainer' ${DATA_FILE}) == "true" ]] ; then
+        legacyPushOption=$(jq -r '.images.pushSourceContainer' ${DATA_FILE} || echo "null")
+        if [[ -f "${DATA_FILE}" && ${legacyPushOption} == "true" ]] ; then
             PAYLOAD=$(jq -c '. += {"source_container_image_enabled":true}' <<< $PAYLOAD)
         fi
+        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' ${DATA_FILE} || echo false)
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
 
-        for REPOSITORY in $(jq -r '.components[].repository' "${SNAPSHOT_SPEC_FILE}")
+        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
+        for ((i = 0; i < $NUM_COMPONENTS; i++))
         do
+            COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
+            COMPONENT_PAYLOAD=$PAYLOAD
+            REPOSITORY=$(jq -r '.repository' <<< $COMPONENT)
             PYXIS_REPOSITORY=${REPOSITORY##*/}
             # Replace "----" with "/"
             PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
@@ -117,6 +123,17 @@ spec:
                 exit 1
             fi
 
+            # Wrap in if statement so legacy functionality is used if set and payload not changed twice
+            if [[ -f "${DATA_FILE}" && ${legacyPushOption} != "true" && ${legacyPushOption} != "false" ]] ; then
+              # Set source_container_image_enabled based on pushSourceContainer value in components or use default if
+              # it is not set in the component
+              if [[ $(jq -r '.pushSourceContainer' <<< $COMPONENT) == "true" ]] ||
+                [[ $(jq 'has("pushSourceContainer")' <<< $COMPONENT) == "false" && \
+                ${defaultPushSourceContainer} == "true" ]] ; then
+                  COMPONENT_PAYLOAD=$(jq -c '. += {"source_container_image_enabled":true}' <<< $COMPONENT_PAYLOAD)
+              fi
+            fi
+
             # verify that publish_on_push is set to true.
             # otherwise, do not publish the image.
             PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< $PYXIS_REPOSITORY_JSON)
@@ -127,7 +144,7 @@ spec:
             fi
 
             curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
-                -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
+                -X PATCH -H 'Content-Type: application/json' --data-binary "${COMPONENT_PAYLOAD}"
         done
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-mapping.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-mapping.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-source-container-mapping
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a multiple component and pushSourceContainer
+    set in the snapshot. A curl call should be executed to set the source_container_image_enabled
+    to the proper values for the components.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1",
+                    "pushSourceContainer": "true"
+                  },
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image2",
+                    "pushSourceContainer": "false"
+                  }, 
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image3"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/mydata.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "true"
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: mydata.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 6 ]; then
+                  echo Error: curl was expected to be called 6 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 2 | tail -n 1) \
+                  == *'"source_container_image_enabled":true}' ]]
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 3 | tail -n 1) \
+                  == *"/my-product/my-image2 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 4 | tail -n 1) \
+                  != *'"source_container_image_enabled":true}' ]]
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 5 | tail -n 1) \
+                  == *"/my-product/my-image3 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  == *'"source_container_image_enabled":true}' ]]
+      runAfter:
+        - run-task

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-priority.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-priority.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-pyxis-repository-source-container-priority
+spec:
+  description: |
+    Run the publish-pyxis-repository task with a single component with pushSourceContainer
+    set to true in the images section of the data key but false in the component. The legacy, images,
+    value should be used, so a curl call should be executed to set the source_container_image_enabled
+    to true for the component. This test will be removed once the legacy code is removed in a future
+    task version.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "my-app",
+                "components": [
+                  {
+                    "repository": "quay.io/redhat-prod/my-product----my-image1",
+                    "pushSourceContainer": "false"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/mydata.json << EOF
+              {
+                "images": {
+                  "pushSourceContainer": "true"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-pyxis-repository
+      params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: mydata.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat $(workspaces.data.path)/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
+                  == *"/my-product/my-image1 "* ]]
+              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
+                  == *'"source_container_image_enabled":true}' ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit changes the publish-pyxis-repository task to take the pushSourceContainer value from mapping.components and mapping.defaults into account. If a value exists in mapping.components for the component being processed, that value is used. Otherwise, it looks at mapping.defaults. Neither is considered, however, if it is set in the normal spot of images.pushSourceContainer. The
images.pushSourceContainer support will be removed in a future commit.