### PR TITLE
fix(RELEASE-1178): fetching of Dockerfile oci artifact

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -18,6 +18,10 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published.                                                                                                         | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       | -             |
 
+## Changes in 3.3.1
+* Fix fetching of Dockerfile oci artifact
+  * The pull spec is composed from the digest, but we need to replace `:` with `-`
+
 ## Changes in 3.3.0
 * Updated the base image used in this task
   * The new image supports the --dockerfile cli argument for create_container_image

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.3.0"
+    app.kubernetes.io/version: "3.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -121,7 +121,7 @@ spec:
             DOCKERFILE_DIR="$(mktemp -d)"
             DOCKERFILE_PATH=""
             # try fetching Dockerfile for the image
-            if oras pull --registry-config "$AUTH_FILE" "${SOURCE_REPO}:${DIGEST}.dockerfile" -o "${DOCKERFILE_DIR}"
+            if oras pull --registry-config "$AUTH_FILE" "${SOURCE_REPO}:${DIGEST/:/-}.dockerfile" -o "${DOCKERFILE_DIR}"
             then
               DOCKERFILE_PATH="${DOCKERFILE_DIR}/Dockerfile"
               if [ ! -f "${DOCKERFILE_PATH}" ]; then

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -44,7 +44,7 @@ function skopeo() {
 }
 
 function get-image-architectures() {
-  if [[ "$*" =~ registry.io/multi-arch-image.?@mydigest.? ]]; then
+  if [[ "$*" =~ registry.io/multi-arch-image.?@sha256:mydigest.? ]]; then
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
     echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
   else
@@ -61,14 +61,14 @@ function oras() {
   if [[ "$*" == "manifest fetch --registry-config"* ]]
   then
     echo '{"mediaType": "my_media_type"}'
-  elif [[ "$*" == "pull --registry-config"*dockerfile-not-found* ]]
+  elif [[ "$*" == "pull --registry-config"*dockerfile-not-found:sha256-*.dockerfile* ]]
   then
     echo Mock oras called with: $*
     return 1
-  elif [[ "$*" == "pull --registry-config"*dockerfile-file-missing* ]]
+  elif [[ "$*" == "pull --registry-config"*dockerfile-file-missing:sha256-*.dockerfile* ]]
   then
     echo Mock oras called with: $*
-  elif [[ "$*" == "pull --registry-config"* ]]
+  elif [[ "$*" == "pull --registry-config"*":sha256-"*.dockerfile* ]]
   then
     echo Mock oras called with: $*
     echo mydocker > $6/Dockerfile

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -30,7 +30,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "source1@mydigest1",
+                    "containerImage": "source1@sha256:mydigest1",
                     "repository": "registry.io/multi-arch-image1",
                     "tags": [
                       "testtag"
@@ -38,7 +38,7 @@ spec:
                   },
                   {
                     "name": "comp2",
-                    "containerImage": "source2@mydigest2",
+                    "containerImage": "source2@sha256:mydigest2",
                     "repository": "registry.io/multi-arch-image2",
                     "tags": [
                       "testtag"
@@ -46,7 +46,7 @@ spec:
                   },
                   {
                     "name": "comp3",
-                    "containerImage": "source3@mydigest3",
+                    "containerImage": "source3@sha256:mydigest3",
                     "repository": "registry.io/multi-arch-image3",
                     "tags": [
                       "testtag"
@@ -103,9 +103,9 @@ spec:
               fi
 
               cat > $(workspaces.data.path)/skopeo_expected_calls.txt << EOF
-              inspect --raw docker://registry.io/multi-arch-image1@mydigest1
-              inspect --raw docker://registry.io/multi-arch-image2@mydigest2
-              inspect --raw docker://registry.io/multi-arch-image3@mydigest3
+              inspect --raw docker://registry.io/multi-arch-image1@sha256:mydigest1
+              inspect --raw docker://registry.io/multi-arch-image2@sha256:mydigest2
+              inspect --raw docker://registry.io/multi-arch-image3@sha256:mydigest3
               EOF
 
               # check that the actual calls match the expected calls

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -30,7 +30,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "source1@mydigest1",
+                    "containerImage": "source1@sha256:mydigest1",
                     "repository": "registry.io/image1",
                     "tags": [
                       "testtag"
@@ -38,7 +38,7 @@ spec:
                   },
                   {
                     "name": "comp2",
-                    "containerImage": "source2@mydigest2",
+                    "containerImage": "source2@sha256:mydigest2",
                     "repository": "registry.io/image2",
                     "tags": [
                       "testtag"
@@ -46,7 +46,7 @@ spec:
                   },
                   {
                     "name": "comp3",
-                    "containerImage": "source3@mydigest3",
+                    "containerImage": "source3@sha256:mydigest3",
                     "repository": "registry.io/image3",
                     "tags": [
                       "testtag"
@@ -103,9 +103,9 @@ spec:
               fi
 
               cat > $(workspaces.data.path)/skopeo_expected_calls.txt << EOF
-              inspect --raw docker://registry.io/image1@mydigest1
-              inspect --raw docker://registry.io/image2@mydigest2
-              inspect --raw docker://registry.io/image3@mydigest3
+              inspect --raw docker://registry.io/image1@sha256:mydigest1
+              inspect --raw docker://registry.io/image2@sha256:mydigest2
+              inspect --raw docker://registry.io/image3@sha256:mydigest3
               EOF
 
               # check that the actual calls match the expected calls

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -30,7 +30,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "containerImage": "source@mydigest",
+                    "containerImage": "source@sha256:mydigest",
                     "repository": "registry.io/multi-arch-image",
                     "tags": [
                       "testtag"
@@ -107,7 +107,7 @@ spec:
               fi
 
               [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
-              = "inspect --raw docker://registry.io/multi-arch-image@mydigest" ]
+              = "inspect --raw docker://registry.io/multi-arch-image@sha256:mydigest" ]
 
               if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 3 ]; then
                 echo Error: oras was expected to be called 3 times. Actual calls:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -29,7 +29,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "containerImage": "source@mydigest",
+                    "containerImage": "source@sha256:mydigest",
                     "repository": "registry.io/image",
                     "tags": [
                       "testtag"
@@ -112,7 +112,7 @@ spec:
               fi
 
               [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
-                = "inspect --raw docker://registry.io/image@mydigest" ]
+                = "inspect --raw docker://registry.io/image@sha256:mydigest" ]
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -30,7 +30,7 @@ spec:
                 "components": [
                   {
                     "name": "comp",
-                    "containerImage": "source@mydigest",
+                    "containerImage": "source@sha256:mydigest",
                     "repository": "quay.io/redhat-prod/myproduct----myimage",
                     "tags": [
                       "myprefix-mytimestamp",


### PR DESCRIPTION
The pull spec is composed from the digest,
but we need to replace `:` with `-`.