### PR TITLE
feat(RELEASE-1120): remove fbc.request from tasks

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -14,6 +14,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.3.1
+* Removed references of the redundant field `fbc.request` as FBC releases uses `iib` exclusively as its internal request pipeline
+
 ## Changes in 3.3.0
 * Added a new result `isFbcOptIn` to expose the FBC opt-in status
 

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -73,9 +73,6 @@ spec:
 
         echo -n "$(workspaces.data.path)/ir-$(context.taskRun.uid)-result.json" > "$(results.requestResultsFile.path)"
 
-        # IIB is the default internal pipeline for fbc requests
-        request=$(jq -r '.fbc.request // "iib"' "${DATA_FILE}")
-
         default_build_timeout_seconds="1500"
         default_request_timeout_seconds="1500"
 
@@ -140,7 +137,7 @@ spec:
         # The internal-request script will create the InternalRequest and wait until it finishes to get its status
         # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
         echo "Creating InternalRequest to add FBC contribution to index image:"
-        internal-request -r "${request}" \
+        internal-request -r "iib" \
             -p binaryImage="$(params.binaryImage)" \
             -p fromIndex="$(params.fromIndex)" \
             -p targetIndex="${target_index}" \

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -7,7 +7,6 @@ Creates an InternalRequest to sign an index image
 | Name                 | Description                                                                               | Optional | Default value          |
 |----------------------|-------------------------------------------------------------------------------------------|----------|------------------------|
 | dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                      |
-| request              | Signing pipeline name to handle this request                                              | Yes      | hacbs-signing-pipeline |
 | referenceImage       | The image to be signed                                                                    | No       | -                      |
 | manifestListDigests  | The manifest digests for each arch in manifest list                                       | No       | -                      |
 | requester            | Name of the user that requested the signing, for auditing purposes                        | No       | -                      |
@@ -26,6 +25,10 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 3.4.0
+* Removed the `request` parameter and references of `fbc.request` from the task and set the default
+  internal request pipeline to `hacbs-signing-pipeline`
 
 ## Changes in 3.3.0
 * Updated the base image used in this task

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -15,10 +15,6 @@ spec:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-    - name: request
-      type: string
-      description: Signing pipeline name to handle this request
-      default: "hacbs-signing-pipeline"
     - name: referenceImage
       type: string
       description: The image to be signed.
@@ -52,18 +48,18 @@ spec:
             exit 1
         fi
 
-        request=$(jq -r '.sign.request // .fbc.request // "$(params.request)"' ${DATA_FILE})
+        request=$(jq -r '.sign.request // "hacbs-signing-pipeline"' "${DATA_FILE}")
         default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
-        pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
-            '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' ${DATA_FILE})
-        config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' ${DATA_FILE})
-        reference_image=$(params.referenceImage)
+        pipeline_image=$(jq -r --arg default_pipeline_image "${default_pipeline_image}" \
+            '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
+        config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' "${DATA_FILE}")
+        reference_image="$(params.referenceImage)"
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
-        reference_image=$(translate-delivery-repo $reference_image | jq -r '.[] | select(.repo=="redhat.io") | .url')
+        reference_image=$(translate-delivery-repo "$reference_image" | jq -r '.[] | select(.repo=="redhat.io") | .url')
 
         # get all digests from manifest list
         for manifest_digest in $(params.manifestListDigests)
@@ -74,12 +70,12 @@ spec:
           echo "- requester=$(params.requester)"
 
           internal-request -r "${request}" \
-              -p pipeline_image=${pipeline_image} \
-              -p reference=${reference_image} \
-              -p manifest_digest=${manifest_digest} \
-              -p requester=$(params.requester) \
-              -p config_map_name=${config_map_name} \
-              -t $(params.requestTimeout) \
-              -l ${pipelinerun_label}=$(params.pipelineRunUid)
+              -p pipeline_image="${pipeline_image}" \
+              -p reference="${reference_image}" \
+              -p manifest_digest="${manifest_digest}" \
+              -p requester="$(params.requester)" \
+              -p config_map_name="${config_map_name}" \
+              -t "$(params.requestTimeout)" \
+              -l "${pipelinerun_label}"="$(params.pipelineRunUid)"
           echo "done"
         done


### PR DESCRIPTION
this commit removes the fbc.request data field references from `add-fbc-contribution` and `sign-index-image` tasks. Also removes the request parameter from the `sign-index-image` as it is not used anywhere.