### PR TITLE
chore(RELEASE-980): update image in push-rpm-manifests-to-pyxis

### DIFF
--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -11,6 +11,11 @@ Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an
 | server | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes | production |
 | concurrentLimit | The maximum number of images to be processed at once | Yes | 4 |
 
+## Changes in 0.4.1
+* updated the base image used in this task
+  * the new image contains an updated upload_rpm_manifest script with nvra and summary
+    fields populated for each rpm item
+
 ## Changes in 0.4.0
 * updated the base image used in this task
 

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-manifests-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,7 +36,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -85,7 +85,7 @@ spec:
 
     - name: push-rpm-manifests-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
The new image contains an updated upload_rpm_manifest script with nvra and summary fields populated for each rpm item.

Here's the related change in the utils image: https://github.com/konflux-ci/release-service-utils/pull/190