### PR TITLE
feat(RELEASE-1158): introduce reduce-snapshot

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -319,6 +319,10 @@
       "type": "string",
       "description": "A script that can alter files in the infra-deployment repo before a a PR is created"
     },
+    "singleComponentMode": {
+      "type": "string",
+      "description": "Whether testing and releasing single component is enabled."
+    },
     "mapping": {
       "type": "object",
       "additionalProperties": false,

--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -27,6 +27,9 @@ should not be present in the Release data section).
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
+## Changes in 4.5.2
+* Introduce new step to collect information needed for reduce-snapshot task
+
 ## Changes in 4.5.1
   * Fix linting issues in this task
 

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.5.1"
+    app.kubernetes.io/version: "4.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -60,6 +60,15 @@ spec:
     - name: resultsDir
       type: string
       description: The relative path in the workspace to the results directory
+    - name: singleComponentMode
+      type: string
+      description: single component mode
+    - name: snapshotName
+      type: string
+      description: name of Snapshot resource
+    - name: snapshotNamespace
+      type: string
+      description: namespace where Snapshot is located
   steps:
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -131,6 +140,25 @@ spec:
         DATA_PATH="$(params.subdirectory)/data.json"
         echo -n "$DATA_PATH" > "$(results.data.path)"
         echo "$merged_output" | tee "$(workspaces.data.path)/$DATA_PATH"
+    - name: collect-single-component-mode-data
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      env:
+        - name: "SNAPSHOT"
+          value: '$(params.snapshot)'
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+      
+        # check if RP/RPA has a single-component mode
+        DATA_PATH="$(params.subdirectory)/data.json"
+        SINGLE_COMPONENT_MODE=$(jq -r '.singleComponentMode // "false"' "$(workspaces.data.path)/$DATA_PATH")
+        SNAPSHOT_NAME=$(echo "${SNAPSHOT}" | cut -f2 -d/)
+        SNAPSHOT_NAMESPACE=$(echo "${SNAPSHOT}" | cut -f1 -d/)
+
+        echo -n "${SINGLE_COMPONENT_MODE}" | tee "$(results.singleComponentMode.path)"
+        echo -n "${SNAPSHOT_NAME}" | tee "$(results.snapshotName.path)"
+        echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
+
     - name: check-data-key-sources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |

--- a/tasks/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data-with-data.yaml
@@ -59,6 +59,7 @@ spec:
                   - foo
                 origin: foo
                 data:
+                  singleComponentMode: true
                   one:
                     two: three
                     four:
@@ -123,6 +124,8 @@ spec:
       params:
         - name: data
           value: $(tasks.run-task.results.data)
+        - name: singleComponentMode
+          value: $(tasks.run-task.results.singleComponentMode)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -131,6 +134,8 @@ spec:
       taskSpec:
         params:
           - name: data
+            type: string
+          - name: singleComponentMode
             type: string
         steps:
           - name: check-result
@@ -141,7 +146,11 @@ spec:
 
               echo Test that data result was set properly
               test "$(cat "$(workspaces.data.path)/$(params.data)")" \
-                == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"}}'
+               == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"},"singleComponentMode":true}'
+              
+              echo Test that the singleComponentMode result was properly set
+              test "$(params.singleComponentMode)" == "true"  
+
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -126,6 +126,12 @@ spec:
           value: $(tasks.run-task.results.snapshotSpec)
         - name: fbcFragment
           value: $(tasks.run-task.results.fbcFragment)
+        - name: singleComponentMode
+          value: $(tasks.run-task.results.singleComponentMode)
+        - name: snapshotName
+          value: $(tasks.run-task.results.snapshotName)
+        - name: snapshotNamespace
+          value: $(tasks.run-task.results.snapshotNamespace)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -146,6 +152,12 @@ spec:
           - name: snapshotSpec
             type: string
           - name: fbcFragment
+            type: string
+          - name: singleComponentMode
+            type: string
+          - name: snapshotName
+            type: string
+          - name: snapshotNamespace
             type: string
         workspaces:
           - name: data
@@ -178,6 +190,12 @@ spec:
 
               echo Test the fbcFragment result was properly set
               test "$(params.fbcFragment)" == "newimage"
+
+              echo Test that the snapshotName result was properly set
+              test "$(params.snapshotName)" == "snapshot-sample"
+
+              echo Test that the snapshotNamespace result was properly set
+              test "$(params.snapshotNamespace)" == "default"
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/reduce-snapshot/README.md
+++ b/tasks/reduce-snapshot/README.md
@@ -1,0 +1,13 @@
+# reduce-snapshot
+
+Tekton task to reduce a snapshot to a single component based on the component that the snapshot was built for.
+
+## Parameters
+
+| Name                                | Description                                              | Optional | Default value |
+|-------------------------------------|----------------------------------------------------------|----------|---------------|
+| SNAPSHOT                            | String representation of Snapshot spec                   | No       | -             |
+| SINGLE_COMPONENT                    | Single mode component enabled                            | No       | -             |
+| SINGLE_COMPONENT_CUSTOM_RESOURCE    | Custom Resource to query for built component in Snapshot | No       | -             |
+| SINGLE_COMPONENT_CUSTOM_RESOURCE_NS | Namespace where Custom Resource is found                 | No       | -             |
+| SNAPSHOT_PATH                       | The location to place the reduced Snapshot               | No       | -             |

