### PR TITLE
refactor(RELEASE-384): tag expansion done in apply-mapping

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -11,6 +11,12 @@ Snapshot based on component name.
 A `mapped` result is also returned from this task containing a simple true/false value that is
 meant to inform whether a mapped Snapshot is being returned or the original one.
 
+This task supports variable expansion in tag values from the mapping. The currently supported variables are:
+* "{{ timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
+* "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
+* "{{ git_short_sha }}" -> The git sha reduced to 7 characters
+* "{{ digest_sha }}" -> The image digest of the respective component
+
 ## Parameters
 
 | Name | Description | Optional | Default value |
@@ -18,6 +24,12 @@ meant to inform whether a mapped Snapshot is being returned or the original one.
 | snapshotPath | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No | |
 | releasePlanAdmissionPath | Path to the JSON string of the ReleasePlanAdmission in the config workspace which contains the mapping to apply | No | |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
+
+## Changes in 0.11.0
+ * The tags provided in `mapping.defaults.tags` are combined with each components `.tags` entry to form
+   one set of tags
+   * The resulting tags are stored in the snapshot spec file under each component
+   * The supported variables will be replaced in the tags
 
 ## Changes in 0.10.0
  * Removed default values for `snapshotPath` and `releasePlanAdmissionPath`

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "0.10.0"
+    app.kubernetes.io/version: "0.11.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -65,6 +65,36 @@ spec:
             exit 0
         fi
 
+        translate_tags () { # Expected arguments are [tags, timestamp, git sha, 7 character git sha, source sha]
+        # The tags argument is a json array
+            if [[ $1 == '' ]] ; then
+                echo ''
+                return
+            fi
+
+            SUPPORTED_VARIABLES='[
+                {"{{timestamp}}": "'$2'"},
+                {"{{ timestamp }}": "'$2'"},
+                {"{{git_sha}}": "'$3'"},
+                {"{{ git_sha }}": "'$3'"},
+                {"{{git_short_sha}}": "'$4'"},
+                {"{{ git_short_sha }}": "'$4'"},
+                {"{{digest_sha}}": "'$5'"},
+                {"{{ digest_sha }}": "'$5'"}
+            ]'
+            tags=$1
+
+            NUM_VARIABLES=$(jq 'length' <<< "${SUPPORTED_VARIABLES}")
+            for ((i = 0; i < $NUM_VARIABLES; i++)); do
+                variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
+                KEY=$(jq -r 'to_entries[] | .key' <<< $variable)
+                VALUE=$(jq -r 'to_entries[] | .value' <<< $variable)
+                tags=$(echo -n $tags | sed "s/$KEY/$VALUE/g")
+            done
+
+            echo -n $tags | jq -c
+        }
+
         # Merge the mapping key contents in the ReleasePlanAdmission data with the components key in the snapshot based
         # on component name. Save the output as a compact json in mapped_snapshot.json file in the workspace
         { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${MAPPING}"; } | jq -c -s '.[0] as $snapshot
@@ -80,3 +110,27 @@ spec:
           echo "ERROR: Resulting snapshot contains 0 components"
           exit 1
         fi
+
+        # Expand the tags in the ReleasePlanAdmission
+        defaultTags=$(jq '.defaults.tags' <<< $MAPPING)
+        defaultTimestampFormat=$(jq -r '.defaults.timestampFormat // "%s"' <<< $MAPPING)
+        currentTimestamp="$(date "+%Y%m%d %T")"
+        NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
+        for ((i = 0; i < $NUM_MAPPED_COMPONENTS; i++)) ; do
+            component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
+            imageTags=$(jq '.tags' <<< $component)
+            git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
+            build_sha=$(jq -r '.containerImage' <<< $component | cut -d ':' -f 2)
+            passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
+              '.timestampFormat // $default' <<< $component)
+            timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"
+
+            allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
+              "$imageTags" '$defaults? + $imageTags? | unique')
+            tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
+              "${git_sha:0:7}" "${build_sha}")
+            if [ $(jq 'length' <<< $tags) -gt 0 ] ; then
+              jq --argjson i "$i" --argjson updatedTags $tags '.components[$i].tags = $updatedTags' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            fi
+        done

