### PR TITLE
Fix the visualization of FBC pipeline task dependencies

### DIFF
--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -203,6 +203,8 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: ocpVersion
           value: "$(tasks.get-ocp-version.results.stored-version)"
+      runAfter:
+        - get-ocp-version
     - name: check-fbc-packages
       workspaces:
         - name: data
@@ -253,6 +255,7 @@ spec:
           value: "$(tasks.collect-data.results.resultsDir)"
       runAfter:
         - check-fbc-packages
+        - update-ocp-tag
         - verify-enterprise-contract
     - name: extract-requester-from-release
       taskRef:


### PR DESCRIPTION
While Tekton will schedule the tasks based on dependencies detected from the results, the visualization of the tasks does not show these dependencies. The runAfter property needs to be used to enable better visualization.