### PR TITLE
fix(KFLUXBUGS-1614): fbc pipeline should stop passing binaryImage to iib

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.0.2
+* Drop the `binaryImage` param from the task `add-fbc-contribution-to-index-image`, so IIB can auto resolve it.
+
 ## Changes in 4.0.1
 * Add some extra task `runAfter` relationships so that pipelines render more nicely in the Konflux UI.
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.0.1"
+    app.kubernetes.io/version: "4.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -244,8 +244,6 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: binaryImage
-          value: "$(tasks.update-ocp-tag.results.updated-binaryImage)"
         - name: fromIndex
           value: "$(tasks.update-ocp-tag.results.updated-fromIndex)"
         - name: targetIndex

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -89,10 +89,6 @@
           "type": "string",
           "description": "The target index image e.g. quay.io/redhat/redhat----preview-operator-index:v4.10 "
         },
-        "binaryImage": {
-          "type": "string",
-          "description": "The OCP binary image to be baked into the index image e.g. registry.redhat.io/openshift4/ose-operator-registry:v4.11"
-        },
         "configMapName": {
           "type": "string",
           "description": "The configmap that exists on the cluster"

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -8,11 +8,13 @@ Task to create a internalrequest to add fbc contributions to index images
 |----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
 | snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | No       | -                    |
 | dataPath       | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                    |
-| binaryImage    | binaryImage value updated by update-ocp-tag task                                          | No       | -                    |
 | fromIndex      | fromIndex value updated by update-ocp-tag task                                            | No       | -                    |
 | pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
+
+## Changes in 3.4.0
+* Removed the `binaryImage` parameter so IIB can auto resolve it
 
 ## Changes in 3.3.1
 * Removed references of the redundant field `fbc.request` as FBC releases uses `iib` exclusively as its internal request pipeline

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.3.1"
+    app.kubernetes.io/version: "3.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -18,9 +18,6 @@ spec:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-    - name: binaryImage
-      type: string
-      description: binaryImage value updated by update-ocp-tag task
     - name: fromIndex
       type: string
       description: fromIndex value updated by update-ocp-tag task
@@ -138,7 +135,6 @@ spec:
         # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
         echo "Creating InternalRequest to add FBC contribution to index image:"
         internal-request -r "iib" \
-            -p binaryImage="$(params.binaryImage)" \
             -p fromIndex="$(params.fromIndex)" \
             -p targetIndex="${target_index}" \
             -p fbcFragment="${fbc_fragment}" \

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -52,8 +52,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex
@@ -105,13 +103,6 @@ spec:
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.binaryImage' <<< "${requestParams}")
-              if [ "${value}" != "registry.redhat.io/openshift4/ose-operator-registry:v4.12" ]
-              then
-                echo "binaryImage does not match"
                 exit 1
               fi
 

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -55,8 +55,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -57,8 +57,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -54,8 +54,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex
@@ -107,13 +105,6 @@ spec:
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.binaryImage' <<< "${requestParams}")
-              if [ "${value}" != "registry.redhat.io/openshift4/ose-operator-registry:v4.12" ]
-              then
-                echo "binaryImage does not match"
                 exit 1
               fi
 

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -49,8 +49,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -51,8 +51,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -51,8 +51,6 @@ spec:
       taskRef:
         name: add-fbc-contribution
       params:
-        - name: binaryImage
-          value: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: targetIndex
@@ -126,13 +124,6 @@ spec:
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.binaryImage' <<< "${requestParams}")
-              if [ "${value}" != "registry.redhat.io/openshift4/ose-operator-registry:v4.12" ]
-              then
-                echo "binaryImage does not match"
                 exit 1
               fi
 

--- a/tasks/prepare-fbc-release/README.md
+++ b/tasks/prepare-fbc-release/README.md
@@ -14,6 +14,9 @@ to each component, so other task can use them.
 | snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace      | No       | -                  |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace | No       | -                  |
 
+## Changes in 1.4.0
+* Removed the `binaryImage` parameter so IIB can auto resolve it
+
 ## Changes in 1.3.1
 * Changed the replace_tag function to only replace the version when the {{ OCP_VERSION }}
   placeholder is given

--- a/tasks/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/prepare-fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: prepare-fbc-release
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -13,7 +13,7 @@ spec:
     A tekton task to prepare FBC Release by collecting a valid
     OCP version for each component from given
     containerImage(fbcFragment) in the snapshot, and update
-    the fromIndex, targetIndex and binaryImage with collected
+    the fromIndex and targetIndex with collected
     OCP version and store updated values to snapshot respective
     to each component, so other task can use them.
   params:
@@ -31,7 +31,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
         #!/usr/bin/env bash
-        set -euo pipefail
+        set -euxo pipefail
 
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
         if [ ! -f "${SNAPSHOT_PATH}" ] ; then
@@ -50,12 +50,10 @@ spec:
         # Read components and initial values
         fromIndex=$(jq -r '.fbc.fromIndex' "$DATA_FILE")
         targetIndex=$(jq -r '.fbc.targetIndex' "$DATA_FILE")
-        binaryImage=$(jq -r '.fbc.binaryImage' "$DATA_FILE")
 
         # Print initial values
         echo "Initial fromIndex: $fromIndex"
         echo "Initial targetIndex: $targetIndex"
-        echo "Initial binaryImage: $binaryImage"
         echo
 
         # Get the number of components
@@ -103,11 +101,10 @@ spec:
             # Compute updated values
             updatedFromIndex=$(replace_tag "$fromIndex" "$ocpVersion")
             updatedTargetIndex=$(replace_tag "$targetIndex" "$ocpVersion")
-            updatedBinaryImage=$(replace_tag "$binaryImage" "$ocpVersion")
 
             # if {{OCP_VERSION}} is not set, the original targetIndex will be kept but its ocp version should
             # match base image version.
-            for index in "${updatedFromIndex}" "${updatedTargetIndex}" "${updatedBinaryImage}"; do
+            for index in "${updatedFromIndex}" "${updatedTargetIndex}"; do
               validateOCPVersion "${index}" "${ocpVersion}"
             done
 
@@ -116,7 +113,6 @@ spec:
             echo "ocpVersion: $ocpVersion"
             echo "Updated fromIndex for $componentName: $updatedFromIndex"
             echo "Updated targetIndex for $componentName: $updatedTargetIndex"
-            echo "Updated binaryImage for $componentName: $updatedBinaryImage"
             echo
 
             # Apply each update directly
@@ -125,7 +121,5 @@ spec:
             jq ".components[$i].updatedFromIndex |= \"$updatedFromIndex\"" \
               "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
             jq ".components[$i].updatedTargetIndex |= \"$updatedTargetIndex\"" \
-              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
-            jq ".components[$i].updatedBinaryImage |= \"$updatedBinaryImage\"" \
               "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
         done

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -24,8 +24,7 @@ spec:
               {
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12",
-                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.10",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.10"
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.10"
                 }
               }
               EOF

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -7,8 +7,7 @@ spec:
   description: |
     Run the prepare-fbc-release task and verify
     that the task succesfully update the snapshot
