### PR TITLE
fix: override timeout of push-disk-images task

### DIFF
--- a/pipelines/push-disk-images-to-cdn/README.md
+++ b/pipelines/push-disk-images-to-cdn/README.md
@@ -19,3 +19,6 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 0.1.1
+- Override timeout of push-disk-images task. Default is now 2h.

--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -185,6 +185,7 @@ spec:
       runAfter:
         - verify-enterprise-contract
     - name: push-disk-images
+      timeout: "2h00m0s"
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in


### PR DESCRIPTION
- Default is now 2h.