### PR TITLE
feat(RELEASE-1144): push content sets to Pyxis

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes     | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                       | No       | -             |
 
+## Changes in 1.2.0
+* The `push-rpm-manifest-to-pyxis` task is renamed to `push-rpm-data-to-pyxis`
+
 ## Changes in 1.1.0
 * The `publish-pyxis-repository` now gets the `resultsDirPath` parameter from the `collect-data` results
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -398,8 +398,8 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-rpm-manifests-to-pyxis
-    - name: push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
+    - name: push-rpm-data-to-pyxis
       taskRef:
         resolver: "git"
         params:
@@ -408,7 +408,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+            value: tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
       params:
         - name: pyxisJsonPath
           value: $(tasks.create-pyxis-image.results.pyxisDataPath)
@@ -432,7 +432,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                       | No        | -            |
 
+## Changes in 5.2.0
+* The `push-rpm-manifest-to-pyxis` task is renamed to `push-rpm-data-to-pyxis`
+
 ## Changes in 5.1.0
 * Add tasks `collect-registry-token-secret` and `make-repo-public`
   * `collect-registry-token-secret` will get the secret containing the token to access quay.io API

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.1.0"
+    app.kubernetes.io/version: "5.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -235,7 +235,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-snapshot
-    - name: push-rpm-manifests-to-pyxis
+    - name: push-rpm-data-to-pyxis
       taskRef:
         resolver: "git"
         params:
@@ -244,7 +244,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+            value: tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
       params:
         - name: pyxisJsonPath
           value: $(tasks.create-pyxis-image.results.pyxisDataPath)
@@ -313,7 +313,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision       | The revision in the taskGitUrl repo to be used                               | No       | -             |
 
+## Changes in 4.2.0
+* The `push-rpm-manifest-to-pyxis` task is renamed to `push-rpm-data-to-pyxis`
+
 ## Changes in 4.1.0
 * The `publish-pyxis-repository` now gets the `resultsDirPath` parameter from the `collect-data` results
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -353,8 +353,8 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-rpm-manifests-to-pyxis
-    - name: push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
+    - name: push-rpm-data-to-pyxis
       taskRef:
         resolver: "git"
         params:
@@ -363,7 +363,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+            value: tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
       params:
         - name: pyxisJsonPath
           value: $(tasks.create-pyxis-image.results.pyxisDataPath)
@@ -387,7 +387,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       runAfter:
-        - push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
       taskRef:
         kind: Task
         params:

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -21,6 +21,9 @@
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored   | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                          | No       | -             |
 
+## Changes in 4.1.0
+* The `push-rpm-manifest-to-pyxis` task is renamed to `push-rpm-data-to-pyxis`
+
 ## Changes in 4.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 
@@ -36,9 +39,9 @@
 ## Changes in 3.11.0
 * Updated the image passed to the `infra-deployments-pr` task
 
-## Changes in 3.10.0 
+## Changes in 3.10.0
 * Removed `verify-access-to-resources` script and replaced it with a task.
-  
+
 ## Changes in 3.9.0
 * The `create-pyxis-image` task no longer receives the `dataPath` parameter
 

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -257,7 +257,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-snapshot
-    - name: push-rpm-manifests-to-pyxis
+    - name: push-rpm-data-to-pyxis
       taskRef:
         resolver: "git"
         params:
@@ -266,7 +266,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/push-rpm-manifests-to-pyxis/push-rpm-manifests-to-pyxis.yaml
+            value: tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
       params:
         - name: pyxisJsonPath
           value: $(tasks.create-pyxis-image.results.pyxisDataPath)
@@ -299,7 +299,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-rpm-manifests-to-pyxis
+        - push-rpm-data-to-pyxis
     - name: update-cr-status
       params:
         - name: resource

--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -1,15 +1,23 @@
-# push-rpm-manifests-to-pyxis
+# push-rpm-data-to-pyxis
 
 Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an RPM Manifest.
