### PR TITLE
feat(RELEASE-1116): timestamp variable is for build date

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -12,7 +12,8 @@ A `mapped` result is also returned from this task containing a simple true/false
 meant to inform whether a mapped Snapshot is being returned or the original one.
 
 This task supports variable expansion in tag values from the mapping. The currently supported variables are:
-* "{{ timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
+* "{{ timestamp }}" -> The build-date label from the image in the format provided by timestampFormat or %s as the default
+* "{{ release_timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
 * "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
 * "{{ git_short_sha }}" -> The git sha reduced to 7 characters
 * "{{ digest_sha }}" -> The image digest of the respective component
@@ -24,6 +25,11 @@ This task supports variable expansion in tag values from the mapping. The curren
 | snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |  
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
+
+## Changes in 1.6.0
+* The {{ timestamp }} tag now uses the build-date label of the image
+* Added {{ release_timestamp }} tag which works as the old {{ timestamp }} tag did
+* If a tag is translated with a value equal to null, the task will now fail
 
 ## Changes in 1.5.1
 * Fixing checkton/shellcheck linting issues in the task and test

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.5.1"
+    app.kubernetes.io/version: "1.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,7 +62,8 @@ spec:
             exit 0
         fi
 
-        translate_tags () { # Expected arguments are [tags, timestamp, git sha, 7 character git sha, source sha]
+        # Expected arguments are [tags, timestamp, release_timestamp, git sha, 7 character git sha, source sha]
+        translate_tags () {
         # The tags argument is a json array
             if [[ $1 == '' ]] ; then
                 echo ''
@@ -72,12 +73,14 @@ spec:
             SUPPORTED_VARIABLES='[
                 {"{{timestamp}}": "'$2'"},
                 {"{{ timestamp }}": "'$2'"},
-                {"{{git_sha}}": "'$3'"},
-                {"{{ git_sha }}": "'$3'"},
-                {"{{git_short_sha}}": "'$4'"},
-                {"{{ git_short_sha }}": "'$4'"},
-                {"{{digest_sha}}": "'$5'"},
-                {"{{ digest_sha }}": "'$5'"}
+                {"{{release_timestamp}}": "'$3'"},
+                {"{{ release_timestamp }}": "'$3'"},
+                {"{{git_sha}}": "'$4'"},
+                {"{{ git_sha }}": "'$4'"},
+                {"{{git_short_sha}}": "'$5'"},
+                {"{{ git_short_sha }}": "'$5'"},
+                {"{{digest_sha}}": "'$6'"},
+                {"{{ digest_sha }}": "'$6'"}
             ]'
             tags=$1
 
@@ -86,6 +89,13 @@ spec:
                 variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
                 KEY=$(jq -r 'to_entries[] | .key' <<< "$variable")
                 VALUE=$(jq -r 'to_entries[] | .value' <<< "$variable")
+                # If a tag is going to be replaced by a null value, error out
+                if [[ "$VALUE" == "null" ]] && \
+                  [[ $(jq --arg key "$KEY" '. | map(select(test($key))) | length' <<< "$tags") -gt 0 ]] ; then
+                    echo "Requested substitution for key: $KEY but calculated value for it was null"
+                    echo "Failing..."
+                    exit 1
+                fi
                 tags=$(echo -n "$tags" | sed "s/$KEY/$VALUE/g")
             done
 
@@ -186,11 +196,22 @@ spec:
             build_sha=$(echo "$IMAGE_REF" | cut -d ':' -f 2)
             passedTimestampFormat=$(jq -r --arg default "$defaultTimestampFormat" \
               '.timestampFormat // $default' <<< "$component")
-            timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"
+            release_timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"
+            arch_json="$(get-image-architectures "${IMAGE_REF}")"
+            # The build-date label is not the same per architecture, but we don't support separate tags per arch. So,
+            # we just use the first digest listed
+            arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
+            os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
+            build_date="$(skopeo inspect --no-tags --override-os "${os}" --override-arch "${arch}" \
+              docker://"${IMAGE_REF}" | jq -r '.Labels."build-date"')"
+            timestamp="$(date -d "${build_date}" "+$passedTimestampFormat")"
+            if [ "${build_date}" == "null" ] ; then
+              timestamp="null"
+            fi
 
             allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
               "$imageTags" '$defaults? + $imageTags? | unique')
