### PR TITLE
fix: commonTags is empty with new tag format

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.7.1
+- The when conditions that skipped tasks if the `push-snapshot` result `commonTags` was empty was removed
+  - This is due to the migration to the new tag format. A similar when will be readded with RELEASE-932
+
 ## Changes in 0.7.0
 - The apply-mapping task now gets the dataPath parameter instead of releasePlanAdmissionPath
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.7.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -253,10 +253,6 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: populate-release-notes-images
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -277,10 +273,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: embargo-check
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -301,10 +293,6 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: collect-pyxis-params
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -323,10 +311,6 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       timeout: "2h00m0s"
       taskRef:
         resolver: "git"
@@ -358,10 +342,6 @@ spec:
       runAfter:
         - embargo-check
     - name: create-pyxis-image
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -434,10 +414,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -463,10 +439,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -488,10 +460,6 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: create-advisory
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: releasePlanAdmissionPath
           value: "$(tasks.collect-data.results.releasePlanAdmission)"

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.5.1
+* The when conditions that skipped tasks if the `push-snapshot` result `commonTags` was empty was removed
+  * This is due to the migration to the new tag format. A similar when will be readded with RELEASE-932
+
 ## Changes in 3.5.0
 * The apply-mapping task now gets the dataPath parameter instead of releasePlanAdmissionPath
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -249,10 +249,6 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: collect-pyxis-params
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       taskRef:
         resolver: "git"
         params:
@@ -281,10 +277,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/rh-sign-image/rh-sign-image.yaml
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
@@ -313,10 +305,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/create-pyxis-image/create-pyxis-image.yaml
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: server
           value: $(tasks.collect-pyxis-params.results.server)
@@ -380,10 +368,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
-      when:
-        - input: $(tasks.push-snapshot.results.commonTags)
-          operator: notin
-          values: [""]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)


### PR DESCRIPTION
The commonTags result is empty with the new tag format for floatingTags. However, we don't want to skip tasks if users are using the new tag format. This commit removes the when conditions. They will be readded with RELEASE-932.