### PR TITLE
fix(RELEASE-979): embargo-check runs before pushing

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.11.1
+- The `embargo-check` task runs before the `push-snapshot` task so that embargoed content is not pushed anywhere
+
 ## Changes in 0.11.0
 - The `rh-sign-image` task no longer receives the `commonTags` parameter
 - The `populate-release-notes-images` task no longer receives the `commonTags` parameter

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.11.0"
+    app.kubernetes.io/version: "0.11.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -228,32 +228,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - apply-mapping
-    - name: push-snapshot
-      when:
-        - input: "$(tasks.apply-mapping.results.mapped)"
-          operator: in
-          values: ["true"]
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/push-snapshot/push-snapshot.yaml
-      params:
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: dataPath
-          value: "$(tasks.collect-data.results.data)"
-        - name: resultsDirPath
-          value: "$(tasks.collect-data.results.resultsDir)"
-      workspaces:
-        - name: data
-          workspace: release-workspace
-      runAfter:
-        - verify-enterprise-contract
     - name: populate-release-notes-images
       params:
         - name: dataPath
@@ -292,6 +266,32 @@ spec:
           workspace: release-workspace
       runAfter:
         - populate-release-notes-images
+    - name: push-snapshot
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-snapshot/push-snapshot.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - embargo-check
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"


### PR DESCRIPTION
This commit updates the rh-advisories pipeline to run the embargo-check task before running push-snapshot so that embargoed content is not pushed to quay.