### PR TITLE
refactor(RELEASE-1024): update checkton version and allow it to fail

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,14 +8,14 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run yamllint
         uses: frenck/action-yamllint@v1
   tknparse:
     runs-on: ubuntu-latest
     steps:
       - name: checkout files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: install tkn
         uses: ./.github/actions/install-tkn
       - name: Get changed files
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -53,19 +53,8 @@ jobs:
           fetch-depth: 0
       - name: Run Checkton
         id: checkton
-        uses: chmeliik/checkton@v0.1.2 
+        uses: chmeliik/checkton@v0.2.2
         # Migrating to the konflux-ci org
         with:
           fail-on-findings: true
           find-copies-harder: true
-        continue-on-error: true 
-      - name: View SARIF Checkton Results 
-        run: cat "${{ steps.checkton.outputs.sarif }}"
-      - name: Check if Checkton failed
-        run: |
-          if [ "${{ steps.checkton.outcome }}" != "success" ]; then
-            echo "Checkton found issues"
-            exit 1
-          else
-            echo "Checkton found no issues"
-          fi


### PR DESCRIPTION
Originally, our goal was to write a special
script to parse the sarif file and print a nice summary.

But since then, Adam improved the output of the checkton action, so that it has all we need (including link to wiki for each issue), so we can just use that.

I tested this with a dummy commit that added an issue and it failed as expected:
https://github.com/konflux-ci/release-service-catalog/actions/runs/10615655743/job/29424220769?pr=536
```
Files to check:
  M	.github/workflows/lint.yaml
  M	tasks/collect-data/collect-data.yaml
❌ Found ShellCheck warnings! /o\
warning: Double quote to prevent globbing and word splitting.
    ┌─ tasks/collect-data/collect-data.yaml:105:45
    │
105 │         get-resource "releaseserviceconfig" ${RELEASE_SERVICE_CONFIG} \
    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = SC2086
    = Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2086

warning: 1 warnings emitted
```