### PR TITLE
fix(KFLUXBUGS-1182): update infra deployment use target git repo from data

### DIFF
--- a/tasks/update-infra-deployments/README.md
+++ b/tasks/update-infra-deployments/README.md
@@ -1,23 +1,33 @@
 # update-infra-deployments
 
-* This task clones redhat-appstudio/infra-deployments GH repository.
-* It then runs a script obtained from the infra-deployment-update-script key in data which can modify text files.
-* It then generates pull-request for redhat-appstudio/infra-deployments repository using the modified files.
+* This task clones a GitHub repository specified in the 'targetGHRepo' key of the input data file.
+* If 'targetGHRepo' is not provided, it defaults to 'defaultTargetGHRepo: redhat-appstudio/infra-deployments'.
+* It then runs a script obtained from the 'infra-deployment-update-script' key in the data file, which can modify text files.
+* Finally, it generates a pull request for the specified repository using the modified files.
 
 
 ## Parameters
-| Name                    | Description                                                                                  | Optional | Default Value                                                                                                                                    |
-|-------------------------|----------------------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| dataJsonPath            | Path to data json file. It should contain a key called 'infra-deployment-update-script'      | false    |                                                                                                                                                  |
-| snapshotPath            | Path to snapshot json file                                                                   | false    |                                                                                                                                                  |
-| originRepo              | URL of github repository which was built by the Pipeline                                     | false    |                                                                                                                                                  |
-| revision                | Git reference which was built by the Pipeline                                                | false    |                                                                                                                                                  |
-| targetGHRepo            | GitHub repository of the infra-deployments code                                              | true     | redhat-appstudio/infra-deployments                                                                                                               |
-| gitImage                | Image reference containing the git command                                                   | true     | registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8 |
-| scriptImage             | Image reference for SCRIPT execution                                                         | true     | quay.io/mkovarik/ose-cli-git:4.11                                                                                                                |
-| sharedSecret            | Secret in the namespace which contains private key for the GitHub App                        | true     | infra-deployments-pr-creator                                                                                                                     |
-| githubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
-| githubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
+| Name                           | Description                                                                                  | Optional | Default Value                                                                                                                                    |
+|--------------------------------|----------------------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| dataJsonPath                   | Path to data json file. It should contain a key called 'infra-deployment-update-script'      | false    |                                                                                                                                                  |
+| snapshotPath                   | Path to snapshot json file                                                                   | false    |                                                                                                                                                  |
+| originRepo                     | URL of github repository which was built by the Pipeline                                     | false    |                                                                                                                                                  |
+| revision                       | Git reference which was built by the Pipeline                                                | false    |                                                                                                                                                  |
+| defaultTargetGHRepo            | GitHub repository of the infra-deployments code                                              | true     | redhat-appstudio/infra-deployments                                                                                                               |
+| gitImage                       | Image reference containing the git command                                                   | true     | registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8 |
+| scriptImage                    | Image reference for SCRIPT execution                                                         | true     | quay.io/mkovarik/ose-cli-git:4.11                                                                                                                |
+| sharedSecret                   | Secret in the namespace which contains private key for the GitHub App                        | true     | infra-deployments-pr-creator                                                                                                                     |
+| defaultGithubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
+| defaultGithubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
+
+## Changes in 1.0.0
+- Modified `update-infra-deployments` task to dynamically fetch
+  `targetGHRepo`, `githubAppID`, and `githubAppInstallationID` from the dataJsonPath JSON file.
+  (defaults to redhat-appstudio/infra-deployments for targetGHRepo,
+  and provided defaults for githubAppID and githubAppInstallationID)
+- Added `defaultTargetGHRepo`, `defaultGithubAppID`, and `defaultGithubAppInstallationID` parameters
+  to the update-infra-deployments task to specify the default values
+  for the GitHub repository and app configurations.
 
 ## Changes since 0.4.1
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/update-infra-deployments/update-infra-deployments.yaml
@@ -3,24 +3,32 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
   name: update-infra-deployments
 spec:
   description: |
-   This task clones redhat-appstudio/infra-deployments GH repository.
-   It then runs a script obtained from the infra-deployment-update-script key in data which can modify text files
-   It then generates pull-request for redhat-appstudio/infra-deployments repository using the modified files.
+    This task clones a GitHub repository specified in the 'targetGHRepo' key of the input data file.
+    If 'targetGHRepo' is not provided, it defaults to 'redhat-appstudio/infra-deployments'.
+    It then runs a script obtained from the 'infra-deployment-update-script' key in the data file, which can modify
+    text files.
+    Finally, it generates a pull request for the specified repository using the modified files.
   params:
     - name: dataJsonPath
       description: path to data json file
     - name: snapshotPath
       description: path to snapshot json file
-    - name: targetGHRepo
+    - name: defaultTargetGHRepo
       description: GitHub repository of the infra-deployments code
       default: redhat-appstudio/infra-deployments
