### PR TITLE
feat(RELEASE-1037): add placeholder internal resources

### DIFF
--- a/internal/pipelines/e2e/README.md
+++ b/internal/pipelines/e2e/README.md
@@ -1,0 +1,62 @@
+# E2E test Pipeline
+
+Minimal Tekton Pipeline to be used by the E2E tests. The Pipeline is designed to include only tasks that could be
+affected by RHTAP services or which results could affect the RHTAP workflow.
+
+## Parameters
+
+| Name                            | Description                                                                                            | Optional | Default value |
+|---------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No       | -             |
+| releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                | No       | -             |
+| releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                       | No       | -             |
+| releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                       | No       | -             |
+| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                   | No       | -             |
+| enterpriseContractPolicy        | JSON representation of the policy to be applied when validating the enterprise contract                | No       | -             |
+| enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes | pipeline_intention=release |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                      | Yes      | 40m0s         |
+| postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                             | Yes      | true          |
+| verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                              | No       | -             |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
+
+## Changes in 3.0.0
+* Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
+
+## Changes in 2.2.2
+* Increase `enterpriseContractTimeout` parameter default value.
+
+## Changes in 2.2.1
+* Add `enterpriseContractTimeout` parameter.
+
+## Changes in 2.2.0
+* `enterpriseContractExtraRuleData` added as a pipeline parameter, which is
+  then passed to EC. Allows for easier runtime changes to rule data.
+
+## Changes in 2.1.0
+* update the taskGitUrl default value due to migration
+  to konflux-ci GitHub org
+
+## Changes in 2.0.0
+* releaseServiceConfig added as a pipeline parameter that is passed to the collect-data task
+
+## Changes in 1.0.0
+* Parameters supplied by the Release Service operator now use camelCase format
+
+## Changes in 0.5.0
+* Modified the pipeline to dynamically source the `snapshot_spec.json`
+  file from the results of the `collect-data` task.
+
+## Changes in 0.4.1
+* The cleanup-workspace task now receives a pipelineRunUid parameter to cleanup InternalRequests
+
+## Changes in 0.4.0
+* taskGitRevision no longer has a default. It will be provided by the operator and will always have the same value as
+  the git revision in the PipelineRef definition of the PipelineRun if using a git resolver. See RHTAPREL-790 for details
+
+## Changes in 0.3.0
+* taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks
+* taskGitRevision parameter is added. It is used to provide the revision to be used in the taskGitUrl repo
+
+## Changes in 0.1.0
+* Switch to using bundle resolvers for the verify-enterprise-contract task

--- a/internal/pipelines/e2e/e2e.yaml
+++ b/internal/pipelines/e2e/e2e.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: e2e
+  labels:
+    app.kubernetes.io/version: "3.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Minimal Tekton Pipeline to be used by the E2E tests. The Pipeline is designed to include only tasks that could be
+    affected by RHTAP services or which results could affect the RHTAP workflow.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: enterpriseContractTimeout
+      type: string
+      description: Timeout setting for `ec validate`
+      default: 40m0s
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: $(params.verify_ec_task_bundle)
+          - name: kind
+            value: task
+          - name: name
+            value: verify-enterprise-contract
+      params:
+        - name: IMAGES
+          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: TIMEOUT
+          value: $(params.enterpriseContractTimeout)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
+  finally:
+    - name: cleanup
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/cleanup-workspace/cleanup-workspace.yaml
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/internal/resources/cleanup-workspace.yaml
+++ b/internal/resources/cleanup-workspace.yaml
@@ -1,0 +1,1 @@
+../tasks/cleanup-workspace/cleanup-workspace.yaml

--- a/internal/resources/e2e.yaml
+++ b/internal/resources/e2e.yaml
@@ -1,0 +1,1 @@
+../pipelines/e2e/e2e.yaml

--- a/internal/tasks/cleanup-workspace/README.md
+++ b/internal/tasks/cleanup-workspace/README.md
@@ -1,0 +1,34 @@
+# cleanup-workspace
+
+Tekton task to delete a given directory in a passed workspace and cleanup InternalRequests related to the current PipelineRun.
+
+## Parameters
+
+| Name           | Description                                                                                                      | Optional | Default value |
+|----------------|------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| subdirectory   | The directory to remove within the workspace                                                                     | No       | -             |
+| delay          | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
+| pipelineRunUid | The uid of the current pipelineRun. It is only available at the pipeline level                                   | Yes      | ""            |
+
+## Changes in 0.8.0
+* Updated the base image used in this task
+
+## Changes in 0.7.0
+* Updated the base image used in this task
+
+## Changes in 0.6.0
+* The task now removes all internalrequest CRs for the current pipelinerun via the pipelineRunUid parameter
+
+## Changes in 0.4.0
+* Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
+
+## Changes in 0.3.0
+* Add delay parameter with a default of 60 (in seconds)
+
+## Changes in 0.2
+* Update Tekton API to v1
+
+## Changes in 0.1
+* Base image was changed from `release-utils` to `release-base-image`
+* The syntax for `taskRef.bundle` and `pipelineRef.bundle` is deprecated,
+  bundles resolver is used with new format.

