### PR TITLE
fix(KFLUXBUGS-1263): fix images data in resulting advisory json

### DIFF
--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -11,6 +11,9 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 | commonTags   | Space separated list of common tags to be used when publishing       | No       | -             |
 
+## Changes in 1.2.1
+* Fix the format and values of the images inside the resulting advisory data
+
 ## Changes in 1.2.0
 * The task now looks for tags in each component of the snapshot spec file and uses them instead of the commonTags if
   any exist

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,8 +47,10 @@ spec:
         # Convert space separated list of common tags into an array
         commonTags=$(jq -cn --arg tags "$(params.commonTags)" '$tags|split(" ")')
 
-        for component in $(jq -c '.components[]' "${SNAPSHOT_FILE}")
+        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
+        for ((i = 0; i < $NUM_COMPONENTS; i++))
         do
+            component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< $component)
             repo=$(jq -r '.repository' <<< $component)
             deliveryRepo=$(translate-delivery-repo $repo | jq -r '.[] | select(.repo=="redhat.io") | .url')
@@ -65,10 +67,6 @@ spec:
             # containerImage should be of the form registry.redhat.io/foo/bar@sha256:abcde
             # This value will be used as the basis for the example values that follow
             containerImage="${deliveryRepo}@sha256:${sha}"
-            # repository should be foo/bar
-            repository=$(echo ${containerImage} | cut -d '/' -f 2- | cut -d '@' -f 1)
-            # purl should be pkg:oci/foo@sha256:abcde?repository_url=registry.redhat.io/foo/bar
-            purl="pkg:oci/$(echo $repository | cut -d '/' -f 1)@sha256:${sha}?repository_url=${deliveryRepo}"
             # Construct CVE json
             CVEsJson='{"cves":{"fixed":{}}}'
             for cve in $(jq -c '.releaseNotes.cves[] | select(.component=="'$name'")' ${DATA_FILE}) ; do
@@ -81,12 +79,16 @@ spec:
             # Add one entry per arch (amd64 for example)
             get-image-architectures "${image}" | while IFS= read -r arch_json;
             do
-                arch=$(echo "${arch_json}" | jq -r .platform.architecture)
+                arch=$(jq -r .platform.architecture <<< "${arch_json}")
+                digest=$(jq -r .digest <<< "${arch_json}")
+                containerImage="${deliveryRepo}@${digest}"
+                # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
+                purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
                 jsonString=$(jq -cn \
                     --arg arch "$arch" \
                     --arg containerImage "$containerImage" \
                     --arg purl "$purl" \
-                    --arg repository "$repository" \
+                    --arg repository "$deliveryRepo" \
                     --argjson tags "$tags" \
                     '{"architecture": $arch, "containerImage":$containerImage,
                     "purl": $purl, "repository": $repository, "tags": $tags}')

--- a/tasks/populate-release-notes-images/tests/mocks.sh
+++ b/tasks/populate-release-notes-images/tests/mocks.sh
@@ -4,6 +4,6 @@ set -eux
 # mocks to be injected into task step scripts
 
 function get-image-architectures() {
-    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
-    echo '{"platform":{"architecture": "s390x", "os": "linux"}, "digest": "deadbeef"}'
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "sha256:abcdefg"}'
+    echo '{"platform":{"architecture": "s390x", "os": "linux"}, "digest": "sha256:deadbeef"}'
 }

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-populate-release-notes-images-multiple-images
 spec:
   description: |
-    Run the populate-release-notes-images task with mulitple images in the snapshot JSON and verify
+    Run the populate-release-notes-images task with multiple images in the snapshot JSON and verify
     the data JSON has the proper content
   workspaces:
     - name: tests-workspace
@@ -101,36 +101,42 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              echo Checking image1arch1...
               image1arch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $image1arch1) == "amd64"
-              test $(jq -r '.containerImage' <<< $image1arch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $image1arch1) == "registry.redhat.io/product/repo@sha256:abcdefg"
               test $(jq -r '.purl' <<< $image1arch1) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $image1arch1) == "product/repo"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $image1arch1) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $image1arch1) == '["foo","bar"]'
 
