### PR TITLE
fix(RELEASE-929): push-rpm-manifests-to-pyxis supports multiarch

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,11 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
 
+## Changes in 2.6.0
+* containerImage is no longer saved in the pyxis.json entries
+  * This was already saved in pyxis.json per component, it doesn't need to be duplicated in the pyxisImages keys
+* os is now saved to the pyxis.json pyxisImages entries
+
 ## Changes in 2.5.0
 * The task now looks for tags in each component of the snapshot spec file and uses them instead of commonTags if any
   exist

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.5.0"
+    app.kubernetes.io/version: "2.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -155,13 +155,13 @@ spec:
                 IMAGEID=$(awk '/The image id is/{print $NF}' /tmp/output)
                 JSON_OUTPUT=$(jq --argjson component_index $i --argjson arch_index $index \
                   --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \
-                  --arg arch_digest "${ARCH_DIGEST}" --arg containerImage "${CONTAINER_IMAGE}" \
+                  --arg arch_digest "${ARCH_DIGEST}" --arg os "${OS}" \
                     '.components[$component_index].pyxisImages[$arch_index] += {
                       "arch": $arch,
                       "imageId": $imageId,
                       "digest": $digest,
                       "arch_digest": $arch_digest,
-                      "containerImage": $containerImage}' <<< "$JSON_OUTPUT")
+                      "os": $os}' <<< "$JSON_OUTPUT")
 
                 index=$((index + 1))
             done <<< $(get-image-architectures "${PULLSPEC}" | jq -c)

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -127,24 +127,24 @@ spec:
                 exit 1
               fi
 
