### PR TITLE
feat(RELEASE-1044): add requireInternalServices parameter to verify-a…

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -20,6 +20,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+### Changes in 3.7.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 3.6.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.6.2"
+    app.kubernetes.io/version: "3.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -96,6 +96,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "true"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 0.3.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 0.2.4
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "0.2.4"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/push-disk-images-to-cdn/README.md
+++ b/pipelines/push-disk-images-to-cdn/README.md
@@ -20,5 +20,8 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 0.2.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ## Changes in 0.1.1
 - Override timeout of push-disk-images task. Default is now 2h.

--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name : requireInternalServices
+          value: "true"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 4.8.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 4.7.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.7.2"
+    app.kubernetes.io/version: "4.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -20,6 +20,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 3.6.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 3.5.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.5.2"
+    app.kubernetes.io/version: "3.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -84,6 +84,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 0.14.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ## Changes in 0.13.3
 - Bugfix: block pipeline progress on the verify-enterprise-contract.
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.13.3"
+    app.kubernetes.io/version: "0.14.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -87,6 +87,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "true"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 4.10.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 4.9.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.9.2"
+    app.kubernetes.io/version: "4.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "true"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 3.11.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 3.10.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.10.2"
+    app.kubernetes.io/version: "3.11.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "true"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -22,6 +22,9 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+### Changes in 3.12.0
+- Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
+
 ### Changes in 3.11.2
 - Increase `enterpriseContractTimeout` parameter default value.
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.11.2"
+    app.kubernetes.io/version: "3.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           value: $(params.releaseServiceConfig)
         - name: snapshot
           value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
     - name: collect-data
       taskRef:
         resolver: "git"

--- a/tasks/verify-access-to-resources/README.md
+++ b/tasks/verify-access-to-resources/README.md
@@ -1,16 +1,20 @@
 # verify-access-to-resources
 
-This Tekton task is used to verify access to various resources in the pipelines. It ensures that the necessary resources, such as the release, release plan, release plan admission, release service config and snapshot, are available and accessible. Addiotinaly it check if internal requests can be created.
+This Tekton task is used to verify access to various resources in the pipelines. It ensures that the necessary resources, such as the release, release plan, release plan admission, release service config and snapshot, are available and accessible. Additionally, it checks if internal requests can be created if `requireInternalServices` is set to `true`.
 
 ## Parameters
 
-| Name                 | Description                                        | Optional | Default value |
-|----------------------|----------------------------------------------------|----------|---------------|
-| release              | Namespace/name of the Release                      | No       | -             |
-| releasePlan          | Namespace/name of the ReleasePlan                  | No       | -             |
-| releasePlanAdmission | Namespace/name of the ReleasePlanAdmission         | No       | -             |
-| releaseServiceConfig | Namespace/name of the ReleaseServiceConfig         | No       | -             |
-| snapshot             | Namespace/name of the Snapshot                     | No       | -             |
+| Name                    | Description                                             | Optional | Default value |
+|-------------------------|---------------------------------------------------------|----------|---------------|
+| release                 | Namespace/name of the Release                           | No       | -             |
+| releasePlan             | Namespace/name of the ReleasePlan                       | No       | -             |
+| releasePlanAdmission    | Namespace/name of the ReleasePlanAdmission              | No       | -             |
+| releaseServiceConfig    | Namespace/name of the ReleaseServiceConfig              | No       | -             |
+| snapshot                | Namespace/name of the Snapshot                          | No       | -             |
+| requireInternalServices | Whether to check if internal requests can be created    | Yes      | false         |
+
+## Changes in 0.3.0
+* Added `requireInternalServices` parameter to determine if internal request checks are required.
 
 ## Changes in 0.2.0
 * Updated the base image used in this task from `hacbs-release/cloud-builders` to `redhat-appstudio/release-service-utils` image

--- a/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -76,6 +76,8 @@ spec:
           value: default/releaseserviceconfig-sample
         - name: snapshot
           value: default/snapshot-sample
+        - name: requireInternalServices
+          value: "true"
       runAfter:
         - setup
   finally:

--- a/tasks/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/verify-access-to-resources/verify-access-to-resources.yaml
@@ -27,6 +27,10 @@ spec:
     - name: snapshot
       description: Namespace/name of the Snapshot
       type: string
+    - name: requireInternalServices
+      description: Whether internal services are required
+      type: string
+      default: "false"
   steps: 
     - name: verify-access-to-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -48,7 +52,12 @@ spec:
           CAN_I_READ_RELEASESERVICECONFIG=$(kubectl auth can-i get releaseserviceconfig/${RELEASESERVICECONFIG_NAME}\
               -n ${RSC_NAMESPACE})
           CAN_I_READ_SNAPSHOTS=$(kubectl auth can-i get snapshot/${SNAPSHOT_NAME} -n ${ORIGIN_NAMESPACE})
-          CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
+
+          if [ "$(params.requireInternalServices)" = "true" ]; then
+            CAN_I_CREATE_INTERNALREQUESTS=$(kubectl auth can-i create internalrequest -n ${TARGET_NAMESPACE})
+          else
+            CAN_I_CREATE_INTERNALREQUESTS="skipped"
+          fi
 
           echo ""
           echo "CAN_I_READ_RELEASES? ${CAN_I_READ_RELEASES}"


### PR DESCRIPTION
Added a new parameter, requireInternalServices, to the verify-access-to-resources task. This allows pipelines that don't need access to internal service to skip the check.

Changes:
- Added a new parameter `requireInternalServices`
- Set the default value of `requireInternalServices` to `false`.
- Updated existing pipelines to use the new parameter.
- Updated README to document the new parameter and its usage.