### PR TITLE
Support multiple components

### DIFF
--- a/tasks/extract-binaries-from-image/README.md
+++ b/tasks/extract-binaries-from-image/README.md
@@ -5,6 +5,9 @@ Tekton task that extracts binaries to be released on github.com from an image.
 The path to the directory inside the provided workspace where the binaries were
 saved is provided as a result.
 
+The binaries must be stored at the same `image_binaries_path` for each component
+passed.
+
 ## Parameters
 
 | Name | Description | Optional | Default value |
@@ -12,6 +15,10 @@ saved is provided as a result.
 | image_binaries_path | Path inside the image where the binaries to extract are stored | Yes | /releases |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace | No | |
 | subdirectory | Subdirectory inside the workspace to be used for storing the binaries | Yes | "" |
+| dataPath | Path to the JSON string of the merged data to use in the data workspace   | No | |
+
+## Changes in 2.0.0
+ - support multiple components in snapshot
 
 ## Changes in 1.2.0
 - updated the base image used in this task

--- a/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-binaries-from-image
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -21,6 +21,10 @@ spec:
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
     - name: subdirectory
       description: Subdirectory inside the workspace to be used for storing the binaries
+      type: string
+      default: ""
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
       type: string
       default: ""
   results:
@@ -41,28 +45,48 @@ spec:
             echo "Error: No valid snapshot file was provided."
             exit 1
         fi
-        IMAGE_URL=$(jq -r '.components[0].containerImage // ""' "${SNAPSHOT_SPEC_FILE}")
-        if [ -z "${IMAGE_URL}" ] ; then
-            echo "Error: Unable to get image url from snapshot."
-            exit 1
-        fi
 
         BINARIES_DIR=binaries
         BINARIES_PATH=$(workspaces.data.path)/$(params.subdirectory)/$BINARIES_DIR
         mkdir -p $BINARIES_PATH
 
-        TMP_DIR=$(mktemp -d)
-        skopeo copy docker://$IMAGE_URL dir:$TMP_DIR
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        DESIRED_COMPONENTS_LIST=()
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+        elif [ $(jq '."content-gateway" | has("components")' "${DATA_FILE}") = true ]; then
+            DESIRED_COMPONENTS_LIST=$(jq -r '."content-gateway".components[].name' "${DATA_FILE}")
+        fi
 
-        cd $TMP_DIR
+        NUM_COMPONENTS=$(jq '.components | length' "$SNAPSHOT_SPEC_FILE")
+        for ((i=0; i < NUM_COMPONENTS; i++)); do
+          COMPONENT=$(jq -c ".components[$i]" "$SNAPSHOT_SPEC_FILE")
+          COMPONENT_NAME=$(echo $COMPONENT | jq -r '.name')
 
