### PR TITLE
fix(RELEASE-1187): error when Dockerfile has a different filename

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -18,8 +18,13 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published.                                                                                                         | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                         | No       | -             |
 
+## Changes in 3.3.2
+* Fixed fetching of Dockerfile oci artifact
+  * The filename can be different than Dockerfile which is what we would expect
+  * Now we get the filename from the manifest
+
 ## Changes in 3.3.1
-* Fix fetching of Dockerfile oci artifact
+* Fixed fetching of Dockerfile oci artifact
   * The pull spec is composed from the digest, but we need to replace `:` with `-`
 
 ## Changes in 3.3.0

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.3.1"
+    app.kubernetes.io/version: "3.3.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -120,10 +120,19 @@ spec:
             select-oci-auth "${SOURCE_REPO}" > "$AUTH_FILE"
             DOCKERFILE_DIR="$(mktemp -d)"
             DOCKERFILE_PATH=""
+            DOCKERFILE_PULL_SPEC="${SOURCE_REPO}:${DIGEST/:/-}.dockerfile"
             # try fetching Dockerfile for the image
-            if oras pull --registry-config "$AUTH_FILE" "${SOURCE_REPO}:${DIGEST/:/-}.dockerfile" -o "${DOCKERFILE_DIR}"
+            if oras pull --registry-config "$AUTH_FILE" "${DOCKERFILE_PULL_SPEC}" -o "${DOCKERFILE_DIR}"
             then
-              DOCKERFILE_PATH="${DOCKERFILE_DIR}/Dockerfile"
+              # fetch the manifest to determine filename
+              DOCKERFILE_MANIFEST="$(oras manifest fetch --registry-config "$AUTH_FILE" "${DOCKERFILE_PULL_SPEC}")"
+              DOCKERFILE_FILENAME="$(jq -r \
+                '.layers[0].annotations."org.opencontainers.image.title" // ""' \
+                <<< "${DOCKERFILE_MANIFEST}")"
+              if [ -z "${DOCKERFILE_FILENAME}" ]; then
+                DOCKERFILE_FILENAME=Dockerfile # default if we cannot determine the filename
+              fi
+              DOCKERFILE_PATH="${DOCKERFILE_DIR}/${DOCKERFILE_FILENAME}"
               if [ ! -f "${DOCKERFILE_PATH}" ]; then
                 echo Error: Dockerfile pull succeeded, but the Dockerfile was not saved.
                 exit 1

--- a/tasks/create-pyxis-image/tests/mocks.sh
+++ b/tasks/create-pyxis-image/tests/mocks.sh
@@ -58,7 +58,10 @@ function select-oci-auth() {
 
 function oras() {
   echo $* >> $(workspaces.data.path)/mock_oras.txt
-  if [[ "$*" == "manifest fetch --registry-config"* ]]
+  if [[ "$*" == "manifest fetch --registry-config"*.dockerfile ]]
+  then
+    echo '{"layers": [{"annotations": {"org.opencontainers.image.title": "Dockerfile.custom"}}]}'
+  elif [[ "$*" == "manifest fetch --registry-config"* ]]
   then
     echo '{"mediaType": "my_media_type"}'
   elif [[ "$*" == "pull --registry-config"*dockerfile-not-found:sha256-*.dockerfile* ]]
@@ -71,7 +74,7 @@ function oras() {
   elif [[ "$*" == "pull --registry-config"*":sha256-"*.dockerfile* ]]
   then
     echo Mock oras called with: $*
-    echo mydocker > $6/Dockerfile
+    echo mydocker > $6/Dockerfile.custom
   else
     echo Mock oras called with: $*
     echo Error: Unexpected call

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -120,8 +120,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 9 ]; then
-                echo Error: oras was expected to be called 9 times. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 12 ]; then
+                echo Error: oras was expected to be called 12 times. Actual calls:
                 cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -120,8 +120,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 6 ]; then
-                echo Error: oras was expected to be called 6 times. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 9 ]; then
+                echo Error: oras was expected to be called 9 times. Actual calls:
                 cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -109,8 +109,8 @@ spec:
               [ "$(cat $(workspaces.data.path)/mock_skopeo.txt | head -n 1)" \
               = "inspect --raw docker://registry.io/multi-arch-image@sha256:mydigest" ]
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 3 ]; then
-                echo Error: oras was expected to be called 3 times. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 4 ]; then
+                echo Error: oras was expected to be called 4 times. Actual calls:
                 cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -105,8 +105,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 2 ]; then
-                echo Error: oras was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 3 ]; then
+                echo Error: oras was expected to be called 3 times. Actual calls:
                 cat "$(workspaces.data.path)/mock_oras.txt"
                 exit 1
               fi


### PR DESCRIPTION
We assumed that the Dockerfile in the *.dockerfile oci artifact would always be called Dockerfile. Wrong assumption. We created [STONEBLD-2822](https://issues.redhat.com//browse/STONEBLD-2822) for the build team to always use the same name (instead of just copying whatever the user has). But for now let's read the filename from the metadata and use that.

Note that this is a quickfix and we will review what we want to do about this when refining [RELEASE-1187](https://issues.redhat.com//browse/RELEASE-1187)