### PR TITLE
fix: use set -e in create-pyxis-image task

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -20,6 +20,11 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
 
+## Changes in 2.7.1
+* Use set -e for the step script. Without it, the script would carry on even if something failed along the way,
+  e.g. if the cleanup_tags script failed because of Pyxis issues, we would still continue onto the next
+  iteration in the loop. We should fail the task in this case.
+
 ## Changes in 2.7.0
 * Updated the base image used in this task
 

--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -21,6 +21,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | dataPath | Path to the JSON string of the merged data to use in the data workspace. Only required if commonTags is not set or empty. | No | |
 
 ## Changes in 2.7.1
+* Only run the cleanup_tags script to clean up tags from previous images if rhPush=true
+  * The script expects to find a registry.access.redhat.com repository entry for the image
+    (which is only created if rhPush=true), so it would fail for images that do not have one.
 * Use set -e for the step script. Without it, the script would carry on even if something failed along the way,
   e.g. if the cleanup_tags script failed because of Pyxis issues, we would still continue onto the next
   iteration in the loop. We should fail the task in this case.

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -158,12 +158,14 @@ spec:
                 # The rh-push-to-external-registry e2e test depends on this line being in the task log
                 IMAGEID=$(awk '/The image id is/{print $NF}' /tmp/output)
 
-                # Remove the new image tags from all previous images
-                PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key cleanup_tags \
-                  --verbose \
-                  --retry \
-                  --pyxis-graphql-api $PYXIS_GRAPHQL_URL \
-                  $IMAGEID
+                # Remove the new image tags from all previous images, but only if rhPush=true
+                if [ "$(params.rhPush)" = "true" ]; then
+                  PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key cleanup_tags \
+                    --verbose \
+                    --retry \
+                    --pyxis-graphql-api $PYXIS_GRAPHQL_URL \
+                    $IMAGEID
+                fi
 
                 JSON_OUTPUT=$(jq --argjson component_index $i --argjson arch_index $index \
                   --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.7.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -73,7 +73,7 @@ spec:
               key: key
       script: |
         #!/usr/bin/env bash
-        set -o pipefail
+        set -eo pipefail
 
         if [[ "$(params.server)" == "production" ]]
         then

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -exo pipefail
 
 # mocks to be injected into task step scripts
 

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -97,8 +97,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 6 ]; then
-                echo Error: cleanup_tags was expected to be called 6 times. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_cleanup_tags.txt ]; then
+                echo Error: cleanup_tags was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -97,8 +97,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 3 ]; then
-                echo Error: cleanup_tags was expected to be called 3 times. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_cleanup_tags.txt ]; then
+                echo Error: cleanup_tags was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -87,8 +87,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 2 ]; then
-                echo Error: cleanup_tags was expected to be called 2 times. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_cleanup_tags.txt ]; then
+                echo Error: cleanup_tags was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -86,8 +86,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 1 ]; then
-                echo Error: cleanup_tags was expected to be called 1 time. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_cleanup_tags.txt ]; then
+                echo Error: cleanup_tags was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-tag-in-component.yaml
@@ -81,8 +81,8 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_cleanup_tags.txt | wc -l) != 1 ]; then
-                echo Error: cleanup_tags was expected to be called 1 time. Actual calls:
+              if [ -f $(workspaces.data.path)/mock_cleanup_tags.txt ]; then
+                echo Error: cleanup_tags was not expected to be called. Actual calls:
                 cat $(workspaces.data.path)/mock_cleanup_tags.txt
                 exit 1
               fi


### PR DESCRIPTION
Without this, the task execution would carry on even if something failed inside the script.