### PR TITLE
fix: apply-mapping fails if / in tag

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -25,6 +25,9 @@ This task supports variable expansion in tag values from the mapping. The curren
 | dataPath | Path to the JSON string of the merged data to use in the data workspace | No | |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
 
+## Changes in 1.0.1
+ * Don't fail if a tag has a `/` in it
+
 ## Changes in 1.0.0
  * Use the data json instead of the ReleasePlanAdmission json
     * releasePlanAdmissionPath parameter removed in favor of dataPath parameter

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -87,7 +87,7 @@ spec:
                 variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
                 KEY=$(jq -r 'to_entries[] | .key' <<< $variable)
                 VALUE=$(jq -r 'to_entries[] | .value' <<< $variable)
-                tags=$(echo -n $tags | sed "s/$KEY/$VALUE/g")
+                tags=$(echo -n $tags | sed "s|$KEY|$VALUE|g")
             done
 
             echo -n $tags | jq -c


### PR DESCRIPTION
This commit changes the sed expression in apply-mapping so that the task does not fail if a tag has a / in it.