-            tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${git_sha}" \
+            tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${release_timestamp}" "${git_sha}" \
               "${git_sha:0:7}" "${build_sha}")
             if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
               jq --argjson i "$i" --argjson updatedTags "$tags" '.components[$i].tags = $updatedTags' \
@@ -202,8 +223,8 @@ spec:
             for ((j = 0; j < STAGED_FILES; j++)) ; do
                 file=$(jq -c --argjson j "$j" '.staged.files[$j]' <<< "$component")
                 filenameArrayPreSubstitution=$(jq '.filename' <<< "$file" | jq -cs)
-                subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" "${timestamp}" "${git_sha}" \
-                  "${git_sha:0:7}" "${build_sha}" | jq -r '.[0]')
+                subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" "${timestamp}" \
+                  "${release_timestamp}" "${git_sha}" "${git_sha:0:7}" "${build_sha}" | jq -r '.[0]')
                 jq --argjson i "$i" --argjson j "$j" --arg filename "$subbedFilename" \
                   '.components[$i].staged.files[$j].filename = $filename' "${SNAPSHOT_SPEC_FILE}" > /tmp/temp \
                   && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"

--- a/tasks/apply-mapping/tests/mocks.sh
+++ b/tasks/apply-mapping/tests/mocks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
 # mocks to be injected into task step scripts
@@ -7,6 +7,9 @@ function date() {
   echo $* >> $(workspaces.config.path)/mock_date.txt
 
   case "$*" in
+      *"2024-07-29T02:17:29 +%Y-%m-%d")
+          echo "2024-07-29"
+          ;;
       *"+%Y%m%d %T")
           echo "19800101 00:00:00"
           ;;
@@ -24,4 +27,27 @@ function date() {
           exit 1
           ;;
   esac
+}
+
+function skopeo() {
+  echo Mock skopeo called with: $* >&2
+  echo $* >> $(workspaces.config.path)/mock_skopeo.txt
+
+  if [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
+  then
+    echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'
+    return
+  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://"* ]]
+  then
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'
+    return
+  fi
+
+  echo Error: Unexpected call
+  exit 1
+}
+
+function get-image-architectures() {
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
+    echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
 }

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-fail-tag-expansion
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file with tags per component, but some of the tags (in this case the timestamp
+    tag) are evaluated with a null value. The task should fail instead of injecting `null`
+    in the tags.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "repo1",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ timestamp }}",
+                        "{{ digest_sha }}"
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/badimage-no-build-date@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: dataPath
+          value: test_data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -47,7 +47,9 @@ spec:
                       "name": "comp2",
                       "repository": "repo2",
                       "tags": [
-                        "tag1-{{timestamp}}"
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ release_timestamp }}",
+                        "tag4-{{release_timestamp}}"
                       ],
                       "timestampFormat": "%Y-%m"
                     },
@@ -131,7 +133,7 @@ spec:
                 jq -c '.components[] | select(.name=="comp1") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
               )" == '["defaultTag","foo-123456",'\
-              '"tag1-1980-01-01","tag2-1980-01-01","123456",'\
+              '"tag1-2024-07-29","tag2-2024-07-29","123456",'\
               '"testrevision-abc","testrev-bar","testrevision","testrev"]'
 
               echo Test that SNAPSHOT contains component comp2
@@ -144,7 +146,7 @@ spec:
               test "$(
                 jq -c '.components[] | select(.name=="comp2") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
-              )" == '["defaultTag","tag1-1980-01"]'
+              )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01"]'
 
               echo Test that repository of component comp3 was overridden by mapping file
               test "$(


### PR DESCRIPTION
This commit modifies the apply-mapping task to treat the timestamp user provided variable as the build timestamp instead of the current time. It is found by inspecting the image's labels. The existing timestamp functionality now exists under the release_timestamp variable.

Also, if a tag is translated with a null value, the task will now fail.