### PR TITLE
feat(RELEASE-971): add task to push disk images

### DIFF
--- a/tasks/push-disk-images/README.md
+++ b/tasks/push-disk-images/README.md
@@ -1,0 +1,11 @@
+# push-disk-images
+
+Tekton task to push disk images via an InternalRequest. The environment to use is pulled from the `cdn.env` key in the data file.
+
+## Parameters
+
+| Name                     | Description                                                                               | Optional | Default value               |
+|--------------------------|-------------------------------------------------------------------------------------------|----------|-----------------------------|
+| snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | No       |                             |
+| dataPath                 | Path to data JSON in the data workspace                                                   | No       |                             |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       |                             |

--- a/tasks/push-disk-images/push-disk-images.yaml
+++ b/tasks/push-disk-images/push-disk-images.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-disk-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to push disk images via an InternalRequest
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+    - name: dataPath
+      type: string
+      description: Path to the data JSON in the data workspace
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+  workspaces:
+    - name: data
+      description: Workspace where the json files are stored
+  steps:
+    - name: run-script
+      image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
+        snapshot=$(jq -c '.' "$(workspaces.data.path)/$(params.snapshotPath)")
+        # .cdn.env is likely to change in the future. This is just for POC
+        env=$(jq -r '.cdn.env' "$(workspaces.data.path)/$(params.dataPath)")
+
+        # There are three envs supported...production, stage, and qa
+        exodusGwSecret=""
+        exodusGwEnv=""
+        pulpSecret=""
+        udcacheSecret=""
+
+        if [ "${env}" = "production" ] ; then
+          exodusGwSecret="exodus-prod-secret"
+          exodusGwEnv="live"
+          pulpSecret="rhsm-pulp-prod-secret"
+          udcacheSecret="udcache-prod-secret"
+        elif [ "${env}" = "stage" ] ; then
+          # The url is the same for exodus in both prod and stage, it is just a different env and pulp url
+          exodusGwSecret="exodus-prod-secret"
+          exodusGwEnv="pre"
+          pulpSecret="rhsm-pulp-stage-secret"
+          udcacheSecret="udcache-stage-secret"
+        elif [ "${env}" = "qa" ]; then
+          exodusGwSecret="exodus-stage-secret"
+          exodusGwEnv="live"
+          pulpSecret="rhsm-pulp-qa-secret"
+          udcacheSecret="udcache-qa-secret"
+        else
+          echo "cdn.env in the data file must be one of [production, stage, qa]."
+          exit 1
+        fi
+
+        echo "Creating InternalRequest to push disk images..."
+        internal-request -r "push-disk-images" \
+                         -p snapshot_json="${snapshot}" \
+                         -p exodusGwSecret="${exodusGwSecret}" \
+                         -p exodusGwEnv="${exodusGwEnv}" \
+                         -p pulpSecret="${pulpSecret}" \
+                         -p udcacheSecret="${udcacheSecret}" \
+                         -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+                         -s true \
+                         -t 7200 \
+                         --service-account release-service-account \
+                         --pipeline-timeout 2h0m0s \
+                         --task-timeout 1h50m0s \
+                         --finally-timeout 0h10m0s \
+                         > "$(workspaces.data.path)"/ir-result.txt
+
+        set +x
+        internalRequest=$(awk 'NR==1{ print $2 }' "$(workspaces.data.path)/ir-result.txt" | xargs)
+        echo "done (${internalRequest})"
+
+        results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')
+        if [ "$(echo "${results}" | jq -r '.result')" == "Success" ]; then
+          echo "Disk images pushed"
+        else
+          echo "Disk image push failed"
+          echo "${results}" | jq -r '.result'
+          exit 1
+        fi