--- a/tasks/apply-mapping/tests/mocks.sh
+++ b/tasks/apply-mapping/tests/mocks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function date() {
+  echo $* >> $(workspaces.config.path)/mock_date.txt
+
+  case "$*" in
+      *"+%Y%m%d %T")
+          echo "19800101 00:00:00"
+          ;;
+      *"+%s")
+          echo "315550800"
+          ;;
+      *"+%Y-%m-%d")
+          echo "1980-01-01"
+          ;;
+      *"+%Y-%m")
+          echo "1980-01"
+          ;;
+      "*")
+          echo Error: Unexpected call
+          exit 1
+          ;;
+  esac
+}

--- a/tasks/apply-mapping/tests/pre-apply-task-hook.sh
+++ b/tasks/apply-mapping/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-tag-expansion
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the releasePlanAdmission with tags per component and verify that the resulting json
+    contains the expected values with tags expanded.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.config.path)/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "managed"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                      {
+                        "name": "url",
+                        "value": "github.com"
+                      },
+                      {
+                        "name": "revision",
+                        "value": "main"
+                      },
+                      {
+                        "name": "pathInRepo",
+                        "value": "pipeline.yaml"
+                      }
+                    ]
+                  },
+                  "serviceAccount": "sa",
+                  "origin": "dev",
+                  "data": {
+                    "mapping": {
+                      "components": [
+                        {
+                          "name": "comp1",
+                          "repository": "repo1",
+                          "tags": [
+                            "tag1-{{timestamp}}",
+                            "tag2-{{ timestamp }}",
+                            "{{git_sha}}",
+                            "{{ git_sha }}-abc",
+                            "{{git_short_sha}}",
+                            "{{ git_short_sha }}-bar",
+                            "foo-{{digest_sha}}",
+                            "{{ digest_sha }}"
+                          ]
+                        },
+                        {
+                          "name": "comp2",
+                          "repository": "repo2",
+                          "tags": [
+                            "tag1-{{timestamp}}"
+                          ],
+                          "timestampFormat": "%Y-%m"
+                        },
+                        {
+                          "name": "comp3",
+                          "repository": "repo3a"
+                        }
+                      ],
+                      "defaults": {
+                        "timestampFormat": "%Y-%m-%d",
+                        "tags": [
+                          "defaultTag"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+              EOF
+
+              cat > $(workspaces.config.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "repository": "repo2"
+                  },
+                  {
+                    "name": "comp3",
+                    "repository": "repo3"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: releasePlanAdmissionPath
+          value: test_release_plan_admission.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that SNAPSHOT contains component comp1
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -r '[ .components[] | select(.name=="comp1") ] | length') -eq 1
+
+              echo Test that comp1 has the proper tags
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -c '.components[] | select(.name=="comp1") | .tags') == \
+                '["defaultTag","foo-tag1","tag1-1980-01-01","tag2-1980-01-01","tag1","testrevision-abc","testrev-bar","testrevision","testrev"]'
+
+              echo Test that SNAPSHOT contains component comp2
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -r '[ .components[] | select(.name=="comp2") ] | length') -eq 1
+
+              echo Test that comp2 has the proper tags
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -c '.components[] | select(.name=="comp2") | .tags') == \
+                '["defaultTag","tag1-1980-01"]'
+
+              echo Test that repository of component comp3 was overriden by mapping file
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -r '.components[] | select(.name=="comp3") | .repository') == repo3a
+
+              echo Test that comp3 has the 1 default tag
+              test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
+                | jq -r '.components[] | select(.name=="comp3") | .tags | length') -eq 1
+      runAfter:
+        - run-task

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -2,12 +2,6 @@
 
 Tekton task to push snapshot images to an image registry using `cosign copy`.
 
