### PR TITLE
feat(RELEASE-930): tekton task tests always run

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -2,20 +2,38 @@
 name: Tekton Task Tests
 on:
   pull_request:
-    paths:
-      - 'tasks/**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   run-tekton-task-tests:
     name: Run Tekton Task tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get changed dirs
+        id: changed-dirs
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            tasks/**
+          dir_names: "true"
+          dir_names_max_depth: "4"
+      - name: Show changed dirs
+        run: |
+          echo ${{ steps.changed-dirs.outputs.all_changed_files }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.10.0
+        if: steps.changed-dirs.outputs.any_changed == 'true'
       - name: Check cluster info
+        if: steps.changed-dirs.outputs.any_changed == 'true'
         run: |
           kubectl cluster-info
       - name: Install Tekton
         timeout-minutes: 10
+        if: steps.changed-dirs.outputs.any_changed == 'true'
         run: |
           kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
 
@@ -34,19 +52,6 @@ jobs:
           done
 
           kubectl get pods --namespace tekton-pipelines
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get changed dirs
-        id: changed-dirs
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            tasks/**
-          dir_names: "true"
-          dir_names_max_depth: "4"
-      - name: Show changed dirs
-        run: |
-          echo ${{ steps.changed-dirs.outputs.all_changed_files }}
       - name: Install tkn
         if: steps.changed-dirs.outputs.any_changed == 'true'
         uses: ./.github/actions/install-tkn


### PR DESCRIPTION
This commit changes the tekton task tests github workflow to run on all pull requests instead of if only the tasks dir was changed. If the tasks dir was not changed, it will just exit 0 without running any tests. This allows us to make the check mandatory for all PRs.