### PR TITLE
fix(KFLUXBUGS-1647): searching for wrong json field on get-ocp-version

### DIFF
--- a/tasks/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/get-ocp-version/get-ocp-version.yaml
@@ -38,7 +38,7 @@ spec:
           arch_json=$(get-image-architectures "${fbc_fragment}")
 
           # it is not required to loop all images as they are all built for the same OCP version
-          manifest_image_sha="$(jq -rs 'map(.platform.digest)[0]'  <<< "$arch_json")"
+          manifest_image_sha="$(jq -rs 'map(.digest)[0]'  <<< "$arch_json")"
 
           # replace the image sha with the manifests's one
           manifest_image="${fbc_fragment%@*}@${manifest_image_sha}"

--- a/tasks/get-ocp-version/tests/mocks.sh
+++ b/tasks/get-ocp-version/tests/mocks.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-function oras() {
-    echo "sha256:manifest"
-}
-
 function skopeo() {
     if [[ "$*" == "inspect --raw docker://quay.io/fbc/multi-arch@sha256:index" ]]; then
         echo '{ "mediaType": "application/vnd.oci.image.index.v1+json" }'
@@ -19,6 +15,6 @@ function skopeo() {
 }
 
 function get-image-architectures() {
-    echo '{"platform":{"digest": "sha256:manifest", "architecture": "amd64", "os": "linux"}}'
-    echo '{"platform":{"digest": "sha256:manifest", "architecture": "ppc64le", "os": "linux"}}'
+    echo '{"mediaType": "application/vnd.oci.image.manifest.v1+json" ,"digest": "sha256:manifest", "size": 100, "platform":{"architecture": "amd64", "os": "linux"}}'
+    echo '{"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:manifest", "size": 100, "platform":{"architecture": "ppc64le", "os": "linux"}}'
 }


### PR DESCRIPTION
this commit fixes the wrong jq search in get-ocp-version where it should search for .digest instead of .platform.digest.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>