### PR TITLE
fix: oras commands to not hide error output

### DIFF
--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -44,7 +44,7 @@ spec:
           select-oci-auth "$4:$5" > "$DEST_AUTH_FILE"
 
           # We need this default value for $7 when oras_args is equal to ()
-          destination_digest=$(oras resolve --registry-config "$DEST_AUTH_FILE" ${7:-} "$4:$5" 2>/dev/null || true)
+          destination_digest=$(oras resolve --registry-config "$DEST_AUTH_FILE" ${7:-} "$4:$5" || true)
 
           if [[ "$destination_digest" != "$1" || -z "$destination_digest" ]]; then
             printf '* Pushing component: %s to %s:%s\n' "$2" "$4" "$5"
@@ -107,7 +107,7 @@ spec:
           arch_json=$(get-image-architectures "${containerImage}")
           arches=$(jq -s 'map(.platform.architecture)' <<< $arch_json)
           oses=$(jq -s 'map(.platform.os)' <<< $arch_json)
-        
+
           # Just read the first from the list of architectures
           os=$(jq -r '.[0]' <<< $oses)
           arch=$(jq -r '.[0]' <<< $arches)
@@ -121,7 +121,7 @@ spec:
           fi
 
           # we do not use oras_args here since we want to get the manifest index image digest
-          origin_digest=$(oras resolve --registry-config "$AUTH_FILE" "${containerImage}" 2>/dev/null)
+          origin_digest=$(oras resolve --registry-config "$AUTH_FILE" "${containerImage}")
 
           RESULTS_JSON=$(jq --arg i "$i" --argjson arches "$arches" --argjson oses "$oses" --arg name "$name" \
             --arg sha "$origin_digest" \
@@ -141,7 +141,7 @@ spec:
             sourceContainer="${source_repo}:${source_tag}"
             # Check if the source container exists
             source_container_digest=$(oras resolve --registry-config "$AUTH_FILE" \
-              "${sourceContainer}" ${oras_args[@]} 2>/dev/null)
+              "${sourceContainer}" ${oras_args[@]})
 
             if [ -z "$source_container_digest" ] ; then
               echo "Error: Source container ${sourceContainer} not found!"

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -111,7 +111,7 @@ spec:
               # so create a custom auth file with just one entry
               AUTH_FILE=$(mktemp)
               select-oci-auth "${sourceContainer}" > "$AUTH_FILE"
-              sourceContainerDigest=$(oras resolve --registry-config "$AUTH_FILE" "${sourceContainer}" 2>/dev/null)
+              sourceContainerDigest=$(oras resolve --registry-config "$AUTH_FILE" "${sourceContainer}")
             fi
 
             for manifest_digest in $manifest_digests; do


### PR DESCRIPTION
I believe the redirection of standard error output was done by mistake, probably assuming that it might polute the variable we're assigning to. But that's not how it works
 - stderr is not used for the assignment.

And recently a user saw a failure of the oras command, but there was no error output, so it was impossible to figure out what happened.

See here: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721633939965029