### PR TITLE
fix(RELEASE-967): incorrect behavior in apply-mapping when no tags defined

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -25,6 +25,12 @@ This task supports variable expansion in tag values from the mapping. The curren
 | dataPath | Path to the JSON string of the merged data to use in the data workspace | No | |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
 
+## Changes in 1.3.1
+* Fix bug when there are no tags
+  * Without a default `[]` value when loading tags for components with jq, the tags variable
+    would be an empty string instead of an empty array, which would result in an error
+    running `jq 'length'` on it
+
 ## Changes in 1.3.0
 *  Updated the base image used in the task
 

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -34,7 +34,7 @@ spec:
       image:
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -eux
 
         SNAPSHOT_SPEC_FILE="$(workspaces.config.path)/$(params.snapshotPath)"
@@ -110,32 +110,32 @@ spec:
         fi
 
         # Expand the tags in the data file
-        defaultTags=$(jq '.defaults.tags // []' <<< $MAPPING)
-        defaultTimestampFormat=$(jq -r '.defaults.timestampFormat // "%s"' <<< $MAPPING)
+        defaultTags=$(jq '.defaults.tags // []' <<< "$MAPPING")
+        defaultTimestampFormat=$(jq -r '.defaults.timestampFormat // "%s"' <<< "$MAPPING")
         currentTimestamp="$(date "+%Y%m%d %T")"
         NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         for ((i = 0; i < $NUM_MAPPED_COMPONENTS; i++)) ; do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
-            imageTags=$(jq '.tags // []' <<< $component)
-            git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
-            build_sha=$(jq -r '.containerImage' <<< $component | cut -d ':' -f 2)
+            imageTags=$(jq '.tags // []' <<< "$component")
+            git_sha=$(jq -r '.source.git.revision' <<< "$component") # this sets the value to "null" if it doesn't exist
+            build_sha=$(jq -r '.containerImage' <<< "$component" | cut -d ':' -f 2)
             passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
-              '.timestampFormat // $default' <<< $component)
+              '.timestampFormat // $default' <<< "$component")
             timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"
 
             allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
               "$imageTags" '$defaults? + $imageTags? | unique')
             tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
               "${git_sha:0:7}" "${build_sha}")
-            if [ "$(jq 'length' <<< $tags)" -gt 0 ] ; then
+            if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
               jq --argjson i "$i" --argjson updatedTags $tags '.components[$i].tags = $updatedTags' \
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 
             # Also substitute filename values in the staged section of components
-            STAGED_FILES=$(jq '.staged.files | length' <<< $component)
+            STAGED_FILES=$(jq '.staged.files | length' <<< "$component")
             for ((j = 0; j < $STAGED_FILES; j++)) ; do
-                file=$(jq -c --argjson j "$j" '.staged.files[$j]' <<< $component)
+                file=$(jq -c --argjson j "$j" '.staged.files[$j]' <<< "$component")
                 filenameArrayPreSubstitution=$(jq '.filename' <<< $file | jq -cs)
                 subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" "${timestamp}" "${git_sha}" \
                   "${git_sha:0:7}" "${build_sha}" | jq -r '.[0]')

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -110,13 +110,13 @@ spec:
         fi
 
         # Expand the tags in the data file
-        defaultTags=$(jq '.defaults.tags' <<< $MAPPING)
+        defaultTags=$(jq '.defaults.tags // []' <<< $MAPPING)
         defaultTimestampFormat=$(jq -r '.defaults.timestampFormat // "%s"' <<< $MAPPING)
         currentTimestamp="$(date "+%Y%m%d %T")"
         NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         for ((i = 0; i < $NUM_MAPPED_COMPONENTS; i++)) ; do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
-            imageTags=$(jq '.tags' <<< $component)
+            imageTags=$(jq '.tags // []' <<< $component)
             git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
             build_sha=$(jq -r '.containerImage' <<< $component | cut -d ':' -f 2)
             passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
@@ -127,7 +127,7 @@ spec:
               "$imageTags" '$defaults? + $imageTags? | unique')
             tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
               "${git_sha:0:7}" "${build_sha}")
-            if [ $(jq 'length' <<< $tags) -gt 0 ] ; then
+            if [ "$(jq 'length' <<< $tags)" -gt 0 ] ; then
               jq --argjson i "$i" --argjson updatedTags $tags '.components[$i].tags = $updatedTags' \
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi


### PR DESCRIPTION
When loading the default tags or component tags, there was no default value, so if there were no tags defined, we would end up with a null value / empty string. And this would cause an error message when running `jq 'length'` on this.