### PR TITLE
feat: nicer display for fbc pipelines

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.0.1
+* Add some extra task `runAfter` relationships so that pipelines render more nicely in the Konflux UI.
+
 ## Changes in 4.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -203,6 +203,9 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: ocpVersion
           value: "$(tasks.get-ocp-version.results.stored-version)"
+      runAfter:
+        - collect-data
+        - get-ocp-version
     - name: check-fbc-packages
       workspaces:
         - name: data
@@ -254,6 +257,8 @@ spec:
       runAfter:
         - check-fbc-packages
         - verify-enterprise-contract
+        - update-ocp-tag
+        - collect-data
     - name: extract-requester-from-release
       taskRef:
         resolver: "git"
@@ -309,6 +314,9 @@ spec:
         - input: "$(tasks.add-fbc-contribution-to-index-image.results.mustSignIndexImage)"
           operator: in
           values: ["true"]
+      runAfter:
+        - extract-requester-from-release
+        - add-fbc-contribution-to-index-image
     - name: extract-index-image
       workspaces:
         - name: data


### PR DESCRIPTION
Functionally, this was all doing the right thing before. Tasks later in the pipeline wait automatically for preceding tasks if the output of a preceding task is used as a param of a later task.

However, our UI doesn't render the pipeline nicely if we only rely on those dependencies. By using `runAfter`, we can hint to the UI how the pipelinerun should be rendered.