### PR TITLE
feat(RELEASE-941): add update-cr-status to push-to-external-registry 

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.5.0
+- Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
+
 ## Changes in 4.4.0
 - The apply-mapping task now gets the dataPath parameter instead of releasePlanAdmissionPath
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.4.0"
+    app.kubernetes.io/version: "4.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -221,6 +221,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
+    - name: update-cr-status
+      params:
+        - name: resource
+          value: $(params.release)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/update-cr-status/update-cr-status.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-snapshot
   finally:
     - name: cleanup
       taskRef:


### PR DESCRIPTION
This commit adds the update-cr-status task to update the status with the results set in the finished tasks.
Signed-off-by: Leandro Mendes <lmendes@redhat.com>