--- a/tasks/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/reduce-snapshot/reduce-snapshot.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: reduce-snapshot
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to reduce snapshot
+  params:
+    - name: SNAPSHOT
+      type: string
+      description: String representation of Snapshot spec
+    - name: SINGLE_COMPONENT
+      type: string
+      description: Single mode component enabled
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+      type: string
+      description: Custom Resource to query for built component in Snapshot
+    - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+      type: string
+      default: ""
+      description: Namespace where Custom Resource is found
+    - name: SNAPSHOT_PATH
+      type: string
+      description: The location to place the reduced Snapshot
+  workspaces:
+    - name: data
+      description: Workspace to save the CR jsons to
+  steps:
+    - name: reduce
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: SINGLE_COMPONENT
+          value: $(params.SINGLE_COMPONENT)
+        - name: CUSTOM_RESOURCE
+          value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE)
+        - name: CUSTOM_RESOURCE_NAMESPACE
+          value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE_NS)
+        - name: SNAPSHOT_PATH
+          value: $(params.SNAPSHOT_PATH)
+      image: quay.io/enterprise-contract/ec-cli@sha256:913c7dac3d41877b01835d2e55bcd970c6cdbf4944f8176e9e3de9548642a2b4
+      command: [reduce-snapshot.sh]
+      onError: continue  # progress even if the step fails

--- a/tasks/reduce-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/reduce-snapshot/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot-disabled-single-component-mode
+spec:
+  description: |
+    Run the reduce snapshot task with single component mode being false
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  test.appstudio.openshift.io/type: component
+                  appstudio.openshift.io/component: tom
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: false
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-sample
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: default
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+                echo "ERROR: Resulting snapshot does not contain 2 components"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot-missing-resources
+spec:
+  description: |
+    Run the reduce task to reduce to a single component but CR to query is missing.
+    Therefore, the entire snapshot file is returned instead of being reduced.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  test.appstudio.openshift.io/type: component
+                  appstudio.openshift.io/component: tom
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: true
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-unknown
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: default
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+                echo "ERROR: Resulting snapshot does not contain 2 components"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot-no-labels
+spec:
+  description: |
+    Run the reduce snapshot task with missing labels
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: true
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-sample
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: default
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+                echo "ERROR: Resulting snapshot does not contain 2 components"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot-no-namespace-parameter
+spec:
+  description: |
+    Run the reduce task to reduce to a single component without the CUSTOM_RESOURCE_NAMESPACE parameter
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  test.appstudio.openshift.io/type: component
+                  appstudio.openshift.io/component: tom
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: true
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-sample
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 1 ]; then
+                echo "ERROR: Resulting snapshot does not contain 1 component"
+                exit 1
+              fi
+              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/snapshot.json")" != "tom" ]; then
+                echo "ERROR: Resulting snapshot does not contain the 'tom' component"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot-wrong-component
+spec:
+  description: |
+    Run the reduce task with a snapshot mentioning a component that does not exist.
+    Therefore, the entire snapshot should be returned instead of it being reduced
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  test.appstudio.openshift.io/type: component
+                  appstudio.openshift.io/component: scoobydoo
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: true
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-sample
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: default
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+                echo "ERROR: Resulting snapshot does not contain 2 components"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-reduce-snapshot
+spec:
+  description: |
+    Run the reduce task to reduce to a single component
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  test.appstudio.openshift.io/type: component
+                  appstudio.openshift.io/component: tom
+              spec:
+                application: foo
+                components:
+                  - name: scott
+                    containerImage: newimage
+                  - name: tom
+                    containerImage: newimage2
+              EOF
+              kubectl apply -f snapshot
+              
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/snapshot.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: reduce-snapshot
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/snapshot.json
+        - name: SINGLE_COMPONENT
+          value: true
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/snapshot-sample
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: default
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/snapshot.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat "$(workspaces.data.path)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 1 ]; then
+                echo "ERROR: Resulting snapshot does not contain 1 component"
+                exit 1
+              fi
+              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/snapshot.json")" != "tom" ]; then
+                echo "ERROR: Resulting snapshot does not contain the 'tom' component"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete snapshot snapshot-sample


### PR DESCRIPTION
- This PR contains a new Task called `reduce-snapshot`
- It is designed to **reduce a Snapshot** to a Single Component
  such that the Snapshot can be passed downstream to other tasks.
- It uses a **shared script from Enterprise Contract** so that the
  `ITS EC pipeline` uses the same logic to reduce the snapshot.
- A new step was added to the `collect-data` task, to provide
  data needed for the parameters of the `reduce-snapshot` task.
- A new RPA data parameter called `singleComponentMode` is used to
  activate the feature.
