### PR TITLE
chore(KFLUXBUGS-1480): bump base image in rpm-manifest task

### DIFF
--- a/tasks/push-rpm-manifests-to-pyxis/README.md
+++ b/tasks/push-rpm-manifests-to-pyxis/README.md
@@ -11,6 +11,11 @@ Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 0.4.4
+* Updated the base image used in this task
+  * The new image contains an updated upload_rpm_manifest script that will retry the POST
+    request if it fails with error code 504
+
 ## Changes in 0.4.3
 * Create new docker config for each `cosign download sbom` call
   * It only contains an entry for the specific image

--- a/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-manifests-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.3"
+    app.kubernetes.io/version: "0.4.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,7 +36,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+        quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -93,7 +93,7 @@ spec:
 
     - name: push-rpm-manifests-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+        quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-manifests-to-pyxis/tests/test-push-rpm-manifests-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
The base image in the upload-rpm-manifests task is bumped to include a change in the utils image that will retry the POST request if it fails with HTTP error code 504.