### PR TITLE
feat(RELEASE-932): apply-mapping sets mapped to false if no tags

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.12.0
+- The when conditions removed in v0.7.1 are readded, but use the `mapped` result from `apply-mapping`
+
 ## Changes in 0.11.0
 - The `rh-sign-image` task no longer receives the `commonTags` parameter
 - The `populate-release-notes-images` task no longer receives the `commonTags` parameter

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.11.0"
+    app.kubernetes.io/version: "0.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -255,6 +255,10 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: populate-release-notes-images
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -273,6 +277,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: embargo-check
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -293,6 +301,10 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: collect-pyxis-params
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -311,6 +323,10 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       timeout: "2h00m0s"
       taskRef:
         resolver: "git"
@@ -340,6 +356,10 @@ spec:
       runAfter:
         - embargo-check
     - name: create-pyxis-image
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -408,6 +428,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -433,6 +457,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -454,6 +482,10 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: create-advisory
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: releasePlanAdmissionPath
           value: "$(tasks.collect-data.results.releasePlanAdmission)"

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.9.0
+* The when conditions removed in v3.5.1 are readded, but use the `mapped` result from `apply-mapping`
+
 ## Changes in 3.8.0
 * The `rh-sign-image` task no longer receives the `commonTags` parameter
 * The `create-pyxis-image` task no longer receives the `commonTags` nor `dataPath` parameter

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -251,6 +251,10 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: collect-pyxis-params
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -269,6 +273,10 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       timeout: "2h00m0s"
       taskRef:
         resolver: "git"
@@ -296,6 +304,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: create-pyxis-image
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -364,6 +376,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: run-file-updates
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)

--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -25,6 +25,9 @@ This task supports variable expansion in tag values from the mapping. The curren
 | dataPath | Path to the JSON string of the merged data to use in the data workspace | No | |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
 
+## Changes in 1.2.0
+ * The `mapped` result is false if any component has no tags defined
+
 ## Changes in 1.1.0
  * Updated the base image used in this task
 

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,7 +28,7 @@ spec:
   results:
     - name: mapped
       type: string
-      description: A true/false value depicting whether or not the snapshot was mapped.
+      description: A true/false value depicting whether or not all components in the snapshot were mapped.
   steps:
     - name: apply-mapping
       image:
@@ -130,5 +130,7 @@ spec:
             if [ $(jq 'length' <<< $tags) -gt 0 ] ; then
               jq --argjson i "$i" --argjson updatedTags $tags '.components[$i].tags = $updatedTags' \
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            else
+              printf "false" > $(results.mapped.path)
             fi
         done

--- a/tasks/apply-mapping/tests/test-apply-mapping-tagless-component.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tagless-component.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-tagless-component
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file that includes a component with no tags. Verify that the mapped task result
+    is false.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.config.path)/test_data.json << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "repo1",
+                      "tags": [
+                        "tag"
+                      ]
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "repo2"
+                    }
+                  ],
+                  "defaults": {
+                    "timestampFormat": "%Y-%m-%d"
+                  }
+                }
+              }
+              EOF
+
+              cat > $(workspaces.config.path)/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: dataPath
+          value: test_data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: mapped
+          value: $(tasks.run-task.results.mapped)
+      taskSpec:
+        params:
+          - name: mapped
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            env:
+              - name: "MAPPED"
+                value: '$(params.mapped)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              test $MAPPED == "false"
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit updates the apply-mapping task to set the mapped result to false if any mapped component has no tags. It also updates the rh-advisories and rh-push-to-registry-redhat-io pipelines to readd the when conditions removed in PR #437, but now using the mapped result instead of commonTags result.