### PR TITLE
fix: block advisory pipeline progress on the ec check

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.13.3
+- Bugfix: block pipeline progress on the verify-enterprise-contract.
+
 ### Changes in 0.13.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.13.2"
+    app.kubernetes.io/version: "0.13.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -277,6 +277,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
+        - verify-enterprise-contract
         - push-snapshot
     - name: push-snapshot
       when:
@@ -351,6 +352,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - embargo-check
+        - verify-enterprise-contract
     - name: create-pyxis-image
       taskRef:
         resolver: "git"


### PR DESCRIPTION
I noticed that the rh-advisories pipeline doesn't actually gate important activities on ec validation.

These runAfter relationships should prevent moving through the signing and push tasks until after ec validation completes.