### PR TITLE
feat(RHTAPWATCH-1204): use custom cert in push-snapshot

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -4,12 +4,17 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 
 ## Parameters
 
-| Name               | Description                                                               | Optional | Default value        |
-|--------------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath       | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -                    |
-| dataPath           | Path to the JSON string of the merged data to use in the data workspace   | No       | -                    |
-| resultsDirPath     | Path to results directory in the data workspace                           | No       | -                    |
-| retries            | Retry copy N times                                                        | Yes      | 0                    |
+| Name                 | Description                                                               | Optional | Default value        |
+|----------------------|---------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath         | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -                    |
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace   | No       | -                    |
+| resultsDirPath       | Path to results directory in the data workspace                           | No       | -                    |
+| retries              | Retry copy N times                                                        | Yes      | 0                    |
+| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca           |
+| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt        |
+
+## Changes in 6.3.0
+* Add support for custom CA cert in push-snapshot task
 
 ## Changes in 6.2.1
 * Create new docker config for each cosign call

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.2.1"
+    app.kubernetes.io/version: "6.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,6 +25,14 @@ spec:
       description: Retry copy N times.
       type: string
       default: "0"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
   workspaces:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
@@ -179,3 +187,16 @@ spec:
         done
         echo -n "${RESULTS_JSON}" | tee $RESULTS_FILE
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
+      volumeMounts:
+        - name: trusted-ca
+          mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true

--- a/tasks/push-snapshot/tests/mocks.sh
+++ b/tasks/push-snapshot/tests/mocks.sh
@@ -17,6 +17,15 @@ function cosign() {
     fi
   fi
 
+  if [[ "$*" == "copy -f private-registry.io/image:tag "*":"* ]]
+  then
+    if [[ $(cat /etc/ssl/certs/ca-custom-bundle.crt) != "mycert" ]]
+    then
+      echo Custom certificate not mounted
+      return 1
+    fi
+  fi
+
   if [[ "$*" != "copy -f "*":"*" "*":"* ]]
   then
     echo Error: Unexpected call

--- a/tasks/push-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/push-snapshot/tests/pre-apply-task-hook.sh
@@ -5,3 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
 yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy configmap (and delete it first if it exists)
+kubectl delete configmap test-use-custom-ca-cert --ignore-not-found
+kubectl create configmap test-use-custom-ca-cert --from-literal=cert=mycert

--- a/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-mount-certs
+spec:
+  description: |
+    Run the push-snapshot task and verify custom certificate is mounted
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir $(workspaces.data.path)/results
+              cat > $(workspaces.data.path)/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repository": "prod-registry.io/prod-location1",
+                    "tags": [
+                      "tag1-12345",
+                      "tag2-zyxw"
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "private-registry.io/image:tag",
+                    "repository": "prod-registry.io/prod-location2",
+                    "tags": [
+                      "some-cool-tag"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: results
+        - name: caTrustConfigMapName
+          value: test-use-custom-ca-cert
+        - name: caTrustConfigMapKey
+          value: cert
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # 2 for comp1 (the 2 provided tags)
+              # 3 for comp2 (provided tag, once for image, once for source container, + once for source tag)
+              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
+                cat $(workspaces.data.path)/mock_cosign.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat $(workspaces.data.path)/mock_skopeo.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_oras.txt | wc -l) != 8 ]; then
+                echo Error: oras was expected to be called 8 times. Actual calls:
+                cat $(workspaces.data.path)/mock_oras.txt
+                exit 1
+              fi
+
+              test $(jq -r '.images[0].name' $(workspaces.data.path)/results/push-snapshot-results.json) == "comp1"
+              test $(jq -r '.images[0].shasum' $(workspaces.data.path)/results/push-snapshot-results.json) == \
+                "sha256:6ff029b0b6cf82e3df2a2360dc88cd527c51132b557207d64634d9c245e0d15e"
+              test $(jq -r '.images[0].urls | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "2"
+              test $(jq -r '.images[0].arches | length' $(workspaces.data.path)/results/push-snapshot-results.json) \
+                == "2"
+      runAfter:
+        - run-task


### PR DESCRIPTION
Adjusting the push-snapshot task so it can push to a repository that uses a self-signed certificate. It does that by mounting a config map containing custom CA certificate/bundle to a path which the OS uses for loading certificates.