### PR TITLE
feat(RELEASE-878): collect-data creates result dir

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -27,6 +27,10 @@ should not be present in the Release data section).
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
+## Changes in 4.3.0
+  * Task creates a results dir in the workspace (inside the subdirectory if set). The path to this
+    inside the workspace is emitted as a task result
+
 ## Changes in 4.2.0
   * Replace redirects with `tee` so that more is output in the task log to make debugging easier
 

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.2.0"
+    app.kubernetes.io/version: "4.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -57,6 +57,9 @@ spec:
     - name: data
       type: string
       description: The relative path in the workspace to the stored data json
+    - name: resultsDir
+      type: string
+      description: The relative path in the workspace to the results directory
   steps:
     - name: collect-data
       image: quay.io/redhat-appstudio/release-service-utils:bc81bfed6062a386e48a76b252c6f33b52c411b0
@@ -75,9 +78,14 @@ spec:
         #!/usr/bin/env sh
         set -eo pipefail
 
+        RESULTS_DIR_PATH="results"
         if [ -n "$(params.subdirectory)" ]; then
           mkdir -p $(workspaces.data.path)/$(params.subdirectory)
+          RESULTS_DIR_PATH="$(params.subdirectory)/results"
         fi
+
+        mkdir "$(workspaces.data.path)/$RESULTS_DIR_PATH"
+        echo -n $RESULTS_DIR_PATH > $(results.resultsDir.path)
 
         RELEASE_PATH=$(params.subdirectory)/release.json
         echo -n $RELEASE_PATH > $(results.release.path)

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -112,6 +112,8 @@ spec:
           workspace: tests-workspace
     - name: check-result
       params:
+        - name: resultsDir
+          value: $(tasks.run-task.results.resultsDir)
         - name: release
           value: $(tasks.run-task.results.release)
         - name: releasePlan
@@ -131,6 +133,8 @@ spec:
         - run-task
       taskSpec:
         params:
+          - name: resultsDir
+            type: string
           - name: release
             type: string
           - name: releasePlan
@@ -151,6 +155,9 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              echo Test that the results directory was created
+              test -d "$(workspaces.data.path)/$(resultsDir)"
 
               echo Test that Release CR was saved to workspace
               test $(cat "$(workspaces.data.path)/$(params.release)" | jq -r '.metadata.name') == release-sample


### PR DESCRIPTION
This commit modifies the collect-data task to create a results dir in the workspace. This is so that other tasks can write their artifact files to this directory and we do not need to copy the creation of the directory in case it does not exist to every other task.