### PR TITLE
fix(CLOUDDST-23731): cosign after push

### DIFF
--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -277,7 +277,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - embargo-check
+        - push-snapshot
     - name: push-snapshot
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -304,7 +304,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - rh-sign-image
-        - rh-sign-image-cosign
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -233,7 +233,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - verify-enterprise-contract
+        - push-snapshot
     - name: push-snapshot
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -260,7 +260,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - rh-sign-image
-        - rh-sign-image-cosign
     - name: collect-pyxis-params
       taskRef:
         resolver: "git"

--- a/tasks/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/collect-cosign-params/collect-cosign-params.yaml
@@ -21,7 +21,8 @@ spec:
   results:
     - name: cosign-secret-name
       type: string
-      description: Name of secret which contains AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and SIGN_KEY
+      description: >-
+        Name of secret which contains AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and SIGN_KEY
   steps:
     - name: collect-params
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f

--- a/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -25,11 +25,11 @@ spec:
     - name: sign-image
       image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
       env:
-        - name: AWS_REGION
+        - name: AWS_DEFAULT_REGION
           valueFrom:
             secretKeyRef:
               name: $(params.secretName)
-              key: AWS_REGION
+              key: AWS_DEFAULT_REGION
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
+++ b/tasks/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@
 kubectl delete secret test-cosign-secret --ignore-not-found
 
 kubectl create secret generic test-cosign-secret\
-  --from-literal=AWS_REGION=us-test-1\
+  --from-literal=AWS_DEFAULT_REGION=us-test-1\
   --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
   --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
   --from-literal=SIGN_KEY=aws://arn:mykey


### PR DESCRIPTION
Cosign sign requires images already been pushed to destination repo. The commit also fixed an environment variable in cosign task.