### PR TITLE
fix(RELEASE-994): incorrect handling of multiarch images with 1 arch

### DIFF
--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -11,6 +11,9 @@ Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an
 | server | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes | production |
 | concurrentLimit | The maximum number of images to be processed at once | Yes | 4 |
 
+## Changes in 0.4.2
+* fixed a bug that would treat a multiarch image containing just one arch as a plain single arch image
+
 ## Changes in 0.4.1
 * updated the base image used in this task
   * the new image contains an updated upload_rpm_manifest script with nvra and summary

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -41,7 +41,7 @@ spec:
         - mountPath: /workdir
           name: workdir
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -eux
 
         PYXIS_FILE="$(workspaces.data.path)/$(params.pyxisJsonPath)"

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-manifests-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/version: "0.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,8 +62,11 @@ spec:
           for (( j=0; j < $NUM_PYXIS_IMAGES; j++ )); do
             PYXIS_IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< "${COMPONENT}")
             FILE="$(jq -r '.imageId' <<< "$PYXIS_IMAGE").json"
-            # You can't pass --platform to a single arch image or cosign errors
-            if [ "${NUM_PYXIS_IMAGES}" -eq 1 ] ; then
+            DIGEST="$(jq -r '.digest' <<< "$PYXIS_IMAGE")"
+            ARCH_DIGEST="$(jq -r '.arch_digest' <<< "$PYXIS_IMAGE")"
+            # You can't pass --platform to a single arch image or cosign errors.
+            # If digest equals arch_digest, then it's a single arch image
+            if [ "$DIGEST" = "$ARCH_DIGEST" ] ; then
               echo "Fetching sbom for single arch image: $IMAGEURL to: $FILE"
               cosign download sbom --output-file "${FILE}" "${IMAGEURL}"
             else

--- a/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
 # mocks to be injected into task step scripts

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
@@ -36,7 +36,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID1Failing",
                         "digest": "mydigest1",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest1",
                         "os": "linux"
                       }
                     ]
@@ -48,7 +48,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID2",
                         "digest": "mydigest2",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest2",
                         "os": "linux"
                       }
                     ]

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
@@ -34,7 +34,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID1Parallel",
                         "digest": "mydigest2",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest2",
                         "os": "linux"
                       }
                     ]
@@ -46,7 +46,7 @@ spec:
                         "arch": "ppc64le",
                         "imageId": "myImageID2Parallel",
                         "digest": "mydigest2",
-                        "arch_digest": "deadbeef",
+                        "arch_digest": "mydigest2",
                         "os": "linux"
                       }
                     ]
@@ -58,7 +58,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID3Parallel",
                         "digest": "mydigest3",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest3",
                         "os": "linux"
                       }
                     ]
@@ -70,7 +70,7 @@ spec:
                         "arch": "ppc64le",
                         "imageId": "myImageID4Parallel",
                         "digest": "mydigest4",
-                        "arch_digest": "deadbeef",
+                        "arch_digest": "mydigest4",
                         "os": "linux"
                       }
                     ]
@@ -82,7 +82,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID5Parallel",
                         "digest": "mydigest5",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest5",
                         "os": "linux"
                       }
                     ]

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
@@ -34,7 +34,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID1",
                         "digest": "mydigest1",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest1",
                         "os": "linux"
                       }
                     ]
@@ -46,7 +46,7 @@ spec:
                         "arch": "amd64",
                         "imageId": "myImageID3",
                         "digest": "mydigest2",
-                        "arch_digest": "abcdefg",
+                        "arch_digest": "mydigest2",
                         "os": "linux"
                       }
                     ]


### PR DESCRIPTION
This was caught in a test and it's a valid use case that we should support - you could have a multiarch image (with a manifest list) that will only contain one arch image inside.

Previously, we would handle such image as a normal single arch image and the script would fail.