### PR TITLE
feat(RELEASE-457): improve collect-data logging

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -27,6 +27,9 @@ should not be present in the Release data section).
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
+## Changes in 4.2.0
+  * Replace redirects with `tee` so that more is output in the task log to make debugging easier
+
 ## Changes in 4.1.0
   * releaseNotes.type is allowed in both Release and ReleasePlan CRs
 

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -73,7 +73,7 @@ spec:
           value: '$(params.snapshot)'
       script: |
         #!/usr/bin/env sh
-        set -e
+        set -eo pipefail
 
         if [ -n "$(params.subdirectory)" ]; then
           mkdir -p $(workspaces.data.path)/$(params.subdirectory)
@@ -81,29 +81,32 @@ spec:
 
         RELEASE_PATH=$(params.subdirectory)/release.json
         echo -n $RELEASE_PATH > $(results.release.path)
-        get-resource "release" "${RELEASE}" > $(workspaces.data.path)/$RELEASE_PATH
+        get-resource "release" "${RELEASE}" | tee $(workspaces.data.path)/$RELEASE_PATH
 
         RELEASEPLAN_PATH=$(params.subdirectory)/release_plan.json
         echo -n $RELEASEPLAN_PATH > $(results.releasePlan.path)
-        get-resource "releaseplan" "${RELEASE_PLAN}" > $(workspaces.data.path)/$RELEASEPLAN_PATH
+        get-resource "releaseplan" "${RELEASE_PLAN}" | tee $(workspaces.data.path)/$RELEASEPLAN_PATH
 
         RELEASEPLANADMISSION_PATH=$(params.subdirectory)/release_plan_admission.json
         echo -n $RELEASEPLANADMISSION_PATH > $(results.releasePlanAdmission.path)
         get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-          > $(workspaces.data.path)/$RELEASEPLANADMISSION_PATH
+          | tee $(workspaces.data.path)/$RELEASEPLANADMISSION_PATH
 
         RELEASESERVICECONFIG_PATH=$(params.subdirectory)/release_service_config.json
         echo -n $RELEASESERVICECONFIG_PATH > $(results.releaseServiceConfig.path)
         get-resource "releaseserviceconfig" "${RELEASE_SERVICE_CONFIG}" \
-          > $(workspaces.data.path)/$RELEASESERVICECONFIG_PATH
+          | tee $(workspaces.data.path)/$RELEASESERVICECONFIG_PATH
 
+        echo -e "\nFetching Snapshot Spec"
         SNAPSHOTSPEC_PATH=$(params.subdirectory)/snapshot_spec.json
         echo -n $SNAPSHOTSPEC_PATH > $(results.snapshotSpec.path)
-        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" > $(workspaces.data.path)/$SNAPSHOTSPEC_PATH
+        get-resource "snapshot" "${SNAPSHOT}" "{.spec}" | tee $(workspaces.data.path)/$SNAPSHOTSPEC_PATH
 
+        echo -e "\nFetching fbcFragment"
         cat $(workspaces.data.path)/$SNAPSHOTSPEC_PATH | jq -cr '.components[0].containerImage' | tr -d "\n" \
           | tee $(results.fbcFragment.path)
 
+        echo -e "\nFetching merged data json"
         release_result=$(get-resource "release" "${RELEASE}" "{.spec.data}")
 
         release_plan_result=$(get-resource "releaseplan" "${RELEASE_PLAN}" "{.spec.data}")
@@ -119,7 +122,7 @@ spec:
 
         DATA_PATH=$(params.subdirectory)/data.json
         echo -n $DATA_PATH > $(results.data.path)
-        echo "$merged_output" > $(workspaces.data.path)/$DATA_PATH
+        echo "$merged_output" | tee $(workspaces.data.path)/$DATA_PATH
     - name: check-data-key-sources
       image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
       script: |


### PR DESCRIPTION
This commit replaces the `>` commands in collect-data with `tee` so that there is more output in the task pod log. This will make debugging user issues much easier.