### PR TITLE
fix: incorrect task references in push-binaries-to-dev-portal pipeline

### DIFF
--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -19,8 +19,13 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+
+## Changes in 0.2.2
+- Fixed incorrect task references
+  - Some of the references incorrectly specified a name
+
 ## Changes in 0.2.1
 - Update params for `push-to-cdn`and `publish-to-cgw` tasks
-  
+
 ## Changes in 0.2.0
 - Removed `verify-access-to-resources` script and replaced it with a task.

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -182,7 +182,6 @@ spec:
         - name: data
           workspace: release-workspace
       taskRef:
-        name: push-to-cdn
         resolver: "git"
         params:
           - name: url
@@ -209,7 +208,6 @@ spec:
         - name: data
           workspace: release-workspace
       taskRef:
-        name: publish-to-cgw
         resolver: "git"
         params:
           - name: url


### PR DESCRIPTION
Some of the references incorrectly specified a name.