### PR TITLE
feat(RELEASE-238): add support to directly specify registry.redhat.io

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -25,6 +25,13 @@ This task supports variable expansion in tag values from the mapping. The curren
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
 
+## Changes in 1.5.0
+* Change the way the component repository field in RPA mapping is handled:
+  * Added support for converting quay.io repository URLs to registry.redhat.io format and vice versa.
+  * Introduced a new key rh-registry-repo to store the updated repository value in the registry.redhat.io format.
+  * Added a new key registry-access-repo to store the repository value in the registry.access.redhat.com format.
+  * If the repository key contains registry.redhat.io, it will be rewritten to the equivalent quay repo. Otherwise, it is left as is  
+
 ## Changes in 1.4.0
 * Add a check that all component containerImage values use a sha reference
   * If some value does not comply, fail the task

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,8 +31,7 @@ spec:
       description: A true/false value depicting whether or not the snapshot was mapped.
   steps:
     - name: apply-mapping
-      image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -93,12 +92,66 @@ spec:
             echo -n $tags | jq -c
         }
 
-        # Merge the mapping key contents in the data json file with the components key in the snapshot based
-        # on component name. Save the output as a compact json in mapped_snapshot.json file in the workspace
-        { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${MAPPING}"; } | jq -c -s '.[0] as $snapshot
-          | .[0].components + .[1].components | group_by(.name) | [.[] | select(length > 1)]
-          | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents | $snapshot | .components = $mergedComponents' \
-          > "${SNAPSHOT_SPEC_FILE}"
+        convert_to_quay () { # Convert the registry.redhat.io URL to the quay.io format
+            local repository=$1
+            case "$repository" in
+                registry.redhat.io/*)
+                    echo "${repository/registry.redhat.io/quay.io/redhat-prod}" \
+                        | sed 's|/|----|g; s|quay.io----redhat-prod----|quay.io/redhat-prod/|'
+                    ;;
+                registry.stage.redhat.io/*)
+                    echo "${repository/registry.stage.redhat.io/quay.io/redhat-pending}" \
+                        | sed 's|/|----|g; s|quay.io----redhat-pending----|quay.io/redhat-pending/|'
+                    ;;
+                *)
+                    echo "$repository"
+                    ;;
+            esac
+        }
+
+        # This block is temporary to support both quay.io and registry.redhat.io
+        # It should be removed once all repositories are migrated to registry.redhat.io
+        convert_to_registry () { # Convert the repository URL to the registry.redhat.io format
+            local repository=$1
+            case "$repository" in
+                quay.io/redhat-prod/*)
+                    echo "${repository/quay.io\/redhat-prod/registry.redhat.io}" | sed 's|----|/|g'
+                    ;;
+                quay.io/redhat-pending/*)
+                    echo "${repository/quay.io\/redhat-pending/registry.stage.redhat.io}" | sed 's|----|/|g'
+                    ;;
+                registry.redhat.io/* | registry.stage.redhat.io/*)
+                    # Return the original Red Hat registry paths
+                    echo "$repository"
+                    ;;
+                *)
+                    # Return empty for unhandled formats
+                    echo ""
+                    ;;
+            esac
+        }
+
+        convert_to_registry_access () { # Convert the repository URL to the registry.access.redhat.com format
+            local repository=$1
+            case "$repository" in
+                registry.redhat.io/*)
+                    echo "${repository/registry.redhat.io/registry.access.redhat.com}"
+                    ;;
+                registry.stage.redhat.io/*)
+                    echo "${repository/registry.stage.redhat.io/registry.access.stage.redhat.com}"
+                    ;;
+                *)
+                    echo ""
+                    ;;
+            esac
+        }
+
+        # Merge the mapping key contents in the data JSON file with the components key in the snapshot based
+        # on component name. Save the output as a compact JSON in the mapped_snapshot.json file in the workspace
+        { echo -n $(cat "${SNAPSHOT_SPEC_FILE_ORIG}"); echo "${MAPPING}"; } | jq -c -s '
+          .[0] as $snapshot | .[0].components + .[1].components | group_by(.name) |
+          [.[] | select(length > 1)] | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents |
+          $snapshot | .components = $mergedComponents' > "${SNAPSHOT_SPEC_FILE}"
 
         printf "true" | tee $(results.mapped.path)
 
@@ -152,4 +205,31 @@ spec:
                   '.components[$i].staged.files[$j].filename = $filename' "${SNAPSHOT_SPEC_FILE}" > /tmp/temp \
                   && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             done
+
+            # Determine the format of the original repository and update keys accordingly
+            repository=$(jq -r '.repository' <<< "$component")
+            echo "Processing component: $NAME"
+            echo "Original repository: $repository"
+
+            # This block is temporary to support both quay.io and registry.redhat.io
+            # It should be removed once all repositories are migrated to registry.redhat.io
+            if [[ "$repository" == quay.io/redhat-prod/* || "$repository" == quay.io/redhat-pending/* ]]; then
+                repository=$(convert_to_registry "$repository")
+            fi
+
+            # Convert to registry and quay format
+            if [[ "$repository" == registry.redhat.io/* || "$repository" == registry.stage.redhat.io/* ]]; then
+              rh_registry_repo=$repository
+              registry_access_repo=$(convert_to_registry_access "$repository")
+              repository=$(convert_to_quay "$repository")
+      
+              jq --argjson i "$i" \
+                --arg repository "$repository" \
+                --arg rh_registry_repo "$rh_registry_repo" \
+                --arg registry_access_repo "$registry_access_repo" \
+                '(.components[$i].repository = $repository) |
+                    .components[$i]["rh-registry-repo"] = $rh_registry_repo |
+                    .components[$i]["registry-access-repo"] = $registry_access_repo' \
+              "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            fi
         done

--- a/tasks/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-multi-redhat-components
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json containing multiple components 
+    and Red Hat specific repository formats. Verify that the resulting json contains the expected transformations.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-multi-component
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-multi-component-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.config.path)/test_data_multi_component.json << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "quay.io/redhat-prod/product-name----image1"
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "registry.redhat.io/product-name/image2"
+                    },
+                    {
+                      "name": "comp3",
+                      "repository": "quay.io/redhat-pending/product-name----image3"
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.config.path)/test_snapshot_spec_multi_component.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "imageurl2@sha256:789012",
+                    "source": {
+                      "git": {
+                        "revision": "myrev2",
+                        "url": "myurl2"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "imageurl3@sha256:345678",
+                    "source": {
+                      "git": {
+                        "revision": "myrev3",
+                        "url": "myurl3"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+    - name: run-task-multi-component
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec_multi_component.json
+        - name: dataPath
+          value: test_data_multi_component.json
+      runAfter:
+        - setup-multi-component
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+    - name: check-result-multi-component
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result-multi-component
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Test for comp1
+              echo Test that SNAPSHOT contains component comp1
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '[ .components[] | select(.name=="comp1") ] | length') -eq 1
+
+              echo Test that rh-registry-repo for comp1 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo"') == \
+                registry.redhat.io/product-name/image1
+
+              echo Test that registry-access-repo for comp1 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo"') == \
+                registry.access.redhat.com/product-name/image1
+
+              # Test for comp2
+              echo Test that SNAPSHOT contains component comp2
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '[ .components[] | select(.name=="comp2") ] | length') -eq 1
+
+              echo Test that quay.io repository for comp2 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp2") | .repository') == \
+                quay.io/redhat-prod/product-name----image2
+
+              echo Test that registry-access-repo for comp2 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp2") | ."registry-access-repo"') == \
+                registry.access.redhat.com/product-name/image2
+
+              # Test for comp3
+              echo Test that SNAPSHOT contains component comp3
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '[ .components[] | select(.name=="comp3") ] | length') -eq 1
+
+              echo Test that rh-registry-repo for comp3 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp3") | ."rh-registry-repo"') == \
+                registry.stage.redhat.io/product-name/image3
+
+              echo Test that registry-access-repo for comp3 is correctly set
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_multi_component.json \
+                | jq -r '.components[] | select(.name=="comp3") | ."registry-access-repo"') == \
+                registry.access.stage.redhat.com/product-name/image3
+      runAfter:
+        - run-task-multi-component

--- a/tasks/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-other-formats
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json where the repository is in a format not specifically
+    handled by the task. Verify that the resulting json remains unchanged in the repository field.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-other-formats
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-other-formats-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.config.path)/test_data_other_formats.json << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "quay.io/my-sample/my-image"
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > $(workspaces.config.path)/test_snapshot_spec_other_formats.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1@sha256:123456"
+                  }
+                ]
+              }
+              EOF
+    - name: run-task-other-formats
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec_other_formats.json
+        - name: dataPath
+          value: test_data_other_formats.json
+      runAfter:
+        - setup-other-formats
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+    - name: check-result-other-formats
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: check-result-other-formats
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that SNAPSHOT contains component comp1
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_other_formats.json \
+                | jq -r '[ .components[] | select(.name=="comp1") ] | length') -eq 1
+
+              echo Test that repository of component comp1 stayed intact
+              test $(cat $(workspaces.config.path)/test_snapshot_spec_other_formats.json \
+                | jq -r '.components[] | select(.name=="comp1") | .repository') == \
+                quay.io/my-sample/my-image
+
+              echo Test that rh-registry-repo for comp1 is not set because it was not in a known format
+              test -z "$(cat $(workspaces.config.path)/test_snapshot_spec_other_formats.json \
+                | jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo" // empty')"
+
+              echo Test that registry-access-repo for comp1 is not set because it was not in a known format
+              test -z "$(cat $(workspaces.config.path)/test_snapshot_spec_other_formats.json \
+                | jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo" // empty')"
+      runAfter:
+        - run-task-other-formats

--- a/tasks/create-advisory/README.md
+++ b/tasks/create-advisory/README.md
@@ -18,6 +18,9 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                           |
 
+## Changes in 4.4.0
+- Update task to use repository value from snapshot JSON insted of data JSON.
+
 ## Changes in 4.3.0
 * Updated the base image used in this task
 

--- a/tasks/create-advisory/create-advisory.yaml
+++ b/tasks/create-advisory/create-advisory.yaml
@@ -81,14 +81,14 @@ spec:
         #
         # detect which one to use based on repositories specified
         #
-        pending_repositories=$(jq -r '.mapping.components[] | select(.repository |
+        pending_repositories=$(jq -r '.components[] | select(.repository |
           contains("quay.io/redhat-pending/")) |
-          .repository' $(workspaces.data.path)/$(params.dataPath))
-        prod_repositories=$(jq -r '.mapping.components[] | select(.repository | contains("quay.io/redhat-prod/")) |
-          .repository' $(workspaces.data.path)/$(params.dataPath))
-        orphan_repositories=$(jq -r '.mapping.components[] | select(.repository | contains("quay.io/redhat-prod/") |
+          .repository' $(workspaces.data.path)/$(params.snapshotPath))
+        prod_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/")) |
+          .repository' $(workspaces.data.path)/$(params.snapshotPath))
+        orphan_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/") |
           not) | select(.repository | contains("quay.io/redhat-pending/") | not) |
-          .repository' $(workspaces.data.path)/$(params.dataPath))
+          .repository' $(workspaces.data.path)/$(params.snapshotPath))
 
         foundPendingRepositories=false
         if [ -n "${pending_repositories}" ]; then
@@ -106,8 +106,8 @@ spec:
         fi
 
         echo "foundPendingRepositories: ${foundPendingRepositories}"
-        echo "foundProdRepositories ${foundProdRepositories}"
-        echo "foundOrphanRepositories ${foundOrphanRepositories}"
+        echo "foundProdRepositories: ${foundProdRepositories}"
+        echo "foundOrphanRepositories: ${foundOrphanRepositories}"
 
         if [ "${foundPendingRepositories}" == "true" ] && [ "${foundProdRepositories}" == "true" ]; then
           echo "Error: cannot publish to both redhat-pending and redhat-prod repositories"

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: |
     Run the create-advisory task with a ReleasePlanAdmission that contains a mapping which contains
-    neither prod or pending repos and verify the task fails as expected
+    neither prod nor pending repos and verify the task fails as expected
   workspaces:
     - name: tests-workspace
   tasks:
@@ -65,7 +65,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "repository": "repo"
+                    "repository": "quay.io/redhat-dev/repo"
                   }
                 ]
               }
@@ -84,14 +84,6 @@ spec:
                   "spec": {
                     "foo": "bar"
                   }
-                },
-                "mapping": {
-                  "components": [
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-dev/repo"
-                    }
-                  ]
                 }
               }
               EOF

--- a/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
@@ -64,8 +64,12 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comp",
-                    "repository": "repo"
+                    "name": "comp-dev",
+                    "repository": "quay.io/redhat-dev/repo"
+                  },
+                  {
+                    "name": "comp-prod",
+                    "repository": "quay.io/redhat-prod/repo"
                   }
                 ]
               }
@@ -84,18 +88,6 @@ spec:
                   "spec": {
                     "foo": "bar"
                   }
-                },
-                "mapping": {
-                  "components": [
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-dev/repo"
-                    },
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-prod/repo"
-                    }
-                  ]
                 }
               }
               EOF

--- a/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -65,7 +65,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "repository": "repo"
+                    "repository": "quay.io/redhat-pending/repo"
                   }
                 ]
               }
@@ -98,14 +98,6 @@ spec:
                   "spec": {
                     "foo": "bar"
                   }
-                },
-                "mapping": {
-                  "components": [
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-pending/repo"
-                    }
-                  ]
                 }
               }
               EOF

--- a/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -63,7 +63,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "repository": "repo"
+                    "repository": "quay.io/redhat-pending/repo"
                   }
                 ]
               }
@@ -82,14 +82,6 @@ spec:
                   "spec": {
                     "foo": "bar"
                   }
-                },
-                "mapping": {
-                  "components": [
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-pending/repo"
-                    }
-                  ]
                 }
               }
               EOF

--- a/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -65,7 +65,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "repository": "repo"
+                    "repository": "quay.io/redhat-prod/repo"
                   }
                 ]
               }
@@ -78,14 +78,6 @@ spec:
                 },
                 "sign": {
                   "configMapName": "cm"
-                },
-                "mapping": {
-                  "components": [
-                    {
-                      "name": "comp",
-                      "repository": "quay.io/redhat-prod/repo"
-                    }
-                  ]
                 }
               }
               EOF

--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -10,6 +10,13 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 2.2.0
+* Updated to use the `rh-registry-repo` key from the snapshot JSON for constructing 
+  the image repository path, instead of relying on the data field. This change 
+  ensures that the task correctly references the internal Red Hat registry format.
+* Removed the use of the `translate-delivery-repo` script as the task now directly 
+  accesses the `rh-registry-repo` value from the snapshot JSON.
+
 ## Changes in 2.1.0
 * Updated the base image used in this task
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,11 +44,10 @@ spec:
         for ((i = 0; i < $NUM_COMPONENTS; i++))
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
-            name=$(jq -r '.name' <<< $component)
-            repo=$(jq -r '.repository' <<< $component)
-            deliveryRepo=$(translate-delivery-repo $repo | jq -r '.[] | select(.repo=="redhat.io") | .url')
-            tags=$(jq -c '.tags' <<< $component)
-            image=$(jq -r '.containerImage' <<< $component)
+            name=$(jq -r '.name' <<< "$component")
+            deliveryRepo=$(jq -er '."rh-registry-repo"' <<< "$component")
+            tags=$(jq -c '.tags' <<< "$component")
+            image=$(jq -r '.containerImage' <<< "$component")
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"
                 exit 1

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
@@ -86,6 +86,7 @@ spec:
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
                     "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
                       "foo",
                       "bar"

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
@@ -32,7 +32,8 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "prod-registry.io/prod-location",
+                    "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
                       "foo",
                       "bar"

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
@@ -63,6 +63,7 @@ spec:
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
                     "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
                       "foo",
                       "bar"
@@ -72,6 +73,7 @@ spec:
                     "name": "comp2",
                     "containerImage": "registry.io/image2@sha256:abcde",
                     "repository": "quay.io/redhat-pending/product2----repo2",
+                    "rh-registry-repo": "registry.stage.redhat.io/product2/repo2",
                     "tags": [
                       "foo",
                       "bar"

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
@@ -70,6 +70,7 @@ spec:
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
                     "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
                       "foo",
                       "bar"

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
@@ -63,6 +63,7 @@ spec:
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
                     "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
                       "foo",
                       "bar"

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -13,6 +13,11 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
 
+## Changes in 3.4.0
+* Added changes in order to eliminate the `translate-delivery-repo` script because the
+ `registry.redhat.io` and `registry.access.redhat.com ` repo are now available
+ in snapshot with key `rh-registry-repo` and `registry-access-repo` respectively.
+
 ## Changes in 3.3.0
 * This task now also signs the manifest list digest when processing a multi-arch image
 

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -72,21 +72,13 @@ spec:
 
             referenceContainerImage=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
 
-            reference=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
+            rh_registry_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"rh-registry-repo\"]" ${SNAPSHOT_PATH})
+            registry_access_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"registry-access-repo\"]" ${SNAPSHOT_PATH})
 
             git_sha=$(jq -r ".components[${COMPONENTS_INDEX}].source.git.revision" ${SNAPSHOT_PATH})
 
             TAGS=$(jq -r ".components[${COMPONENTS_INDEX}].tags | join(\" \")" ${SNAPSHOT_PATH})
 
-            # Translate direct quay.io reference to public facing registry json
-            # quay.io/redhat-prod/product----repo ->
-            #   [{"repo":"redhat.io","url":registry.redhat.io/product/repo"},
-            #   {"repo":"access.redhat.com","url":"registry.access.redhat.com/product/repo"}]
-            # quay.io/redhat-pending/product----repo ->
-            #   [{"repo":"redhat.io","url":registry.stage.redhat.io/product/repo"},
-            #   {"repo":"access.redhat.com","url":"registry.access.stage.redhat.com/product/repo"}]
-            referenceJson=$(translate-delivery-repo $reference)
-        
             # check if multi-arch
             RAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${referenceContainerImage})
             # Always sign the top level sha
@@ -118,7 +110,8 @@ spec:
 
             for manifest_digest in $manifest_digests; do
               for tag in ${TAGS}; do
-                for registry_reference in $(jq -r '.[] | .url' <<< $referenceJson); do
+                # Iterate over both rh-registry-repo and registry-access-repo
+                for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
                   echo "Creating InternalRequest to sign image with tag ${tag}:"
                   echo "- reference=${registry_reference}:${tag}"
                   echo "- manifest_digest=${manifest_digest}"
@@ -147,7 +140,7 @@ spec:
               for tag in ${TAGS}; do
                 sourceTag=${tag}-source
 
-                for registry_reference in $(jq -r '.[] | .url' <<< $referenceJson); do
+                for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
                   echo "Creating InternalRequest to sign image with tag ${sourceTag}:"
                   echo "- reference=${registry_reference}:${sourceTag}"
                   echo "- manifest_digest=${sourceContainerDigest}"

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -30,6 +30,8 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "quay.io/redhat-pending/prod----repo0",
+                    "rh-registry-repo": "registry.stage.redhat.io/prod/repo0",
+                    "registry-access-repo": "registry.access.stage.redhat.com/prod/repo0",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"
@@ -39,6 +41,8 @@ spec:
                     "name": "comp1",
                     "containerImage": "registry.io/image1@sha256:0001",
                     "repository": "quay.io/redhat-pending/prod----repo1",
+                    "rh-registry-repo": "registry.stage.redhat.io/prod/repo1",
+                    "registry-access-repo": "registry.access.stage.redhat.com/prod/repo1",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"
@@ -48,6 +52,8 @@ spec:
                     "name": "comp2",
                     "containerImage": "registry.io/image2@sha256:0002",
                     "repository": "quay.io/redhat-pending/prod----repo2",
+                    "rh-registry-repo": "registry.stage.redhat.io/prod/repo2",
+                    "registry-access-repo": "registry.access.stage.redhat.com/prod/repo2",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-rh-sign-image-push-source-container
 spec:
   description: |
-    Test creating a internal request to sign an image with the pushSourceContainer
+    Test creating an internal request to sign an image with the pushSourceContainer
     values set in the mapping and components
   workspaces:
     - name: tests-workspace
@@ -37,6 +37,8 @@ spec:
                     },
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "quay.io/redhat-prod/myproduct0----myrepo0",
+                    "rh-registry-repo": "registry.redhat.io/myproduct0/myrepo0",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct0/myrepo0",
                     "pushSourceContainer": true,
                     "tags": [
                       "some-prefix-12345",
@@ -52,6 +54,8 @@ spec:
                     },
                     "containerImage": "registry.io/image1@sha256:1111",
                     "repository": "quay.io/redhat-prod/myproduct1----myrepo1",
+                    "rh-registry-repo": "registry.redhat.io/myproduct1/myrepo1",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct1/myrepo1",
                     "pushSourceContainer": false,
                     "tags": [
                       "some-prefix-12345",
@@ -67,6 +71,8 @@ spec:
                     },
                     "containerImage": "registry.io/image2@sha256:2222",
                     "repository": "quay.io/redhat-prod/myproduct2----myrepo2",
+                    "rh-registry-repo": "registry.redhat.io/myproduct2/myrepo2",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct2/myrepo2",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-rh-sign-image-single-component-multi-arch
 spec:
-  description: Test creating a internal request to sign a multi-arch image
+  description: Test creating an internal request to sign a multi-arch image
   workspaces:
     - name: tests-workspace
   tasks:
@@ -30,6 +30,8 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/multi-arch-image0@sha256:0000",
                     "repository": "quay.io/redhat-prod/myproduct----myrepo",
+                    "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"
@@ -113,7 +115,6 @@ spec:
                   exit 1
                 fi
                 counter=$((counter+1))
-
               done
       runAfter:
         - run-task

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-rh-sign-image-single-component
 spec:
-  description: Test creating a internal request to sign an image
+  description: Test creating an internal request to sign an image
   workspaces:
     - name: tests-workspace
   tasks:
@@ -28,15 +28,15 @@ spec:
                 "components": [
                   {
                     "name": "comp0",
-
                     "source": {
                       "git": {
                         "revision": "deadbeef"
                       }
                     },
-
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "quay.io/redhat-prod/myproduct----myrepo",
+                    "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"
@@ -53,7 +53,6 @@ spec:
                     "pushSourceContainer": "true"
                   }
                 },
-
                 "sign": {
                   "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
@@ -137,26 +136,23 @@ spec:
                 exit 1
               fi
 
-              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
-              then
+              if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]; then
                 echo "config_map_name does not match"
                 exit 1
               fi
 
-              if [ $(jq -r '.requester' <<< "${params}") != "testuser-single" ]
-              then
+              if [ $(jq -r '.requester' <<< "${params}") != "testuser-single" ]; then
                 echo "requester does not match"
                 exit 1
               fi
 
               if [ $(jq -r '.pipeline_image' <<< "${params}") != \
-                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
-              then
+                 "quay.io/redhat-isv/operator-pipelines-images:released" ]; then
                 echo "pipeline_image does not match"
                 exit 1
               fi
 
-              # last internal request for source container check
+              # Last internal request for source container check
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
                 tail -1)"
               params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -36,6 +36,8 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "quay.io/redhat-prod/myproduct----myrepo",
+                    "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"


### PR DESCRIPTION
This commit adds support to allow users to specify "registry.redhat.io"
directly in RPA. Before this, the user was required to enter repository value in
the `quay.io/redhat-prod/product----repo` format.    

* Repository Handling:
  * Added support for converting quay.io repository URLs to registry.redhat.io format and vice versa.
  * Introduced a new key rh-registry-repo to store the updated repository value in the registry.redhat.io format.
  * Added a new key registry-access-repo to store the repository value in the registry.access.redhat.com format.
    
Related tasks are updated, including tests to support this feature.

- `apply-mapping`
- `create advisory`
- `populate-release-notes-image`
- `rh-sign-image` 