### PR TITLE
refactor(RELEASE-921): make for loops safe

### DIFF
--- a/tasks/embargo-check/embargo-check.yaml
+++ b/tasks/embargo-check/embargo-check.yaml
@@ -58,7 +58,9 @@ spec:
 
         RC=0
 
-        for issue in $(jq -cr '.releaseNotes.issues.fixed[]?' "${DATA_FILE}") ; do
+        NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
+        for ((i = 0; i < $NUM_ISSUES; i++)); do
+            issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< $issue)
             API=$(jq -r '.[] | select(.servers[] | contains("'$server'")) | .api' <<< $SUPPORTED_ISSUE_TRACKERS)
             API_URL="https://$(jq -r '.source' <<< $issue)/${API}/$(jq -r '.id' <<< $issue)"
@@ -100,7 +102,7 @@ spec:
             -s true \
             > $(workspaces.data.path)/ir-result.txt || \
             (grep "^\[" $(workspaces.data.path)/ir-result.txt | jq . && exit 1)
-        
+
         internalRequest=$(awk 'NR==1{ print $2 }' $(workspaces.data.path)/ir-result.txt | xargs)
         echo "done (${internalRequest})"
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -69,7 +69,10 @@ spec:
             containerImage="${deliveryRepo}@sha256:${sha}"
             # Construct CVE json
             CVEsJson='{"cves":{"fixed":{}}}'
-            for cve in $(jq -c '.releaseNotes.cves[] | select(.component=="'$name'")' ${DATA_FILE}) ; do
+            CVES=$(jq -c '[.releaseNotes.cves[]? | select(.component=="'$name'")]' ${DATA_FILE})
+            NUM_CVES=$(jq 'length' <<< "$CVES")
+            for ((j = 0; j < $NUM_CVES; j++)); do
+                cve=$(jq -c --argjson j "$j" '.[$j]' <<< "$CVES")
                 cveJson=$(jq -n \
                     --arg id $(jq -r '.key' <<< $cve) \
                     --argjson packages $(jq -c '.packages' <<< $cve) \


### PR DESCRIPTION
When iterating over json strings in a bash script, it's not safe to just do a basic for loop that uses spaces as delimiters. Instead, it's better to iterate over json array indexes and load the array item inside the loop.

I didn't upversion the tasks because this has zero effect on functionality. But please let me know if you think I should do it.