### PR TITLE
chore(RELEASE-1184): increase concurrency and timeout for signing

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes     | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                       | No       | -             |
 
+## Changes in 1.3.1
+* Increase timeout for signing IRs from 20 to 30 min
+  * We got reports from users that they repeatedly see timeouts here
+
 ## Changes in 1.3.0
 * Add new reduce-snapshot task
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -365,8 +365,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
           # The RADAS timeout when it fails to receive a response is 5 mins.
-          # We quadruple the requestTimeout to allow RADAS to retry its request.
-          value: 1200
+          # Give RADAS enough time to retry its request.
+          value: 1800
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision       | The revision in the taskGitUrl repo to be used                               | No       | -             |
 
+## Changes in 4.3.1
+* Increase timeout for signing IRs from 20 to 30 min
+  * We got reports from users that they repeatedly see timeouts here
+
 ## Changes in 4.3.0
 * Add new reduce-snapshot task
 

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.3.0"
+    app.kubernetes.io/version: "4.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -320,8 +320,8 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
           # The RADAS timeout when it fails to receive a response is 5 mins.
-          # We quadruple the requestTimeout to allow RADAS to retry its request.
-          value: 1200
+          # Give RADAS enough time to retry its request.
+          value: 1800
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
       workspaces:

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -10,8 +10,11 @@ Task to create internalrequests to sign snapshot components
 | dataPath        | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                    |
 | requester       | Name of the user that requested the signing, for auditing purpose                         | No       | -                    |
 | requestTimeout  | InternalRequest timeout                                                                   | Yes      | 180                  |
-| concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 4                    |
+| concurrentLimit | The maximum number of images to be processed at once                                      | Yes      | 16                    |
 | pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
+
+## Changes in 3.4.1
+* Increased default `concurrentLimit` to 16 to make signing faster.
 
 ## Changes in 3.4.0
 * Added changes in order to eliminate the `translate-delivery-repo` script because the

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "3.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,7 +28,7 @@ spec:
     - name: concurrentLimit
       type: string
       description: The maximum number of images to be processed at once
-      default: 4
+      default: 16
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
@@ -88,7 +88,7 @@ spec:
               nested_digests=$(jq -r '.manifests[].digest' <<< "$RAW_OUTPUT")
               manifest_digests="$manifest_digests $nested_digests"
             fi
-        
+
             sourceContainerDigest=
             # Push source container if the component has pushSourceContainer: true or if the
             # pushSourceContainer key is missing from the component and the defaults has


### PR DESCRIPTION
* increase concurrent signing requests to 16
  * Signing is becoming a bottleneck in the release pipelines. Increasing the number of concurrent requests to 16 should help. This was consulted with the RADAS team.
See Jira for more context.

* increase timeout for signing requests
  * We got reports from users that the timeout is being hit.
    This is happening repeatedly. The signing pipeline is still
    running, so we should keep checking longer.
    See here for more details:
    https://issues.redhat.com/browse/RELEASE-1117?focusedId=25649635&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25649635