### PR TITLE
refactor(RELEASE-384): commonTags come from snapshot

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,10 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
 
+## Changes in 2.5.0
+* The task now looks for tags in each component of the snapshot spec file and uses them instead of commonTags if any
+  exist
+
 ## Changes in 2.4.0
 * containerImageIDs result is removed as the data is present in pyxis.json that is written to the workspace
 * the containerImage is now saved in the pyxis.json entries

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.4.0"
+    app.kubernetes.io/version: "2.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -102,14 +102,14 @@ spec:
         echo -n "${PYXIS_DATA_PATH}" > $(results.pyxisDataPath.path)
 
         if [ -n "$(params.commonTags)" ]; then
-          TAGS="$(params.commonTags)"
+          COMMON_TAGS="$(params.commonTags)"
         else
           DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
           if [ ! -f "${DATA_FILE}" ] ; then
               echo "No data JSON was provided."
               exit 1
           fi
-          TAGS=$(jq -r '.images.defaultTag' "${DATA_FILE}")
+          COMMON_TAGS=$(jq -r '.images.defaultTag' "${DATA_FILE}")
         fi
 
         echo "${pyxisCert}" > /tmp/crt
@@ -126,6 +126,10 @@ spec:
             DIGEST="${CONTAINER_IMAGE##*@}"
             PULLSPEC="${REPOSITORY}@${DIGEST}"
             MEDIA_TYPE=$(skopeo inspect --raw "docker://${PULLSPEC}" | jq -r .mediaType)
+            TAGS=$COMMON_TAGS
+            if [ $(jq ".components[${i}].tags | length" "${SNAPSHOT_SPEC_FILE}") -gt 0 ] ; then
+                TAGS=$(jq -r ".components[${i}].tags | join(\" \")" "${SNAPSHOT_SPEC_FILE}")
+            fi
 
             index=0
             while IFS= read -r ARCH_DETAIL;

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-tag-in-component
+spec:
+  description: >
+    Run the create-pyxis-image task with a single containerImage in the snapshot that has tags defined
+    in the component section of the snapshot. Check that they are used in the pyxis request.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "source@mydigest",
+                    "repository": "quay.io/redhat-prod/myproduct----myimage",
+                    "tags": [
+                      "myprefix-mytimestamp",
+                      "myprefix"
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+        - name: snapshotPath
+          value: mapped_snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: rhPush
+          value: "false"
+        - name: commonTags
+          value: "notused"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 1 ]; then
+                echo Error: create_container_image was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if ! grep -- "--tags myprefix-mytimestamp myprefix" \
+                < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              then
+                echo Error: create_container_image call was expected to include "--tags myprefix-mytimestamp myprefix".
+                echo Actual call:
+                cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -11,6 +11,10 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 | commonTags   | Space separated list of common tags to be used when publishing       | No       | -             |
 
+## Changes in 1.2.0
+* The task now looks for tags in each component of the snapshot spec file and uses them instead of the commonTags if
+  any exist
+
 ## Changes in 1.1.0
 * Existing CVE data is present in the resulting releaseNotes key instead of overwritten
 * Update task image for fix in get-image-architectures script

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,13 +45,17 @@ spec:
 
         # Common vars
         # Convert space separated list of common tags into an array
-        tags=$(jq -cn --arg tags "$(params.commonTags)" '$tags|split(" ")')
+        commonTags=$(jq -cn --arg tags "$(params.commonTags)" '$tags|split(" ")')
 
         for component in $(jq -c '.components[]' "${SNAPSHOT_FILE}")
         do
             name=$(jq -r '.name' <<< $component)
             repo=$(jq -r '.repository' <<< $component)
             deliveryRepo=$(translate-delivery-repo $repo | jq -r '.[] | select(.repo=="redhat.io") | .url')
+            tags=$commonTags
+            if [ $(jq '.tags | length' <<< $component) -gt 0 ] ; then
+                tags=$(jq -c '.tags' <<< $component)
+            fi
             image=$(jq -r '.containerImage' <<< $component)
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image-comp-tags.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image-comp-tags.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-images-single-image-comp-tags
+spec:
+  description: |
+    Run the populate-release-notes-images task with a single image in the snapshot JSON that has
+    tags in the snapshot and verify the data JSON has the proper content, using the tags from
+    the snapshot instead of the commonTags
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_id": 123,
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/product----repo",
+                    "tags": [
+                      "foo",
+                      "bar"
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: populate-release-notes-images
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: snapshotPath
+          value: "snapshot.json"
+        - name: commonTags
+          value: "notused"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:6835e64a1811b30c8a48816ab6e2076cc4963759
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $imagearch1) == "amd64"
+              test $(jq -r '.containerImage' <<< $imagearch1) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $imagearch1) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $imagearch1) == "product/repo"
+              test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
+
+              imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
+              test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
+              test $(jq -r '.containerImage' <<< $imagearch2) == "registry.redhat.io/product/repo@sha256:123456"
+              test $(jq -r '.purl' <<< $imagearch2) == \
+                "pkg:oci/product@sha256:123456?repository_url=registry.redhat.io/product/repo"
+              test $(jq -r '.repository' <<< $imagearch2) == "product/repo"
+              test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
+      runAfter:
+        - run-task

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -14,6 +14,9 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 2.6.0
+* The task now looks for tags in each component of the snapshot spec file and uses them instead of commonTags if any exist
+
 ## Changes in 2.5.0
 * Add support for checking the `mapping` key for `pushSourceContainer`
   * Can be per component or in the `mapping.defaults` section

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "2.5.0"
+    app.kubernetes.io/version: "2.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -79,6 +79,11 @@ spec:
 
             git_sha=$(jq -r ".components[${COMPONENTS_INDEX}].source.git.revision" ${SNAPSHOT_PATH})
 
