### PR TITLE
feat(RELEASE-938): create-github-release writes a results file

### DIFF
--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.3.0
+- The create-github-release task now gets the `resultsDir` parameter from the collect-data results
+
 ## Changes in 3.2.0
 - `enterpriseContractExtraRuleData` added as a pipeline parameter, which is
   then passed to EC. Allows for easier runtime changes to rule data.

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -331,6 +331,8 @@ spec:
           value: $(tasks.collect-gh-params.results.githubSecret)
         - name: content_directory
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
       runAfter:
         - collect-gh-params
         - sign-base64-blob

--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -13,6 +13,10 @@ a `release` dir.
 | repository | The github repository to release to | No | - |
 | release_version | The version string to use creating the release | No | - |
 | content_directory | The directory inside the workspace to find files for release | No | - |
+| resultsDirPath | Path to results directory in the data workspace | No | - |
+
+## Changes in 2.0.0
+- The task now writes created artifacts to a results json file in the workspace
 
 ## Changes in 1.1.0
 - Updated the base image used in this task

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,6 +24,9 @@ spec:
     - name: content_directory
       type: string
       description: "The directory inside the workspace to find files for release"
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
   workspaces:
     - name: data
       description: The workspace where the binaries to release reside
@@ -37,12 +40,16 @@ spec:
       script: |
         #!/usr/bin/env sh
         set -ex
+
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-github-release-results.json"
         
         cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
         set -o pipefail
         shopt -s failglob
         gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS *.sig \
           --repo $REPOSITORY --title "Release $RELEASE_VERSION" | tee $(results.url.path)
+
+        jq -n --arg release "$(cat $(results.url.path))" '{"github-release": {"url": $release}}' | tee $RESULTS_FILE
       env:
         - name: GH_TOKEN
           valueFrom:

--- a/tasks/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-release.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               mkdir $(workspaces.data.path)/release/
               cat > $(workspaces.data.path)/release/foo.json << EOF
               { "example github release file": "just mock data" }
@@ -42,6 +43,8 @@ spec:
           value: 1.2.3
         - name: content_directory
           value: release/
+        - name: resultsDirPath
+          value: "results"
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
This commit changes the create-github-release task to write the created
github release url to a results file.