### PR TITLE
feat(RELEASE-981): refactor verify-access-to-resources into a standalone task

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -18,6 +18,8 @@ Tekton release pipeline to interact with FBC Pipeline
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
+### Changes in 3.6.0
+- Removed `verify-access-to-resources` script and replaced it with a task.
 
 ### Changes in 3.5.0
 - add the task `update-cr-status` at the end of the pipeline to save all pipeline results

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.5.0"
+    app.kubernetes.io/version: "3.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -80,56 +80,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -18,3 +18,6 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 0.2.0
+- Removed `verify-access-to-resources` script and replaced it with a task.

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,56 +67,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.7.0
+- Removed `verify-access-to-resources` script and replaced it with a task.
+
 ## Changes in 4.6.0
 - The `push-snapshot` task now gets the `resultsDirPath` parameter from `collect-data` results
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.6.0"
+    app.kubernetes.io/version: "4.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,56 +67,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.5.0
+- Removed `verify-access-to-resources` script and replaced it with a task.
+
 ## Changes in 3.4.0
 - Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
 

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "3.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -68,56 +68,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.12.0
+- Removed `verify-access-to-resources` script and replaced it with a task
+
 ## Changes in 0.11.1
 - The `embargo-check` task runs before the `push-snapshot` task so that embargoed content is not pushed anywhere
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.11.1"
+    app.kubernetes.io/version: "0.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -71,56 +71,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 4.9.0
+- Removed `verify-access-to-resources` script and replaced it with a task
+
 ## Changes in 4.8.0
 - The `create-pyxis-image` task no longer receives the `dataPath` parameter
 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.8.0"
+    app.kubernetes.io/version: "4.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,56 +67,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.9.0
+* Removed `verify-access-to-resources` script and replaced it with a task.
+
 ## Changes in 3.8.0
 * The `rh-sign-image` task no longer receives the `commonTags` parameter
 * The `create-pyxis-image` task no longer receives the `commonTags` nor `dataPath` parameter

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,56 +67,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -21,6 +21,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.10.0 
+- Removed `verify-access-to-resources` script and replaced it with a task.
+  
 ## Changes in 3.9.0
 - The `create-pyxis-image` task no longer receives the `dataPath` parameter
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.9.0"
+    app.kubernetes.io/version: "3.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,56 +67,18 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: hub/kubernetes-actions/kubernetes-actions.yaml
+            value: tasks/verify-access-to-resources/verify-access-to-resources.yaml
       params:
-        - name: image
-          value: "quay.io/hacbs-release/cloud-builders-kubectl\
-            @sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753"
-        - name: script
-          value: |
-            ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
-            TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
-            RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
-
-            RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
-            RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
-            RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
-            RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
-            SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
-
-            CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
-                -n ${TARGET_NAMESPACE})
-            CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
-                -n ${RSC_NAMESPACE})
-            CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
-
-            echo ""
-            echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
-            echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
-            echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
-            echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
-            echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
-            echo ""
-            echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
-            echo ""
-
-            if [ "${CAN_I_READ_RELEASES}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" == "no" ] ||\
-                [ "${CAN_I_READ_RELEASESERVICECONFIG}" == "no" ] ||\
-                [ "${CAN_I_READ_SNAPSHOTS}" == "no" ] ||\
-                [ "${CAN_I_CREATE_INTERNALREQUESTS}" == "no" ] ; then
-              echo "Error: Cannot read or create required Release resources!"
-              echo ""
-              echo "This indicates that your workspace is not correctly setup"
-              echo "Please reach out to a workspace administrator"
-              exit 1
-            fi
-
-            echo "Access to Release resources verified"
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/tasks/verify-access-to-resources/README.md
+++ b/tasks/verify-access-to-resources/README.md
@@ -1,0 +1,13 @@
+# verify-access-to-resources
+
+This Tekton task is used to verify access to various resources in the pipelines. It ensures that the necessary resources, such as the release, release plan, release plan admission, release service config and snapshot, are available and accessible. Addiotinaly it check if internal requests can be created.
+
+## Parameters
+
+| Name                 | Description                                        | Optional | Default value |
+|----------------------|----------------------------------------------------|----------|---------------|
+| release              | Namespace/name of the Release                      | No       | -             |
+| releasePlan          | Namespace/name of the ReleasePlan                  | No       | -             |
+| releasePlanAdmission | Namespace/name of the ReleasePlanAdmission         | No       | -             |
+| releaseServiceConfig | Namespace/name of the ReleaseServiceConfig         | No       | -             |
+| snapshot             | Namespace/name of the Snapshot                     | No       | -             |

--- a/tasks/verify-access-to-resources/tests/pre-apply-task-hook.sh
+++ b/tasks/verify-access-to-resources/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-access-to-resources-permissions
+spec:
+  description: |
+    Run the verify-access-to-resources task and verifies access to resources.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releaseserviceconfig << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseServiceConfig
+              metadata:
+                name: releaseserviceconfig-sample
+                namespace: default
+              EOF
+              kubectl apply -f releaseserviceconfig
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: verify-access-to-resources
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: releasePlanAdmission
+          value: default/releaseplanadmission-sample
+        - name: releaseServiceConfig
+          value: default/releaseserviceconfig-sample
+        - name: snapshot
+          value: default/snapshot-sample
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releaseserviceconfig releaseserviceconfig-sample
+              kubectl delete snapshot snapshot-sample

