### PR TITLE
fix(RELEASE-1025): bump image in publish-to-cgw

### DIFF
--- a/tasks/publish-to-cgw/README.md
+++ b/tasks/publish-to-cgw/README.md
@@ -16,6 +16,9 @@ Tekton task to publish content to Red Hat's Developer portal using pubtools-cont
 | cgwHostname | The hostname of the content-gateway to publish the metadata to | yes | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret | The kubernetes secret to use to authenticate to content-gateway | yes | publish-to-cgw-secret |
 
+## Changes in 0.2.2
+* Update the base image used in this task to provide jsonschema module
+
 ## Changes in 0.2.1
 * Update cgw_metadata file creation
   * update downloadURL prefix

--- a/tasks/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/publish-to-cgw.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-cgw
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
       description: Workspace to save the CR jsons to
   steps:
     - name: run-push-cgw-metadata
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
       env:
         - name: CGW_USERNAME
           valueFrom:

--- a/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -98,7 +98,7 @@ spec:
           - name: resultDataPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
             script: |
               #!/usr/bin/env bash
               python3 <<EOF


### PR DESCRIPTION
This commit bumps the base image in the publish-to-cgw task so that the image includes the required jsonschema module.