### PR TITLE
feat(CLOUDDST-22843): add rh-sign-image-cosign task

### DIFF
--- a/tasks/rh-sign-image-cosign/README.md
+++ b/tasks/rh-sign-image-cosign/README.md
@@ -1,0 +1,10 @@
+# rh-sign-image-cosign
+
+Tekton task to sign container images in snapshot by cosign.
+
+## Parameters
+
+| Name           | Description                                                               | Optional | Default value  |
+|----------------|---------------------------------------------------------------------------|----------|----------------|
+| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       |                |
+| secretName     | Name of secret containing needed credentials                              | No       |                |

--- a/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rh-sign-image-cosign
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Task to sign container images in snapshot by cosign
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+      type: string
+    - name: secretName
+      description: Name of secret containing needed credentials
+      type: string
+  workspaces:
+    - name: data
+      description: Workspace to read and save files
+  steps:
+    - name: sign-image
+      image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+      env:
+        - name: AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              name: $(params.secretName)
+              key: AWS_REGION
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: $(params.secretName)
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.secretName)
+              key: AWS_SECRET_ACCESS_KEY
+        - name: SIGN_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.secretName)
+              key: SIGN_KEY
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
+        COMPONENTS_LENGTH=$(jq '.components |length' ${SNAPSHOT_PATH})
+
+        for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
+            COMPONENT_NAME=$(jq -r ".components[${COMPONENTS_INDEX}].name" ${SNAPSHOT_PATH})
+            echo "Processing component ${COMPONENT_NAME}"
+
+            # Get public image references
+            INTERNAL_CONTAINER_REF=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
+            PUB_CONTAINER_REFS=$(translate-delivery-repo $INTERNAL_CONTAINER_REF | jq -r ".[].url")
+
+            # Check if image is manifest list
+            BUILD_CONTAINER_IMAGE=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
+            DIGEST="${BUILD_CONTAINER_IMAGE/*@}"
+            INTERNAL_CONTAINER_IMAGE="${INTERNAL_CONTAINER_REF}@${DIGEST}"
+            IMAGE=$(skopeo inspect --raw "docker://${INTERNAL_CONTAINER_IMAGE}")
+            MEDIA_TYPE=$(echo "$IMAGE" | jq -r '.mediaType')
+            LIST=0
+            if [ "$MEDIA_TYPE" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then LIST=1; fi
+            if [ "$MEDIA_TYPE" = "application/vnd.oci.image.index.v1+json" ]; then LIST=1; fi
+
+            # Sign each manifest in manifest list
+            COSIGN_COMMON_ARGS="-y --tlog-upload=false --key $SIGN_KEY"
+            if [ $LIST -eq 1 ]; then
+                for PUB_CONTAINER_REF in $PUB_CONTAINER_REFS; do
+                    for MDIGEST in $(echo "$IMAGE" | jq -r '.manifests[]|.digest'); do
+                        echo "Signing manifest ${INTERNAL_CONTAINER_REF}@${MDIGEST}"
+                        cosign -t 3m0s sign\
+                        ${COSIGN_COMMON_ARGS}\
+                        --sign-container-identity "${PUB_CONTAINER_REF}@${MDIGEST}"\
+                        "${INTERNAL_CONTAINER_REF}@${MDIGEST}"
+                    done
+                done
+            fi
+
+            # Sign manifest list itself or manifest if it's not list
+            for PUB_CONTAINER_REF in $PUB_CONTAINER_REFS; do
+                echo "Signing manifest ${INTERNAL_CONTAINER_REF}@${DIGEST}"
+                cosign -t 3m0s sign\
+                ${COSIGN_COMMON_ARGS}\
+                --sign-container-identity "${PUB_CONTAINER_REF}@${DIGEST}"\
+                "${INTERNAL_CONTAINER_REF}@${DIGEST}"
+            done
+        done
+        echo "done"

--- a/tasks/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/rh-sign-image-cosign/tests/mocks.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -eux
+# mocks to be injected into task step scripts
+echo "MOCK SETUP"
+
+
+_TEST_MANIFEST_LIST_OCI_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:0000"
+_TEST_MANIFEST_LIST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:1111"
+_TEST_MANIFEST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:2222"
+
+_DOCKER_MANIFEST_LIST=$(cat << EOF
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 528,
+      "digest": "sha256:1111-1",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "os.version": "4.9.0-8-amd64",
+        "features": [
+          "sse4"
+        ]
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 527,
+      "digest": "sha256:1111-2",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux",
+        "os.version": "4.14.0-115-arm64",
+        "variant": "v8"
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 526,
+      "digest": "sha256:1111-3",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      }
+    }
+  ]
+}
+EOF
+)
+_DOCKER_MANIFEST=$(cat << EOF
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 7023,
+    "digest": "sha256:ec4e3d3b8f35e01df8b97b23d6530e3d8b69f792b54d3b726d79b8f9e8a27e3c"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 32654,
+      "digest": "sha256:8c662931926fae64a0e5f21db4bcf6e4c6d29851706e6dd987758a4d8552b7f0"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 16724,
+      "digest": "sha256:16e4f9a1b23b571e7d5e7f241e5f6f1534b933b23f8c4f6e7e4b1e6f5b5f6e5f"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 73109,
+      "digest": "sha256:713c5c50d3d5f6b7f3c5f4e7e7e9b9b5e4b7c3f6e6d4d5f7f6b5f7b7e7b5f6f7"
+    }
+  ]
+}
+EOF
+)
+_DOCKER_MANIFEST_LIST_OCI=$(cat <<EOF
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 707,
+      "digest": "sha256:0000-1",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "os.version": "4.19.0-12-amd64"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 706,
+      "digest": "sha256:0000-2",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux",
+        "os.version": "4.19.0-12-arm64",
+        "variant": "v8"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 705,
+      "digest": "sha256:0000-3",
+      "platform": {
+        "architecture": "s390x",
+        "os": "linux"
+      }
+    }
+  ],
+  "annotations": {
+    "org.opencontainers.image.created": "2024-06-21T10:30:00Z",
+    "org.opencontainers.image.authors": "Jane Doe <jane.doe@example.com>",
+    "org.opencontainers.image.version": "1.0.0"
+  }
+}
+EOF
+)
+
+function skopeo() {
+  echo "$@" >> $(workspaces.data.path)/mock_skopeo_calls
+  if [ "$1" = "inspect" ]; then
+    if [ "$3" = "docker://${_TEST_MANIFEST_LIST_OCI_REFERENCE}" ]; then
+      echo "$_DOCKER_MANIFEST_LIST_OCI" | jq -r
+    elif [ "$3" = "docker://${_TEST_MANIFEST_LIST_REFERENCE}" ]; then
+      echo "$_DOCKER_MANIFEST_LIST" | jq -r
+    elif [ "$3" = "docker://${_TEST_MANIFEST_REFERENCE}" ]; then
+      echo "$_DOCKER_MANIFEST" | jq -r
+    fi
+  fi
+}
+function cosign () {
+  echo "$@" >> $(workspaces.data.path)/mock_cosign_calls
+  echo "running cosign: $@"
+}

