### PR TITLE
Drop enterpriseContractPublicKey param from all pipelines

### DIFF
--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -13,13 +13,15 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 3.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ### Changes in 2.2.2
 - Increase `enterpriseContractTimeout` parameter default value.

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: e2e
   labels:
-    app.kubernetes.io/version: "2.2.2"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,10 +32,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -110,8 +106,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -12,13 +12,15 @@ Tekton release pipeline to interact with FBC Pipeline
 | releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                         | No        | -                                                               |
 | snapshot                        | The namespaced name (namespace/name) of the snapshot                                                     | No        | -                                                               |
 | enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                      | No        | -                                                               |
-| enterpriseContractPublicKey     | Public key to use for validation by the enterprise contract                                              | Yes       | k8s://openshift-pipelines/public-key                            |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..."                                              | Yes       | pipeline_intention=release                            |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
+
+### Changes in 4.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ### Changes in 3.7.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -165,8 +161,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -12,13 +12,15 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 1.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ### Changes in 0.3.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -134,8 +130,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/push-disk-images-to-cdn/README.md
+++ b/pipelines/push-disk-images-to-cdn/README.md
@@ -12,13 +12,15 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 10m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+## Changes in 1.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ## Changes in 0.2.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.

--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -154,8 +150,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -12,13 +12,15 @@ Tekton pipeline to release Snapshots to an external registry.
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 5.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ### Changes in 4.8.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.8.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -156,8 +152,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -12,13 +12,15 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
+
+### Changes in 4.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
 ### Changes in 3.6.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "3.6.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,10 +32,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -153,8 +149,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -15,7 +15,6 @@ the rh-push-to-registry-redhat-io pipeline.
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
@@ -23,13 +22,16 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
+## Changes in 1.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
+
 ### Changes in 0.14.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
 
 ## Changes in 0.13.3
 - Bugfix: block pipeline progress on the verify-enterprise-contract.
 
-### Changes in 0.13.2
+## Changes in 0.13.2
 - Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 0.13.1

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "0.14.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -187,8 +183,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -12,7 +12,6 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
@@ -20,10 +19,13 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-### Changes in 4.10.0
+## Changes in 5.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
+
+## Changes in 4.10.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
 
-### Changes in 4.9.2
+## Changes in 4.9.2
 - Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 4.9.1

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "4.10.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -156,8 +152,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -12,7 +12,6 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
@@ -20,10 +19,13 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-### Changes in 3.11.0
+## Changes in 4.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
+
+## Changes in 3.11.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
 
-### Changes in 3.10.2
+## Changes in 3.10.2
 - Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 3.10.1

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "3.11.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -183,8 +179,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -14,7 +14,6 @@
 | releaseServiceConfig | The namespaced name (namespace/name) of the releaseServiceConfig | No | - |
 | snapshot | The namespaced name (namespace/name) of the snapshot | No | - |
 | enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
-| enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                        | Yes       | 40m0s                                                           |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
@@ -22,10 +21,13 @@
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used | No | - |
 
-### Changes in 3.12.0
+## Changes in 4.0.0
+- Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
+
+## Changes in 3.12.0
 - Add `requireInternalServices` parameter to the 'verify-access-to-resources' task.
 
-### Changes in 3.11.2
+## Changes in 3.11.2
 - Increase `enterpriseContractTimeout` parameter default value.
 
 ## Changes in 3.11.1

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "3.12.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,10 +31,6 @@ spec:
     - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
-    - name: enterpriseContractPublicKey
-      type: string
-      description: Public key to use for validation by the enterprise contract
-      default: k8s://openshift-pipelines/public-key
     - name: enterpriseContractExtraRuleData
       type: string
       description: |
@@ -156,8 +152,6 @@ spec:
           value: "1"
         - name: IGNORE_REKOR
           value: "true"
-        - name: PUBLIC_KEY
-          value: $(params.enterpriseContractPublicKey)
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT


### PR DESCRIPTION
Users can specify a key on their policy resource, but it gets ignored since these param values always override it with that openshift-pipelines key.

After this change, the verify task will always take the value from the policy.

https://issues.redhat.com/browse/KONFLUX-3963