### PR TITLE
test(RELEASE-1019): fix kubectl mock in tasks

### DIFF
--- a/tasks/create-advisory/tests/mocks.sh
+++ b/tasks/create-advisory/tests/mocks.sh
@@ -9,6 +9,6 @@ function kubectl() {
   then
     echo '{"result":"Success","advisory_url":"https://github.com/org/repo/advisory"}'
   else
-    kubectl $*
+    /usr/bin/kubectl $*
   fi
 }

--- a/tasks/embargo-check/tests/mocks.sh
+++ b/tasks/embargo-check/tests/mocks.sh
@@ -41,6 +41,6 @@ function kubectl() {
   then
     echo '{"result":"Failure","embargoed_cves":"CVE-999"}'
   else
-    kubectl $*
+    /usr/bin/kubectl $*
   fi
 }


### PR DESCRIPTION
This commit fixes the kubectl mocks in task unit tests to not recursively call itself endlessly in the case of an unexpected call.