### PR TITLE
fix(KFLUXBUGS-1697): retries at tekton pipeline level

### DIFF
--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
 
+## Changes in 5.2.1
+* Add retries for some tasks
+
 ## Changes in 5.2.0
 * Add new reduce-snapshot task
 

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.2.0"
+    app.kubernetes.io/version: "5.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -188,6 +188,7 @@ spec:
       runAfter:
         - apply-mapping
     - name: push-snapshot
+      retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
@@ -232,6 +233,7 @@ spec:
       runAfter:
         - collect-data
     - name: make-repo-public
+      retries: 5
       when:
         - input: "$(tasks.collect-registry-token-secret.results.registrySecret)"
           operator: notin

--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -22,6 +22,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes     | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                       | No       | -             |
 
+## Changes in 1.3.2
+* Add retries for some tasks
+
 ## Changes in 1.3.1
 * Increase timeout for signing IRs from 20 to 30 min
   * We got reports from users that they repeatedly see timeouts here

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.3.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -302,6 +302,7 @@ spec:
         - verify-enterprise-contract
         - push-snapshot
     - name: push-snapshot
+      retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
@@ -376,6 +377,7 @@ spec:
         - embargo-check
         - verify-enterprise-contract
     - name: create-pyxis-image
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -400,6 +402,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -426,6 +429,7 @@ spec:
       runAfter:
         - push-rpm-data-to-pyxis
     - name: push-rpm-data-to-pyxis
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -494,6 +498,7 @@ spec:
       runAfter:
         - populate-release-notes-images
     - name: create-advisory
+      retries: 5
       params:
         - name: releasePlanAdmissionPath
           value: "$(tasks.collect-data.results.releasePlanAdmission)"

--- a/pipelines/rh-push-to-external-registry/README.md
+++ b/pipelines/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                       | No        | -            |
 
+## Changes in 5.3.1
+* Add retries for some tasks
+
 ## Changes in 5.3.0
 * Add new reduce-snapshot task
 

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.3.0"
+    app.kubernetes.io/version: "5.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -188,6 +188,7 @@ spec:
       runAfter:
         - apply-mapping
     - name: push-snapshot
+      retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
@@ -236,6 +237,7 @@ spec:
       runAfter:
         - collect-data
     - name: create-pyxis-image
+      retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
@@ -262,6 +264,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: push-rpm-data-to-pyxis
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -300,6 +303,7 @@ spec:
       runAfter:
         - collect-data
     - name: make-repo-public
+      retries: 5
       when:
         - input: "$(tasks.collect-registry-token-secret.results.registrySecret)"
           operator: notin

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision       | The revision in the taskGitUrl repo to be used                               | No       | -             |
 
+## Changes in 4.3.2
+* Add retries for some tasks
+
 ## Changes in 4.3.1
 * Increase timeout for signing IRs from 20 to 30 min
   * We got reports from users that they repeatedly see timeouts here

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.3.1"
+    app.kubernetes.io/version: "4.3.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -257,6 +257,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: push-snapshot
+      retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
@@ -331,6 +332,7 @@ spec:
         - verify-enterprise-contract
         - apply-mapping
     - name: create-pyxis-image
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -355,6 +357,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      retries: 5
       taskRef:
         resolver: "git"
         params:
@@ -381,6 +384,7 @@ spec:
       runAfter:
         - push-rpm-data-to-pyxis
     - name: push-rpm-data-to-pyxis
+      retries: 5
       taskRef:
         resolver: "git"
         params:

--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -4,14 +4,14 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 
 ## Parameters
 
-| Name                 | Description                                                               | Optional | Default value        |
-|----------------------|---------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath         | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -                    |
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace   | No       | -                    |
-| resultsDirPath       | Path to results directory in the data workspace                           | No       | -                    |
-| retries              | Retry copy N times                                                        | Yes      | 0                    |
-| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca           |
-| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt        |
+| Name                 | Description                                                               | Optional | Default value |
+|----------------------|---------------------------------------------------------------------------|----------|---------------|
+| snapshotPath         | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -             |
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace   | No       | -             |
+| resultsDirPath       | Path to results directory in the data workspace                           | No       | -             |
+| retries              | Retry copy N times                                                        | Yes      | 0             |
+| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
+| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
 
 ## Changes in 6.3.0
 * Add support for custom CA cert in push-snapshot task


### PR DESCRIPTION
- some of the release pipeline tasks are idempotent
  so we can add retries at the tekton pipeline level.
- The rh-sign-image task is not very efficient when retrying, so
  we cannot add retries for it at pipeline level. It will be
  addressed at a later time.
- set default task-level retries to 3 for push-snapshot.
