### PR TITLE
fix(RELEASE-1118): fix partial oci auth match in rpm task

### DIFF
--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -11,6 +11,11 @@ Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 0.4.3
+* Create new docker config for each `cosign download sbom` call
+  * It only contains an entry for the specific image
+  * This is to fix a bug with partial oci auth matches
+
 ## Changes in 0.4.2
 * fixed a bug that would treat a multiarch image containing just one arch as a plain single arch image
 

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-manifests-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.4.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -54,11 +54,16 @@ spec:
 
         mkdir /workdir/sboms
         cd /workdir/sboms
+        DOCKER_CONFIG="$(mktemp -d)"
+        export DOCKER_CONFIG
 
         for (( i=0; i < $NUM_COMPONENTS; i++ )); do
           COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
           IMAGEURL=$(jq -r '.containerImage' <<< "${COMPONENT}")
           NUM_PYXIS_IMAGES=$(jq '.pyxisImages | length' <<< "${COMPONENT}")
+          # cosign has very limited support for selecting the right auth entry,
+          # so create a custom auth file with just one entry
+          select-oci-auth "$IMAGEURL" > "$DOCKER_CONFIG"/config.json
           for (( j=0; j < $NUM_PYXIS_IMAGES; j++ )); do
             PYXIS_IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< "${COMPONENT}")
             FILE="$(jq -r '.imageId' <<< "$PYXIS_IMAGE").json"

--- a/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/mocks.sh
@@ -44,3 +44,7 @@ function upload_rpm_manifest() {
     rm $LOCK_FILE
   fi
 }
+
+function select-oci-auth() {
+  echo $* >> $(workspaces.data.path)/mock_select-oci-auth.txt
+}

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
@@ -94,5 +94,11 @@ spec:
                 cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
                 exit 1
               fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_select-oci-auth.txt")" != 2 ]; then
+                echo Error: select-oci-with was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_select-oci-auth.txt"
+                exit 1
+              fi
       runAfter:
         - run-task


### PR DESCRIPTION
cosign is flakey when there are partially matching auth entries in the docker config file. This commit modifies the push-rpm-manifests-to-pyxis task to create a new docker config file for each image processed so that the only entry in the docker config file will be one for the image about to have its sbom downloaded.