+In addition, it will also update ContainerImage.content_sets field in Pyxis to include
+all repository_id strings found in rpm purl strings in the sboms.
 
 ## Parameters
 
 | Name            | Description                                                                                         | Optional | Default value |
 |-----------------|-----------------------------------------------------------------------------------------------------|----------|---------------|
-| pyxisJsonPath   | Path to the JSON string of the saved Pyxis data in the data workspace                               | No       | -             | 
+| pyxisJsonPath   | Path to the JSON string of the saved Pyxis data in the data workspace                               | No       | -             |
 | pyxisSecret     | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert   | No       | -             |
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
+
+## Changes in 1.0.0
+* Renamed task from `push-rpm-manifest-to-pyxis` to `push-rpm-data-to-pyxis`
+* Updated the image used in this task
+  * The `upload_rpm_manifest` is renamed to `upload_rpm_data` and on top of RPM Manifest,
+    it also updates the ContainerImage.content_sets field in Pyxis
 
 ## Changes in 0.4.4
 * Updated the base image used in this task

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -2,15 +2,17 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: push-rpm-manifests-to-pyxis
+  name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "0.4.4"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
     Tekton task that extracts all rpms from the sboms and pushes them to Pyxis as an RPM Manifest.
+    In addition, it will also update ContainerImage.content_sets field in Pyxis to include
+    all repository_id strings found in rpm purl strings in the sboms.
   params:
     - name: pyxisJsonPath
       description: Path to the JSON string of the saved Pyxis data in the data workspace
@@ -36,7 +38,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+        quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -91,9 +93,9 @@ spec:
           exit 1
         fi
 
-    - name: push-rpm-manifests-to-pyxis
+    - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+        quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
       env:
         - name: pyxisCert
           valueFrom:
@@ -144,13 +146,13 @@ spec:
         total=$(ls *.json | wc -l )
         count=0
         success=true
-        echo "Starting RPM Manifest upload for $total files in total. " \
+        echo "Starting RPM data upload for $total files in total. " \
           "Up to $N files will be uploaded at once..."
 
         for FILE in *.json; do
           IMAGEID=$(echo $FILE | cut -d '.' -f 1)
-          echo Uploading RPM Manifest to Pyxis for IMAGE: $IMAGEID with SBOM: $FILE
-          upload_rpm_manifest --retry --image-id $IMAGEID --sbom-path $FILE --verbose > ${IMAGEID}.out 2>&1 &
+          echo Uploading RPM data to Pyxis for IMAGE: "$IMAGEID" with SBOM: "$FILE"
+          upload_rpm_data --retry --image-id "$IMAGEID" --sbom-path "$FILE" --verbose > "${IMAGEID}.out" 2>&1 &
 
           jobs+=($!)  # Save the background process ID
           images+=($IMAGEID)
@@ -160,13 +162,13 @@ spec:
             echo Waiting for the current batch of background processes to finish
             for job_id in "${!jobs[@]}"; do
               if ! wait ${jobs[job_id]}; then
-                echo "Error: upload of rpm manifests failed for one of the images"
+                echo "Error: upload of rpm data failed for one of the images"
                 success=false
               fi
             done
 
             echo
-            echo Printing outputs for current upload_rpm_manifest script runs
+            echo Printing outputs for current upload_rpm_data script runs
             for img in ${images[@]}; do
               echo "=== $img ==="
               cat "${img}.out"

--- a/tasks/push-rpm-data-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-data-to-pyxis/tests/mocks.sh
@@ -17,9 +17,9 @@ function cosign() {
   touch /workdir/sboms/${4}
 }
 