+            TAGS="$(params.commonTags)"
+            if [ $(jq ".components[${COMPONENTS_INDEX}].tags | length" ${SNAPSHOT_PATH}) -gt 0 ] ; then
+              TAGS=$(jq -r ".components[${COMPONENTS_INDEX}].tags | join(\" \")" ${SNAPSHOT_PATH})
+            fi
+
             # Translate direct quay.io reference to public facing registry json
             # quay.io/redhat-prod/product----repo ->
             #   [{"repo":"redhat.io","url":registry.redhat.io/product/repo"},
@@ -116,7 +121,7 @@ spec:
             fi
 
             for manifest_digest in $manifest_digests; do
-              for tag in $(params.commonTags); do
+              for tag in ${TAGS}; do
                 for registry_reference in $(jq -r '.[] | .url' <<< $referenceJson); do
                   echo "Creating InternalRequest to sign image with tag ${tag}:"
                   echo "- reference=${registry_reference}:${tag}"
@@ -143,7 +148,7 @@ spec:
             done
 
             if [ "${sourceContainerDigest}" != "" ] ; then
-              for tag in $(params.commonTags); do
+              for tag in ${TAGS}; do
                 sourceTag=${tag}-source
 
                 for registry_reference in $(jq -r '.[] | .url' <<< $referenceJson); do

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-image-tag-in-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-image-tag-in-component.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-single-component-image-tag-in-component
+spec:
+  description: |
+    Test creating a internal request to sign an image with the image tags
+    coming from the snapshot file instead of the commonTags parameter
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+
+                    "source": {
+                      "git": {
+                        "revision": "deadbeef"
+                      }
+                    },
+
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct----myrepo",
+                    "tags": [
+                      "some-prefix-12345",
+                      "some-prefix"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "true"
+                  }
+                },
+
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-single
+        - name: commonTags
+          value: "notused"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # First internal request with fixed tag and registry.redhat.io
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -1 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.redhat.io/myproduct/myrepo:some-prefix-12345" ]; then
+                echo "fixed tag reference does not match for first IR"
+                exit 1
+              fi
+
+              # Second internal request with fixed tag and registry.access.redhat.com
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -2 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix-12345" ]; then
+                echo "fixed tag reference does not match for second IR"
+                exit 1
+              fi
+
+              # Third internal request with floating tag and registry.redhat.io
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -3 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") != "registry.redhat.io/myproduct/myrepo:some-prefix" ]; then
+                echo "floating tag reference does not match for third IR"
+                exit 1
+              fi
+
+              # Fourth internal request with floating tag and registry.access.redhat.com
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                head -4 | tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix" ]; then
+                echo "floating tag reference does not match for fourth IR"
+                exit 1
+              fi
+
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != "sha256:0000" ]; then
+                echo "manifest_digest does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
+              then
+                echo "config_map_name does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.requester' <<< "${params}") != "testuser-single" ]
+              then
+                echo "requester does not match"
+                exit 1
+              fi
+
+              if [ $(jq -r '.pipeline_image' <<< "${params}") != \
+                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
+              then
+                echo "pipeline_image does not match"
+                exit 1
+              fi
+
+              # last internal request for source container check
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                tail -1)"
+              params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+
+              if [ $(jq -r '.reference' <<< "${params}") \
+                != "registry.access.redhat.com/myproduct/myrepo:some-prefix-source" ]; then
+                echo "floating tag reference does not match for source container IR"
+                exit 1
+              fi
+
+              if [ $(jq -r '.manifest_digest' <<< "${params}") != \
+                  "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1" ]; then
+                echo "manifest_digest does not match for source container IR"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit refactors the create-pyxis-image, rh-sign-image and
populate-release-notes-images task to read the tags for each
component in the snapshot spec json when the commonTags parameter
is empty.