-              # check if the correct arch, image id, and containerImage are set in the json file
+              # check if the correct arch, image id, and os are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
-                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
-                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )
-                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[1].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0004" )
-                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0005" )
-                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[2].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0006" )
-                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -120,13 +120,13 @@ spec:
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
-                and ( .containerImage == "source1@mydigest1" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )
-                and ( .containerImage == "source2@mydigest2" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )
-                and ( .containerImage == "source3@mydigest3" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -116,10 +116,10 @@ spec:
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
-                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
               jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
-                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -114,7 +114,7 @@ spec:
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
-                and ( .containerImage == "source@mydigest" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
       runAfter:
         - run-task

--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -10,3 +10,6 @@ Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No | - |
 | server | The server type to use. Options are 'production' and 'stage' | Yes | production |
 | concurrentLimit | The maximum number of images to be processed at once | Yes | 4 |
+
+## Changes in 0.1.1
+* multi-arch images are now properly supported

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-manifests-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -50,20 +50,36 @@ spec:
             exit 1
         fi
 
-        IMAGEURLS=($(cat "${PYXIS_FILE}" | jq -r '.components[].pyxisImages[].containerImage' | sort | uniq))
+        NUM_COMPONENTS=$(jq '.components | length' "${PYXIS_FILE}")
 
         mkdir /workdir/sboms
         cd /workdir/sboms
 
-        for i in ${!IMAGEURLS[@]}; do
-          echo "Fetching sbom for image: ${IMAGEURLS[$i]}"
-          FILE="$(echo ${IMAGEURLS[$i]} | tr "/@:" ---).json"
-          cosign download sbom --output-file "${FILE}" "${IMAGEURLS[$i]}"
+        for (( i=0; i < $NUM_COMPONENTS; i++ )); do
+          COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
+          IMAGEURL=$(jq -r '.containerImage' <<< "${COMPONENT}")
+          NUM_PYXIS_IMAGES=$(jq '.pyxisImages | length' <<< "${COMPONENT}")
+          for (( j=0; j < $NUM_PYXIS_IMAGES; j++ )); do
+            PYXIS_IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< "${COMPONENT}")
+            FILE="$(jq -r '.imageId' <<< "$PYXIS_IMAGE").json"
+            # You can't pass --platform to a single arch image or cosign errors
+            if [ "${NUM_PYXIS_IMAGES}" -eq 1 ] ; then
+              echo "Fetching sbom for single arch image: $IMAGEURL to: $FILE"
+              cosign download sbom --output-file "${FILE}" "${IMAGEURL}"
+            else
+              OS=$(jq -r '.os' <<< "$PYXIS_IMAGE")
+              ARCH=$(jq -r '.arch' <<< "$PYXIS_IMAGE")
+              PLATFORM="${OS}/${ARCH}"
+              echo "Fetching sbom for image: $IMAGEURL with platform: $PLATFORM to: $FILE"
+              cosign download sbom --output-file "${FILE}" --platform "${PLATFORM}" "${IMAGEURL}"
+            fi
+          done
         done
 
         SBOM_COUNT=$(ls *.json | wc -l )
-        if [ $SBOM_COUNT != ${#IMAGEURLS[@]} ]; then
-          echo "ERROR: Expected to fetch sbom for ${#IMAGEURLS[@]} images, but only $SBOM_COUNT were saved"
+        PYXIS_IMAGES=$(jq '[.components[].pyxisImages | length] | add' "${PYXIS_FILE}")
+        if [ $SBOM_COUNT != $PYXIS_IMAGES ]; then
+          echo "ERROR: Expected to fetch sbom for $PYXIS_IMAGES images, but only $SBOM_COUNT were saved"
           exit 1
         fi
 
@@ -111,54 +127,45 @@ spec:
         N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
         declare -a jobs=()
         declare -a files=()
-        total=$(jq '[.components[].pyxisImages | length] | add' "${PYXIS_FILE}")
+        total=$(ls *.json | wc -l )
         count=0
         success=true
         echo "Starting RPM Manifest upload for $total files in total. " \
           "Up to $N files will be uploaded at once..."
 
-        # Loop through all components then all images in case there is a space
-        # in one of the keys or values, which would break jq looping
-        NUM_COMPONENTS=$(jq '.components | length' "${PYXIS_FILE}")
-        for ((i = 0; i < $NUM_COMPONENTS; i++)); do
-          COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
-          NUM_IMAGES=$(jq '.pyxisImages | length' <<< $COMPONENT)
-          for ((j = 0; j < $NUM_IMAGES; j++)); do
-            IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< $COMPONENT)
-            IMAGEID=$(jq -r '.imageId' <<< $IMAGE)
-            SBOM="$(jq -r '.containerImage' <<< $IMAGE | tr "/@:" ---).json"
-            echo Uploading RPM Manifest to Pyxis for IMAGE: $IMAGEID with SBOM: $SBOM
-            upload_rpm_manifest --retry --image-id $IMAGEID --sbom-path $SBOM > ${IMAGEID}.out 2>&1 &
+        for FILE in *.json; do
+          IMAGEID=$(echo $FILE | cut -d '.' -f 1)
+          echo Uploading RPM Manifest to Pyxis for IMAGE: $IMAGEID with SBOM: $FILE
+          upload_rpm_manifest --retry --image-id $IMAGEID --sbom-path $FILE > ${IMAGEID}.out 2>&1 &
 
-            jobs+=($!)  # Save the background process ID
-            images+=($IMAGEID)
-            ((++count))
+          jobs+=($!)  # Save the background process ID
+          images+=($IMAGEID)
+          ((++count))
 
-            if [ $((count%N)) -eq 0 -o $((count)) -eq $total ]; then
-              echo Waiting for the current batch of background processes to finish
-              for job_id in "${!jobs[@]}"; do
-                if ! wait ${jobs[job_id]}; then
-                  echo "Error: upload of ${IMAGE} failed"
-                  success=false
-                fi
-              done
-
-              echo
-              echo Printing outputs for current upload_rpm_manifest script runs
-              for img in ${images[@]}; do
-                echo "=== $img ==="
-                cat "${img}.out"
-                echo
-              done
-
-              if [ $success != "true" ]; then
-                echo ERROR: At least one upload in the last batch failed
-                exit 1
+          if [ $((count%N)) -eq 0 -o $((count)) -eq $total ]; then
+            echo Waiting for the current batch of background processes to finish
+            for job_id in "${!jobs[@]}"; do
+              if ! wait ${jobs[job_id]}; then
+                echo "Error: upload of ${IMAGE} failed"
+                success=false
               fi
+            done
 
-              # Reset job and files arrays for the next batch
-              jobs=()
-              images=()
+            echo
+            echo Printing outputs for current upload_rpm_manifest script runs
+            for img in ${images[@]}; do
+              echo "=== $img ==="
+              cat "${img}.out"
+              echo
+            done
+
+            if [ $success != "true" ]; then
+              echo ERROR: At least one upload in the last batch failed
+              exit 1
             fi
-          done
+
+            # Reset job and files arrays for the next batch
+            jobs=()
+            images=()
+          fi
         done

--- a/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
@@ -7,8 +7,8 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> $(workspaces.data.path)/mock_cosign.txt
 
-  if [[ "$*" != "download sbom --output-file imageurl"[1-5]*".json imageurl"[1-5] && \
-     "$*" != "download sbom --output-file quay.io-org-repo-sha256-0123456abcdef.json quay.io/org/repo@sha256:0123456abcdef" ]]
+  if [[ "$*" != "download sbom --output-file myImageID"[1-5]*".json imageurl"[1-5] && \
+     "$*" != "download sbom --output-file myImageID"[1-5]*".json --platform linux/"*" multiarch-"[1-5] ]]
   then
     echo Error: Unexpected call
     exit 1

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis
+  name: test-push-rpm-manifests-to-pyxis-multi-arch
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters - a happy path scenario.
+    Run the push-rpm-manifests-to-pyxis task with required parameters and multi arch
+    images
   workspaces:
     - name: tests-workspace
   tasks:
@@ -23,35 +24,44 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > $(workspaces.data.path)/pyxis_data.json << EOF
+              cat > $(workspaces.data.path)/pyxis.json << EOF
               {
                 "components": [
                   {
+                    "containerImage": "multiarch-1",
                     "pyxisImages": [
                       {
                         "arch": "amd64",
                         "imageId": "myImageID1",
-                        "digest": "mydigest1",
+                        "digest": "mydigest2",
                         "arch_digest": "abcdefg",
-                        "containerImage": "imageurl1"
+                        "os": "linux"
                       },
                       {
                         "arch": "ppc64le",
                         "imageId": "myImageID2",
-                        "digest": "mydigest1",
+                        "digest": "mydigest2",
                         "arch_digest": "deadbeef",
-                        "containerImage": "imageurl1"
+                        "os": "linux"
                       }
                     ]
                   },
                   {
+                    "containerImage": "multiarch-2",
                     "pyxisImages": [
                       {
                         "arch": "amd64",
                         "imageId": "myImageID3",
-                        "digest": "mydigest2",
+                        "digest": "mydigest3",
                         "arch_digest": "abcdefg",
-                        "containerImage": "quay.io/org/repo@sha256:0123456abcdef"
+                        "os": "linux"
+                      },
+                      {
+                        "arch": "ppc64le",
+                        "imageId": "myImageID4",
+                        "digest": "mydigest4",
+                        "arch_digest": "deadbeef",
+                        "os": "linux"
                       }
                     ]
                   }
@@ -63,7 +73,7 @@ spec:
         name: push-rpm-manifests-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: pyxis_data.json
+          value: pyxis.json
         - name: pyxisSecret
           value: test-push-rpm-manifests-to-pyxis-cert
         - name: server
@@ -87,14 +97,14 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
-                echo Error: cosign was expected to be called 2 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 4 ]; then
+                echo Error: cosign was expected to be called 4 times. Actual calls:
                 cat $(workspaces.data.path)/mock_cosign.txt
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 3 ]; then
-                echo Error: upload_rpm_manifest was expected to be called 3 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 4 ]; then
+                echo Error: upload_rpm_manifest was expected to be called 4 times. Actual calls:
                 cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
                 exit 1
               fi

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
@@ -28,49 +28,62 @@ spec:
               {
                 "components": [
                   {
+                    "containerImage": "imageurl1",
                     "pyxisImages": [
                       {
                         "arch": "amd64",
                         "imageId": "myImageID1Parallel",
                         "digest": "mydigest2",
                         "arch_digest": "abcdefg",
-                        "containerImage": "imageurl1"
-                      },
+                        "os": "linux"
+                      }
+                    ]
+                  },
+                  {
+                    "containerImage": "imageurl2",
+                    "pyxisImages": [
                       {
                         "arch": "ppc64le",
                         "imageId": "myImageID2Parallel",
                         "digest": "mydigest2",
                         "arch_digest": "deadbeef",
-                        "containerImage": "imageurl1"
+                        "os": "linux"
                       }
                     ]
                   },
                   {
+                    "containerImage": "imageurl3",
                     "pyxisImages": [
                       {
                         "arch": "amd64",
                         "imageId": "myImageID3Parallel",
                         "digest": "mydigest3",
                         "arch_digest": "abcdefg",
-                        "containerImage": "imageurl2"
-                      },
+                        "os": "linux"
+                      }
+                    ]
+                  },
+                  {
+                    "containerImage": "imageurl4",
+                    "pyxisImages": [
                       {
                         "arch": "ppc64le",
                         "imageId": "myImageID4Parallel",
                         "digest": "mydigest4",
                         "arch_digest": "deadbeef",
-                        "containerImage": "imageurl2"
+                        "os": "linux"
                       }
                     ]
                   },
                   {
+                    "containerImage": "imageurl5",
                     "pyxisImages": [
                       {
                         "arch": "amd64",
                         "imageId": "myImageID5Parallel",
                         "digest": "mydigest5",
                         "arch_digest": "abcdefg",
-                        "containerImage": "imageurl3"
+                        "os": "linux"
                       }
                     ]
                   }
@@ -108,8 +121,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 3 ]; then
-                echo Error: cosign was expected to be called 3 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
                 cat $(workspaces.data.path)/mock_cosign.txt
                 exit 1
               fi

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
@@ -2,13 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-failure
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-push-rpm-manifests-to-pyxis-single-arch
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters.
-    The first image will fail. The second image will still have a rpm manifest pushed.
+    Run the push-rpm-manifests-to-pyxis task with required parameters and single arch
+    images - a happy path scenario.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -26,7 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > $(workspaces.data.path)/pyxis.json << EOF
+              cat > $(workspaces.data.path)/pyxis_data.json << EOF
               {
                 "components": [
                   {
@@ -34,7 +32,7 @@ spec:
                     "pyxisImages": [
                       {
                         "arch": "amd64",
-                        "imageId": "myImageID1Failing",
+                        "imageId": "myImageID1",
                         "digest": "mydigest1",
                         "arch_digest": "abcdefg",
                         "os": "linux"
@@ -46,7 +44,7 @@ spec:
                     "pyxisImages": [
                       {
                         "arch": "amd64",
-                        "imageId": "myImageID2",
+                        "imageId": "myImageID3",
                         "digest": "mydigest2",
                         "arch_digest": "abcdefg",
                         "os": "linux"
@@ -61,7 +59,7 @@ spec:
         name: push-rpm-manifests-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: pyxis.json
+          value: pyxis_data.json
         - name: pyxisSecret
           value: test-push-rpm-manifests-to-pyxis-cert
         - name: server
@@ -71,3 +69,30 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:8bf56a04aaeb371f4a822d2b76520e9bdcacfb26
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
+                echo Error: cosign was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 2 ]; then
+                echo Error: upload_rpm_manifest was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit changes the push-rpm-manifests-to-pyxis task to properly work with multi arch images. It does this by fetching the sbom per arch instead of just once per component.

As part of this, the create-pyxis-image stores the os value for the image in the pyxis.json file. This replaces the containerImage, which was already in the file in each component.