### PR TITLE
chore(RELEASE-903): remove lingering RSC reference

### DIFF
--- a/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -71,20 +71,6 @@ spec:
               }
               EOF
 
-              cat > $(workspaces.data.path)/test_release_service_config.json << EOF
-              {
-                "apiVersion": "appstudio.redhat.com/v1alpha1",
-                "kind": "ReleaseServiceConfig",
-                "metadata": {
-                  "name": "test",
-                  "namespace": "default"
-                },
-                "spec": {
-                  "advisoryRepo": "github.com/repo"
-                }
-              }
-              EOF
-
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "releaseNotes": {
@@ -110,8 +96,6 @@ spec:
       params:
         - name: releasePlanAdmissionPath
           value: "test_release_plan_admission.json"
-        - name: releaseServiceConfigPath
-          value: "test_release_service_config.json"
         - name: snapshotPath
           value: "test_snapshot_spec.json"
         - name: dataPath


### PR DESCRIPTION
The ReleaseServiceConfig is no longer a parameter to the create-advisory task. This commit updates a test that still had it.