--- a/tasks/push-disk-images/tests/mocks.sh
+++ b/tasks/push-disk-images/tests/mocks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function internal-request() {
+  echo Mock internal-request called with: $*
+  echo $* >> $(workspaces.data.path)/mock_internal-request.txt
+
+  /home/utils/internal-request $@ -s false
+
+  if [[ "$*" == *'snapshot_json={"application":"disk-images","components":[{"name":"failing-disk-image"'* ]]; then
+      echo '{"result":"Failure"}' > $(workspaces.data.path)/mock_internal-request_result.txt
+  elif [[ "$*" == *"exodusGwEnv="@(live|pre)* ]]; then
+      echo '{"result":"Success"}' > $(workspaces.data.path)/mock_internal-request_result.txt
+  else
+      echo Unexpected call to internal-request
+      exit 1
+  fi
+}
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  then
+    cat $(workspaces.data.path)/mock_internal-request_result.txt
+  else
+    /usr/bin/kubectl $*
+  fi
+}

--- a/tasks/push-disk-images/tests/pre-apply-task-hook.sh
+++ b/tasks/push-disk-images/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-fail-ir-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-disk-images task with the InternalRequest failing and ensure the task fails. The InternalRequest
+    itself will never fail, but the status.results field of it will reflect the failure.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "disk-images",
+                "components": [
+                  {
+                    "name": "failing-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "production"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-fail-no-data
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-disk-images task with no data JSON and verify the task fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              
+              cat > "$(workspaces.data.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "disk-images",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-fail-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-disk-images task with no snapshot JSON and verify the task fails as expected
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "production"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-production
+spec:
+  description: |
+    Run the push-disk-images task with the production env and ensure the task succeeds
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "disk-images",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "production"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the request field
+              if [ "$(jq -r '.spec.request' <<< "$internalRequest")" != "push-disk-images" ]; then
+                echo "InternalRequest doesn't contain 'push-disk-images' in 'request' field"
+                exit 1
+              fi
+
+              # Check the serviceAccount field
+              if [ "$(jq -r '.spec.serviceAccount' <<< "$internalRequest")" != "release-service-account" ]; then
+                echo "InternalRequest doesn't contain the proper serviceAccount"
+                exit 1
+              fi
+
+              # Check the snapshot parameter
+              if [ "$(jq -r '.spec.params.snapshot_json' <<< "$internalRequest")" != \
+              '{"application":"disk-images","components":[{"name":"nvidia-disk-image","containerImage":'`
+              `'"quay.io/workload/tenant/disk-image/nvidia@sha256:123456","repository":"repo1"},{"name":'`
+              `'"amd-disk-image","containerImage":"quay.io/workload/tenant/disk-image/amd@sha256:abcdefg"'`
+              `',"repository":"repo2"}]}' ]; then
+                echo "InternalRequest has the wrong snapshot_json parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwSecret parameter
+              if [ "$(jq -r '.spec.params.exodusGwSecret' <<< "$internalRequest")" != "exodus-prod-secret" ]; then
+                echo "InternalRequest has the wrong exodusGwSecret parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwEnv parameter
+              if [ "$(jq -r '.spec.params.exodusGwEnv' <<< "$internalRequest")" != "live" ]; then
+                echo "InternalRequest has the wrong exodusGwEnv parameter"
+                exit 1
+              fi
+
+              # Check the pulpSecret parameter
+              if [ "$(jq -r '.spec.params.pulpSecret' <<< "$internalRequest")" != "rhsm-pulp-prod-secret" ]; then
+                echo "InternalRequest has the wrong pulpSecret parameter"
+                exit 1
+              fi
+
+              # Check the udcacheSecret parameter
+              if [ "$(jq -r '.spec.params.udcacheSecret' <<< "$internalRequest")" != "udcache-prod-secret" ]; then
+                echo "InternalRequest has the wrong udcacheSecret parameter"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-qa
+spec:
+  description: |
+    Run the push-disk-images task with the qa env and ensure the task succeeds
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "disk-images",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "qa"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the request field
+              if [ "$(jq -r '.spec.request' <<< "$internalRequest")" != "push-disk-images" ]; then
+                echo "InternalRequest doesn't contain 'push-disk-images' in 'request' field"
+                exit 1
+              fi
+
+              # Check the serviceAccount field
+              if [ "$(jq -r '.spec.serviceAccount' <<< "$internalRequest")" != "release-service-account" ]; then
+                echo "InternalRequest doesn't contain the proper serviceAccount"
+                exit 1
+              fi
+
+              # Check the snapshot parameter
+              if [ "$(jq -r '.spec.params.snapshot_json' <<< "$internalRequest")" != \
+              '{"application":"disk-images","components":[{"name":"nvidia-disk-image","containerImage":'`
+              `'"quay.io/workload/tenant/disk-image/nvidia@sha256:123456","repository":"repo1"},{"name":'`
+              `'"amd-disk-image","containerImage":"quay.io/workload/tenant/disk-image/amd@sha256:abcdefg"'`
+              `',"repository":"repo2"}]}' ]; then
+                echo "InternalRequest has the wrong snapshot_json parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwSecret parameter
+              if [ "$(jq -r '.spec.params.exodusGwSecret' <<< "$internalRequest")" != "exodus-stage-secret" ]; then
+                echo "InternalRequest has the wrong exodusGwSecret parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwEnv parameter
+              if [ "$(jq -r '.spec.params.exodusGwEnv' <<< "$internalRequest")" != "live" ]; then
+                echo "InternalRequest has the wrong exodusGwEnv parameter"
+                exit 1
+              fi
+
+              # Check the pulpSecret parameter
+              if [ "$(jq -r '.spec.params.pulpSecret' <<< "$internalRequest")" != "rhsm-pulp-qa-secret" ]; then
+                echo "InternalRequest has the wrong pulpSecret parameter"
+                exit 1
+              fi
+
+              # Check the udcacheSecret parameter
+              if [ "$(jq -r '.spec.params.udcacheSecret' <<< "$internalRequest")" != "udcache-qa-secret" ]; then
+                echo "InternalRequest has the wrong udcacheSecret parameter"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-stage
+spec:
+  description: |
+    Run the push-disk-images task with the stage env and ensure the task succeeds
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "disk-images",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "stage"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the request field
+              if [ "$(jq -r '.spec.request' <<< "$internalRequest")" != "push-disk-images" ]; then
+                echo "InternalRequest doesn't contain 'push-disk-images' in 'request' field"
+                exit 1
+              fi
+
+              # Check the serviceAccount field
+              if [ "$(jq -r '.spec.serviceAccount' <<< "$internalRequest")" != "release-service-account" ]; then
+                echo "InternalRequest doesn't contain the proper serviceAccount"
+                exit 1
+              fi
+
+              # Check the snapshot parameter
+              if [ "$(jq -r '.spec.params.snapshot_json' <<< "$internalRequest")" != \
+              '{"application":"disk-images","components":[{"name":"nvidia-disk-image","containerImage":'`
+              `'"quay.io/workload/tenant/disk-image/nvidia@sha256:123456","repository":"repo1"},{"name":'`
+              `'"amd-disk-image","containerImage":"quay.io/workload/tenant/disk-image/amd@sha256:abcdefg"'`
+              `',"repository":"repo2"}]}' ]; then
+                echo "InternalRequest has the wrong snapshot_json parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwSecret parameter
+              if [ "$(jq -r '.spec.params.exodusGwSecret' <<< "$internalRequest")" != "exodus-prod-secret" ]; then
+                echo "InternalRequest has the wrong exodusGwSecret parameter"
+                exit 1
+              fi
+
+              # Check the exodusGwEnv parameter
+              if [ "$(jq -r '.spec.params.exodusGwEnv' <<< "$internalRequest")" != "pre" ]; then
+                echo "InternalRequest has the wrong exodusGwEnv parameter"
+                exit 1
+              fi
+
+              # Check the pulpSecret parameter
+              if [ "$(jq -r '.spec.params.pulpSecret' <<< "$internalRequest")" != "rhsm-pulp-stage-secret" ]; then
+                echo "InternalRequest has the wrong pulpSecret parameter"
+                exit 1
+              fi
+
+              # Check the udcacheSecret parameter
+              if [ "$(jq -r '.spec.params.udcacheSecret' <<< "$internalRequest")" != "udcache-stage-secret" ]; then
+                echo "InternalRequest has the wrong udcacheSecret parameter"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit adds a task to push disk images via an InternalRequest. The steps done in the pull-disk-images task will be removed in a future commit as they are now done in the InternalRequest this task calls.