--- a/tasks/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
+++ b/tasks/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Create a dummy cosignSecretName secret (and delete it first if it exists)
+kubectl delete secret test-cosign-secret --ignore-not-found
+
+kubectl create secret generic test-cosign-secret\
+  --from-literal=AWS_REGION=us-test-1\
+  --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
+  --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
+  --from-literal=SIGN_KEY=aws://arn:mykey
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-cosign-multiple-components
+spec:
+  description: Test signing multiple images by cosign
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              _TEST_MANIFEST_LIST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:1111"
+              _TEST_MANIFEST_LIST_OCI_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:0000"
+              _TEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "$_TEST_MANIFEST_LIST_REFERENCE",
+                    "repository": "$_TEST_REPO"
+                  },
+                  {
+                    "name": "comp1",
+                    "containerImage": "$_TEST_MANIFEST_LIST_OCI_REFERENCE",
+                    "repository": "$_TEST_REPO"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image-cosign
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: secretName
+          value: 'test-cosign-secret'
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              echo "check results"
+              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
+              _TEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+
+              EXPECTED=$(cat <<EOF
+              inspect --raw docker://${_TEST_REPO}@sha256:1111
+              inspect --raw docker://${_TEST_REPO}@sha256:0000
+              EOF
+              )
+              CALLS=$(cat "$(workspaces.data.path)/mock_skopeo_calls")
+              test "$CALLS" = "$EXPECTED"
+
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
+              COSIGN_COMMON="-t 3m0s sign -y --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              EXPECTED=$(cat <<EOF
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:1111-1 ${_TEST_REPO}@sha256:1111-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:1111-2 ${_TEST_REPO}@sha256:1111-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:1111-3 ${_TEST_REPO}@sha256:1111-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:1111-1 ${_TEST_REPO}@sha256:1111-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:1111-2 ${_TEST_REPO}@sha256:1111-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:1111-3 ${_TEST_REPO}@sha256:1111-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:1111 ${_TEST_REPO}@sha256:1111
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:1111 ${_TEST_REPO}@sha256:1111
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:0000-1 ${_TEST_REPO}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:0000-2 ${_TEST_REPO}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:0000-3 ${_TEST_REPO}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:0000-1 ${_TEST_REPO}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:0000-2 ${_TEST_REPO}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:0000-3 ${_TEST_REPO}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:0000 ${_TEST_REPO}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:0000 ${_TEST_REPO}@sha256:0000
+              EOF
+              )
+              test "$CALLS" = "$EXPECTED"
+      runAfter:
+        - run-task

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-cosign-single-component
+spec:
+  description: Test signing a single image by cosign
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              _TEST_MANIFEST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:2222"
+              _TEST_MANIFEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "$_TEST_MANIFEST_REFERENCE",
+                    "repository": "$_TEST_MANIFEST_REPO"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image-cosign
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: secretName
+          value: 'test-cosign-secret'
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              echo "check results"
+              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
+              _TEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+
+              CALLS=$(cat "$(workspaces.data.path)/mock_skopeo_calls")
+              test "$CALLS" = "inspect --raw docker://${_TEST_REPO}@sha256:2222"
+
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
+              COSIGN_COMMON="-t 3m0s sign -y --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              EXPECTED=$(cat <<EOF
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}@sha256:2222 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}@sha256:2222 ${_TEST_REPO}@sha256:2222
+              EOF
+              )
+              test "$CALLS" = "$EXPECTED"
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit adds a task for signing container images by cosign.

This is a follow up of https://github.com/konflux-ci/release-service-catalog/pull/454/