-This task supports variable expansion in tag values from the mapping. The currently supported variables are:
-* "{{ timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
-* "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
-* "{{ git_short_sha }}" -> The git sha reduced to 7 characters
-* "{{ digest_sha }}" -> The image digest of the respective component
-
 ## Parameters
 
 | Name               | Description                                                               | Optional | Default value        |
@@ -15,6 +9,9 @@ This task supports variable expansion in tag values from the mapping. The curren
 | snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       |                      |
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | No       |                      |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes in 4.5.0
+* Tag expansion is removed in favor of doing it in the apply-mapping task
 
 ## Changes in 4.4.0
 * Added support for component specific tags

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "4.4.0"
+    app.kubernetes.io/version: "4.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -64,36 +64,6 @@ spec:
           fi
         }
 
-        translate_tags () { # Expected arguments are [tags, timestamp, git sha, 7 character git sha, source sha]
-        # The tags argument is a json array
-            if [[ $1 == '' ]] ; then
-                echo ''
-                return
-            fi
-
-            SUPPORTED_VARIABLES='[
-                {"{{timestamp}}": "'$2'"},
-                {"{{ timestamp }}": "'$2'"},
-                {"{{git_sha}}": "'$3'"},
-                {"{{ git_sha }}": "'$3'"},
-                {"{{git_short_sha}}": "'$4'"},
-                {"{{ git_short_sha }}": "'$4'"},
-                {"{{digest_sha}}": "'$5'"},
-                {"{{ digest_sha }}": "'$5'"}
-            ]'
-            tags=$1
-
-            NUM_VARIABLES=$(jq 'length' <<< "${SUPPORTED_VARIABLES}")
-            for ((i = 0; i < $NUM_VARIABLES; i++)); do
-                variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
-                KEY=$(jq -r 'to_entries[] | .key' <<< $variable)
-                VALUE=$(jq -r 'to_entries[] | .value' <<< $variable)
-                tags=$(echo -n $tags | sed "s/$KEY/$VALUE/g")
-            done
-
-            echo -n $tags
-        }
-
         SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
             echo "No valid snapshot file was provided."
@@ -106,11 +76,9 @@ spec:
             exit 1
         fi
 
-        defaultTags=$(jq '.mapping.defaults.tags' $DATA_FILE)
         defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' $DATA_FILE)
         floatingTagsCount=$(jq '.images.floatingTags | length' $DATA_FILE)
         oldTimestampFormat=$(jq -r '.images.timestampFormat // "%s"' $DATA_FILE) # to be removed in v5.0.0
-        defaultTimestampFormat=$(jq -r '.mapping.defaults.timestampFormat // "%s"' $DATA_FILE)
         timestamp="$(date "+$oldTimestampFormat")" # Here -> application= line to be removed in v5.0.0
         commonTags=""
         if [ $floatingTagsCount -gt 0 ]; then
@@ -134,18 +102,8 @@ spec:
           # Just read the first from the list of architectures
           read -r arch_json <<< $(get-image-architectures "${containerImage}")
           arch=$(echo "${arch_json}" | jq -r .platform.architecture)
-
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
-          build_sha=$(echo "${containerImage}" | cut -d ':' -f 2)
-          passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
-            '.timestampFormat // $default' <<< $component)
-          timestamp="$(date "+$passedTimestampFormat")"
-
-          allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
-            "$imageTags" '$defaults? + $imageTags? | unique')
-          tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
-            "${git_sha:0:7}" "${build_sha}")
 
           origin_digest=$(skopeo inspect \
             --override-arch "${arch}" \
@@ -181,10 +139,8 @@ spec:
               "${repository}" "${source_tag}" "${arch}"
           fi
 
-          if [[ $(jq 'length' <<< $tags) -ne 0 ]] ; then
-            commonTags="" # To move out of if statement in v5.0.0
-            for tag in $(jq -r '.[]' <<< $tags) ; do
-              commonTags="${commonTags}${tag} "
+          if [[ $(jq 'length' <<< $imageTags) -ne 0 ]] ; then
+            for tag in $(jq -r '.[]' <<< $imageTags) ; do
               # Push the container image
               push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${tag}" \
               "${arch}"
@@ -196,8 +152,6 @@ spec:
                   "${repository}" "${tag}-source" "${arch}"
               fi
             done
-            commonTags=${commonTags% }
-            echo -n $commonTags > $(results.commonTags.path) # To move out of if in v5.0.0
             continue
           fi
           # all code below this line will be removed once all teams are using the new tag format

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -60,12 +60,6 @@ function date() {
       "+%s")
           echo "1696946200" | tee $(workspaces.data.path)/mock_date_epoch.txt
           ;;
-      "+%Y-%m-%d")
-          echo "1980-01-01"
-          ;;
-      "+%Y-%m")
-          echo "1980-01"
-          ;;
       "*")
           echo Error: Unexpected call
           exit 1

