### PR TITLE
fix: variable IMAGE is unexistent in the context

### DIFF
--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -152,7 +152,7 @@ spec:
             echo Waiting for the current batch of background processes to finish
             for job_id in "${!jobs[@]}"; do
               if ! wait ${jobs[job_id]}; then
-                echo "Error: upload of ${IMAGE} failed"
+                echo "Error: upload of rpm manifests failed for one of the images"
                 success=false
               fi
             done


### PR DESCRIPTION
This commit renames IMAGE to IMAGEID in a loop context.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>