-    with the ocpVersion, fromIndex, targetIndex,
-    and binaryImage for all the component in snapshot  
+    with the ocpVersion, fromIndex, targetIndex for all the component in snapshot  
   workspaces:
     - name: tests-workspace
   tasks:
@@ -25,8 +24,7 @@ spec:
               {
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{OCP_VERSION}}",
-                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}"
                 }
               }
               EOF
@@ -119,9 +117,8 @@ spec:
               for ((i=0; i<num_components; i++)); do
                 fromIndex=$(jq -r ".components[$i].updatedFromIndex" "$SNAPSHOT_PATH")
                 targetIndex=$(jq -r ".components[$i].updatedTargetIndex" "$SNAPSHOT_PATH")
-                binaryImage=$(jq -r ".components[$i].updatedBinaryImage" "$SNAPSHOT_PATH")
 
-                for index in "${fromIndex}" "${targetIndex}" "${binaryImage}"; do
+                for index in "${fromIndex}" "${targetIndex}"; do
                   [ "${index#*:}" = "${ocpVersion}" ]
                 done
               done

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -7,8 +7,8 @@ spec:
   description: |
     Run the prepare-fbc-release task and verify
     that the task succesfully update the snapshot
-    with the ocpVersion, fromIndex, targetIndex,
-    and binaryImage for all the component in snapshot  
+    with the ocpVersion, fromIndex and targetIndex 
+    for all the component in snapshot  
   workspaces:
     - name: tests-workspace
   tasks:
@@ -25,8 +25,7 @@ spec:
               {
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12",
-                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.12",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.12"
                 }
               }
               EOF
@@ -104,8 +103,7 @@ spec:
               # Read components and initial values
               fromIndex=$(jq -r '.components[].updatedFromIndex' "$SNAPSHOT_FILE")
               targetIndex=$(jq -r '.components[].updatedTargetIndex' "$SNAPSHOT_FILE")
-              binaryImage=$(jq -r '.components[].updatedBinaryImage' "$SNAPSHOT_FILE")
 
-              for index in "${fromIndex}" "${targetIndex}" "${binaryImage}"; do
+              for index in "${fromIndex}" "${targetIndex}"; do
                 [ "${index#*:}" = "${ocpVersion}" ]
               done

--- a/tasks/update-ocp-tag/README.md
+++ b/tasks/update-ocp-tag/README.md
@@ -9,6 +9,9 @@ occurs when the {{ OCP_VERSION }} placeholder is present.
 | dataPath   | Path to the JSON string of the merged data to use in the data workspace | No       | -             |
 | ocpVersion | OCP version fetched from fbcFragment                                    | No       | -             |
 
+## Changes in 1.5.0
+* Removed result updated-binaryImage from task
+
 ## Changes in 1.4.2
 * Changed to skip validating the targetIndex when empty, as staged indexes does not have it set.
 

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
@@ -31,7 +31,6 @@ spec:
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.12",
                   "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.12",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
                 }
               }
               EOF

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
@@ -28,8 +28,7 @@ spec:
               {
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13",
-                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.13",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:v4.13"
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.13"
                 }
               }
               EOF
@@ -52,8 +51,6 @@ spec:
           value: $(tasks.run-task.results.updated-fromIndex)
         - name: updated-targetIndex
           value: $(tasks.run-task.results.updated-targetIndex)
-        - name: updated-binaryImage
-          value: $(tasks.run-task.results.updated-binaryImage)
       runAfter:
         - run-task
       taskSpec:
@@ -61,8 +58,6 @@ spec:
           - name: updated-fromIndex
             type: string
           - name: updated-targetIndex
-            type: string
-          - name: updated-binaryImage
             type: string
         steps:
           - name: check-result
@@ -72,8 +67,6 @@ spec:
                 value: '$(params.updated-fromIndex)'
               - name: "UPDATED_TARGETINDEX"
                 value: '$(params.updated-targetIndex)'
-              - name: "UPDATED_BINARYIMAGE"
-                value: '$(params.updated-binaryImage)'
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -82,4 +75,3 @@ spec:
               test "$(echo $UPDATED_FROMINDEX)" == \
               "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
               test "$(echo $UPDATED_TARGETINDEX)" == "quay.io/redhat/redhat----preview-operator-index:v4.13"
-              test "$(echo $UPDATED_BINARYIMAGE)" == "registry.redhat.io/openshift4/ose-operator-registry:v4.13"

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
@@ -29,8 +29,7 @@ spec:
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{ OCP_VERSION }}",
                   "targetIndex": "",
-                  "stagedIndex": "true",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:{{ OCP_VERSION }}"
+                  "stagedIndex": "true"
                 }
               }
               EOF
@@ -53,8 +52,6 @@ spec:
           value: $(tasks.run-task.results.updated-fromIndex)
         - name: updated-targetIndex
           value: $(tasks.run-task.results.updated-targetIndex)
-        - name: updated-binaryImage
-          value: $(tasks.run-task.results.updated-binaryImage)
       runAfter:
         - run-task
       taskSpec:
@@ -62,8 +59,6 @@ spec:
           - name: updated-fromIndex
             type: string
           - name: updated-targetIndex
-            type: string
-          - name: updated-binaryImage
             type: string
         steps:
           - name: check-result
