### PR TITLE
feat(RELEASE-982): add the catalog (RHEC) url to a results file

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes     | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                       | No       | -             |
 
+## Changes in 1.1.0
+* The `publish-pyxis-repository` now gets the `resultsDirPath` parameter from the `collect-data` results
+
 ## Changes in 1.0.1
 * Increase `rh-sign-image` timeout from 600s to 1200s as we have seen reports
   of it timing out while waiting for internalRequests to complete.

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -392,6 +392,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision       | The revision in the taskGitUrl repo to be used                               | No       | -             |
 
+## Changes in 4.1.0
+* The `publish-pyxis-repository` now gets the `resultsDirPath` parameter from the `collect-data` results
+
 ## Changes in 4.0.1
 * Increase `rh-sign-image` timeout from 600s to 1200s as we have seen reports
   of it timing out while waiting for internalRequests to complete.

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.0.1"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -347,6 +347,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -15,12 +15,17 @@ does not publish the repository.
 
 ## Parameters
 
-| Name         | Description                                                                                       | Optional | Default value      |
-|--------------|---------------------------------------------------------------------------------------------------|----------|--------------------|
-| server       | The server type to use. Options are 'production' and 'stage'                                      | Yes      | production         |
-| pyxisSecret  | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert | No       | -                  |
-| snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       | -                  |
-| dataPath     | Path to the JSON string of the merged data to use in the data workspace                           | No       | -                  |
+| Name           | Description                                                                                      | Optional | Default value   |
+|----------------|--------------------------------------------------------------------------------------------------|----------|-----------------|
+| server         | The server type to use. Options are 'production' and 'stage'                                     | Yes      | production      |
+| pyxisSecret    | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert| No       | -               |
+| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace                        | No       |                 |
+| dataPath       | Path to the JSON string of the merged data to use in the data workspace                          | No       |                 |
+| resultsDirPath | Path to the results directory in the data workspace                                              | No       |                 |
+
+## Changes in 2.0.0
+* Added JSON results output for published repositories, contains Catalog (RHEC) URL
+* Introduced a new `resultsDirPath` parameter to specify the path to the results directory
 
 ## Changes in 1.1.0
 * Updated the base image used in this task
@@ -40,7 +45,7 @@ does not publish the repository.
 * Add option to skip publishing via `skipRepoPublishing` flag in the data file
 
 ## Changes in 0.3.0
-* remove `dataPath` and `snapshotPath` default values
+* Remove `dataPath` and `snapshotPath` default values
 
 ## Changes in 0.2.2
 * Add support for server types of production-internal and stage-internal

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,9 @@ spec:
       type: string
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+    - name: resultsDirPath
+      description: Path to the results directory in the data workspace
       type: string
   workspaces:
     - name: data
@@ -85,6 +88,10 @@ spec:
         fi
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/publish-pyxis-repository-results.json"
+
+        # Use a unique key to avoid conflicts with other tasks
+        RESULTS_JSON='{"catalog_urls":[]}'
 
         # Default to false
         if [[ -f "${DATA_FILE}" && $(jq -r ".pyxis.skipRepoPublishing" "${DATA_FILE}") == "true" ]] ; then
@@ -102,6 +109,7 @@ spec:
         do
             COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
             PAYLOAD='{"published":true}'
+            COMPONENT_NAME=$(jq -r '.name' <<< "$COMPONENT")
             REPOSITORY=$(jq -r '.repository' <<< $COMPONENT)
             PYXIS_REPOSITORY=${REPOSITORY##*/}
             # Replace "----" with "/"
@@ -136,6 +144,24 @@ spec:
 
             curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
                 -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
+
+            # Determine the correct CATALOG_BASE_URL based on the repository prefix
+            if [[ "$REPOSITORY" == quay.io/redhat-prod/* ]]
+            then
+              CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
+            elif [[ "$REPOSITORY" == quay.io/redhat-pending/* ]]
+            then
+              CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
+            else
+              echo "Unknown repository prefix. Exiting..."
+              exit 1
+            fi
+
+            URL="${CATALOG_BASE_URL}/${PYXIS_REPOSITORY}/${PYXIS_REPOSITORY_ID}"
+            RESULTS_JSON=$(jq --arg name "$COMPONENT_NAME" --arg url "$URL" \
+              '.catalog_urls += [{"name": $name, "url": $url}]' <<< "$RESULTS_JSON")
         done
+
+        jq <<< "${RESULTS_JSON}" | tee "$RESULTS_FILE"
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
@@ -25,6 +25,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -63,6 +65,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: mydata.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -24,6 +24,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -45,6 +47,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: ""
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -26,6 +26,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -47,6 +49,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: ""
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
@@ -22,6 +22,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: ""
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -23,6 +23,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -43,6 +45,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: ""
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -24,6 +24,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -52,6 +54,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -24,6 +24,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -53,7 +55,9 @@ spec:
         - name: snapshotPath
           value: snapshot_spec.json
         - name: dataPath
-          value: data.json          
+          value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -25,6 +25,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir "$(workspaces.data.path)"/results
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
@@ -55,6 +57,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: mydata.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
@@ -21,6 +21,8 @@ spec:
           value: ""
         - name: dataPath
           value: ""
+        - name: resultsDirPath
+          value: results
         - name: server
           value: qa
       workspaces:

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-publish-pyxis-repository
 spec:
   description: |
-    Run the publish-pyxis-repository task with multiple components.
+    Run the publish-pyxis-repository task with multiple components and verify catalog URLs.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -23,18 +23,23 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
+              mkdir -p "$(workspaces.data.path)/results"
+
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                    "repository": "quay.io/redhat-prod/my-product----my-image1",
+                    "name": "component1"
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image2"
+                    "repository": "quay.io/redhat-prod/my-product----my-image2",
+                    "name": "component2"
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image3"
+                    "repository": "quay.io/redhat-prod/my-product----my-image3",
+                    "name": "component3"
                   }
                 ]
               }
@@ -50,6 +55,8 @@ spec:
           value: snapshot_spec.json
         - name: dataPath
           value: data.json
+        - name: resultsDirPath
+          value: results
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -68,6 +75,38 @@ spec:
             script: |
               #!/usr/bin/env sh
               set -eux
+
+              RESULTS_FILE="$(workspaces.data.path)/results/publish-pyxis-repository-results.json"
+
+              if [ ! -f "$RESULTS_FILE" ]; then
+                  echo "Error: Results file not found."
+                  exit 1
+              fi
+
+              EXPECTED_RESULTS='{
+                "catalog_urls": [
+                  {
+                    "name": "component1",
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image1/1"
+                  },
+                  {
+                    "name": "component2",
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image2/3"
+                  },
+                  {
+                    "name": "component3",
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image3/5"
+                  }
+                ]
+              }'
+
+              # Use jq to compare JSON objects
+              if ! echo "$EXPECTED_RESULTS" | jq --argfile actual "$RESULTS_FILE" -e '. == $actual' > /dev/null; then
+                  echo "Error: Results do not match expected output."
+                  echo "Expected: $EXPECTED_RESULTS"
+                  echo "Actual: $(cat "$RESULTS_FILE")"
+                  exit 1
+              fi
 
               if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 6 ]; then
                   echo Error: curl was expected to be called 6 times. Actual calls:


### PR DESCRIPTION
This commit adds the catalog (RHEC) url to a results file A task generates a results/publish-pyxis-repository-results.json file with all the catalog url generated.