### PR TITLE
chore: rework task ordering

### DIFF
--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -205,6 +205,8 @@ spec:
           - name: pathInRepo
             value: tasks/populate-release-notes-images/populate-release-notes-images.yaml
         resolver: git
+      runAfter:
+        - apply-mapping
       workspaces:
         - name: data
           workspace: release-workspace
@@ -253,7 +255,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - embargo-check
+        - rh-sign-image
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"
@@ -324,7 +326,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - rh-sign-image
+        - push-snapshot
     - name: publish-pyxis-repository
       taskRef:
         resolver: "git"
@@ -348,7 +350,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - create-pyxis-image
+        - push-rpm-manifests-to-pyxis
     - name: push-rpm-manifests-to-pyxis
       taskRef:
         resolver: "git"
@@ -369,6 +371,8 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+      runAfter:
+        - create-pyxis-image
     - name: run-file-updates
       params:
         - name: fileUpdatesPath
@@ -442,6 +446,7 @@ spec:
       runAfter:
         - check-data-keys
         - embargo-check
+        - publish-pyxis-repository
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -211,7 +211,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - verify-enterprise-contract
+        - rh-sign-image
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"
@@ -257,6 +257,9 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
+        - apply-mapping
     - name: create-pyxis-image
       taskRef:
         resolver: "git"
@@ -280,7 +283,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - rh-sign-image
+        - push-snapshot
     - name: publish-pyxis-repository
       taskRef:
         resolver: "git"
@@ -304,7 +307,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - create-pyxis-image
+        - push-rpm-manifests-to-pyxis
     - name: push-rpm-manifests-to-pyxis
       taskRef:
         resolver: "git"
@@ -325,6 +328,8 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+      runAfter:
+        - create-pyxis-image
     - name: run-file-updates
       params:
         - name: fileUpdatesPath


### PR DESCRIPTION
- sign before we push
- push before we create-pyxis-image
- push-rpms before we publish-pyxis-repository
- ensure we always run apply-mapping early on
- make sure create-advisory is last


![new-push](https://github.com/konflux-ci/release-service-catalog/assets/3596711/6b6efcae-40eb-47fc-a25c-5e992795c78f)
