### PR TITLE
feat(ISV-5129): create product-level SBOMs

### DIFF
--- a/tasks/create-product-sbom/README.md
+++ b/tasks/create-product-sbom/README.md
@@ -1,0 +1,11 @@
+# create-product-sbom
+
+Tekton task to create a product-level SBOM to be uploaded to Atlas from
+releaseNotes content.
+
+## Parameters
+
+| Name             | Description                                                              | Optional | Default value |
+|------------------|--------------------------------------------------------------------------|----------|---------------|
+| dataJsonPath     | Path to the JSON string of the merged data containing the release notes  | No       | -             |
+

--- a/tasks/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/create-product-sbom/create-product-sbom.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: create-product-sbom
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Create product-level SBOM from release notes.
+  params:
+    - name: dataJsonPath
+      description: Relative path to the JSON data file in the workspace.
+      type: string
+  workspaces:
+    - name: data
+      description: Workspace to save the product-level SBOM to.
+  results:
+    - name: productSBOMPath
+      description: Relative path to the created product-level SBOM in the data workspace.
+  steps:
+    - name: create-sbom
+      image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        SBOM_FILE="product_sbom.json"
+        SBOM_PATH="$(dirname "$(params.dataJsonPath)")/${SBOM_FILE}"
+        OUTPUT_PATH=$(workspaces.data.path)/${SBOM_PATH}
+
+        create_product_sbom --data-path "$(workspaces.data.path)/$(params.dataJsonPath)" \
+          --output-path "$OUTPUT_PATH"
+
+        echo -n "$SBOM_PATH" > "$(results.productSBOMPath.path)"

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-product-sbom-basic
+spec:
+  description: |
+    Create a product-level SBOM where components contain only one purl.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "images": [
+                    {
+                      "component": "test-component-1",
+                      "purl": "test-component-1-purl-1"
+                    },
+                    {
+                      "component": "test-component-2",
+                      "purl": "test-component-2-purl-1"
+                    }
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: create-product-sbom
+      params:
+        - name: dataJsonPath
+          value: "data.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: sbom
+          value: $(tasks.run-task.results.productSBOMPath)
+      taskSpec:
+        params:
+          - name: sbom
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cp "$(workspaces.data.path)/$(params.sbom)" sbom.json
+
+              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product"
+
+              # Check product SPDX package and relationship
+              test "$(jq -r '.packages[0].SPDXID' sbom.json)" == "SPDXRef-product"
+              test "$(jq -r '.packages[0].name' sbom.json)" == "Red Hat Openstack Product"
+              test "$(jq -r '.packages[0].versionInfo' sbom.json)" == "123"
+              test "$(jq -r '.packages[0].externalRefs[0].referenceLocator' sbom.json)" == \
+                "cpe:/a:example:openstack:el8"
+
+              test "$(jq -r '.relationships[0].relationshipType' sbom.json)" == "DESCRIBES"
+              test "$(jq -r '.relationships[0].relatedSpdxElement' sbom.json)" == "SPDXRef-product"
+
+              # Check component SPDX packages and relationships
+              # Component 1
+              test "$(jq -r '.packages[1].name' sbom.json)" == "test-component-1"
+              test "$(jq -r '.packages[1].externalRefs[0].referenceLocator' sbom.json)" == \
+                "test-component-1-purl-1"
+
+              test "$(jq -r '.relationships[1].relationshipType' sbom.json)" == "PACKAGE_OF"
+              test "$(jq -r '.relationships[1].relatedSpdxElement' sbom.json)" == "SPDXRef-component-0"
+
+              # Component 2
+              test "$(jq -r '.packages[2].name' sbom.json)" == "test-component-2"
+              test "$(jq -r '.packages[2].externalRefs[0].referenceLocator' sbom.json)" == \
+                "test-component-2-purl-1"
+
+              test "$(jq -r '.relationships[2].relationshipType' sbom.json)" == "PACKAGE_OF"
+              test "$(jq -r '.relationships[2].relatedSpdxElement' sbom.json)" == "SPDXRef-component-1"
+
+              test "$(jq -r '.packages | length' sbom.json)" == 3
+              test "$(jq -r '.relationships | length' sbom.json)" == 3
+      runAfter:
+        - run-task

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-product-sbom-multiple-purls
+spec:
+  description: |
+    Create a product-level SBOM where components can contain multiple purls.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "images": [
+                    {
+                      "component": "test-component-1",
+                      "purl": "test-component-1-purl-1"
+                    },
+                    {
+                      "component": "test-component-1",
+                      "purl": "test-component-1-purl-2"
+                    },
+                    {
+                      "component": "test-component-2",
+                      "purl": "test-component-2-purl-1"
+                    }
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: create-product-sbom
+      params:
+        - name: dataJsonPath
+          value: "data.json"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: sbom
+          value: $(tasks.run-task.results.productSBOMPath)
+      taskSpec:
+        params:
+          - name: sbom
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cp "$(workspaces.data.path)/$(params.sbom)" sbom.json
+
+              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product"
+
+              # Check product SPDX package and relationship
+              test "$(jq -r '.packages[0].SPDXID' sbom.json)" == "SPDXRef-product"
+              test "$(jq -r '.packages[0].name' sbom.json)" == "Red Hat Openstack Product"
+              test "$(jq -r '.packages[0].versionInfo' sbom.json)" == "123"
+              test "$(jq -r '.packages[0].externalRefs[0].referenceLocator' sbom.json)" == \
+                "cpe:/a:example:openstack:el8"
+
+              test "$(jq -r '.relationships[0].relationshipType' sbom.json)" == "DESCRIBES"
+              test "$(jq -r '.relationships[0].relatedSpdxElement' sbom.json)" == "SPDXRef-product"
+
+              # Check component SPDX packages and relationships
+              # Component 1
+              test "$(jq -r '.packages[1].name' sbom.json)" == "test-component-1"
+              test "$(jq -r '.packages[1].externalRefs[0].referenceLocator' sbom.json)" == \
+                "test-component-1-purl-1"
+              test "$(jq -r '.packages[1].externalRefs[1].referenceLocator' sbom.json)" == \
+                "test-component-1-purl-2"
+
+              test "$(jq -r '.relationships[1].relationshipType' sbom.json)" == "PACKAGE_OF"
+              test "$(jq -r '.relationships[1].relatedSpdxElement' sbom.json)" == "SPDXRef-component-0"
+
+              # Component 2
+              test "$(jq -r '.packages[2].name' sbom.json)" == "test-component-2"
+              test "$(jq -r '.packages[2].externalRefs[0].referenceLocator' sbom.json)" == \
+                "test-component-2-purl-1"
+
+              test "$(jq -r '.relationships[2].relationshipType' sbom.json)" == "PACKAGE_OF"
+              test "$(jq -r '.relationships[2].relatedSpdxElement' sbom.json)" == "SPDXRef-component-1"
+
+              test "$(jq -r '.packages | length' sbom.json)" == 3
+              test "$(jq -r '.relationships | length' sbom.json)" == 3
+      runAfter:
+        - run-task

--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -10,6 +10,9 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 2.2.2
+* Add component association information
+
 ## Changes in 2.2.1
 * Add unique tag info to purl
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "2.2.1"
+    app.kubernetes.io/version: "2.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -95,13 +95,15 @@ spec:
                 fi
 
                 jsonString=$(jq -cn \
+                    --arg component "$name" \
                     --arg arch "$arch" \
                     --arg containerImage "$containerImage" \
                     --arg purl "$purl" \
                     --arg repository "$deliveryRepo" \
                     --argjson tags "$tags" \
                     '{"architecture": $arch, "containerImage":$containerImage,
-                    "purl": $purl, "repository": $repository, "tags": $tags}')
+                    "purl": $purl, "repository": $repository, "tags": $tags,
+                    "component": $component}')
                 if [ $(jq '.cves.fixed | length' <<< $CVEsJson) -gt 0 ]; then
                     jsonString=$(jq --argjson cves "$CVEsJson" '. += $cves' <<< $jsonString)
                 fi

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
@@ -96,7 +96,7 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               imagearch1=$(jq '.releaseNotes.content.images[0]' "$(workspaces.data.path)/data.json")
@@ -106,6 +106,7 @@ spec:
                 "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
               test $(jq -r '.repository' <<< $imagearch1) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch1) == '["foo","bar"]'
+              test "$(jq -rc '.component' <<< "$imagearch1")" == "comp"
 
               imagearch2=$(jq '.releaseNotes.content.images[1]' "$(workspaces.data.path)/data.json")
               test $(jq -r '.architecture' <<< $imagearch2) == "s390x"
@@ -114,5 +115,6 @@ spec:
                 "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
               test $(jq -r '.repository' <<< $imagearch2) == "registry.redhat.io/product/repo"
               test $(jq -rc '.tags' <<< $imagearch2) == '["foo","bar"]'
+              test "$(jq -rc '.component' <<< "$imagearch2")" == "comp"
       runAfter:
         - run-task


### PR DESCRIPTION
Added a Task that creates a product-level SBOM from release notes.

TODO:
- [x]  Bump version of `populate-release-notes-images` task (Waiting for #548)