### PR TITLE
fix: increase timeout for push-disk-images IR

### DIFF
--- a/tasks/push-disk-images/README.md
+++ b/tasks/push-disk-images/README.md
@@ -11,5 +11,8 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
 
+## Changes in 0.2.1
+* Increase the InternalRequest PipelineRun timeout to 4 hours in total
+
 ## Changes in 0.2.0
 * The task now supports pushing disk images to Developer Portal

--- a/tasks/push-disk-images/push-disk-images.yaml
+++ b/tasks/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -81,10 +81,10 @@ spec:
                          -p cgwSecret="${cgwSecret}" \
                          -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
                          -s true \
-                         -t 7200 \
+                         -t 14400 \
                          --service-account release-service-account \
-                         --pipeline-timeout 2h0m0s \
-                         --task-timeout 1h50m0s \
+                         --pipeline-timeout 4h0m0s \
+                         --task-timeout 3h50m0s \
                          --finally-timeout 0h10m0s \
                          > "$(workspaces.data.path)"/ir-result.txt
 


### PR DESCRIPTION
The disk images for RHEL AI are very big and
we repeatedly saw timeouts. We will make it
customizable here:
https://issues.redhat.com/browse/RELEASE-1143

But for now, let's increase the values.