### PR TITLE
feat(RELEASE-951): integrate Checkton for linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,3 +43,25 @@ jobs:
         run: python -m pip install gitlint
       - name: Run gitlint check
         run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+  checkton:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+      # Differential Checkton requires full git history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Checkton
+        id: checkton
+        uses: chmeliik/checkton@v0.1.2 
+        # Migrating to the konflux-ci org
+        with:
+         # Let there be green. GitHub's code scanning will do the reporting.
+          fail-on-findings: false
+          find-copies-harder: true
+      - name: Upload SARIF File
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.checkton.outputs.sarif }}
+          # Avoid clashing with ShellCheck
+          category: checkton


### PR DESCRIPTION
This updats the linting workflow by adding Checkton. Checkton will review code for linting errors.
_**Please see other PR [here](https://github.com/hacbs-release/app-interface-deployments/pull/127)**_
Changes:
* Added a step to the workflow to run Checkton for PR.
* Configured Checkton to upload the SARIF report
*