### PR TITLE
fix(KFLUXBUGS-1498): expose the fbc opt in flag

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -14,6 +14,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.3.0
+* Added a new result `isFbcOptIn` to expose the FBC opt-in status
+
 ## Changes in 3.2.2
 * Fixing checkton/shellcheck linting issues in the task and test
 

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.2.2"
+    app.kubernetes.io/version: "3.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,6 +40,8 @@ spec:
       description: Whether the index image should be signed
     - name: mustPublishIndexImage
       description: Whether the index image should be published
+    - name: isFbcOptIn
+      description: Indicates whether the FBC fragment is opt-in (true/false)
     - name: requestTargetIndex
       description: The targetIndex used in this request
     - name: requestResultsFile
@@ -167,8 +169,24 @@ spec:
 
         jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.sign_index_image' |tr -d "\n" \
             | tee "$(results.mustSignIndexImage.path)"
-        jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.publish_index_image' |tr -d "\n" \
-            | tee "$(results.mustPublishIndexImage.path)"
+
+        mustPublishIndexImage=$(jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.publish_index_image')
+        fbc_opt_in=$(jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.fbc_opt_in')
+
+        # Store the results in Tekton's results files
+        echo -n "${mustPublishIndexImage}" | tee "$(results.mustPublishIndexImage.path)"
+        echo -n "${fbc_opt_in}" | tee "$(results.isFbcOptIn.path)"
+
+        # Whether the index image will be published
+        if [ "$mustPublishIndexImage" = "true" ]; then
+          echo "Index image will be published."
+        elif [ "$fbc_opt_in" = "false" ]; then
+          echo "Index image will not be published because FBC opt-in is set to false in Pyxis."
+        elif [ "${staged_index}" = "true" ]; then
+          echo "Index image will not be published because this is a staging release."
+        else
+          echo "Index image will not be published for an unspecified reason."
+        fi
 
         jq '.reason // "Unset"'  <<< "${conditions}" | tee "$(results.requestReason.path)"
         jq '.message // "Unset"' <<< "${conditions}" | tee "$(results.requestMessage.path)"

--- a/tasks/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/add-fbc-contribution/tests/mocks.sh
@@ -34,7 +34,7 @@ function set_ir_status() {
 {
   "status": {
     "results": {
-      "genericResult": "{\"public_index_image\":\"foo\",\"sign_index_image\":\"bar\"}",
+      "genericResult": "{\"fbc_opt_in\":\"true\",\"publish_index_image\":\"false\",\"sign_index_image\":\"false\"}",
       "iibLog": "Dummy IIB Log",
       "exitCode": "${EXITCODE}"
     }

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -71,10 +71,22 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:
+        - name: isFbcOptIn
+          value: $(tasks.run-task.results.isFbcOptIn)
+        - name: mustPublishIndexImage
+          value: $(tasks.run-task.results.mustPublishIndexImage)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: isFbcOptIn
+            type: string
+          - name: mustPublishIndexImage
+            type: string  
+        workspaces:
+          - name: data
         steps:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -133,6 +145,16 @@ spec:
               if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image0@sha256:0000" ]
               then
                 echo "fbcFragment does not match"
+                exit 1
+              fi
+
+              if [ "$(params.mustPublishIndexImage)" != "false" ]; then
+                echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
+                exit 1
+              fi
+
+              if [ "$(params.isFbcOptIn)" != "true" ]; then
+                echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
                 exit 1
               fi
       runAfter:


### PR DESCRIPTION
* Added a new result `isFbcOptIn`, to expose the FBC opt-in status.

* Extracted and stored fbc_opt_in from the `genericResult` to make the opt-in status available for downstream tasks.

Note: This change will expose the `fbc_opt_in` flag only in case of success **until** Johnny's change for [KFLUXBUGS-1278](https://issues.redhat.com/browse/KFLUXBUGS-1278) gets merged. Once that is done we can see the flag even in case of IR failure.