--- a/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
@@ -32,35 +32,18 @@ spec:
                     "containerImage": "registry.io/image1:tag1",
                     "repository": "prod-registry.io/prod-location1",
                     "tags": [
-                      "tag1-{{timestamp}}",
-                      "tag2-{{ timestamp }}",
-                      "{{git_sha}}",
-                      "{{ git_sha }}-abc",
-                      "{{git_short_sha}}",
-                      "{{ git_short_sha }}-bar",
-                      "foo-{{digest_sha}}",
-                      "{{ digest_sha }}"
+                      "tag1-12345",
+                      "tag2-zyxw"
                     ],
-                    "pushSourceContainer": false,
-                    "source": {
-                      "git": {
-                        "revision": "testrevision"
-                      }
-                    }
+                    "pushSourceContainer": false
                   },
                   {
                     "name": "comp2",
                     "containerImage": "registry.io/image2:tag2",
                     "repository": "prod-registry.io/prod-location2",
                     "tags": [
-                      "{{timestamp}}"
-                    ],
-                    "timestampFormat": "%Y-%m"
-                  },
-                  {
-                    "name": "comp3",
-                    "containerImage": "registry.io/image3:tag3",
-                    "repository": "prod-registry.io/prod-location3"
+                      "some-cool-tag"
+                    ]
                   }
                 ]
               }
@@ -70,11 +53,7 @@ spec:
               {
                 "mapping": {
                   "defaults": {
-                    "pushSourceContainer": true,
-                    "timestampFormat": "%Y-%m-%d",
-                    "tags": [
-                      "defaultTag"
-                    ]
+                    "pushSourceContainer": true
                   }
                 }
               }
@@ -108,20 +87,18 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              # 9 for comp1 (the 8 provided tags + default)
-              # 5 for comp2 (provided tag + default, once for image, once for source container, + once for source tag)
-              # 3 for comp3 (default tag, once for the image, once for the source container + once for source tag)
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 17 ]; then
-                echo Error: cosign was expected to be called 17 times. Actual calls:
+              # 2 for comp1 (the 2 provided tags)
+              # 3 for comp2 (provided tag, once for image, once for source container, + once for source tag)
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
                 cat $(workspaces.data.path)/mock_cosign.txt
                 exit 1
               fi
 
-              # 10 for comp1 (same 9 as cosign + 1 for origin digest
-              # 7 for comp2 (same 5 as cosign + 1 for origin digest + 1 for source container digest
-              # 5 for comp3 ( same 3 as cosign + 1 for origin digest + 1 for source container digest
-              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 22 ]; then
-                echo Error: skopeo was expected to be called 22 times. Actual calls:
+              # 3 for comp1 (same 2 as cosign + 1 for origin digest
+              # 5 for comp2 (same 3 as cosign + 1 for origin digest + 1 for source container digest
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 8 ]; then
+                echo Error: skopeo was expected to be called 8 times. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi


### PR DESCRIPTION
This moves the new per component tag expansion to be done in the apply-mapping task instead of the push-snapshot task. The expansion results are written directly into the snapshot spec file. This makes it so that other tasks can easily consume the tags for each component.