### PR TITLE
feat(RELEASE-939): fbc tasks write artifacts to file

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 3.4.0
+- The `add-fbc-contribution-to-index-image` and `extract-index-image` tasks now gets the `resultsDir` parameter from `collect-data` results
+
 ### Changes in 3.3.0
 - `enterpriseContractExtraRuleData` added as a pipeline parameter, which is
   then passed to EC. Allows for easier runtime changes to rule data.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -285,6 +285,8 @@ spec:
           value: "$(tasks.update-ocp-tag.results.updated-targetIndex)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       runAfter:
         - check-fbc-packages
         - verify-enterprise-contract
@@ -359,6 +361,8 @@ spec:
       params:
         - name: inputDataFile
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestResultsFile)
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
     - name: publish-index-image
       workspaces:
         - name: data

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -12,6 +12,10 @@ Task to create a internalrequest to add fbc contributions to index images
 | fromIndex      | fromIndex value updated by update-ocp-tag task                                            | No       |                      |
 | pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       |                      |
+| resultsDirPath | Path to results directory in the data workspace                                           | No       |                      |
+
+## changes in 3.0.0
+- the task now writes the updated targetIndex to a results json file in the workspace
 
 ## changes in 2.5.0
 - updated the base image used in this task

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "2.5.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,6 +30,9 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
   results:
     - name: buildTimestamp
       description: Build timestamp used in the tag
@@ -59,6 +62,7 @@ spec:
         set -eo pipefail
 
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/add-fbc-contribution-results.json"
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
@@ -121,6 +125,7 @@ spec:
 
         echo -n $timestamp > $(results.buildTimestamp.path)
         echo -n $target_index > $(results.requestTargetIndex.path)
+        jq -n --arg target_index "$target_index" '{"index_image": {"target_index": $target_index}}' | tee $RESULTS_FILE
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -22,6 +22,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -63,6 +64,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -25,6 +25,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -68,6 +69,8 @@ spec:
           value: data.json
         - name: snapshotPath
           value: snapshot_spec.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -65,6 +66,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -22,6 +22,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -60,6 +61,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -22,6 +22,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -62,6 +63,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -22,6 +22,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
@@ -62,6 +63,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -96,6 +99,10 @@ spec:
                 echo "iibOverwriteFromIndexCredential does not match"
                 exit 1
               fi
+
+              test $(jq -r '.index_image.target_index' \
+                $(workspaces.data.path)/results/add-fbc-contribution-results.json) == \
+                "quay.io/scoheb/fbc-target-index-testing:v4.12"
 
               if [ $(jq -r '.targetIndex' <<< "${requestParams}") != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]
               then

--- a/tasks/extract-index-image/README.md
+++ b/tasks/extract-index-image/README.md
@@ -10,6 +10,10 @@ the workspace name for this task *must* be input.
 | Name | Description | Optional | Default value |
 |------|-------------|----------|---------------|
 | inputDataFile | File to read json data from | No | - |
+| resultsDirPath | Path to results directory in the data workspace | No | - |
+
+## Changes in 1.0.0
+- The task now writes the index_image and index_image_resolved values to a results json file in the workspace
 
 ## Changes in 0.4.0
 - Updated the base image used in this task

--- a/tasks/extract-index-image/extract-index-image.yaml
+++ b/tasks/extract-index-image/extract-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-index-image
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -14,6 +14,9 @@ spec:
   params:
     - name: inputDataFile
       type: string
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
   workspaces:
     - name: data
       description: Workspace where the inputDataFile is stored
@@ -30,6 +33,8 @@ spec:
         #!/usr/bin/env sh
         set -ex
 
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/extract-index-image-results.json"
+
         jsonBuildInfo=`jq -cr .jsonBuildInfo $(params.inputDataFile)`
 
         indexImage=`echo $jsonBuildInfo | jq -cr .index_image`
@@ -37,3 +42,6 @@ spec:
 
         indexImageResolved=`echo $jsonBuildInfo | jq -cr .index_image_resolved`
         echo -n $indexImageResolved > $(results.indexImageResolved.path)
+
+        jq -n --arg image "$indexImage" --arg resolved "$indexImageResolved" \
+          '{"index_image": {"index_image": $image, "index_image_resolved": $resolved}}' | tee $RESULTS_FILE

--- a/tasks/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
@@ -12,12 +12,31 @@ spec:
   workspaces:
     - name: tests-workspace
   tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir $(workspaces.data.path)/results
     - name: run-task
       taskRef:
         name: extract-index-image
       params:
         - name: inputDataFile
           value: file.json
+        - name: resultsDirPath
+          value: results
       workspaces:
-        - name: input
+        - name: data
           workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image.yaml
@@ -24,6 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/file.json << EOF
               {
                 "jsonBuildInfo": {
@@ -66,6 +67,8 @@ spec:
       params:
         - name: inputDataFile
           value: $(workspaces.data.path)/file.json
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:
@@ -77,6 +80,9 @@ spec:
           value: $(tasks.run-task.results.indexImage)
         - name: indexImageResolved
           value: $(tasks.run-task.results.indexImageResolved)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
         params:
           - name: indexImage
@@ -95,5 +101,13 @@ spec:
 
               echo Test the indexImageResolved result was properly set
               test $(echo $(params.indexImageResolved)) == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+
+              echo Check the results file
+              test $(jq -r '.index_image.index_image' \
+                $(workspaces.data.path)/results/extract-index-image-results.json) == \
+                "redhat.com/rh-stage/iib:01"
+              test $(jq -r '.index_image.index_image_resolved' \
+                $(workspaces.data.path)/results/extract-index-image-results.json) == \
+                "redhat.com/rh-stage/iib@sha256:abcdefghijk"
       runAfter:
         - run-task


### PR DESCRIPTION
This commit changes the add-fbc-contribution task to write the targetIndex to a results file and similarly changes the extract-index-image task to write the index_image and index_image_resolved to a results file.