### PR TITLE
fix(KFLUXBUGS-1278): expose iib errors

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -14,6 +14,10 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.2.1
+* The InternalRequest will no longer fail, so success/failure check is found from a result on the internal pipelineRun
+* The last 2,000 characters of the IIB log is printed
+
 ## Changes in 3.2.0
 * Changed the way service account secret is determined
   * Setting `.fbc.iibServiceAccountSecret` is no longer allowed (it was never used anyway). Instead, it's based on the stagedIndex setting now.

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -57,7 +57,7 @@ spec:
     - name: add-contribution
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         #
         set -eo pipefail
 
@@ -172,3 +172,7 @@ spec:
         jq '.message // "Unset"' <<< "${conditions}" | tee $(results.requestMessage.path)
 
         jq -r '.indexImageDigests' <<< "${results}" |  tee $(results.indexImageDigests.path)
+
+        jq -r '.iibLog' <<< "${results}"
+        RC="$(jq -r '.exitCode' <<< "${results}")"
+        exit "$RC"

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-ir-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the add-fbc-contribution task with an IR that has exitCode set to 1 in its status.
+    The task should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir $(workspaces.data.path)/results
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "fail.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0"
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "iibServiceConfigSecret": "test-iib-service-config-secret",
+                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "buildTimeoutSeconds": 420,
+                  "requestTimeoutSeconds": 120
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: binaryImage
+          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+        - name: fromIndex
+          value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: targetIndex
+          value: "quay.io/scoheb/fbc-target-index-testing:v4.12"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+        - name: resultsDirPath
+          value: results
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit changes the add-fbc-contribution task to show the iib logs and to handle the InternalRequest pipelineRun always exiting cleanly. It instead checks the status for the exitCode.