### PR TITLE
fix(KFLUXBUGS-1264): increase request timeout

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -21,6 +21,11 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.5.1
+- The RADAS timeout when it fails to receive a response is 5 mins.
+  We double the requestTimeout in the rh-sign-image task to allow
+  RADAS to retry its request.
+
 ## Changes in 0.5.0
 - Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -336,6 +336,10 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
+        - name: requestTimeout
+          # The RADAS timeout when it fails to receive a response is 5 mins.
+          # We double the requestTimeout to allow RADAS to retry its request.
+          value: 600
         - name: commonTags
           value: $(tasks.push-snapshot.results.commonTags)
         - name: pipelineRunUid

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -18,6 +18,11 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.3.1
+* The RADAS timeout when it fails to receive a response is 5 mins.
+  We double the requestTimeout in the rh-sign-image task to allow
+  RADAS to retry its request.
+
 ## Changes in 3.3.0
 * Add new task `push-rpm-manifests-to-pyxis` to run after `create-pyxis-image`
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -284,6 +284,10 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
+        - name: requestTimeout
+          # The RADAS timeout when it fails to receive a response is 5 mins.
+          # We double the requestTimeout to allow RADAS to retry its request.
+          value: 600
         - name: commonTags
           value: $(tasks.push-snapshot.results.commonTags)
         - name: pipelineRunUid


### PR DESCRIPTION
* The RADAS timeout when it fails to receive a response is 5 mins. We double the requestTimeout in the rh-sign-image task to allow RADAS to retry its request.