### PR TITLE
feat(RELEASE-1102): remove unused data.fbc paremeters from the fbc tasks

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -7,14 +7,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "iibOverwriteFromIndexCredential": {
-          "type": "string",
-          "description": "The credentials used to overwrite the existing index e.g. example-iib-overwrite-fromindex-credential"
-        },
-        "iibServiceConfigSecret": {
-          "type": "string",
-          "description": "The secret containing the information required by the IIB service e.g. example-iib-service-config-secret"
-        },
         "request": {
           "type": "string",
           "description": "The internal pipeline name to handle requests e.g. iib"

--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -13,6 +13,10 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.4.1
+* Removed references to data parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential` as
+  they should not be changed by users.
+
 ## Changes in 3.4.0
 * Removed the `binaryImage` parameter so IIB can auto resolve it
 

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "3.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -73,9 +73,6 @@ spec:
         default_build_timeout_seconds="1500"
         default_request_timeout_seconds="1500"
 
-        iib_overwrite_from_index_credential=$(jq -r \
-          '.fbc.iibOverwriteFromIndexCredential // "iib-overwrite-fromimage-credentials"' "${DATA_FILE}")
-        iib_service_config_secret=$(jq -r '.fbc.iibServiceConfigSecret // "iib-services-config"' "${DATA_FILE}")
         build_tags=$(jq '.fbc.buildTags // []' "${DATA_FILE}")
         add_arches=$(jq '.fbc.addArches // []' "${DATA_FILE}")
         hotfix=$(jq -r '.fbc.hotfix // "false"' "${DATA_FILE}")
@@ -90,9 +87,9 @@ spec:
         fbc_fragment=$(jq -cr '.components[0].containerImage' "${SNAPSHOT_PATH}")
 
         if [ "${staged_index}" = "true" ]; then
-          iib_service_account_secret=iib-service-account-stage
+          iib_service_account_secret="iib-service-account-stage"
         else
-          iib_service_account_secret=iib-service-account-prod
+          iib_service_account_secret="iib-service-account-prod"
         fi
 
         timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' "${DATA_FILE}")
@@ -138,9 +135,7 @@ spec:
             -p fromIndex="$(params.fromIndex)" \
             -p targetIndex="${target_index}" \
             -p fbcFragment="${fbc_fragment}" \
-            -p iibServiceConfigSecret="${iib_service_config_secret}" \
             -p iibServiceAccountSecret="${iib_service_account_secret}" \
-            -p iibOverwriteFromIndexCredential="${iib_overwrite_from_index_credential}" \
             -p buildTimeoutSeconds="${build_timeout_seconds}" \
             -p buildTags="${build_tags}" \
             -p addArches="${add_arches}" \

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -39,8 +39,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "hotfix": true,
                   "issueId": "bz123456",
@@ -87,19 +85,6 @@ spec:
 
               internalRequest=$(echo "${internalRequest}" | xargs)
               requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-
-              if [ "$(jq -r '.iibServiceConfigSecret' <<< "${requestParams}")" != "test-iib-service-config-secret" ];
-              then
-                echo "iibServiceConfigSecret does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.iibOverwriteFromIndexCredential' <<< "${requestParams}")
-              if [ "${value}" != "test-iib-overwrite-fromindex-credential" ]
-              then
-                echo "iibOverwriteFromIndexCredential does not match"
-                exit 1
-              fi
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -43,8 +43,6 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "buildTimeoutSeconds": 420,
                   "requestTimeoutSeconds": 120

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -42,8 +42,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "preGA": "true",
                   "hotfix": "true",

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -40,8 +40,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "preGA": "true",
                   "productName": "pre-ga-product",
@@ -89,19 +87,6 @@ spec:
 
               internalRequest=$(echo "${internalRequest}" | xargs)
               requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-
-              if [ "$(jq -r '.iibServiceConfigSecret' <<< "${requestParams}")" != "test-iib-service-config-secret" ];
-              then
-                echo "iibServiceConfigSecret does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.iibOverwriteFromIndexCredential' <<< "${requestParams}")
-              if [ "${value}" != "test-iib-overwrite-fromindex-credential" ]
-              then
-                echo "iibOverwriteFromIndexCredential does not match"
-                exit 1
-              fi
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -39,7 +39,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
                   "stagedIndex": true,
                   "buildTimeoutSeconds": 420
                 }

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -39,8 +39,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "buildTimeoutSeconds": 1,
                   "requestTimeoutSeconds": 1

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -39,8 +39,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
-                  "iibServiceConfigSecret": "test-iib-service-config-secret",
-                  "iibOverwriteFromIndexCredential": "test-iib-overwrite-fromindex-credential",
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "buildTimeoutSeconds": 420,
                   "requestTimeoutSeconds": 120
@@ -98,19 +96,6 @@ spec:
 
               internalRequest=$(echo "${internalRequest}" | xargs)
               requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-
-              if [ "$(jq -r '.iibServiceConfigSecret' <<< "${requestParams}")" != "test-iib-service-config-secret" ];
-              then
-                echo "iibServiceConfigSecret does not match"
-                exit 1
-              fi
-
-              value=$(jq -r '.iibOverwriteFromIndexCredential' <<< "${requestParams}")
-              if [ "${value}" != "test-iib-overwrite-fromindex-credential" ]
-              then
-                echo "iibOverwriteFromIndexCredential does not match"
-                exit 1
-              fi
 
               test "$(jq -r '.index_image.target_index' \
                 "$(workspaces.data.path)"/results/add-fbc-contribution-results.json)" == \


### PR DESCRIPTION
this commit removes references of unused or unecessary parameters in FBC Release Pipeline and tasks, namely: iibServiceConfigSecret, and iibOverwriteFromIndexCredential.