### PR TITLE
feat(RELEASE-1033): add support for dockerfile in create-pyxis-image

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -18,6 +18,11 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published.                                                                                                         | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       | -             |
 
+## Changes in 3.3.0
+* Updated the base image used in this task
+  * The new image supports the --dockerfile cli argument for create_container_image
+* Added support for Dockerfile upload to Pyxis
+
 ## Changes in 3.2.0
 * Updated the base image used in this task
 

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
       env:
         - name: pyxisCert
           valueFrom:
@@ -62,7 +62,7 @@ spec:
               key: key
       script: |
         #!/usr/bin/env bash
-        set -eo pipefail
+        set -exo pipefail
 
         if [[ "$(params.server)" == "production" ]]
         then
@@ -94,8 +94,12 @@ spec:
         PYXIS_DATA_PATH="$(dirname $(params.snapshotPath))/pyxis.json"
         echo -n "${PYXIS_DATA_PATH}" > $(results.pyxisDataPath.path)
 
+        set +x
         echo "${pyxisCert}" > /tmp/crt
         echo "${pyxisKey}" > /tmp/key
+        set -x
+
+        AUTH_FILE=$(mktemp)
 
         COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         JSON_OUTPUT='{}'
@@ -105,14 +109,29 @@ spec:
               '.components[$id] += { "containerImage": $image, "pyxisImages": []}' <<< "$JSON_OUTPUT")
             REPOSITORY=$(jq -r ".components[${i}].repository" "${SNAPSHOT_SPEC_FILE}")
             REPOSITORY=${REPOSITORY%:*} # strip tag just in case - it should not be there
+            SOURCE_REPO=${CONTAINER_IMAGE%%@sha256:*}
             DIGEST="${CONTAINER_IMAGE##*@}"
             PULLSPEC="${REPOSITORY}@${DIGEST}"
             MEDIA_TYPE=$(skopeo inspect --raw "docker://${PULLSPEC}" | jq -r .mediaType)
             TAGS=$(jq -r ".components[${i}].tags | join(\" \")" "${SNAPSHOT_SPEC_FILE}")
 
             # oras has very limited support for selecting the right auth entry,
-            # so create a custom auth file with just one entry
-            AUTH_FILE=$(mktemp)
+            # so create a custom auth file with just one entry before each oras call
+            select-oci-auth "${SOURCE_REPO}" > "$AUTH_FILE"
+            DOCKERFILE_DIR="$(mktemp -d)"
+            DOCKERFILE_PATH=""
+            # try fetching Dockerfile for the image
+            if oras pull --registry-config "$AUTH_FILE" "${SOURCE_REPO}:${DIGEST}.dockerfile" -o "${DOCKERFILE_DIR}"
+            then
+              DOCKERFILE_PATH="${DOCKERFILE_DIR}/Dockerfile"
+              if [ ! -f "${DOCKERFILE_PATH}" ]; then
+                echo Error: Dockerfile pull succeeded, but the Dockerfile was not saved.
+                exit 1
+              fi
+            else
+              echo "Unable to get Dockerfile for the image. Maybe it's not enabled in the build pipeline?"
+            fi
+
             select-oci-auth "${REPOSITORY}" > "$AUTH_FILE"
 
             index=0
@@ -146,7 +165,8 @@ spec:
                   --digest "$DIGEST" \
                   --architecture-digest "$ARCH_DIGEST" \
                   --architecture "$ARCH" \
