### PR TITLE
feat(RELEASE-1151): support image labels in tag variables

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -12,19 +12,34 @@ A `mapped` result is also returned from this task containing a simple true/false
 meant to inform whether a mapped Snapshot is being returned or the original one.
 
 This task supports variable expansion in tag values from the mapping. The currently supported variables are:
-* "{{ timestamp }}" -> The build-date label from the image in the format provided by timestampFormat or %s as the default
+* "{{ timestamp }}" -> The build-date label from the image in the format provided by timestampFormat or %s as the default.
+  If the build-date label is not available, we use the Created field in the image metadata as a fallback.
 * "{{ release_timestamp }}" -> The current time in the format provided by timestampFormat or %s as the default
 * "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
 * "{{ git_short_sha }}" -> The git sha reduced to 7 characters
 * "{{ digest_sha }}" -> The image digest of the respective component
 
+You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
+
 ## Parameters
 
 | Name              | Description                                                                                  | Optional | Default value |
 |-------------------|----------------------------------------------------------------------------------------------|----------|---------------|
-| snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |  
+| snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
+
+## Changes in 1.7.0
+* Added support for image labels in tag variables,
+  e.g. `{{ labels.mylabel }}`
+* Some more things related to tags:
+  * Templates can include arbitrary amount of spaces in `{{}}` now
+  * Multiple variables can be used at once,
+    e.g. `tag-{{ timestamp }}.{{ labels.release }}`
+  * Added validation of template variables
+  * Added validation of resulting tag values
+  * Expansion of `{{ timestamp }}` now falls back to `Created` field
+    in image metadata if `Labels.build-time` is not available
 
 ## Changes in 1.6.1
 * The task no longer fails if the build-date label is missing from the image
@@ -42,7 +57,7 @@ This task supports variable expansion in tag values from the mapping. The curren
   * Added support for converting quay.io repository URLs to registry.redhat.io format and vice versa.
   * Introduced a new key rh-registry-repo to store the updated repository value in the registry.redhat.io format.
   * Added a new key registry-access-repo to store the repository value in the registry.access.redhat.com format.
-  * If the repository key contains registry.redhat.io, it will be rewritten to the equivalent quay repo. Otherwise, it is left as is  
+  * If the repository key contains registry.redhat.io, it will be rewritten to the equivalent quay repo. Otherwise, it is left as is
 
 ## Changes in 1.4.0
 * Add a check that all component containerImage values use a sha reference

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.6.1"
+    app.kubernetes.io/version: "1.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,44 +62,71 @@ spec:
             exit 0
         fi
 
