### PR TITLE
feat(KFLUXBUGS-1417): use stage creds for staged index iib requests

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -15,10 +15,6 @@
           "type": "string",
           "description": "The secret containing the information required by the IIB service e.g. example-iib-service-config-secret"
         },
-        "iibServiceAccountSecret": {
-          "type": "string",
-          "description": "The secret used to authenticate the IIB service account"
-        },
         "request": {
           "type": "string",
           "description": "The internal pipeline name to handle requests e.g. iib"

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -14,6 +14,14 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.2.0
+* Changed the way service account secret is determined
+  * Setting `.fbc.iibServiceAccountSecret` is no longer allowed (it was never used anyway). Instead, it's based on the stagedIndex setting now.
+  * If `.fbc.stagedIndex` is `true`, we'll use `iib-service-account-stage`.
+    Otherwise we'll use `iib-service-account-prod`.
+  * The reason is that IIB has a priority queue for requests made with our prod
+    kerberos principal and we were asked to use it only for prod index requests.
+
 ## Changes in 3.1.0
 * Updated the base image used in this task
 
@@ -54,7 +62,7 @@ Task to create a internalrequest to add fbc contributions to index images
 
 ## Changes in 1.4.0
 * add the possibility of setting a stagedIndex tag
- 
+
 ## Changes in 1.3.0
 * add the possibility of setting a hotfix tag
 * replace the `fbcOptIn` result with `mustSignIndexImage` and `mustPublishIndexImage`

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "3.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -80,7 +80,6 @@ spec:
         iib_overwrite_from_index_credential=$(jq -r \
           '.fbc.iibOverwriteFromIndexCredential // "iib-overwrite-fromimage-credentials"' ${DATA_FILE})
         iib_service_config_secret=$(jq -r '.fbc.iibServiceConfigSecret // "iib-services-config"' ${DATA_FILE})
-        iib_service_account_secret=$(jq -r '.fbc.iibServiceAccountSecret // "iib-service-account"' ${DATA_FILE})
         build_tags=$(jq '.fbc.buildTags // []' ${DATA_FILE})
         add_arches=$(jq '.fbc.addArches // []' ${DATA_FILE})
         hotfix=$(jq -r '.fbc.hotfix // "false"' ${DATA_FILE})
@@ -93,6 +92,12 @@ spec:
         request_timeout_seconds=$(jq -r --arg request_timeout_seconds ${default_request_timeout_seconds} \
             '.fbc.requestTimeoutSeconds // $request_timeout_seconds' ${DATA_FILE})
         fbc_fragment=$(jq -cr '.components[0].containerImage' ${SNAPSHOT_PATH})
+
+        if [ "${staged_index}" = "true" ]; then
+          iib_service_account_secret=iib-service-account-stage
+        else
+          iib_service_account_secret=iib-service-account-prod
+        fi
 
         timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' ${DATA_FILE})
         timestamp=$(date "+${timestamp_format}")


### PR DESCRIPTION
- Setting `.fbc.iibServiceAccountSecret` is no longer allowed (it was never used anyway). Instead, it's based on the stagedIndex setting now.
- If `.fbc.stagedIndex` is `true`, we'll use `iib-service-account-stage`. Otherwise we'll use `iib-service-account-prod`.

The reason is that IIB has a priority queue for requests made with our prod kerberos principal and we were asked to use it only for prod index requests.

Note that this depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/115673