### PR TITLE
fix: increase request timeout for rh-sign-image

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes     | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                       | No       | -             |
 
+## Changes in 1.0.1
+* Increase `rh-sign-image` timeout from 600s to 1200s as we have seen reports
+  of it timing out while waiting for internalRequests to complete.
+
 ## Changes in 1.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -339,8 +339,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
           # The RADAS timeout when it fails to receive a response is 5 mins.
-          # We double the requestTimeout to allow RADAS to retry its request.
-          value: 600
+          # We quadruple the requestTimeout to allow RADAS to retry its request.
+          value: 1200
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -9,7 +9,7 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | release               | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No | - |
 | releasePlan           | The namespaced name (namespace/name) of the releasePlan                      | No       | -             |
 | releasePlanAdmission  | The namespaced name (namespace/name) of the releasePlanAdmission             | No       | -             |
-| releaseServiceConfig  | The namespaced name (namespace/name) of the releaseServiceConfig             | No       | -             | 
+| releaseServiceConfig  | The namespaced name (namespace/name) of the releaseServiceConfig             | No       | -             |
 | snapshot              | The namespaced name (namespace/name) of the snapshot                         | No       | -             |
 | enterpriseContractPolicy        | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
@@ -18,6 +18,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task    | No       | -             |
 | taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision       | The revision in the taskGitUrl repo to be used                               | No       | -             |
+
+## Changes in 4.0.1
+* Increase `rh-sign-image` timeout from 600s to 1200s as we have seen reports
+  of it timing out while waiting for internalRequests to complete.
 
 ## Changes in 4.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -294,8 +294,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
           # The RADAS timeout when it fails to receive a response is 5 mins.
-          # We double the requestTimeout to allow RADAS to retry its request.
-          value: 600
+          # We quadruple the requestTimeout to allow RADAS to retry its request.
+          value: 1200
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:


### PR DESCRIPTION
Increase `rh-sign-image` timeout from 600s to 1200s as we have seen reports of it timing out while waiting for internalRequests to complete.

See this thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1723733331115419

In the log, you could see most of the internalRequests succeeding, but some still running. Here's a tail of that log that illustrates this:
```
[sign-image]   hacbs-signing-pipeline-wjq6q: succeeded
[sign-image]   hacbs-signing-pipeline-x9f96: succeeded
[sign-image]   hacbs-signing-pipeline-xjqd7: running
[sign-image] ERROR: Timeout while waiting for the InternalRequests to complete
```