### PR TITLE
feat(RELEASE-953): create-advisory writes a results file

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.8.0
+- The create-advisory task now gets the `resultsDir` parameter from the collect-data results
+
 ## Changes in 0.7.1
 - The when conditions that skipped tasks if the `push-snapshot` result `commonTags` was empty was removed
   - This is due to the migration to the new tag format. A similar when will be readded with RELEASE-932

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.7.1"
+    app.kubernetes.io/version: "0.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -467,6 +467,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       taskRef:

--- a/tasks/create-advisory/README.md
+++ b/tasks/create-advisory/README.md
@@ -13,9 +13,13 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the data workspace                   | No       |                             |
 | snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | No       |                             |
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       |                             |
+| resultsDirPath           | Path to results directory in the data workspace                                           | No       |                             |
 | request                  | Type of request to be created                                                             | Yes      | create-advisory             |
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |
+
+## Changes in 4.0.0
+- The task now writes created artifacts to a results json file in the workspace
 
 ## Changes in 3.3.0
 - Removed `releaseServiceConfigPath` parameter as it is no longer needed.

--- a/tasks/create-advisory/create-advisory.yaml
+++ b/tasks/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,6 +25,9 @@ spec:
     - name: dataPath
       type: string
       description: Path to the data JSON in the data workspace
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
     - name: request
       type: string
       description: Type of request to be created
@@ -48,6 +51,8 @@ spec:
       script: |
         #!/bin/sh
         set -e
+
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-advisory-results.json"
 
         # Obtain application from snapshot
         application=$(jq -rc .application $(workspaces.data.path)/$(params.snapshotPath))
@@ -145,4 +150,6 @@ spec:
           exit 1
         fi
 
-        echo -n "$(echo ${results} | jq -r '.advisory_url // ""')" | tee $(results.advisory_url.path)
+        URL=$(echo ${results} | jq -r '.advisory_url // ""')
+        echo -n "$URL" | tee $(results.advisory_url.path)
+        jq -n --arg url "$URL" '{"advisory": {"url": $url}}' | tee $RESULTS_FILE

--- a/tasks/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
@@ -20,6 +20,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -110,6 +112,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -20,6 +20,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
               
+              mkdir $(workspaces.data.path)/results
+
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -82,6 +84,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
@@ -20,6 +20,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -106,6 +108,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -20,6 +20,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
+
               cat > $(workspaces.data.path)/test_snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -55,6 +57,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -19,6 +19,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -81,6 +83,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
@@ -20,6 +20,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -110,6 +112,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -18,6 +18,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -104,6 +106,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid

--- a/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -18,6 +18,8 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              mkdir $(workspaces.data.path)/results
               
               cat > $(workspaces.data.path)/test_release_plan_admission.json << EOF
               {
@@ -100,6 +102,8 @@ spec:
           value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
+        - name: resultsDirPath
+          value: "results"
         - name: synchronously
           value: "false"
         - name: pipelineRunUid
@@ -175,6 +179,10 @@ spec:
 
               echo Test that the advisory_url result was properly set
               test "$(echo $(params.advisory_url))" == "https://github.com/org/repo/advisory"
+
+              echo Test that the advisory_url was properly added to the results file
+              test "$(jq -r '.advisory.url' $(workspaces.data.path)/results/create-advisory-results.json)" == \
+                "https://github.com/org/repo/advisory"
 
               # Check the advisory_secret_name parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name' )" != \


### PR DESCRIPTION
This commit changes the create-advisory task to write the created advisory url to a results file.