### PR TITLE
feat(RELEASE-937): push-snapshot writes a results file

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.6.0
+- The `push-snapshot` task now gets the `resultsDirPath` parameter from `collect-data` results
+
 ## Changes in 4.5.0
 - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.5.0"
+    app.kubernetes.io/version: "4.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -216,6 +216,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,11 +22,14 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.10.0
+- The `push-snapshot` task now gets the `resultsDirPath` parameter from the `collect-data` results
+
 ## Changes in 0.9.0
 - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 
 ## Changes in 0.8.0
-- The create-advisory task now gets the `resultsDir` parameter from the collect-data results
+- The create-advisory task now gets the `resultsDirPath` parameter from the collect-data results
 
 ## Changes in 0.7.1
 - The when conditions that skipped tasks if the `push-snapshot` result `commonTags` was empty was removed

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.9.0"
+    app.kubernetes.io/version: "0.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -247,6 +247,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.7.0
+- The `push-snapshot` task now gets the `resultsDirPath` parameter from `collect-data` results
+
 ## Changes in 4.6.0
  - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.6.0"
+    app.kubernetes.io/version: "4.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -216,6 +216,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.7.0
+* The `push-snapshot` task now gets the `resultsDirPath` parameter from `collect-data` results
+
 ## Changes in 3.6.0
 - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.6.0"
+    app.kubernetes.io/version: "3.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -243,6 +243,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -21,6 +21,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.8.0
+- The `push-snapshot` task now gets the `resultsDirPath` parameter from `collect-data` results
+
 ## Changes in 3.7.0
 - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/version: "3.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -216,6 +216,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -8,7 +8,11 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 |--------------------|---------------------------------------------------------------------------|----------|----------------------|
 | snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       |                      |
 | dataPath           | Path to the JSON string of the merged data to use in the data workspace   | No       |                      |
+| resultsDirPath     | Path to results directory in the data workspace                           | No       |                      |
 | retries            | Retry copy N times                                                        | Yes      | 0                    |
+
+## Changes in 5.0.0
+* The task now writes pushed image details to a results json file in the workspace
 
 ## Changes in 4.7.0
 * Updated the base image used in this task

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "4.7.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -17,6 +17,9 @@ spec:
       type: string
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+    - name: resultsDirPath
+      description: Path to the results directory in the data workspace
       type: string
     - name: retries
       description: Retry copy N times.
@@ -62,6 +65,8 @@ spec:
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
               "$2" "$3"
           fi
+          RESULTS_JSON=$(jq --arg name "$2" --arg url "$4:$5" '.images |= map(select(.name==$name).urls +=
+            [$url])' <<< "$RESULTS_JSON")
         }
 
         SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
@@ -75,6 +80,9 @@ spec:
             echo "No data JSON was provided."
             exit 1
         fi
+
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/push-snapshot-results.json"
+        RESULTS_JSON='{"images":[]}'
 
         defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' $DATA_FILE)
         floatingTagsCount=$(jq '.images.floatingTags | length' $DATA_FILE)
@@ -99,9 +107,9 @@ spec:
           repository=$(jq -r '.repository' <<< $component)
           imageTags=$(jq '.tags' <<< $component)
 
+          arches=$(get-image-architectures "${containerImage}" | jq -s 'map(.platform.architecture)')
           # Just read the first from the list of architectures
-          read -r arch_json <<< $(get-image-architectures "${containerImage}")
-          arch=$(echo "${arch_json}" | jq -r .platform.architecture)
+          arch=$(jq -r '.[0]' <<< $arches)
           name=$(jq -r '.name' <<< $component)
           git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
 
@@ -110,6 +118,9 @@ spec:
             --no-tags \
             --format '{{.Digest}}' \
             "docker://${containerImage}" 2>/dev/null)
+
+          RESULTS_JSON=$(jq --arg i "$i" --argjson arches "$arches" --arg name "$name" --arg sha "$origin_digest" \
+            '.images[$i|tonumber] += {"arches": $arches, "name": $name, "shasum": $sha, "urls": []}' <<< $RESULTS_JSON)
 
           # Push source container if the component has pushSourceContainer: true or if the
           # pushSourceContainer key is missing from the component and the defaults has
@@ -229,4 +240,5 @@ spec:
             done
           fi
         done
+        echo -n "${RESULTS_JSON}" | tee $RESULTS_FILE
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addgitshatag.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -58,6 +59,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addsourceshatag.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -53,6 +54,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-addtimestamptag.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -53,6 +54,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-both.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-both.yaml
@@ -24,6 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -60,6 +61,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-defaulttag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-defaulttag.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -54,6 +55,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -24,6 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -55,6 +56,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -85,5 +88,14 @@ spec:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi
+
+              echo Make sure the results file was still written even though no push happened
+              test $(jq -r '.images[0].name' $(workspaces.data.path)/results/push-snapshot-results.json) == "comp"
+              test $(jq -r '.images[0].shasum' $(workspaces.data.path)/results/push-snapshot-results.json) == \
+                "sha256:fe05fffad63015c37ef9e0c566638bd5480a5a11c710ebf7c2b91f1a5bc4a3e2"
+              test $(jq -r '.images[0].urls | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "1"
+              test $(jq -r '.images[0].arches | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "2"
       runAfter:
         - run-task

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-addgitshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-addgitshatag.yaml
@@ -25,6 +25,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -55,6 +56,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-addsourceshatag.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-addsourceshatag.yaml
@@ -26,6 +26,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -56,6 +57,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -26,6 +26,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
@@ -46,6 +47,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -20,6 +20,8 @@ spec:
           value: mapped_snapshot.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-floatingtags.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-floatingtags.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -60,6 +61,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -24,6 +24,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -61,6 +62,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -66,6 +67,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -56,6 +57,8 @@ spec:
           value: mydata.json
         - name: retries
           value: 3
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-tags.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -68,6 +69,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot.yaml
@@ -23,6 +23,7 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir $(workspaces.data.path)/results
               cat > $(workspaces.data.path)/snapshot.json << EOF
               {
                 "application": "myapp",
@@ -56,6 +57,8 @@ spec:
           value: data.json
         - name: retries
           value: 0
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -86,5 +89,13 @@ spec:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi
+
+              test $(jq -r '.images[0].name' $(workspaces.data.path)/results/push-snapshot-results.json) == "comp"
+              test $(jq -r '.images[0].shasum' $(workspaces.data.path)/results/push-snapshot-results.json) == \
+                "sha256:fe05fffad63015c37ef9e0c566638bd5480a5a11c710ebf7c2b91f1a5bc4a3e2"
+              test $(jq -r '.images[0].urls | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "1"
+              test $(jq -r '.images[0].arches | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "2"
       runAfter:
         - run-task


### PR DESCRIPTION
This commit modifies the push-snapshot task to write information about each image pushed to a results file. The information per image consists of the component name, arch, shasum, and the urls it was pushed to.