### PR TITLE
feat(RELEASE-1037): promote branch pushes to sre duplicate branches

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -97,8 +97,12 @@ if [ -z "${TARGET_BRANCH}" ]; then
 fi
 if [ "${TARGET_BRANCH}" == "staging" ]; then
     SOURCE_BRANCH="development"
+    # App sre restricts what branches we can consume from, so we create duplicate branches internal and stable
+    # to fit their regex requirements
+    SRE_DUPLICATE_BRANCH="internal"
 elif [ "${TARGET_BRANCH}" == "production" ]; then
     SOURCE_BRANCH="staging"
+    SRE_DUPLICATE_BRANCH="stable"
 else
     echo "Invalid target-branch. Only 'staging' and 'production' are allowed"
     print_help
@@ -152,6 +156,7 @@ fi
 
 git checkout $SOURCE_BRANCH
 git push origin $SOURCE_BRANCH:$TARGET_BRANCH
+git push origin $SOURCE_BRANCH:$SRE_DUPLICATE_BRANCH
 
 cd -
 rm -rf ${tmpDir}


### PR DESCRIPTION
App SRE doesn't let us consume from staging or production branches. They also restrict us from using release-4.X type branches. So, push to internal for staging and stable for production to consume the internal resources on the sre clusters.