### PR TITLE
fix(RELEASE-1005): set -x in rh-sign-image task

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -13,6 +13,9 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                      |
 
+## Changes in 3.1.1
+* set -x in the task script for easier debugging
+
 ## Changes in 3.1.0
 * added support for OCI artifacts.
 

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "3.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,7 +41,7 @@ spec:
       script: |
         #!/usr/bin/env sh
         #
-        set -e
+        set -ex
 
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         RUNDIR="$(workspaces.data.path)/$(context.taskRun.uid)"


### PR DESCRIPTION
This will make debugging easier.

The jira I'm referencing doesn't get fixed by this, but it will make it easier to debug what's going on if it happens again.

AFAICS, this task does not deal with any secrets, so setting `set -x` should be fine.