### PR TITLE
fix: skip empty target indexes

### DIFF
--- a/tasks/update-ocp-tag/README.md
+++ b/tasks/update-ocp-tag/README.md
@@ -9,6 +9,9 @@ occurs when the {{ OCP_VERSION }} placeholder is present.
 | dataPath   | Path to the JSON string of the merged data to use in the data workspace | No       | -             |
 | ocpVersion | OCP version fetched from fbcFragment                                    | No       | -             |
 
+## Changes in 1.4.2
+* Changed to skip validating the targetIndex when empty, as staged indexes does not have it set.
+
 ## Changes in 1.4.1
 * Changed the replace_tag function to only replace the OCP version tag of an index image when the {{ OCP_VERSION }}
   placeholder is present

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-ocp-tag-staged-index
+spec:
+  description: |
+    Run the update-ocp-tag task with sample values
+    and verify that all tags get updated to the new OCP version, except for the targetIndex when empty
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > $(workspaces.data.path)/data.json << EOF
+              {
+                "fbc": {
+                  "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{ OCP_VERSION }}",
+                  "targetIndex": "",
+                  "stagedIndex": "true",
+                  "binaryImage": "registry.redhat.io/openshift4/ose-operator-registry:{{ OCP_VERSION }}"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: update-ocp-tag
+      params:
+        - name: dataPath
+          value: data.json
+        - name: ocpVersion
+          value: "v4.13"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: updated-fromIndex
+          value: $(tasks.run-task.results.updated-fromIndex)
+        - name: updated-targetIndex
+          value: $(tasks.run-task.results.updated-targetIndex)
+        - name: updated-binaryImage
+          value: $(tasks.run-task.results.updated-binaryImage)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: updated-fromIndex
+            type: string
+          - name: updated-targetIndex
+            type: string
+          - name: updated-binaryImage
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "UPDATED_FROMINDEX"
+                value: '$(params.updated-fromIndex)'
+              - name: "UPDATED_TARGETINDEX"
+                value: '$(params.updated-targetIndex)'
+              - name: "UPDATED_BINARYIMAGE"
+                value: '$(params.updated-binaryImage)'
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo "Validate all tags got updated to v4.13"
+              test "$UPDATED_FROMINDEX" == \
+              "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13"
+              test "$UPDATED_BINARYIMAGE" == "registry.redhat.io/openshift4/ose-operator-registry:v4.13"
+              test "$UPDATED_TARGETINDEX" == ""

--- a/tasks/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/update-ocp-tag.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-ocp-tag
   labels:
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -70,11 +70,13 @@ spec:
         updatedTargetIndex=$(replace_tag "$(jq -r '.fbc.targetIndex' "$DATA_FILE")")
         updatedBinaryImage=$(replace_tag "$(jq -r '.fbc.binaryImage' "$DATA_FILE")")
 
-        # if {{OCP_VERSION}} is not set, the original targetIndex will be kept but its ocp version should
+        # if {{OCP_VERSION}} is not set, the original Index will be kept but its ocp version should
         # match base image version.
-        for index in "${updatedFromIndex}" "${updatedTargetIndex}" "${updatedBinaryImage}"; do
-          validateOCPVersion "${index}" "$(params.ocpVersion)"
-        done
+        validateOCPVersion "${updatedFromIndex}" "$(params.ocpVersion)"
+        validateOCPVersion "${updatedBinaryImage}" "$(params.ocpVersion)"
+        if [ -n "${updatedTargetIndex}" ]; then
+          validateOCPVersion "${updatedTargetIndex}" "$(params.ocpVersion)"
+        fi
 
         echo "Updated values"
         echo -n "$updatedFromIndex" | tee "$(results.updated-fromIndex.path)"


### PR DESCRIPTION
fix to skip validating targetIndex for stage fbc RPAs, which has targetIndex empty.