-                  --rh-push $(params.rhPush) | tee "/tmp/output"
+                  --rh-push "$(params.rhPush)" \
+                  --dockerfile "${DOCKERFILE_PATH}" | tee "/tmp/output"
                 # The rh-push-to-external-registry e2e test depends on this line being in the task log
                 IMAGEID=$(awk '/The image id is/{print $NF}' /tmp/output)
 

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -61,6 +61,17 @@ function oras() {
   if [[ "$*" == "manifest fetch --registry-config"* ]]
   then
     echo '{"mediaType": "my_media_type"}'
+  elif [[ "$*" == "pull --registry-config"*dockerfile-not-found* ]]
+  then
+    echo Mock oras called with: $*
+    return 1
+  elif [[ "$*" == "pull --registry-config"*dockerfile-file-missing* ]]
+  then
+    echo Mock oras called with: $*
+  elif [[ "$*" == "pull --registry-config"* ]]
+  then
+    echo Mock oras called with: $*
+    echo mydocker > $6/Dockerfile
   else
     echo Mock oras called with: $*
     echo Error: Unexpected call

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -2,11 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-multi-containerimages-one-arch
+  name: test-create-pyxis-image-dockerfile-not-found
 spec:
   description: |
-    Run the create-pyxis-image task with multiple containerImages in the snapshot
-    and a single arch.
+    Run the create-pyxis-image task with a single containerImage in the snapshot.
+    Dockerfile artifact does not exist for this image, so oras pull will fail
+    and create_container_image will be called with an empty dockerfile path.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -29,25 +30,9 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comp1",
-                    "containerImage": "source1@mydigest1",
-                    "repository": "registry.io/image1",
-                    "tags": [
-                      "testtag"
-                    ]
-                  },
-                  {
-                    "name": "comp2",
-                    "containerImage": "source2@mydigest2",
-                    "repository": "registry.io/image2",
-                    "tags": [
-                      "testtag"
-                    ]
-                  },
-                  {
-                    "name": "comp3",
-                    "containerImage": "source3@mydigest3",
-                    "repository": "registry.io/image3",
+                    "name": "comp",
+                    "containerImage": "dockerfile-not-found@sha256:abcdef1234",
+                    "repository": "registry.io/image",
                     "tags": [
                       "testtag"
                     ]
@@ -87,11 +72,11 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
-              #!/usr/bin/env bash
+              #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 3 ]; then
-                echo Error: create_container_image was expected to be called 3 times. Actual calls:
+              if [ $(cat $(workspaces.data.path)/mock_create_container_image.txt | wc -l) != 1 ]; then
+                echo Error: create_container_image was expected to be called 1 time. Actual calls:
                 cat $(workspaces.data.path)/mock_create_container_image.txt
                 exit 1
               fi
@@ -102,39 +87,44 @@ spec:
                 exit 1
               fi
 
-              cat > $(workspaces.data.path)/skopeo_expected_calls.txt << EOF
-              inspect --raw docker://registry.io/image1@mydigest1
-              inspect --raw docker://registry.io/image2@mydigest2
-              inspect --raw docker://registry.io/image3@mydigest3
-              EOF
-
-              # check that the actual calls match the expected calls
-              if [ "$(cat $(workspaces.data.path)/skopeo_expected_calls.txt | md5sum)" \
-                != "$(cat $(workspaces.data.path)/mock_skopeo.txt | md5sum)" ]
+              if ! grep -- "--tags testtag" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: Actual skopeo calls do not match expected calls.
-                echo Expected calls:
-                cat $(workspaces.data.path)/skopeo_expected_calls.txt
-                echo Actual calls:
+                echo Error: create_container_image call was expected to include "--tags testtag". Actual call:
+                cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if ! grep -- "--rh-push false" < $(workspaces.data.path)/mock_create_container_image.txt 2> /dev/null
+              then
+                echo Error: create_container_image call was expected to include "--rh-push false". Actual call:
+                cat $(workspaces.data.path)/mock_create_container_image.txt
+                exit 1
+              fi
+
+              if [ $(cat $(workspaces.data.path)/mock_skopeo.txt | wc -l) != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
                 cat $(workspaces.data.path)/mock_skopeo.txt
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 6 ]; then
-                echo Error: oras was expected to be called 6 times. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 2 ]; then
+                echo Error: oras was expected to be called 2 times. Actual calls:
                 cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi
+
+              [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
+                = "inspect --raw docker://registry.io/image@sha256:abcdef1234" ]
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
                 and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
 
-              jq -e '.components[1].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )
-                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
-
-              jq -e '.components[2].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0003" )
-                and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_select-oci-auth.txt")" != 2 ]; then
+                echo Error: select-oci-with was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_select-oci-auth.txt"
+                exit 1
+              fi
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-fail-dockerfile-not-pulled
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-pyxis-image task with a single containerImage in the snapshot.
+    oras command to pull dockerfile will succeed, but there will be no Dockerfile saved,
+    so the task fails.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/mapped_snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "dockerfile-file-missing@sha256:abcdef1234",
+                    "repository": "registry.io/image",
+                    "tags": [
+                      "testtag"
+                    ]
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+        - name: snapshotPath
+          value: mapped_snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -120,9 +120,9 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_oras.txt | wc -l) != 6 ]; then
-                echo Error: oras was expected to be called 6 times. Actual calls:
-                cat $(workspaces.data.path)/mock_oras.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 9 ]; then
+                echo Error: oras was expected to be called 9 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi
 

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -109,9 +109,9 @@ spec:
               [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
               = "inspect --raw docker://registry.io/multi-arch-image@mydigest" ]
 
-              if [ $(cat $(workspaces.data.path)/mock_oras.txt | wc -l) != 2 ]; then
-                echo Error: oras was expected to be called 2 times. Actual calls:
-                cat $(workspaces.data.path)/mock_oras.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 3 ]; then
+                echo Error: oras was expected to be called 3 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi
 
@@ -121,6 +121,12 @@ spec:
 
               jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
                 and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_select-oci-auth.txt")" != 2 ]; then
+                echo Error: select-oci-with was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_select-oci-auth.txt"
+                exit 1
+              fi
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -68,7 +68,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -105,9 +105,9 @@ spec:
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_oras.txt | wc -l) != 1 ]; then
-                echo Error: oras was expected to be called 1 time. Actual calls:
-                cat $(workspaces.data.path)/mock_oras.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 2 ]; then
+                echo Error: oras was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi
 
@@ -117,6 +117,12 @@ spec:
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
                 and ( .os == "linux" )' $(workspaces.data.path)/$(params.pyxisDataPath)
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_select-oci-auth.txt")" != 2 ]; then
+                echo Error: select-oci-with was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_select-oci-auth.txt"
+                exit 1
+              fi
 
       runAfter:
         - run-task

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
If we're able to pull the dockerfile oci artifact, we will add it to Pyxis when creating the ContainerImage object.

At least initially, most builds will not produce this artifact, so if the oras pull command fails, silently ignore it.

If oras pull succeeds, but no Dockerfile is saved, the task will fail as that would suggest that the artifact was produced incorrectly at build time and it should be investigated.