### PR TITLE
feat(ISV-5125): Add unique tag info to purl

### DIFF
--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -10,6 +10,9 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 2.2.1
+* Add unique tag info to purl
+
 ## Changes in 2.2.0
 * Updated to use the `rh-registry-repo` key from the snapshot JSON for constructing 
   the image repository path, instead of relying on the data field. This change 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,8 @@ spec:
             echo "No valid snapshot file was provided."
             exit 1
         fi
+
+        UNIQUE_TAG_REGEX="(rhel-)?v?[0-9]+\.[0-9]+(\.[0-9]+)?-[0-9]{8,}"
 
         NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
         for ((i = 0; i < $NUM_COMPONENTS; i++))
@@ -76,6 +78,22 @@ spec:
                 containerImage="${deliveryRepo}@${digest}"
                 # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
                 purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+
+                uniqueTag=""
+                NUM_TAGS=$(jq length <<< "$tags")
+                for ((j = 0; j < NUM_TAGS; j++)) ; do
+                    tag=$(jq -r --argjson j "$j" '.[$j]' <<< "$tags")
+                    if [[ $tag =~ $UNIQUE_TAG_REGEX ]] && [[ ${#tag} > ${#uniqueTag} ]] ; then
+                        uniqueTag="${tag}"
+                    fi
+                done
+
+                # if a unique tag is found, then purl will become:
+                # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo&tag=0.1-12345678
+                if [[ -n $uniqueTag ]] ; then
+                    purl="${purl}&tag=${uniqueTag}"
+                fi
+
                 jsonString=$(jq -cn \
                     --arg arch "$arch" \
                     --arg containerImage "$containerImage" \

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
@@ -65,6 +65,8 @@ spec:
                     "repository": "quay.io/redhat-prod/product----repo",
                     "rh-registry-repo": "registry.redhat.io/product/repo",
                     "tags": [
+                      "9.4-1723436855",
+                      "9.4.0-1723436855",
                       "foo",
                       "bar"
                     ]
@@ -106,7 +108,7 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               echo Checking image1arch1...
@@ -114,18 +116,18 @@ spec:
               test $(jq -r '.architecture' <<< $image1arch1) == "amd64"
               test $(jq -r '.containerImage' <<< $image1arch1) == "registry.redhat.io/product/repo@sha256:abcdefg"
               test $(jq -r '.purl' <<< $image1arch1) == \
-                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
               test $(jq -r '.repository' <<< $image1arch1) == "registry.redhat.io/product/repo"
-              test $(jq -rc '.tags' <<< $image1arch1) == '["foo","bar"]'
+              test "$(jq -rc '.tags' <<< "$image1arch1")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
               echo Checking image1arch2...
               image1arch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $image1arch2) == "s390x"
               test $(jq -r '.containerImage' <<< $image1arch2) == "registry.redhat.io/product/repo@sha256:deadbeef"
               test $(jq -r '.purl' <<< $image1arch2) == \
-                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
               test $(jq -r '.repository' <<< $image1arch2) == "registry.redhat.io/product/repo"
-              test $(jq -rc '.tags' <<< $image1arch2) == '["foo","bar"]'
+              test "$(jq -rc '.tags' <<< "$image1arch2")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
               echo Checking image2arch1...
               image2arch1=$(jq '.releaseNotes.content.images[2]' "$(workspaces.data.path)/data.json")


### PR DESCRIPTION
As part of the release-time SBOM work, purls need to include a unique tag. The unique tag has been determined to be a tag of the format <version>-<timestamp>. If such a tag does not exist, it will not be added to the purl.