-        # Expected arguments are [tags, timestamp, release_timestamp, git sha, 7 character git sha, source sha]
-        translate_tags () {
+        # Expected arguments are: [variable, substitute_map, labels_map]
+        substitute() {
+            variable=$1
+            substitute_map=$2
+            labels_map=$3
+
+            result=""
+            if [[ "$variable" == labels.* ]]; then
+                label="${variable#labels.}"
+                result="$(jq -r --arg labelval "$label" '.[$labelval] // ""' <<< "${labels_map}")"
+            else
+                result="$(jq -r --arg variable "$variable" '.[$variable] // ""' <<< "${substitute_map}")"
+            fi
+            echo "$result"
+        }
+
+        # Expected arguments are [tags, substitute_map, labels_map]
         # The tags argument is a json array
-            if [[ $1 == '' ]] ; then
+        translate_tags () {
+            tags=$1
+            substitute_map=$2
+            labels_map=$3
+            if [ "$tags" = '' ] ; then
                 echo ''
                 return
             fi
 
-            SUPPORTED_VARIABLES='[
-                {"{{timestamp}}": "'$2'"},
-                {"{{ timestamp }}": "'$2'"},
-                {"{{release_timestamp}}": "'$3'"},
-                {"{{ release_timestamp }}": "'$3'"},
-                {"{{git_sha}}": "'$4'"},
-                {"{{ git_sha }}": "'$4'"},
-                {"{{git_short_sha}}": "'$5'"},
-                {"{{ git_short_sha }}": "'$5'"},
-                {"{{digest_sha}}": "'$6'"},
-                {"{{ digest_sha }}": "'$6'"}
-            ]'
-            tags=$1
+            translated_tags='[]'
+            NUM_TAGS="$(jq 'length' <<< "${tags}")"
+            for ((i = 0; i < NUM_TAGS; i++)); do
+                tag="$(jq -r --argjson i "$i" '.[$i]' <<< "${tags}")"
 
-            NUM_VARIABLES=$(jq 'length' <<< "${SUPPORTED_VARIABLES}")
-            for ((i = 0; i < NUM_VARIABLES; i++)); do
-                variable=$(jq -c --argjson i "$i" '.[$i]' <<< "${SUPPORTED_VARIABLES}")
-                KEY=$(jq -r 'to_entries[] | .key' <<< "$variable")
-                VALUE=$(jq -r 'to_entries[] | .value' <<< "$variable")
-                # If a tag is going to be replaced by a null value, error out
-                if [[ "$VALUE" == "null" ]] && \
-                  [[ $(jq --arg key "$KEY" '. | map(select(test($key))) | length' <<< "$tags") -gt 0 ]] ; then
-                    echo "Requested substitution for key: $KEY but calculated value for it was null"
-                    echo "Failing..."
+                # Repeatedly translate {{}} references until none are left
+                while [[ $tag =~ \{\{\ *([[:alnum:]_\.]+)\ *\}\} ]]; do
+                  # Extract the variable name (e.g., timestamp), trimming any surrounding spaces
+                  var_name="${BASH_REMATCH[1]}"
+
+                  # Sanity check of the template variable name
+                  if [[ ! "$var_name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                    echo "Error: Invalid variable name in tag definition: $var_name" >&2
                     exit 1
+                  fi
+
+                  replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
+                  if [ -z "$replacement" ]; then
+                      echo Error: Substitution variable unknown or empty: "$var_name" >&2
+                      exit 1
+                  fi
+
+                  # Shellcheck suggests ${var//find/replace}, but
+                  # that won't work here - we need to match arbitrary amount of spaces
+                  # shellcheck disable=SC2001
+                  tag="$(sed "s/{{ *$var_name *}}/$replacement/" <<< "$tag")"
+                done
+
+                # Sanity check of the resulting tag value
+                if [[ ! "$tag" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                  echo "Error: Invalid tag format: $tag" >&2
+                  exit 1
                 fi
-                tags=$(echo -n "$tags" | sed "s/$KEY/$VALUE/g")
+
+                translated_tags="$(jq -c --arg tag "$tag" '. + [$tag]' <<< "$translated_tags")"
             done
 
-            echo -n "$tags" | jq -c
+            echo "$translated_tags"
         }
 
         convert_to_quay () { # Convert the registry.redhat.io URL to the quay.io format
@@ -198,21 +225,32 @@ spec:
               '.timestampFormat // $default' <<< "$component")
             release_timestamp="$(date -d "$currentTimestamp" "+$passedTimestampFormat")"
             arch_json="$(get-image-architectures "${IMAGE_REF}")"
-            # The build-date label is not the same per architecture, but we don't support separate tags per arch. So,
-            # we just use the first digest listed
+            # The build-date label and Created values are not the same per architecture, but we don't support separate
+            # tags per arch. So, we just use the first digest listed.
             arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
             os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
-            build_date="$(skopeo inspect --no-tags --override-os "${os}" --override-arch "${arch}" \
-              docker://"${IMAGE_REF}" | jq -r '.Labels."build-date"')"
-            timestamp="$(date -d "${build_date}" "+$passedTimestampFormat" || true)"
-            if [ "${build_date}" == "null" ] ; then
-              timestamp="null"
+            image_metadata="$(skopeo inspect --no-tags --override-os "${os}" --override-arch "${arch}" \
+              docker://"${IMAGE_REF}" | jq -c)"
+            # For timestamp, use Labels.build-date and fallback to Created
+            build_date="$(jq -r '.Labels."build-date" // .Created' <<< "$image_metadata")"
+            if [ "${build_date}" = "null" ] ; then
+              timestamp=""
+            else
+              timestamp="$(date -d "${build_date}" "+$passedTimestampFormat")"
             fi
 
             allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
               "$imageTags" '$defaults? + $imageTags? | unique')
-            tags=$(translate_tags "${allTagsPreSubstitution}" "${timestamp}" "${release_timestamp}" "${git_sha}" \
-              "${git_sha:0:7}" "${build_sha}")
+            substitute_map="$(jq -n -c \
+              --arg timestamp "${timestamp}" \
+              --arg release_timestamp "${release_timestamp}" \
+              --arg git_sha "${git_sha}" \
+              --arg git_short_sha "${git_sha:0:7}" \
+              --arg digest_sha "${build_sha}" \
+              '$ARGS.named')"
+            labels="$(jq -c '.Labels' <<< "${image_metadata}")"
+
+            tags=$(translate_tags "${allTagsPreSubstitution}" "${substitute_map}" "${labels}")
             if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
               jq --argjson i "$i" --argjson updatedTags "$tags" '.components[$i].tags = $updatedTags' \
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
@@ -223,8 +261,8 @@ spec:
             for ((j = 0; j < STAGED_FILES; j++)) ; do
                 file=$(jq -c --argjson j "$j" '.staged.files[$j]' <<< "$component")
                 filenameArrayPreSubstitution=$(jq '.filename' <<< "$file" | jq -cs)
-                subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" "${timestamp}" \
-                  "${release_timestamp}" "${git_sha}" "${git_sha:0:7}" "${build_sha}" | jq -r '.[0]')
+                subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" \
+                  "${substitute_map}" "${labels}" | jq -r '.[0]')
                 jq --argjson i "$i" --argjson j "$j" --arg filename "$subbedFilename" \
                   '.components[$i].staged.files[$j].filename = $filename' "${SNAPSHOT_SPEC_FILE}" > /tmp/temp \
                   && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
@@ -246,7 +284,7 @@ spec:
               rh_registry_repo=$repository
               registry_access_repo=$(convert_to_registry_access "$repository")
               repository=$(convert_to_quay "$repository")
-      
+
               jq --argjson i "$i" \
                 --arg repository "$repository" \
                 --arg rh_registry_repo "$rh_registry_repo" \

--- a/tasks/apply-mapping/tests/mocks.sh
+++ b/tasks/apply-mapping/tests/mocks.sh
@@ -37,6 +37,14 @@ function skopeo() {
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'
     return
+  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
+  then
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Badlabel": "label with space"}}'
+    return
+  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
+  then
+    echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}, "Created": "2024-07-29T02:17:29"}'
+    return
   elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-fail-invalid-label-value
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file with tags per component, but one of the tags uses templating
+    with an image label and this label has invalid value (including spaces).
+    The task should fail on that.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "repo1",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ timestamp }}",
+                        "{{ labels.Badlabel }}"
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/labels@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: dataPath
+          value: test_data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-fail-invalid-tag-variable
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file with tags per component, but one of the tags uses templating
+    with an invalid variable name (invalid*variable).
+    The task should fail on that.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "repo1",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ timestamp }}",
+                        "{{ labels.Goodlabel }}",
+                        "{{ invalid*variable }}"
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/labels@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: dataPath
+          value: test_data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-fail-missing-label
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file with tags per component, but one of the tags uses templating
+    with an image label and this label does not exist in the image.
+    The task should fail on that.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: config
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "repo1",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ timestamp }}",
+                        "{{ labels.MissingLabel }}"
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/labels@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: test_snapshot_spec.json
+        - name: dataPath
+          value: test_data.json
+      runAfter:
+        - setup
+      workspaces:
+        - name: config
+          workspace: tests-workspace

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -35,12 +35,14 @@ spec:
                       "tags": [
                         "tag1-{{timestamp}}",
                         "tag2-{{ timestamp }}",
+                        "tag3-{{ timestamp }}-{{ git_short_sha }}",
                         "{{git_sha}}",
                         "{{ git_sha }}-abc",
                         "{{git_short_sha}}",
                         "{{ git_short_sha }}-bar",
                         "foo-{{digest_sha}}",
-                        "{{ digest_sha }}"
+                        "{{ digest_sha }}",
+                        "tag-{{ labels.Goodlabel }}"
                       ]
                     },
                     {
@@ -74,7 +76,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "registry.io/image1@sha256:123456",
+                    "containerImage": "registry.io/labels@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "testrevision",
@@ -84,7 +86,7 @@ spec:
                   },
                   {
                     "name": "comp2",
-                    "containerImage": "registry.io/image2@sha256:123456",
+                    "containerImage": "registry.io/onlycreated@sha256:123456",
                     "repository": "repo2"
                   },
                   {
@@ -132,8 +134,8 @@ spec:
               test "$(
                 jq -c '.components[] | select(.name=="comp1") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
-              )" == '["defaultTag","foo-123456",'\
-              '"tag1-2024-07-29","tag2-2024-07-29","123456",'\
+              )" == '["defaultTag","foo-123456","tag-labelvalue",'\
+              '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","123456",'\
               '"testrevision-abc","testrev-bar","testrevision","testrev"]'
 
               echo Test that SNAPSHOT contains component comp2


### PR DESCRIPTION
* Added support for image labels in tag variables, e.g. `{{ labels.mylabel }}`
* Some more things related to tags:
  * Templates can include arbitrary amount of spaces in `{{}}` now
  * Multiple variables can be used at once, e.g. `tag-{{ timestamp }}.{{ labels.release }}`
  * Added validation of template variables
  * Added validation of resulting tag values
  * Expansion of `{{ timestamp }}` now falls back to `Created` field in image metadata if `Labels.build-time` is not available

This also fixes [RELEASE-1177](https://issues.redhat.com/browse/RELEASE-1177)