--- a/internal/tasks/cleanup-workspace/cleanup-workspace.yaml
+++ b/internal/tasks/cleanup-workspace/cleanup-workspace.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: cleanup-workspace
+  labels:
+    app.kubernetes.io/version: "0.8.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to delete a given directory in a passed workspace
+  params:
+    - name: subdirectory
+      type: string
+      description: The directory to remove within the workspace
+    - name: delay
+      type: string
+      default: 60
+      description: Time in seconds to delay the cleanup action
+    - name: pipelineRunUid
+      type: string
+      default: ""
+      description: The uid of the current pipelineRun. It is only available at the pipeline level
+  workspaces:
+    - name: input
+      description: Workspace where the directory to cleanup exists
+  steps:
+    - name: cleanup
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        if [ -n "$(params.pipelineRunUid)" ] ; then
+            # Cleanup all internalrequests
+            kubectl delete internalrequest \
+                -l internal-services.appstudio.openshift.io/pipelinerun-uid=$(params.pipelineRunUid)
+        fi
+
+        if [ -z "$(params.subdirectory)" ] ; then
+            echo "The empty string is not a valid subdirectory"
+            exit 0
+        fi
+
+        echo "Delaying execution by $(params.delay) seconds"
+        sleep $(params.delay)
+
+        CLEANUP_DIR="$(workspaces.input.path)/$(params.subdirectory)"
+
+        if [ -d "${CLEANUP_DIR}" ] ; then
+          # Delete a directory and its contents
+          rm -rf "${CLEANUP_DIR}"/
+        fi

--- a/internal/tasks/cleanup-workspace/tests/mocks.sh
+++ b/internal/tasks/cleanup-workspace/tests/mocks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function sleep() {
+  echo "mocked sleep with arg:" "$*"
+}

--- a/internal/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
+++ b/internal/tasks/cleanup-workspace/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get internalrequests
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-cleanup-workspace-internalrequests
+spec:
+  description: |
+    Run the cleanup-workspace task with internalrequests created
+    to ensure the proper ones are cleaned up
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      params:
+        - name: uid
+          value: $(context.pipelineRun.uid)
+      taskSpec:
+        params:
+          - name: uid
+            type: string
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              cat > irs << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: InternalRequest
+              metadata:
+                name: ir-1
+              spec:
+                request: foo
+              ---
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: InternalRequest
+              metadata:
+                name: ir-2
+                labels:
+                  internal-services.appstudio.openshift.io/pipelinerun-uid: $(params.uid)
+              spec:
+                request: foo
+              EOF
+              kubectl apply -f irs
+    - name: run-task
+      taskRef:
+        name: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: ""
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: input
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/bin/sh
+              set -ex
+
+              # Make sure ir-1 was not deleted
+              if ! kubectl get internalrequest ir-1 ; then
+                  echo "InternalRequest ir-1 was deleted and should not have been"
+                  exit 1
+              fi
+
+              # Make sure ir-2 was deleted
+              if kubectl get internalrequest ir-2 ; then
+                  echo "InternalRequest ir-2 was not deleted and should have been"
+                  exit 1
+              fi
+
+              kubectl delete internalrequests --all

--- a/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-invalid-subdirectory.yaml
+++ b/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-invalid-subdirectory.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-cleanup-workspace-invalid-subdirectory
+spec:
+  description: |
+    Run the cleanup-workspace task with a custom workspace
+    and test scenario when the parameter points to a non-existing directory  
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task-invalid-dir
+      taskRef:
+        name: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: "nonexisting"
+      workspaces:
+        - name: input
+          workspace: tests-workspace

--- a/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-no-subdirectory.yaml
+++ b/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace-no-subdirectory.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-cleanup-workspace-no-subdirectory
+spec:
+  description: |
+    Run the cleanup-workspace task with a custom workspace
+    and test scenario when subdirectory parameter is empty  
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task-empty-string
+      taskRef:
+        name: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: ""
+      workspaces:
+        - name: input
+          workspace: tests-workspace

--- a/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace.yaml
+++ b/internal/tasks/cleanup-workspace/tests/test-cleanup-workspace.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-cleanup-workspace
+spec:
+  description: |
+    Run the cleanup-workspace task with a custom workspace
+    and verify that the cleanup is performed in the given subdirectory.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: input
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: input
+        steps:
+          - name: put-content-in-workspace
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              KEPT_DIR="$(workspaces.input.path)/dir-to-be-kept"
+              REMOVED_DIR="$(workspaces.input.path)/dir-to-be-cleaned-up"
+              mkdir -p $REMOVED_DIR
+              echo "This file and dir will be deleted" >> $REMOVED_DIR/cleanup_test.txt
+              mkdir -p $KEPT_DIR
+              echo "Test successful" >> $KEPT_DIR/cleanup_check.txt
+    - name: run-task
+      taskRef:
+        name: cleanup-workspace
+      params:
+        - name: subdirectory
+          value: "dir-to-be-cleaned-up"
+      runAfter:
+        - setup
+      workspaces:
+        - name: input
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: input
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: input
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              KEPT_DIR="$(workspaces.input.path)/dir-to-be-kept"
+              REMOVED_DIR="$(workspaces.input.path)/dir-to-be-cleaned-up"
+              # Check REMOVED_DIR is deleted and KEPT_DIR is present!
+              if [ -d "$REMOVED_DIR" ]
+              then
+                  echo Dir $REMOVED_DIR is expected to be deleted, but still exists
+                  exit 1
+              fi
+
+              if [ ! -d "$KEPT_DIR" ] || [ ! -f "${KEPT_DIR}/cleanup_check.txt" ]
+              then
+                  echo File ${KEPT_DIR}/cleanup_check.txt is expected to exist, but it does not
+                  exit 1
+              fi   


### PR DESCRIPTION
This commit adds a placeholder task and pipeline in the internal/tasks and internal/pipelines directories respectively. These are just placeholders to test the CI and internal mapping work properly. Once other tasks and pipelines are migrated as part of this epic, they will be removed.