-function upload_rpm_manifest() {
-  echo Mock upload_rpm_manifest called with: $*
-  echo $* >> $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+function upload_rpm_data() {
+  echo Mock upload_rpm_data called with: $*
+  echo $* >> "$(workspaces.data.path)/mock_upload_rpm_data.txt"
 
   if [[ "$*" != "--retry --image-id "*" --sbom-path "*".json --verbose" ]]
   then
@@ -29,7 +29,7 @@ function upload_rpm_manifest() {
 
   if [[ "$3" == myImageID1Failing ]]
   then
-    echo "Simulating a failing RPM Manifest push..."
+    echo "Simulating a failing RPM data push..."
     return 1
   fi
 

--- a/tasks/push-rpm-data-to-pyxis/tests/pre-apply-task-hook.sh
+++ b/tasks/push-rpm-data-to-pyxis/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Create a dummy pyxis secret (and delete it first if it exists)
-kubectl delete secret test-push-rpm-manifests-to-pyxis-cert --ignore-not-found
-kubectl create secret generic test-push-rpm-manifests-to-pyxis-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl delete secret test-push-rpm-data-to-pyxis-cert --ignore-not-found
+kubectl create secret generic test-push-rpm-data-to-pyxis-cert --from-literal=cert=mycert --from-literal=key=mykey
 
 # Add mocks to the beginning of scripts
 yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-failure
+  name: test-push-rpm-data-to-pyxis-failure
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters.
+    Run the push-rpm-data-to-pyxis task with required parameters.
     The first image will fail. The second image will still have a rpm manifest pushed.
   workspaces:
     - name: tests-workspace
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -58,12 +58,12 @@ spec:
               EOF
     - name: run-task
       taskRef:
-        name: push-rpm-manifests-to-pyxis
+        name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
           value: pyxis.json
         - name: pyxisSecret
-          value: test-push-rpm-manifests-to-pyxis-cert
+          value: test-push-rpm-data-to-pyxis-cert
         - name: server
           value: production
       runAfter:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-multi-arch
+  name: test-push-rpm-data-to-pyxis-multi-arch
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters and multi arch
+    Run the push-rpm-data-to-pyxis task with required parameters and multi arch
     images
   workspaces:
     - name: tests-workspace
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,12 +70,12 @@ spec:
               EOF
     - name: run-task
       taskRef:
-        name: push-rpm-manifests-to-pyxis
+        name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
           value: pyxis.json
         - name: pyxisSecret
-          value: test-push-rpm-manifests-to-pyxis-cert
+          value: test-push-rpm-data-to-pyxis-cert
         - name: server
           value: production-internal
       runAfter:
@@ -92,20 +92,20 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 4 ]; then
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_cosign.txt")" != 4 ]; then
                 echo Error: cosign was expected to be called 4 times. Actual calls:
-                cat $(workspaces.data.path)/mock_cosign.txt
+                cat "$(workspaces.data.path)/mock_cosign.txt"
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 4 ]; then
-                echo Error: upload_rpm_manifest was expected to be called 4 times. Actual calls:
-                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_upload_rpm_data.txt")" != 4 ]; then
+                echo Error: upload_rpm_data was expected to be called 4 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_upload_rpm_data.txt"
                 exit 1
               fi
       runAfter:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
@@ -2,24 +2,24 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-no-pyxis-file
+  name: test-push-rpm-data-to-pyxis-no-pyxis-file
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with no pyxis file provided in the workspace.
+    Run the push-rpm-data-to-pyxis task with no pyxis file provided in the workspace.
     This should result in a failure.
   workspaces:
     - name: tests-workspace
   tasks:
     - name: run-task
       taskRef:
-        name: push-rpm-manifests-to-pyxis
+        name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
           value: missing.json
         - name: pyxisSecret
-          value: test-push-rpm-manifests-to-pyxis-cert
+          value: test-push-rpm-data-to-pyxis-cert
         - name: server
           value: production
       workspaces:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-parallel
+  name: test-push-rpm-data-to-pyxis-parallel
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters with multiple images
+    Run the push-rpm-data-to-pyxis task with required parameters with multiple images
     processed in parallel.
   workspaces:
     - name: tests-workspace
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,12 +92,12 @@ spec:
               EOF
     - name: run-task
       taskRef:
