### PR TITLE
fix(KFLUXBUGS-752): skip signing if already signed

### DIFF
--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -13,6 +13,9 @@ Task to create internalrequests to sign snapshot components
 | concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
 
+## Changes in 3.4.1
+* Updated the `rh-sign-image` task to skip signing an image if it is already signed.
+
 ## Changes in 3.4.0
 * Added changes in order to eliminate the `translate-delivery-repo` script because the
  `registry.redhat.io` and `registry.access.redhat.com ` repo are now available

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "3.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -68,6 +68,21 @@ spec:
         N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
         count=0
         COMPONENTS_LENGTH=$(jq '.components |length' ${SNAPSHOT_PATH})
+
+        function is_signed() {
+          local registry_reference=$1
+          local tag=$2
+          local manifest_digest=$3
+
+          # Check if the signature exists using skopeo
+          if skopeo inspect --raw "docker://${registry_reference}:${tag}" \
+            | jq -e ".signatures // {} | any(.digest == \"${manifest_digest}\")"; then
+            return 0  # Signature exists
+          else
+            return 1  # Signature does not exist
+          fi
+        }
+
         for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
 
             referenceContainerImage=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
@@ -88,7 +103,7 @@ spec:
               nested_digests=$(jq -r '.manifests[].digest' <<< "$RAW_OUTPUT")
               manifest_digests="$manifest_digests $nested_digests"
             fi
-        
+
             sourceContainerDigest=
             # Push source container if the component has pushSourceContainer: true or if the
             # pushSourceContainer key is missing from the component and the defaults has
@@ -112,6 +127,12 @@ spec:
               for tag in ${TAGS}; do
                 # Iterate over both rh-registry-repo and registry-access-repo
                 for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
+                  # Check if the image is already signed
+                  if is_signed "${registry_reference}" "${tag}" "${manifest_digest}"; then
+                    echo "Skipping signing for ${registry_reference}:${tag} as it is already signed."
+                    continue  # Skip to the next image
+                  fi
+
                   echo "Creating InternalRequest to sign image with tag ${tag}:"
                   echo "- reference=${registry_reference}:${tag}"
                   echo "- manifest_digest=${manifest_digest}"
@@ -141,6 +162,12 @@ spec:
                 sourceTag=${tag}-source
 
                 for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
+                  # Check if the source container image is already signed
+                  if is_signed "${registry_reference}" "${sourceTag}" "${sourceContainerDigest}"; then
+                    echo "Skipping signing for ${registry_reference}:${sourceTag} as it is already signed."
+                    continue  # Skip to the next source image
+                  fi
+
                   echo "Creating InternalRequest to sign image with tag ${sourceTag}:"
                   echo "- reference=${registry_reference}:${sourceTag}"
                   echo "- manifest_digest=${sourceContainerDigest}"

--- a/tasks/rh-sign-image/tests/mocks.sh
+++ b/tasks/rh-sign-image/tests/mocks.sh
@@ -57,8 +57,17 @@ EOF
 function skopeo() {
   echo $* >> $(workspaces.data.path)/mock_skopeo.txt
   echo Mock skopeo called with: $*  >> /dev/stderr
-  if [[ "$*" == "inspect --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]
-  then
+  
+  # Mock scenarios where the image is already signed for both registries
+  if [[ "$*" == "inspect --raw docker://registry.redhat.io/myproduct/signedrepo"* ]] || \
+     [[ "$*" == "inspect --raw docker://registry.access.redhat.com/myproduct/signedrepo"* ]]; then
+    echo '{
+            "signatures": [
+              { "digest": "sha256:0000" }
+            ]
+          }'
+    return
+  elif [[ "$*" == "inspect --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]; then
     echo '{"mediaType": "my_media_type"}'
   else
     if [[ "$*" != "inspect --no-tags docker://"* ]]
@@ -122,8 +131,7 @@ function skopeo() {
                     "org.opencontainers.image.base.digest": "sha256:5ee218882a725fe3fcc8ebd803e82a7182dbee47aef0efcaf3852df9ad15347b",
                     "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi8/ubi:8.9-1028"
                   }
-                }
-            '
+                }'
         else
           if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
           then

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-skip-signing-when-signed.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-skip-signing-when-signed.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-skip-signing-when-signed
+spec:
+  description: Test skip signing when already signed for the rh-sign-image task
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "source": {
+                      "git": {
+                        "revision": "deadbeef"
+                      }
+                    },
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "quay.io/redhat-prod/myproduct----signedrepo",
+                    "rh-registry-repo": "registry.redhat.io/myproduct/signedrepo",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct/signedrepo",
+                    "tags": [
+                      "some-prefix-12345",
+                      "some-prefix"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "false"
+                  }
+                },
+                "sign": {
+                  "request": "hacbs-signing-pipeline",
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-single
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Check that no internal requests were issued
+              if [ -f "$(workspaces.data.path)/mock_internal-request.txt" ]; then
+                echo "Error: Internal requests were issued even though the image is already signed."
+                exit 1
+              else
+                echo "Test passed: No internal requests were issued."
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit updates the `rh-sign-image` task to skip signing an image
if it is already signed.