--- a/tasks/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/verify-access-to-resources/verify-access-to-resources.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-access-to-resources  
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to verify access to required resources & check if internal requests can be created.
+  params:
+    - name: release
+      description: Namespace/name of the Release
+      type: string
+    - name: releasePlan
+      description: Namespace/name of the ReleasePlan
+      type: string
+    - name: releasePlanAdmission
+      description: Namespace/name of the ReleasePlanAdmission
+      type: string
+    - name: releaseServiceConfig
+      description: Namespace/name of the ReleaseServiceConfig
+      type: string
+    - name: snapshot
+      description: Namespace/name of the Snapshot
+      type: string
+  steps: 
+    - name: verify-access-to-resources
+      image: quay.io/hacbs-release/cloud-builders-kubectl@sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753
+      script: |
+          ORIGIN_NAMESPACE=$(echo $(params.release) | cut -f1 -d/)
+          TARGET_NAMESPACE=$(echo $(params.releasePlanAdmission) | cut -f1 -d/)
+          RSC_NAMESPACE=$(echo $(params.releaseServiceConfig) | cut -f1 -d/)
+
+          RELEASE_NAME=$(echo $(params.release) | cut -f2 -d/)
+          RELEASEPLAN_NAME=$(echo $(params.releasePlan) | cut -f2 -d/)
+          RELEASEPLANADMISSION_NAME=$(echo $(params.releasePlanAdmission) | cut -f2 -d/)
+          RELEASESERVICECONFIG_NAME=$(echo $(params.releaseServiceConfig) | cut -f2 -d/)
+          SNAPSHOT_NAME=$(echo $(params.snapshot) | cut -f2 -d/)
+
+          CAN_I_READ_RELEASES=$(kubectl auth can-i get release/${RELEASE_NAME} -n ${ORIGIN_NAMESPACE})
+          CAN_I_READ_RELEASEPLANS=$(kubectl auth can-i get releaseplan/${RELEASEPLAN_NAME} -n ${ORIGIN_NAMESPACE})
+          CAN_I_READ_RELEASEPLANADMISSIONS=$(kubectl auth can-i get releaseplanadmission/${RELEASEPLANADMISSION_NAME}\
+              -n ${TARGET_NAMESPACE})
+          CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
+              -n ${RSC_NAMESPACE})
+          CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
+          CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
+
+          echo ""
+          echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"
+          echo "CAN_I_READ_RELEASEPLANS? ${CAN_I_READ_RELEASEPLANS}"
+          echo "CAN_I_READ_RELEASEPLANADMISSIONS? ${CAN_I_READ_RELEASEPLANADMISSIONS}"
+          echo "CAN_I_READ_RELEASESERVICECONFIG? ${CAN_I_READ_RELEASESERVICECONFIG}"
+          echo "CAN_I_READ_SNAPSHOTS? ${CAN_I_READ_SNAPSHOTS}"
+          echo ""
+          echo "CAN_I_CREATE_INTERNALREQUESTS? ${CAN_I_CREATE_INTERNALREQUESTS}"
+          echo ""
+
+          if [ "${CAN_I_READ_RELEASES}" = "no" ] ||\
+              [ "${CAN_I_READ_RELEASEPLANS}" = "no" ] ||\
+              [ "${CAN_I_READ_RELEASEPLANADMISSIONS}" = "no" ] ||\
+              [ "${CAN_I_READ_RELEASESERVICECONFIG}" = "no" ] ||\
+              [ "${CAN_I_READ_SNAPSHOTS}" = "no" ] ||\
+              [ "${CAN_I_CREATE_INTERNALREQUESTS}" = "no" ] ; then
+            echo "Error: Cannot read or create required Release resources!"
+            echo ""
+            echo "This indicates that your workspace is not correctly setup"
+            echo "Please reach out to a workspace administrator"
+            exit 1
+          fi
+
+          echo "Access to Release resources verified"


### PR DESCRIPTION
feat([RELEASE-981](https://issues.redhat.com//browse/RELEASE-981)): refactor verify-access-to-resources into a standalone task

This PR refactors the `verify-access-to-resources` script from being hard coded in the pipeline to a dedicated Tekton task.

**Changes:**
- Refactored pipelines to utilize the new `verify-access-to-resources` task.
- Removed the inline script from each pipeline and replaced it with a task reference.
- Updated version and documentation to reflect these changes.
- **Task details:**
  - Added a README for the new task.
  - Implemented a test to ensure the task correctly verifies resource accessibility.

**Note:** 
_verifying the no-access scenario test for the task would require creating a new PipelineRun and RoleBindings, followed by updating `test_tekton_tasks.sh`. Although possible, this approach is overly complex. The task has been validated to work as expected because the command `kubectl auth can-i get releaseplanadmission -n <namespace>  --as=system:serviceaccount:default:default` correctly returns "no." Thus, we can trust this verification. Additionally, a test is already in place to check if the resources are accessible. If the task cannot access the resources, the task will exit with `exit 1`._

Signed-off-by: Sean Conroy <sconroy@redhat.com>