-        name: push-rpm-manifests-to-pyxis
+        name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
           value: pyxis.json
         - name: pyxisSecret
-          value: test-push-rpm-manifests-to-pyxis-cert
+          value: test-push-rpm-data-to-pyxis-cert
         - name: server
           value: production
         - name: concurrentLimit
@@ -116,31 +116,31 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 5 ]; then
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_cosign.txt")" != 5 ]; then
                 echo Error: cosign was expected to be called 5 times. Actual calls:
-                cat $(workspaces.data.path)/mock_cosign.txt
+                cat "$(workspaces.data.path)/mock_cosign.txt"
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 5 ]; then
-                echo Error: upload_rpm_manifest was expected to be called 5 times. Actual calls:
-                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_upload_rpm_data.txt")" != 5 ]; then
+                echo Error: upload_rpm_data was expected to be called 5 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_upload_rpm_data.txt"
                 exit 1
               fi
 
-              # Check that multiple instances of upload_rpm_manifest were running in parallel - up to 4 at once
+              # Check that multiple instances of upload_rpm_data were running in parallel - up to 4 at once
               if ! cat $(workspaces.data.path)/myImageID[1234]Parallel.count | grep 4; then
-                echo Error: Expected to see 4 parallel runs of upload_rpm_manifest at some point.
+                echo Error: Expected to see 4 parallel runs of upload_rpm_data at some point.
                 echo Actual counts:
                 cat $(workspaces.data.path)/myImageID[1234]Parallel.count
                 exit 1
               fi
-              # The last instance of upload_rpm_manifest was in a new batch - it ran alone
+              # The last instance of upload_rpm_data was in a new batch - it ran alone
               test $(wc -l < $(workspaces.data.path)/myImageID5Parallel.count) -eq 1
       runAfter:
         - run-task

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-manifests-to-pyxis-single-arch
+  name: test-push-rpm-data-to-pyxis-single-arch
 spec:
   description: |
-    Run the push-rpm-manifests-to-pyxis task with required parameters and single arch
+    Run the push-rpm-data-to-pyxis task with required parameters and single arch
     images - a happy path scenario.
   workspaces:
     - name: tests-workspace
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,12 +56,12 @@ spec:
               EOF
     - name: run-task
       taskRef:
-        name: push-rpm-manifests-to-pyxis
+        name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
           value: pyxis_data.json
         - name: pyxisSecret
-          value: test-push-rpm-manifests-to-pyxis-cert
+          value: test-push-rpm-data-to-pyxis-cert
         - name: server
           value: production
       runAfter:
@@ -78,20 +78,20 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:ccea6ba4c34af8ef699b45a478bbd924e5a36644
             script: |
               #!/usr/bin/env sh
               set -eux
 
-              if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_cosign.txt")" != 2 ]; then
                 echo Error: cosign was expected to be called 2 times. Actual calls:
-                cat $(workspaces.data.path)/mock_cosign.txt
+                cat "$(workspaces.data.path)/mock_cosign.txt"
                 exit 1
               fi
 
-              if [ $(cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt | wc -l) != 2 ]; then
-                echo Error: upload_rpm_manifest was expected to be called 2 times. Actual calls:
-                cat $(workspaces.data.path)/mock_upload_rpm_manifest.txt
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_upload_rpm_data.txt")" != 2 ]; then
+                echo Error: upload_rpm_data was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_upload_rpm_data.txt"
                 exit 1
               fi
 


### PR DESCRIPTION
* Renamed task from `push-rpm-manifest-to-pyxis` to `push-rpm-data-to-pyxis`
  * Updated the image used in this task
  * The `upload_rpm_manifest` is renamed to `upload_rpm_data` and on top of RPM Manifest, it also updates the ContainerImage.content_sets field in Pyxis
* Updated references to the task in all affected pipelines

For reference, this is the change in the utils image: https://github.com/konflux-ci/release-service-utils/pull/248