### PR TITLE
feat(RELEASE-911): add save-collectors-results

### DIFF
--- a/tasks/save-collectors-results/README.md
+++ b/tasks/save-collectors-results/README.md
@@ -1,0 +1,12 @@
+# save-collectors-results
+
+A tekton task that updates the passed CR status with the contents stored in the files in the resultsDir.
+
+## Parameters
+
+| Name           | Description                                                                                                          | Optional | Default value |
+|----------------|----------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| resourceType   | The type of resource that is being patched                                                                           | Yes      | release       |
+| statusKey      | The top level key to overwrite in the resource status                                                                | Yes      | collectors    |
+| resource       | The namespaced name of the resource to be patched                                                                    | No       | -             |
+| resultsDirPath | Path to the directory containing the result files in the data workspace which will be added to the resource's status | No       | -             |

--- a/tasks/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/save-collectors-results/save-collectors-results.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: save-collectors-results
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to update the passed CR status with the
+    collectors results.
+  params:
+    - name: resourceType
+      description: The type of resource that is being patched
+      type: string
+      default: release
+    - name: statusKey
+      description: The top level key to overwrite in the resource status
+      type: string
+      default: collectors
+    - name: resource
+      description: The namespaced name of the resource to be patched
+      type: string
+    - name: resultsDirPath
+      description: |
+        The relative path in the workspace where the collectors results
+        are saved to
+      type: string
+  workspaces:
+    - name: data
+      description: Workspace where the results directory is stored
+  steps:
+    - name: save-collectors-results
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        RESULTS_JSON="{}"
+        RESULTS_DIR="$(workspaces.data.path)/$(params.resultsDirPath)"
+        for resultsFile in $([ -d "$RESULTS_DIR" ] && find "$RESULTS_DIR" -type f); do
+            if ! jq . >/dev/null 2>&1 "${resultsFile}" ; then
+                echo "Ignoring not JSON file: ${resultsFile}."
+                continue
+            fi
+        
+            fileName=$(basename "$resultsFile")
+        
+            # Check if the file name does NOT match the pattern
+            if ! [[ "$fileName" =~ ^(managed|tenant)-([a-zA-Z0-9_-]+)\.json$ ]]; then
+                echo "Ignoring invalid file name: $fileName"
+            else    
+                prefix="${BASH_REMATCH[1]}"
+                collector="${BASH_REMATCH[2]}"
+        
+                # Update RESULTS_JSON with the content of the current file under the correct key
+                RESULTS_JSON=$(jq --arg prefix "$prefix" --arg collector "$collector" \
+                    --slurpfile content "$resultsFile" \
+                    '.[$prefix][$collector] = $content[0]' <<< "$RESULTS_JSON")
+            fi
+        done
+
+        IFS='/' read -r namespace name <<< "$(params.resource)"
+
+        kubectl --warnings-as-errors=true patch "$(params.resourceType)" -n "$namespace" "$name" \
+          --type=merge --subresource status --patch "status: {'$(params.statusKey)':${RESULTS_JSON}}"

--- a/tasks/save-collectors-results/tests/pre-apply-task-hook.sh
+++ b/tasks/save-collectors-results/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results-file-not-json
+spec:
+  description: |
+    Run the save-collectors-results task where a file in the provided results dir
+    is not proper json. The pipeline should not fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              this
+              is
+               not
+              json
+              }
+              EOF
+              
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-not-json
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-not-json
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results-multiple-result-files
+spec:
+  description: |
+    Run the save-collectors-results task with rbac present and multiple result
+    files in the results directory. The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/managed-one.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/results/managed-two.json" << EOF
+              {
+                  "baz": "qux"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-multiple
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-status-multiple
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains the expected data
+              test "$(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath='{.status.collectors.managed.one.foo}')" == bar
+              
+              test "$(kubectl get release release-cr-status-multiple -n default \
+                -o jsonpath='{.status.collectors.managed.two.baz}')" == qux
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-multiple

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results-no-results
+spec:
+  description: |
+    Run the save-collectors-results task where there are no files in the results dir.
+    The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-no-results
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-no-results
+        - name: resultsDirPath
+          value: nonexistent
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results-nonexistent-status-field
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the save-collectors-results task to update a field that does not exist in the
+    CRD status. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/test.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-nonexistent-status-field
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-nonexistent-status-field
+        - name: resultsDirPath
+          value: results
+        - name: statusKey
+          value: devnull
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-nonexistent-status-field

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results
+spec:
+  description: |
+    Run the save-collectors-results task with rbac present, one proper results
+    file in the results directory and one with an invalid name. The latter should
+    be ignored and the pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/managed-one.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+              cat > "$(workspaces.data.path)/results/two.json" << EOF
+              {
+                  "baz": "qux"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-status
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains proper data
+              test "$(kubectl get release release-cr-status -n default \
+                  -o jsonpath='{.status.collectors.managed.one.foo}')" == bar
+              
+              echo Test that invalid file names were ignored
+              test -z "$(kubectl get release release-cr-status -n default \
+                  -o jsonpath='{.status.collectors.managed.two.baz}' 2>/dev/null)"
+
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results-resource-nonexistent
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the save-collectors-results task where the provided resource
+    does not exist on the cluster. The pipeline should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/managed-test.json" << EOF
+              {
+                  "automated": true
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/my-release
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/save-collectors-results/tests/test-save-collectors-results.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-save-collectors-results
+spec:
+  description: |
+    Run the save-collectors-results task with rbac present and one proper results
+    file in the results directory. The pipeline should succeed.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results/"
+              cat > "$(workspaces.data.path)/results/managed-test.json" << EOF
+              {
+                  "foo": "bar"
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: save-collectors-results
+      params:
+        - name: resource
+          value: default/release-cr-status
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              echo Test that the Release.Status contains proper data
+              test "$(kubectl get release release-cr-status -n default \
+                  -o jsonpath='{.status.collectors.managed.test.foo}')" == bar
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status


### PR DESCRIPTION
The new task is designed to add the collectors results into a given resource status key. By default this will be the collectors key in release resources.