### PR TITLE
feat(RELEASE-978): add image reference check in apply-mapping

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -25,6 +25,10 @@ This task supports variable expansion in tag values from the mapping. The curren
 | dataPath | Path to the JSON string of the merged data to use in the data workspace | No | |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components | Yes | false |
 
+## Changes in 1.4.0
+* Add a check that all component containerImage values use a sha reference
+  * If some value does not comply, fail the task
+
 ## Changes in 1.3.1
 * Fix bug when there are no tags
   * Without a default `[]` value when loading tags for components with jq, the tags variable

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,9 +116,18 @@ spec:
         NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         for ((i = 0; i < $NUM_MAPPED_COMPONENTS; i++)) ; do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
+
+            # images are required to use sha reference - check this
+            NAME=$(jq -r '.name' <<< "$component")
+            IMAGE_REF=$(jq -r '.containerImage' <<< "$component")
+            if ! [[ "$IMAGE_REF" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
+              echo "Component ${NAME} contains an invalid containerImage value. sha reference is required: ${IMAGE_REF}"
+              exit 1
+            fi
+
             imageTags=$(jq '.tags // []' <<< "$component")
             git_sha=$(jq -r '.source.git.revision' <<< "$component") # this sets the value to "null" if it doesn't exist
-            build_sha=$(jq -r '.containerImage' <<< "$component" | cut -d ':' -f 2)
+            build_sha=$(echo "$IMAGE_REF" | cut -d ':' -f 2)
             passedTimestampFormat=$(jq -r --arg default $defaultTimestampFormat \
               '.timestampFormat // $default' <<< "$component")
             timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -2,14 +2,14 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-fail-on-empty
+  name: test-apply-mapping-fail-on-invalid-image-reference
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json and data json mapping that
-    results in empty component list. Set task parameter failOnEmptyResult to true
-    and verify that the task fails as expected.
+    Run the apply-mapping task with a snapshot.spec json where
+    some of the containerImage values are not sha references.
+    This will result in a failure.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -20,8 +20,6 @@ spec:
       taskSpec:
         workspaces:
           - name: config
-        results:
-          - name: snapshot
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -29,40 +27,42 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > $(workspaces.config.path)/data.json << EOF
+              cat > "$(workspaces.config.path)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
                     {
-                      "name": "comp3",
-                      "repository": "repo3"
+                      "name": "comp1",
+                      "repository": "repo1"
                     },
                     {
-                      "name": "comp4",
-                      "customfield": "repo4"
+                      "name": "comp2",
+                      "repository": "repo2"
+                    },
+                    {
+                      "name": "comp3",
+                      "repository": "repo3"
                     }
                   ]
                 }
               }
               EOF
 
-              cat > "$(workspaces.config.path)/snapshot_spec.json" << EOF
+              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1@sha256:123456",
-                    "source": {
-                      "git": {
-                        "revision": "myrev",
-                        "url": "myurl"
-                      }
-                    }
+                    "containerImage": "imageurl1@sha256:123456"
                   },
                   {
                     "name": "comp2",
-                    "containerImage": "imageurl2@sha256:123456"
+                    "containerImage": "imageurl2:tag"
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "imageurl3:tag"
                   }
                 ]
               }
@@ -72,13 +72,11 @@ spec:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: "snapshot_spec.json"
+          value: test_snapshot_spec.json
         - name: dataPath
-          value: "data.json"
-        - name: failOnEmptyResult
-          value: "true"
+          value: test_data.json
+      runAfter:
+        - setup
       workspaces:
         - name: config
           workspace: tests-workspace
-      runAfter:
-        - setup

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -32,7 +32,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1",
+                    "containerImage": "imageurl1@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "myrev",
@@ -42,10 +42,12 @@ spec:
                   },
                   {
                     "name": "comp3",
+                    "containerImage": "imageurl3@sha256:123456",
                     "repository": "repo3"
                   },
                   {
                     "name": "comp4",
+                    "containerImage": "imageurl4@sha256:123456",
                     "repository": "repo4"
                   }
                 ]

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -41,7 +41,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1",
+                    "containerImage": "imageurl1@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "myrev",
@@ -50,7 +50,8 @@ spec:
                     }
                   },
                   {
-                    "name": "comp2"
+                    "name": "comp2",
+                    "containerImage": "imageurl2@sha256:123456"
                   }
                 ]
               }

--- a/tasks/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   description: |
     Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
-    the data file with tags per component and verify that the resulting json
-    contains the expected values with tags expanded.
+    the data file with staged files per component and verify that the resulting json
+    contains the expected values with filenames expanded.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -68,7 +68,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "registry.io/image1:tag1",
+                    "containerImage": "registry.io/image1@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "testrevision",
@@ -78,7 +78,7 @@ spec:
                   },
                   {
                     "name": "comp2",
-                    "containerImage": "registry.io/image2:tag2",
+                    "containerImage": "registry.io/image2@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "testrevision2",
@@ -124,6 +124,6 @@ spec:
               echo Test that comp2 has the proper files
               test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -c '.components[] | select(.name=="comp2") | .staged.files') == \
-                '[{"source":"two.qcow2","filename":"ai-tag2"}]'
+                '[{"source":"two.qcow2","filename":"ai-123456"}]'
       runAfter:
         - run-task

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -72,7 +72,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "registry.io/image1:tag1",
+                    "containerImage": "registry.io/image1@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "testrevision",
@@ -82,10 +82,12 @@ spec:
                   },
                   {
                     "name": "comp2",
+                    "containerImage": "registry.io/image2@sha256:123456",
                     "repository": "repo2"
                   },
                   {
                     "name": "comp3",
+                    "containerImage": "registry.io/image3@sha256:123456",
                     "repository": "repo3"
                   }
                 ]
@@ -125,7 +127,7 @@ spec:
               echo Test that comp1 has the proper tags
               test $(cat $(workspaces.config.path)/test_snapshot_spec.json \
                 | jq -c '.components[] | select(.name=="comp1") | .tags') == \
-                '["defaultTag","foo-tag1","tag1-1980-01-01","tag2-1980-01-01","tag1","testrevision-abc","testrev-bar","testrevision","testrev"]'
+                '["defaultTag","foo-123456","tag1-1980-01-01","tag2-1980-01-01","123456","testrevision-abc","testrev-bar","testrevision","testrev"]'
 
               echo Test that SNAPSHOT contains component comp2
               test $(cat $(workspaces.config.path)/test_snapshot_spec.json \

--- a/tasks/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping.yaml
@@ -55,7 +55,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1",
+                    "containerImage": "imageurl1@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "myrev",
@@ -65,15 +65,17 @@ spec:
                   },
                   {
                     "name": "comp3",
+                    "containerImage": "imageurl3@sha256:123456",
                     "repository": "repo3"
                   },
                   {
                     "name": "comp4",
+                    "containerImage": "imageurl4@sha256:123456",
                     "repository": "repo4"
                   },
                   {
                     "name": "comp5",
-                    "containerImage": "imageurl5"
+                    "containerImage": "imageurl5@sha256:123456"
                   }
                 ]
               }


### PR DESCRIPTION
containerImage values are required to use a sha reference. A check was added for this. The task will fail if one or more images use an invalid reference.