### PR TITLE
Increase default EC timeout

### DIFF
--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -15,11 +15,14 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 2.2.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 2.2.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "2.2.1"
+    app.kubernetes.io/version: "2.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -14,11 +14,14 @@ Tekton release pipeline to interact with FBC Pipeline
 | enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                                               |
 | enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key                            |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..."                                              | Yes       | pipeline_intention=release                            |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
+
+### Changes in 3.6.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ### Changes in 3.6.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.6.1"
+    app.kubernetes.io/version: "3.6.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: verify_ec_task_bundle
       type: string
       description: The location of the bundle containing the verify-enterprise-contract task

--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -14,11 +14,14 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 0.2.4
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 0.2.3
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "0.2.3"
+    app.kubernetes.io/version: "0.2.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -14,11 +14,14 @@ Tekton pipeline to release Snapshots to an external registry.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 4.7.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 4.7.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.7.1"
+    app.kubernetes.io/version: "4.7.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -14,11 +14,14 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 3.5.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 3.5.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.5.1"
+    app.kubernetes.io/version: "3.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,7 +45,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -17,11 +17,14 @@ the rh-push-to-registry-redhat-io pipeline.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 0.13.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 0.13.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.13.1"
+    app.kubernetes.io/version: "0.13.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -14,11 +14,14 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 4.9.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 4.9.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.9.1"
+    app.kubernetes.io/version: "4.9.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -14,11 +14,14 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 3.10.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 3.10.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.10.1"
+    app.kubernetes.io/version: "3.10.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -16,11 +16,14 @@
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 3.11.2
+- Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 3.11.1
 - Add `enterpriseContractTimeout` parameter.

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.11.1"
+    app.kubernetes.io/version: "3.11.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,7 +44,7 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 10m0s
+      default: 40m0s
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline


### PR DESCRIPTION
This is needed only for super big images.

It's not necessarily needed for all of these pipelines, but I thought it would be better if it were just consistent.