+    - name: defaultGithubAppID
+      description: Default ID of Github app used for updating PR
+      default: "305606"
+    - name: defaultGithubAppInstallationID
+      description: Default Installation ID of Github app in the organization
+      default: "35269675"
     - name: gitImage
       description: Image reference containing the git command
       default: >-
@@ -32,12 +40,6 @@ spec:
     - name: sharedSecret
       default: infra-deployments-pr-creator
       description: secret in the namespace which contains private key for the GitHub App
-    - name: githubAppID
-      description: ID of Github app used for updating PR
-      default: "305606"
-    - name: githubAppInstallationID
-      description: Installation ID of Github app in the organization
-      default: "35269675"
   volumes:
     - name: infra-deployments-pr-creator
       secret:
@@ -52,10 +54,9 @@ spec:
         - name: shared-dir
           mountPath: /shared
       workingDir: /shared
-      env:
-        - name: TARGET_GH_REPO
-          value: "$(params.targetGHRepo)"
       script: |
+        TARGET_GH_REPO=$(cat "$(params.dataJsonPath)" | jq -r '.targetGHRepo // "$(params.defaultTargetGHRepo)"')
+        echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
       image: $(params.scriptImage)
@@ -64,14 +65,14 @@ spec:
           mountPath: /shared
       workingDir: /shared
       script: |
+        set -x
         cd cloned
         
         echo "snapshot:"
         cat "$(params.snapshotPath)"
         echo ""
         
-        # we assume we only have one component in the service.
-        #
+        # We assume we only have one component in the service.
         revision=$(cat "$(params.snapshotPath)" | jq -r .components[0].source.git.revision)
         echo "revision: $revision"
         echo $revision > ../revision.txt
@@ -80,7 +81,7 @@ spec:
         echo "origin repo: $originRepo"
         echo $originRepo > ../originRepo.txt
 
-        # get SCRIPT from Data
+        # Get SCRIPT from Data
         echo "data: $(params.dataJsonPath)"
         SCRIPT=$(cat "$(params.dataJsonPath)" | jq -r '."infra-deployment-update-script" // empty')
 
@@ -117,14 +118,16 @@ spec:
       env:
         - name: GITHUBAPP_KEY_PATH
           value: /secrets/deploy-key/private-key
-        - name: GITHUBAPP_APP_ID
-          value: "$(params.githubAppID)"
-        - name: GITHUBAPP_INSTALLATION_ID
-          value: "$(params.githubAppInstallationID)"
         - name: GITHUB_API_URL
           value: https://api.github.com
-        - name: TARGET_GH_REPO
-          value: "$(params.targetGHRepo)"
+        - name: DATA_JSON_PATH
+          value: "$(params.dataJsonPath)"
+        - name: DEFAULT_TARGET_GH_REPO
+          value: "$(params.defaultTargetGHRepo)"
+        - name: DEFAULT_GITHUB_APP_ID
+          value: "$(params.defaultGithubAppID)"
+        - name: DEFAULT_GITHUB_APP_INSTALLATION_ID
+          value: "$(params.defaultGithubAppInstallationID)"
       script: |
         #!/usr/bin/env python3
         import json
@@ -139,6 +142,25 @@ spec:
         EXPIRE_MINUTES_AS_SECONDS = int(os.environ.get('GITHUBAPP_TOKEN_EXPIRATION_MINUTES', 10)) * 60
         # TODO support github enteprise
         GITHUB_API_URL = os.environ.get('GITHUB_API_URL')
+
+        # Fetch targetGHRepo, githubAppID, and githubAppInstallationID from data JSON file
+        with open(os.environ.get('DATA_JSON_PATH'), 'r') as f:
+            data = json.load(f)
+            target_gh_repo = data.get(
+                'targetGHRepo',
+                os.environ.get('DEFAULT_TARGET_GH_REPO')
+            )
+            github_app_id = str(data.get(
+                'githubAppID',
+                os.environ.get('DEFAULT_GITHUB_APP_ID')
+            ))
+            github_app_installation_id = str(data.get(
+                'githubAppInstallationID',
+                os.environ.get('DEFAULT_GITHUB_APP_INSTALLATION_ID')
+            ))
+            os.environ['TARGET_GH_REPO'] = target_gh_repo
+            os.environ['GITHUBAPP_APP_ID'] = github_app_id
+            os.environ['GITHUBAPP_INSTALLATION_ID'] = github_app_installation_id
 
         with open('originRepo.txt', 'r') as fileA:
           originRepo = fileA.read().rstrip()


### PR DESCRIPTION
- Modified `update-infra-deployments` task to dynamically fetch
  `targetGHRepo`, `githubAppID`, and `githubAppInstallationID` from the dataJsonPath JSON file.
  (defaults to redhat-appstudio/infra-deployments for targetGHRepo,
  and provided defaults for githubAppID and githubAppInstallationID)
- Added `defaultTargetGHRepo`, `defaultGithubAppID`, and `defaultGithubAppInstallationID` parameters
  to the update-infra-deployments task to specify the default values
  for the GitHub repository and app configurations.