### PR TITLE
feat(CLOUDDST-22844): add cosign tasks to pipelines

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.13.0
+- Add tasks `collect-cosign-params` and `rh-sign-image-cosign` to sign images by cosign. `rh-sign-image-cosign` is only run if sign.cosignSecretName is set in the data file.
+
 ## Changes in 0.12.0
 - Removed `verify-access-to-resources` script and replaced it with a task
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -230,6 +230,48 @@ spec:
           workspace: release-workspace
       runAfter:
         - populate-release-notes-images
+    - name: collect-cosign-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collect-cosign-params/collect-cosign-params.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: rh-sign-image-cosign
+      when:
+        - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: secretName
+          value: "$(tasks.collect-cosign-params.results.cosign-secret-name)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - embargo-check
     - name: push-snapshot
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -256,6 +298,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - rh-sign-image
+        - rh-sign-image-cosign
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 3.10.0
+* Add tasks `collect-cosign-params` and `rh-sign-image-cosign` to sign images by cosign. `rh-sign-image-cosign` is only run if sign.cosignSecretName is set in the data file.
+
 ## Changes in 3.9.0
 * Removed `verify-access-to-resources` script and replaced it with a task.
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -186,6 +186,48 @@ spec:
           workspace: release-workspace
       runAfter:
         - apply-mapping
+    - name: collect-cosign-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collect-cosign-params/collect-cosign-params.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+    - name: rh-sign-image-cosign
+      when:
+        - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: secretName
+          value: "$(tasks.collect-cosign-params.results.cosign-secret-name)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
     - name: push-snapshot
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -212,6 +254,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - rh-sign-image
+        - rh-sign-image-cosign
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"

--- a/tasks/collect-cosign-params/README.md
+++ b/tasks/collect-cosign-params/README.md
@@ -1,0 +1,9 @@
+# collect-cosign-params
+
+Tekton task that collects cosign options from the data file.
+
+## Parameters
+
+| Name      | Description                                                             | Optional | Default value  |
+|-----------|-------------------------------------------------------------------------|----------|----------------|
+| dataPath  | Path to the JSON string of the merged data to use in the data workspace | No       |                |

--- a/tasks/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/collect-cosign-params/collect-cosign-params.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-cosign-params
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Task that collects cosign options from the data file
+  params:
+    - name: dataPath
+      type: string
+      description: Path to the JSON string of the merged data containing the configuration options to use
+  workspaces:
+    - name: data
+      description: Workspace to read and save files
+  results:
+    - name: cosign-secret-name
+      type: string
+      description: Name of secret which contains AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and SIGN_KEY
+  steps:
+    - name: collect-params
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env sh
+        set -x
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No valid data file was provided."
+            exit 1
+        fi
+
+        if [ $(jq '.sign | has("cosignSecretName")' $DATA_FILE) == false ] ; then
+            echo "No secret name provided via 'sign.cosignSecretName' key in Data."
+            echo -n "" > $(results.cosign-secret-name.path)
+            exit
+        fi
+        cosignSecretName=$(jq -r '.sign."cosignSecretName"' $DATA_FILE)
+        echo -n "$cosignSecretName" > $(results.cosign-secret-name.path)

--- a/tasks/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
+++ b/tasks/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-cosign-params-no-secret-in-data
+spec:
+  description: |
+    Run the collect-cosign-params task without sign.cosignSecretName in data
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "sign": {}
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: collect-cosign-params
+      params:
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: cosign-secret-name
+          value: $(tasks.run-task.results.cosign-secret-name)
+      taskSpec:
+        params:
+          - name: cosign-secret-name
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "SECRET"
+                value: '$(params.cosign-secret-name)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              test "${SECRET}" = ""

--- a/tasks/collect-cosign-params/tests/test-collect-cosign-params.yaml
+++ b/tasks/collect-cosign-params/tests/test-collect-cosign-params.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-cosign-params
+spec:
+  description: |
+    Run the collect-cosign-params task and verify the results
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "sign": {
+                  "cosignSecretName": "my-secret"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: collect-cosign-params
+      params:
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: cosign-secret-name
+          value: $(tasks.run-task.results.cosign-secret-name)
+      taskSpec:
+        params:
+          - name: cosign-secret-name
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "SECRET"
+                value: '$(params.cosign-secret-name)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              test "$SECRET" = "my-secret"


### PR DESCRIPTION
This commit adds a task for collecting options required by cosign and adds cosign tasks to release pipelines.