### PR TITLE
fix(KFLUXBUGS-1294): remove all previous tags in create-pyxis-image task

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,11 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
 
+## Changes in 2.6.1
+* For each image that is created in Pyxis, the task will now also remove
+  all its tags from all previous images
+  * This is done via a new script called cleanup_tags from the utils image
+
 ## Changes in 2.6.0
 * containerImage is no longer saved in the pyxis.json entries
   * This was already saved in pyxis.json per component, it doesn't need to be duplicated in the pyxisImages keys

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.6.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -59,7 +59,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/redhat-appstudio/release-service-utils:b3059c67d4bdb6c9cf1739fdfb2c0cb595fe0f86
+      image: quay.io/redhat-appstudio/release-service-utils:bcc8bcfb3bdc32498c5d3327abf01975df7495bd
       env:
         - name: pyxisCert
           valueFrom:
@@ -78,15 +78,19 @@ spec:
         if [[ "$(params.server)" == "production" ]]
         then
           PYXIS_URL="https://pyxis.api.redhat.com/"
+          PYXIS_GRAPHQL_URL="https://graphql-pyxis.api.redhat.com/graphql/"
         elif [[ "$(params.server)" == "stage" ]]
         then
           PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
+          PYXIS_GRAPHQL_URL="https://graphql-pyxis.preprod.api.redhat.com/graphql/"
         elif [[ "$(params.server)" == "production-internal" ]]
         then
           PYXIS_URL="https://pyxis.engineering.redhat.com/"
+          PYXIS_GRAPHQL_URL="https://graphql.pyxis.engineering.redhat.com/graphql/"
         elif [[ "$(params.server)" == "stage-internal" ]]
         then
           PYXIS_URL="https://pyxis.stage.engineering.redhat.com/"
+          PYXIS_GRAPHQL_URL="https://graphql.pyxis.stage.engineering.redhat.com/graphql/"
         else
           echo "Invalid server parameter. Only 'production','production-internal,'stage-internal' and 'stage' allowed."
           exit 1
@@ -153,6 +157,14 @@ spec:
                   --rh-push $(params.rhPush) | tee "/tmp/output"
                 # The rh-push-to-external-registry e2e test depends on this line being in the task log
                 IMAGEID=$(awk '/The image id is/{print $NF}' /tmp/output)
+
+                # Remove the new image tags from all previous images
+                PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key cleanup_tags \
+                  --verbose \
+                  --retry \
+                  --pyxis-graphql-api $PYXIS_GRAPHQL_URL \
+                  $IMAGEID
+
                 JSON_OUTPUT=$(jq --argjson component_index $i --argjson arch_index $index \
                   --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \
                   --arg arch_digest "${ARCH_DIGEST}" --arg os "${OS}" \

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -5,12 +5,25 @@ set -eux
 
 function create_container_image() {
   echo $* >> $(workspaces.data.path)/mock_create_container_image.txt
+  # The image id is a 4 digit number with leading zeros calculated from the call number,
+  # e.g. 0001, 0002, 0003...
   echo The image id is $(awk 'END{printf("%04i", NR)}' $(workspaces.data.path)/mock_create_container_image.txt)
 
   if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --skopeo-result /tmp/skopeo-inspect.json --media-type my_media_type --architecture-digest "*" --rh-push "* ]]
   then
     echo Error: Unexpected call
     echo Mock create_container_image called with: $*
+    exit 1
+  fi
+}
+
+function cleanup_tags() {
+  echo $* >> $(workspaces.data.path)/mock_cleanup_tags.txt
+
+  if [[ "$*" != "--verbose --retry --pyxis-graphql-api https://graphql-pyxis.preprod.api.redhat.com/graphql/ "00?? ]]
+  then
+    echo Error: Unexpected call
+    echo Mock cleanup_tags called with: $*
     exit 1
   fi
 }

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -97,6 +97,12 @@ spec:
                 exit 1
               fi
 
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 6 ]; then
+                echo Error: cleanup_tags was expected to be called 6 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
+                exit 1
+              fi
+
               cat > $(workspaces.data.path)/skopeo_expected_calls.txt << EOF
               inspect --raw docker://registry.io/multi-arch-image1@mydigest1
               inspect --no-tags --override-os linux --override-arch amd64 \

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -72,7 +72,7 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:   
+      params:
         - name: pyxisDataPath
           value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
@@ -94,6 +94,12 @@ spec:
               if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 3 ]; then
                 echo Error: create_container_image was expected to be called 3 times. Actual calls:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 3 ]; then
+                echo Error: cleanup_tags was expected to be called 3 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi
 

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-create-pyxis-image-one-containerimage-multi-arch
 spec:
   description: |
-    Run the create-pyxis-image task with a single containerImage in the snapshot and 
+    Run the create-pyxis-image task with a single containerImage in the snapshot and
     multiple architectures.
   workspaces:
     - name: tests-workspace
@@ -62,7 +62,7 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:   
+      params:
         - name: pyxisDataPath
           value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
@@ -84,6 +84,12 @@ spec:
               if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 2 ]; then
                 echo Error: create_container_image was expected to be called 2 time. Actual calls:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 2 ]; then
+                echo Error: cleanup_tags was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi
 

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -61,7 +61,7 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:   
+      params:
         - name: pyxisDataPath
           value: $(tasks.run-task.results.pyxisDataPath)
       workspaces:
@@ -83,6 +83,12 @@ spec:
               if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 1 ]; then
                 echo Error: create_container_image was expected to be called 1 time. Actual calls:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 1 ]; then
+                echo Error: cleanup_tags was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi
 

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -78,6 +78,12 @@ spec:
                 exit 1
               fi
 
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 1 ]; then
+                echo Error: cleanup_tags was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
+                exit 1
+              fi
+
               if ! grep -- "--tags myprefix-mytimestamp myprefix" \
                 < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
@@ -81,6 +81,12 @@ spec:
                 exit 1
               fi
 
+              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 1 ]; then
+                echo Error: cleanup_tags was expected to be called 1 time. Actual calls:
+                cat $(workspaces.data.path)/mock_cleanup_tags.txt
+                exit 1
+              fi
+
               if ! grep -- "--tags myprefix-mytimestamp myprefix" \
                 < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then


### PR DESCRIPTION
When creating Container Image objects in Pyxis, we will now remove all the new image's tags from previous images in Pyxis.

This is necessary because otherwise there are duplicate tag entries shown in Red Hat Catalog - all the floating tags need to be removed during the release which is what the new cleanup_tags script will do.

Depends on https://github.com/konflux-ci/release-service-utils/pull/152 (merged)