### PR TITLE
feat(CLDX-81): add sign-binaries task to push-binaries pipeline

### DIFF
--- a/pipelines/push-binaries-to-dev-portal/README.md
+++ b/pipelines/push-binaries-to-dev-portal/README.md
@@ -1,12 +1,12 @@
 # Push to Developer Portal Pipeline
 
-Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
+Tekton pipeline to sign and release Red Hat binaries to the Red Hat Developer Portal.
 
 ## Parameters
 
 | Name                            | Description                                                                                            | Optional | Default value |
 |---------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
-| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No       | -             |  
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No       | -             |
 | releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                | No       | -             |
 | releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                       | No       | -             |
 | releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                       | No       | -             |
@@ -18,6 +18,9 @@ Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                              | No       | -             |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
+
+## Changes in 1.1.0
+* Add the `sign-binaries` task to this pipeline.
 
 ## Changes in 1.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,13 +4,13 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton pipeline to release Red Hat binaries to the Red Hat Developer Portal.
+    Tekton pipeline to sign and release Red Hat binaries to the Red Hat Developer Portal.
   params:
     - name: release
       type: string
@@ -161,6 +161,34 @@ spec:
           value: "$(tasks.collect-data.results.data)"
       runAfter:
         - verify-enterprise-contract
+    - name: sign-binaries
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/sign-binaries/sign-binaries.yaml
+      params:
+        - name: quayURL
+          value: 'quay.io/konflux-artifacts'
+        - name: quaySecret
+          value: quay-credentials
+        - name: windowsCredentials
+          value: windows-credentials
+        - name: macHostCredentials
+          value: mac-host-credentials
+        - name: macSigningCredentials
+          value: mac-signing-credentials
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - extract-binaries-from-image
     - name: prepare-exodus-params
       workspaces:
         - name: data
@@ -178,7 +206,7 @@ spec:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
       runAfter:
-        - extract-binaries-from-image
+        - sign-binaries
     - name: push-to-cdn
       workspaces:
         - name: data

--- a/tasks/sign-binaries/README.md
+++ b/tasks/sign-binaries/README.md
@@ -10,4 +10,11 @@ Tekton task to sign windows and mac binaries before they are pushed to the Red H
 | quaySecret | Secret to interact with Quay | No |  |
 | windowsCredentials | Secret to interact with the Windows signing host | No |  |
 | windowsSSHKey | Secret containing private key and fingerprint for Windows signing host | Yes | windows-ssh-key |
+| macHostCredentials | Secret to interact with the Mac signing host | No |  |
+| macSigningCredentials | Secret to interact with the Mac signing utils | No |  |
+| macSSHKey | Secret containing SSH private key for the Mac signing host | Yes | mac-ssh-key |
 | pipelineRunUid | Unique ID of the pipelineRun | No |  |
+
+
+## Changes in 1.0.0
+* Added parameters for mac signing steps

--- a/tasks/sign-binaries/sign-binaries.yaml
+++ b/tasks/sign-binaries/sign-binaries.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-binaries
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,6 +25,16 @@ spec:
       type: string
       description: Secret containing SSH private key for the Windows signing host
       default: windows-ssh-key
+    - name: macHostCredentials
+      type: string
+      description: Secret to interact with the Mac signing host
+    - name: macSigningCredentials
+      type: string
+      description: Secret to interact with the Mac signing utils
+    - name: macSSHKey
+      type: string
+      description: Secret containing SSH private key for the Mac signing host
+      default: mac-ssh-key
     - name: pipelineRunUid
       type: string
       description: Unique identifier for the pipeline run

--- a/tasks/sign-binaries/tests/pre-apply-task-hook.sh
+++ b/tasks/sign-binaries/tests/pre-apply-task-hook.sh
@@ -9,6 +9,9 @@ yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 # Delete existing secrets if they exist
 kubectl delete secret windows-credentials --ignore-not-found
 kubectl delete secret windows-ssh-key --ignore-not-found
+kubectl delete secret mac-signing-credentials --ignore-not-found
+kubectl delete secret mac-host-credentials --ignore-not-found
+kubectl delete secret mac-ssh-key --ignore-not-found
 kubectl delete secret quay-secret --ignore-not-found
 # Create the windows-credentials secret
 kubectl create secret generic windows-credentials \
@@ -28,4 +31,24 @@ kubectl create secret generic windows-ssh-key \
 kubectl create secret generic quay-secret \
     --from-literal=username=myusername \
     --from-literal=password=mypass \
+    --namespace=default
+
+# Create the mac-host-credentials secret
+kubectl create secret generic mac-host-credentials \
+    --from-literal=mac-host="some_host" \
+    --from-literal=mac-user="some_user" \
+    --from-literal=mac-password="some_password" \
+
+# Create the mac-signing-credentials secret
+kubectl create secret generic mac-signing-credentials \
+    --from-literal=keychain_password="some_password" \
+    --from-literal=signing_identity="some_identity" \
+    --from-literal=apple_id="some_id" \
+    --from-literal=app_specific_password="some_password" \
+    --from-literal=team_id="some_id" \
+
+# Create the mac-ssh-key secret
+kubectl create secret generic mac-ssh-key \
+    --from-literal=id_rsa="some private key" \
+    --from-literal=fingerprint="some fingerprint" \
     --namespace=default

--- a/tasks/sign-binaries/tests/test-sign-binaries.yaml
+++ b/tasks/sign-binaries/tests/test-sign-binaries.yaml
@@ -20,6 +20,10 @@ spec:
           value: windows-credentials
         - name: ssh_key_secret
           value: windows-ssh-key
+        - name: macHostCredentials
+          value: mac-host-credentials
+        - name: macSigningCredentials
+          value: mac-signing-credentials
         - name: quaySecret
           value: quay-secret
         - name: quayURL


### PR DESCRIPTION
This commit adds the sign-binaries task to the push-binaries pipeline. There will still be follow-up commits as part of the [CLDX-76](https://issues.redhat.com//browse/CLDX-76) epic to implement the remaining steps.