-        for DIGEST in $(jq -r ".layers[].digest" manifest.json)
-        do
-            FILE=${DIGEST#sha256:}
-            tar -xzvf $FILE
+          # If desired components list is not empty and COMPONENT_NAME is not in desired components list, skip
+          if [ -n "$DESIRED_COMPONENTS_LIST" ] && ! echo "$DESIRED_COMPONENTS_LIST" | grep -qw "$COMPONENT_NAME"; then
+            continue
+          fi
+
+          IMAGE_URL=$(echo $COMPONENT | jq -r '.containerImage // ""')
+          if [ -z "${IMAGE_URL}" ] ; then
+              echo "Error: Unable to get image url from snapshot."
+              exit 1
+          fi
+
+          TMP_DIR=$(mktemp -d)
+          skopeo copy docker://$IMAGE_URL dir:$TMP_DIR
+
+          cd $TMP_DIR
+
+          for DIGEST in $(jq -r ".layers[].digest" manifest.json)
+          do
+              FILE=${DIGEST#sha256:}
+              tar -xzvf $FILE
+          done
+
+          cp "$IMAGE_PATH"/* $BINARIES_PATH/
         done
-
-        cp "$IMAGE_PATH"/* $BINARIES_PATH/
 
         echo -n $(params.subdirectory)/$BINARIES_DIR | tee $(results.binaries_path.path)
       env:

--- a/tasks/extract-binaries-from-image/tests/mocks.sh
+++ b/tasks/extract-binaries-from-image/tests/mocks.sh
@@ -6,11 +6,14 @@ function skopeo() {
   echo "Mock skopeo called with: $*"
   echo "$*" >> $(workspaces.data.path)/mock_skopeo.txt
 
-  if [[ "$*" != "copy docker://registry.io/image:tag dir:/"* ]]
-  then
-    echo Error: Unexpected call
-    exit 1
-  fi
-
-  cp $(workspaces.data.path)/image_data/* $TMP_DIR/
+  case "$*" in
+    "copy docker://registry.io/image:tag dir:"* | "copy docker://registry.io/image2:tag dir:"* | "copy docker://registry.io/image3:tag dir:"*)
+      # Extract tar files into the destination directory
+      cp $(workspaces.data.path)/image_data/* $TMP_DIR/
+      ;;
+    *)
+      echo "Error: Unexpected call"
+      exit 1
+      ;;
+  esac
 }

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-binaries-multiple-components-desired-only
+spec:
+  description: |
+    Run the extract-binaries-from-image task with three components in the snapshot
+    but only extract binaries for the desired components. Result should be 2.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-snapshot
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag"
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image3:tag"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "content-gateway": {
+                  "components": [
+                    {"name": "comp"},
+                    {"name": "comp2"}
+                  ]
+                }
+              }
+              EOF
+
+              mkdir -p $(workspaces.data.path)/image_data
+              cd $(workspaces.data.path)/image_data
+
+              cat > manifest.json <<EOF
+              {
+                "layers": [
+                  {"digest": "sha256:1111"},
+                  {"digest": "sha256:2222"}
+                ]
+              }
+              EOF
+
+              TAR_IN1=$(mktemp -d)
+              TAR_IN2=$(mktemp -d)
+
+              mkdir -p $TAR_IN1/my-binaries-path
+              echo text1 > $TAR_IN1/my-binaries-path/file1.txt
+              tar czf 1111 -C $TAR_IN1 my-binaries-path
+
+              mkdir -p $TAR_IN2/my-binaries-path
+              echo text2 > $TAR_IN2/my-binaries-path/file2.txt
+              tar czf 2222 -C $TAR_IN2 my-binaries-path
+    - name: run-task
+      taskRef:
+        name: extract-binaries-from-image
+      params:
+        - name: image_binaries_path
+          value: my-binaries-path
+        - name: snapshotPath
+          value: snapshot.json
+        - name: subdirectory
+          value: my-subdir
+        - name: dataPath
+          value: "data.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: binaries_path
+          value: $(tasks.run-task.results.binaries_path)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: binaries_path
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              ACTUAL_CALLS=$(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l)
+              EXPECTED_CALLS=2
+
+              if [ "$ACTUAL_CALLS" != "$EXPECTED_CALLS" ]; then
+                echo "Error: skopeo was expected to be called $EXPECTED_CALLS times. Actual calls: $ACTUAL_CALLS"
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              if [ "$(params.binaries_path)" != "my-subdir/binaries" ]; then
+                  echo "Error: Unexpected binaries_path result"
+                  exit 1
+              fi
+
+              cd $(workspaces.data.path)/$(params.binaries_path)
+
+              test -f file1.txt
+              test -f file2.txt
+      runAfter:
+        - run-task

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-binaries-multiple-components
+spec:
+  description: |
+    Run the extract-binaries-from-image task with three components in the snapshot
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-snapshot
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag"
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image3:tag"
+                  }
+                ]
+              }
+              EOF
+
+              mkdir -p $(workspaces.data.path)/image_data
+              cd $(workspaces.data.path)/image_data
+
+              cat > manifest.json <<EOF
+              {
+                "layers": [
+                  {"digest": "sha256:1111"},
+                  {"digest": "sha256:2222"}
+                ]
+              }
+              EOF
+
+              TAR_IN1=$(mktemp -d)
+              TAR_IN2=$(mktemp -d)
+
+              mkdir -p $TAR_IN1/my-binaries-path
+              echo text1 > $TAR_IN1/my-binaries-path/file1.txt
+              tar czf 1111 -C $TAR_IN1 my-binaries-path
+
+              mkdir -p $TAR_IN2/my-binaries-path
+              echo text2 > $TAR_IN2/my-binaries-path/file2.txt
+              tar czf 2222 -C $TAR_IN2 my-binaries-path
+    - name: run-task
+      taskRef:
+        name: extract-binaries-from-image
+      params:
+        - name: image_binaries_path
+          value: my-binaries-path
+        - name: snapshotPath
+          value: snapshot.json
+        - name: subdirectory
+          value: my-subdir
+        - name: dataPath
+          value: "data.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: binaries_path
+          value: $(tasks.run-task.results.binaries_path)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: binaries_path
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              ACTUAL_CALLS=$(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l)
+              EXPECTED_CALLS=3
+
+              if [ "$ACTUAL_CALLS" != "$EXPECTED_CALLS" ]; then
+                echo "Error: skopeo was expected to be called $EXPECTED_CALLS times. Actual calls: $ACTUAL_CALLS"
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              if [ "$(params.binaries_path)" != "my-subdir/binaries" ]; then
+                  echo "Error: Unexpected binaries_path result"
+                  exit 1
+              fi
+
+              cd $(workspaces.data.path)/$(params.binaries_path)
+
+              test -f file1.txt
+              test -f file2.txt
+      runAfter:
+        - run-task


### PR DESCRIPTION
Add support for Snapshots that contain multiple components with binaries to be extracted.
An optional parameter has been included so users can specify a subset of components in the Snapshot.

[Jira Issue](https://issues.redhat.com/browse/RELEASE-969)