@@ -73,8 +68,6 @@ spec:
                 value: '$(params.updated-fromIndex)'
               - name: "UPDATED_TARGETINDEX"
                 value: '$(params.updated-targetIndex)'
-              - name: "UPDATED_BINARYIMAGE"
-                value: '$(params.updated-binaryImage)'
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -82,5 +75,4 @@ spec:
               echo "Validate all tags got updated to v4.13"
               test "$UPDATED_FROMINDEX" == \
               "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
-              test "$UPDATED_BINARYIMAGE" == "registry.redhat.io/openshift4/ose-operator-registry:v4.13"
               test "$UPDATED_TARGETINDEX" == ""

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
@@ -28,8 +28,7 @@ spec:
               {
                 "fbc": {
                   "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{ OCP_VERSION }}",
-                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}",
-                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:{{ OCP_VERSION }}"
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}"
                 }
               }
               EOF
@@ -52,8 +51,6 @@ spec:
           value: $(tasks.run-task.results.updated-fromIndex)
         - name: updated-targetIndex
           value: $(tasks.run-task.results.updated-targetIndex)
-        - name: updated-binaryImage
-          value: $(tasks.run-task.results.updated-binaryImage)
       runAfter:
         - run-task
       taskSpec:
@@ -61,8 +58,6 @@ spec:
           - name: updated-fromIndex
             type: string
           - name: updated-targetIndex
-            type: string
-          - name: updated-binaryImage
             type: string
         steps:
           - name: check-result
@@ -72,8 +67,6 @@ spec:
                 value: '$(params.updated-fromIndex)'
               - name: "UPDATED_TARGETINDEX"
                 value: '$(params.updated-targetIndex)'
-              - name: "UPDATED_BINARYIMAGE"
-                value: '$(params.updated-binaryImage)'
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -82,4 +75,3 @@ spec:
               test "$(echo $UPDATED_FROMINDEX)" == \
               "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
               test "$(echo $UPDATED_TARGETINDEX)" == "quay.io/redhat/redhat----preview-operator-index:v4.13"
-              test "$(echo $UPDATED_BINARYIMAGE)" == "registry.redhat.io/openshift4/ose-operator-registry:v4.13"

--- a/tasks/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/update-ocp-tag.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-ocp-tag
   labels:
-    app.kubernetes.io/version: "1.4.2"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,9 +26,6 @@ spec:
     - name: updated-targetIndex
       type: string
       description: Index image (catalog of catalogs) the FBC fragment will be added to with updated tag
-    - name: updated-binaryImage
-      type: string
-      description: OCP binary image to be baked into the index image with updated tag
   workspaces:
     - name: data
       description: The workspace where the snapshot spec and data json files reside
@@ -68,12 +65,10 @@ spec:
         # Access the updated image
         updatedFromIndex=$(replace_tag "$(jq -r '.fbc.fromIndex' "$DATA_FILE")")
         updatedTargetIndex=$(replace_tag "$(jq -r '.fbc.targetIndex' "$DATA_FILE")")
-        updatedBinaryImage=$(replace_tag "$(jq -r '.fbc.binaryImage' "$DATA_FILE")")
 
         # if {{OCP_VERSION}} is not set, the original Index will be kept but its ocp version should
         # match base image version.
         validateOCPVersion "${updatedFromIndex}" "$(params.ocpVersion)"
-        validateOCPVersion "${updatedBinaryImage}" "$(params.ocpVersion)"
         if [ -n "${updatedTargetIndex}" ]; then
           validateOCPVersion "${updatedTargetIndex}" "$(params.ocpVersion)"
         fi
@@ -82,6 +77,4 @@ spec:
         echo -n "$updatedFromIndex" | tee "$(results.updated-fromIndex.path)"
         echo
         echo -n "$updatedTargetIndex" | tee "$(results.updated-targetIndex.path)"
-        echo
-        echo -n "$updatedBinaryImage" | tee "$(results.updated-binaryImage.path)"
         echo


### PR DESCRIPTION
this commit removes the binaryImage reference from FBC Release pipeline and tasks so the IIB build can auto resolve it.