+              echo Checking image1arch2...
               image1arch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $image1arch2) == "s390x"
-              test $(jq -r '.containerImage' <<< $image1arch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $image1arch2) == "registry.redhat.io/product/repo@sha256:deadbeef"
               test $(jq -r '.purl' <<< $image1arch2) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $image1arch2) == "product/repo"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $image1arch2) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $image1arch2) == '["foo","bar"]'
 
+              echo Checking image2arch1...
               image2arch1=$(jq '.releaseNotes.content.images[2]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $image2arch1) == "amd64"
-              test $(jq -r '.containerImage' <<< $image2arch1) == "registry.stage.redhat.io/product2/repo2@sha256:abcde"
+              test $(jq -r '.containerImage' <<< $image2arch1) == \
+                "registry.stage.redhat.io/product2/repo2@sha256:abcdefg"
               test $(jq -r '.purl' <<< $image2arch1) == \
-                "pkg:oci/product2@sha256:abcde?repository_url=registry.stage.redhat.io/product2/repo2"
-              test $(jq -r '.repository' <<< $image2arch1) == "product2/repo2"
+                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.stage.redhat.io/product2"
+              test $(jq -r '.repository' <<< $image2arch1) == "registry.stage.redhat.io/product2/repo2"
               test $(jq -rc '.tags' <<< $image2arch1) == '["foo","bar"]'
 
+              echo Checking image2arch2...
               image2arch2=$(jq '.releaseNotes.content.images[3]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $image2arch2) == "s390x"
-              test $(jq -r '.containerImage' <<< $image2arch2) == "registry.stage.redhat.io/product2/repo2@sha256:abcde"
+              test $(jq -r '.containerImage' <<< $image2arch2) == \
+                "registry.stage.redhat.io/product2/repo2@sha256:deadbeef"
               test $(jq -r '.purl' <<< $image2arch2) == \
-                "pkg:oci/product2@sha256:abcde?repository_url=registry.stage.redhat.io/product2/repo2"
-              test $(jq -r '.repository' <<< $image2arch2) == "product2/repo2"
+                "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.stage.redhat.io/product2"
+              test $(jq -r '.repository' <<< $image2arch2) == "registry.stage.redhat.io/product2/repo2"
               test $(jq -rc '.tags' <<< $image2arch2) == '["foo","bar"]'
       runAfter:
         - run-task

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image-comp-tags.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image-comp-tags.yaml
@@ -103,18 +103,18 @@ spec:
 
               imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $imagearch1) == "amd64"
-              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:abcdefg"
               test $(jq -r '.purl' <<< $imagearch1) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch1) == "product/repo"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $imagearch1) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
 
               imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
-              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:deadbeef"
               test $(jq -r '.purl' <<< $imagearch2) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch2) == "product/repo"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $imagearch2) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
       runAfter:
         - run-task

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
@@ -98,18 +98,18 @@ spec:
 
               imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $imagearch1) == "amd64"
-              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:abcdefg"
               test $(jq -r '.purl' <<< $imagearch1) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch1) == "product/repo"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $imagearch1) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
 
               imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
-              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:deadbeef"
               test $(jq -r '.purl' <<< $imagearch2) == \
-                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
-              test $(jq -r '.repository' <<< $imagearch2) == "product/repo"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+              test $(jq -r '.repository' <<< $imagearch2) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
       runAfter:
         - run-task


### PR DESCRIPTION
As pointed out in the bug report, some of the data in content.images in the advisory were not calculated properly.

Namely, this includes these fixes:
 - use arch-specific digests both in resulting containerImage and purl entries
 - for purl name, use the last part of the image string
 - for purl repo url, use everything except the last part
 - url-encode `:` in purl
 - include arch in purl
 - include registry address in repository field

To give an example, for a repo of value
registry.redhat.io/rhel9/bootc-image-builder
here are the resulting values:
 - purl name: bootc-image-builder
 - purl repository_url: registry.redhat.io/rhel9
 - repository: registry.redhat.io/rhel9/bootc-image-builder