### PR TITLE
feat(RELEASE-935): add update-cr-status task

### DIFF
--- a/.github/resources/crd_rbac.yaml
+++ b/.github/resources/crd_rbac.yaml
@@ -11,6 +11,7 @@ rules:
       - internalrequests
       - internalrequests/status
       - releases
+      - releases/status
       - releaseplans
       - releaseplanadmissions
       - releaseserviceconfigs

--- a/tasks/update-cr-status/README.md
+++ b/tasks/update-cr-status/README.md
@@ -1,0 +1,12 @@
+# update-cr-status
+
+A tekton task that updates the passed CR status with the contents stored in the files in the resultsDir.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| resourceType | The type of resource that is being patched | Yes | release |
+| statusKey | The top level key to overwrite in the resource status | Yes | artifacts |
+| resource | The namespaced name of the resource to be patched | No | - |
+| resultsDirPath | Path to the directory containing the result files in the data workspace which will be added to the resource's status | No | - |

--- a/tasks/update-cr-status/tests/pre-apply-task-hook.sh
+++ b/tasks/update-cr-status/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/tasks/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-missing-rbac
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-cr-status task where the rbac to update the status
+    of the provided resource is not present. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/one.json" << EOF
+              {
+                  "name": "foo",
+                  "active": false
+              }
+              EOF
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-missing-rbac
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/releaseplan-missing-rbac
+        - name: resourceType
+          value: releasePlan
+        - name: resultsDirPath
+          value: results
+        - name: statusKey
+          value: releasePlanAdmission
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete releaseplan releaseplan-missing-rbac

--- a/tasks/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-multiple-result-files
+spec:
+  description: |
+    Run the update-cr-status task with rbac present and multiple result
+    files in the results directory. The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/one.json" << EOF
+              {
+                  "one": {
+                      "foo": "bar"
+                  },
+                  "two": {
+                      "a": "b"
+                  }
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/results/two.json" << EOF
+              {
+                  "one": {
+                      "union": "value"
+                  },
+                  "z": {
+                      "cat": "dog"
+                  }
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-multiple
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status-multiple
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains the union data
+              test $(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath={.status.artifacts.one.foo}) == bar
+
+              test $(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath={.status.artifacts.one.union}) == value
+
+              echo Test that the Release.Status contains the unique data from first file
+              test $(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath={.status.artifacts.two.a}) == b
+
+              echo Test that the Release.Status contains the unique data from second file
+              test $(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath={.status.artifacts.z.cat}) == dog
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-multiple

--- a/tasks/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-no-overwrite
+spec:
+  description: |
+    Run the update-cr-status task with rbac present and a proper results
+    file, but with information already in the resource status. The pipeline
+    should succeed and existing status should not be overwritten.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              {
+                 "author": "user",
+                 "standingAuthorization": false
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-overwrite
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+              kubectl patch release release-cr-status-overwrite -n default \
+                --type=merge --subresource status --patch "status: {automated: false}"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status-overwrite
+        - name: resultsDirPath
+          value: results
+        - name: statusKey
+          value: attribution
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains the old data
+              test $(kubectl get release release-cr-status-overwrite -n default \
+                -o jsonpath={.status.automated}) == false
+
+              echo Test that the Release.Status contains the new data
+              test $(kubectl get release release-cr-status-overwrite -n default \
+                -o jsonpath={.status.attribution.author}) == user
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-overwrite

--- a/tasks/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-no-results
+spec:
+  description: |
+    Run the update-cr-status task where there are no files in the results dir.
+    The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-no-results
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-no-results
+        - name: resultsDirPath
+          value: nonexistent
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-nonexistent-status-field
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-cr-status task to update a field that does not exist in the
+    CRD status. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-nonexistent-status-field
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-nonexistent-status-field
+        - name: resultsDirPath
+          value: results
+        - name: statusKey
+          value: devnull
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-nonexistent-status-field

--- a/tasks/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-resource-nonexistent
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-cr-status task where the provided resource
+    does not exist on the cluster. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              {
+                  "automated": true
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/my-release
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-results-not-json
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-cr-status task where a file in the provided results dir
+    is not proper json. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              this
+              is
+               not
+              json
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/my-release
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status
+spec:
+  description: |
+    Run the update-cr-status task with rbac present and one proper results
+    file in the results directory. The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains proper data
+              test $(kubectl get release release-cr-status -n default -o jsonpath={.status.artifacts.foo}) == bar
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status

--- a/tasks/update-cr-status/update-cr-status.yaml
+++ b/tasks/update-cr-status/update-cr-status.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-cr-status
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    A tekton task that updates the passed CR status with the
+    contents stored in the resultsFile.
+  params:
+    - name: resourceType
+      description: The type of resource that is being patched
+      type: string
+      default: release
+    - name: statusKey
+      description: The top level key to overwrite in the resource status
+      type: string
+      default: artifacts
+    - name: resource
+      description: The namespaced name of the resource to be patched
+      type: string
+    - name: resultsDirPath
+      description: |
+        Path to the directory containing the result files in the data workspace which will be added to the
+        resource's status
+      type: string
+  workspaces:
+    - name: data
+      description: Workspace where the results directory is stored
+  steps:
+    - name: update-cr-status
+      image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        RESULTS_JSON="{}"
+        RESULTS_DIR="$(workspaces.data.path)/$(params.resultsDirPath)"
+        for resultsFile in $([ -d "$RESULTS_DIR" ] && find "$RESULTS_DIR" -type f); do
+            if ! jq . >/dev/null 2>&1 "${resultsFile}" ; then
+                echo "Passed results JSON file ${resultsFile} in results directory was not proper JSON."
+                exit 1
+            fi
+            # If two files have arrays with the same key, it will be overwritten. Otherwise, the jsons
+            # are merged (only arrays are not merged properly with this notation).
+            RESULTS_JSON=$(jq -c "${RESULTS_JSON} * ." "${resultsFile}")
+        done
+
+        IFS='/' read -r namespace name <<< "$(params.resource)"
+
+        kubectl --warnings-as-errors=true patch $(params.resourceType) -n $namespace $name \
+          --type=merge --subresource status --patch "status: {'$(params.statusKey)':${RESULTS_JSON}}"


### PR DESCRIPTION
Add a new tekton task that will update the status of the passed custom resource with the results file it is provided.