### PR TITLE
feat(RELEASE-1176): only sign registry.access if required

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,16 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.5.0
+* Only sign `registry.access*` references if required
+  * Task `publish-pyxis-repository` has a new `signRegistryAccessPath` result that is passed
+    to tasks `rh-sign-image` and `rh-sign-image-cosign`. It points to a file that contains a list of repositories
+    for which we also need to sign `registry.access*` references. We will skip those by default.
+  * Some task reordering was required for this:
+    * We run `rh-sign-image` before `push-snapshot` because it's less reliable. We want to keep this.
+    * `publish-pyxis-repository` was run towards the end, but now it needs to run early on,
+      because`rh-sign-image` needs its result.
+
 ## Changes in 1.4.0
 * Increase timeout for rh-sign-image task to be 6 hrs
 * Add new mandatory parameter value for releasePlanAdmissionPath for rh-sign-image task

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -301,6 +301,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: secretName
           value: "$(tasks.collect-cosign-params.results.cosign-secret-name)"
+        - name: signRegistryAccessPath
+          value: $(tasks.publish-pyxis-repository.results.signRegistryAccessPath)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -387,12 +389,15 @@ spec:
           value: $(tasks.collect-pyxis-params.results.server)
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
+        - name: signRegistryAccessPath
+          value: $(tasks.publish-pyxis-repository.results.signRegistryAccessPath)
       workspaces:
         - name: data
           workspace: release-workspace
       runAfter:
         - embargo-check
         - verify-enterprise-contract
+        - publish-pyxis-repository
     - name: create-pyxis-image
       retries: 5
       taskRef:
@@ -444,7 +449,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-rpm-data-to-pyxis
+        - collect-pyxis-params
     - name: push-rpm-data-to-pyxis
       retries: 5
       taskRef:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,16 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.5.0
+* Only sign `registry.access*` references if required
+  * Task `publish-pyxis-repository` has a new `signRegistryAccessPath` result that is passed
+    to tasks `rh-sign-image` and `rh-sign-image-cosign`. It points to a file that contains a list of repositories
+    for which we also need to sign `registry.access*` references. We will skip those by default.
+  * Some task reordering was required for this:
+    * We run `rh-sign-image` before `push-snapshot` because it's less reliable. We want to keep this.
+    * `publish-pyxis-repository` was run towards the end, but now it needs to run early on,
+      because`rh-sign-image` needs its result.
+
 ## Changes in 4.4.0
 * Increase timeout for rh-sign-image task to be 6 hrs
 * Add new mandatory parameter value for releasePlanAdmissionPath for rh-sign-image task

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.4.0"
+    app.kubernetes.io/version: "4.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -257,6 +257,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: secretName
           value: "$(tasks.collect-cosign-params.results.cosign-secret-name)"
+        - name: signRegistryAccessPath
+          value: $(tasks.publish-pyxis-repository.results.signRegistryAccessPath)
       workspaces:
         - name: data
           workspace: release-workspace
@@ -338,12 +340,15 @@ spec:
           value: $(params.taskGitUrl)
         - name: taskGitRevision
           value: $(params.taskGitRevision)
+        - name: signRegistryAccessPath
+          value: $(tasks.publish-pyxis-repository.results.signRegistryAccessPath)
       workspaces:
         - name: data
           workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
         - apply-mapping
+        - publish-pyxis-repository
     - name: create-pyxis-image
       retries: 5
       taskRef:
@@ -395,7 +400,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - push-rpm-data-to-pyxis
+        - collect-pyxis-params
     - name: push-rpm-data-to-pyxis
       retries: 5
       taskRef:

--- a/tasks/publish-pyxis-repository/README.md
+++ b/tasks/publish-pyxis-repository/README.md
@@ -1,7 +1,8 @@
 # publish-pyxis-repository
 
 Tekton task to mark all repositories in the mapped snapshot as published in Pyxis.
-This is currently only meant to be used in the rh-push-to-registry-redhat-io pipeline,
+This is currently only meant to be used in the rh-push-to-registry-redhat-io
+and rh-advisories pipelines,
 so it will convert the values to the ones used for registry.redhat.io releases.
 E.g. repository "quay.io/redhat-prod/my-product----my-image" will be converted to use
 registry "registry.access.redhat.com" and repository "my-product/my-image" to identify
@@ -11,6 +12,17 @@ is true in the data JSON.
 Additionally, this task respects the `publish-on-push` flag. If `false`, then the task
 does not publish the repository.
 
+The task emits a result: `signRegistryAccessPath`
+
+This contains the relative path in the workspace to a text file that contains a list of repositories
+that needs registry.access.redhat.com image references to be signed (i.e.
+requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
+
+Note: This task runs quite early on in the pipeline, because we need the result it produces
+for the signing tasks (and `rh-sign-image` runs quite early to begin with). So this means
+that if you're releasing to a repo for the first time, the repository might get published
+even before the actual image is pushed and published. But we checked with RHEC team and this
+shouldn't cause any problems, because RHEC will ignore repos with no published images.
 
 
 ## Parameters
@@ -22,6 +34,15 @@ does not publish the repository.
 | snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace                            | No       |                 |
 | dataPath       | Path to the JSON string of the merged data to use in the data workspace                              | No       |                 |
 | resultsDirPath | Path to the results directory in the data workspace                                                  | No       |                 |
+
+## Changes in 3.0.0
+* data json is now mandatory - technically, for some use cases the file is not needed, but requiring it always
+  makes it consistent with other tasks and it also makes the task script more readable
+* A new `signRegistryAccessPath` result is emitted
+  * This contains the relative path in the workspace to a text file that contains a list of repositories
+    that needs registry.access.redhat.com image references to be signed (i.e.
+    requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
+
 
 ## Changes in 2.0.0
 * Added JSON results output for published repositories, contains Catalog (RHEC) URL

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,6 +41,13 @@ spec:
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
+  results:
+    - name: signRegistryAccessPath
+      type: string
+      description: |
+        The relative path in the workspace to a text file that contains a list of repositories
+        that needs registry.access.redhat.com image references to be signed (i.e.
+        requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
   steps:
     - name: publish-pyxis-repository
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -57,7 +64,7 @@ spec:
               key: key
       script: |
         #!/usr/bin/env bash
-        set -eu
+        set -eux
 
         PYXIS_REGISTRY=registry.access.redhat.com
 
@@ -78,8 +85,11 @@ spec:
           exit 1
         fi
 
+        # Disable trace logging to avoid leaking of cert+key
+        set +x
         echo "${pyxisCert}" > /tmp/crt
         echo "${pyxisKey}" > /tmp/key
+        set -x
 
         SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
@@ -88,16 +98,22 @@ spec:
         fi
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/publish-pyxis-repository-results.json"
+        SIGN_REGISTRY_ACCESS_PATH="$(dirname "$(params.dataPath)")/sign-registry-access.txt"
+        echo -n "$SIGN_REGISTRY_ACCESS_PATH" > "$(results.signRegistryAccessPath.path)"
+        SIGN_REGISTRY_ACCESS_PATH="$(workspaces.data.path)/${SIGN_REGISTRY_ACCESS_PATH}"
+        touch "$SIGN_REGISTRY_ACCESS_PATH"
 
         # Use a unique key to avoid conflicts with other tasks
         RESULTS_JSON='{"catalog_urls":[]}'
 
         # Default to false
-        if [[ -f "${DATA_FILE}" && $(jq -r ".pyxis.skipRepoPublishing" "${DATA_FILE}") == "true" ]] ; then
-            echo "skipRepoPublishing is set to true, exiting..."
-            exit
-        fi
+        skipRepoPublishing="$(jq -r ".pyxis.skipRepoPublishing // false" "${DATA_FILE}")"
 
         defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' ${DATA_FILE} || echo false)
 
@@ -123,6 +139,17 @@ spec:
                 echo "Pyxis response for ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY}:"
                 echo $PYXIS_REPOSITORY_JSON
                 exit 1
+            fi
+
+            PYXIS_REPOSITORY_REQUIRES_TERMS=$(jq '.requires_terms' <<< "$PYXIS_REPOSITORY_JSON")
+            if [ "$PYXIS_REPOSITORY_REQUIRES_TERMS" = false ]; then
+              echo "$PYXIS_REPOSITORY" >> "$SIGN_REGISTRY_ACCESS_PATH"
+            fi
+
+            # Default to false
+            if [ "$skipRepoPublishing" = true ] ; then
+                echo "skipRepoPublishing is set to true, skipping publishing..."
+                continue
             fi
 
             # Set source_container_image_enabled based on pushSourceContainer value in components or use default if

--- a/tasks/publish-pyxis-repository/tests/mocks.sh
+++ b/tasks/publish-pyxis-repository/tests/mocks.sh
@@ -16,9 +16,12 @@ function curl() {
       echo '{"detail": "Document in containerRepository not found.", "status": 404, "title": "Not Found", "type": "about:blank", "trace_id": "0x4d7be17d142d24c5f2b10b5f1745cc89"}'
     else
       if [[ "$*" == *"my-image0"* ]]; then
-        echo '{"_id": "'$CALL_ID'", "publish_on_push": "false"}'
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": false, "requires_terms": true}'
+      # condition for image not requiring terms
+      elif [[ "$*" == *"my-image"[56]* ]]; then
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": true, "requires_terms": false}'
       else
-        echo '{"_id": "'$CALL_ID'", "publish_on_push": "true"}'
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": true, "requires_terms": true}'
       fi
     fi
   elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published":true}' ]]

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -37,6 +37,12 @@ spec:
               }
               EOF
 
+              cat > "$(workspaces.data.path)/mydata.json" << EOF
+              {
+                "mapping": {
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: publish-pyxis-repository
@@ -46,7 +52,7 @@ spec:
         - name: snapshotPath
           value: snapshot_spec.json
         - name: dataPath
-          value: ""
+          value: mydata.json
         - name: resultsDirPath
           value: results
       workspaces:

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -39,6 +39,12 @@ spec:
               }
               EOF
 
+              cat > "$(workspaces.data.path)/mydata.json" << EOF
+              {
+                "mapping": {
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: publish-pyxis-repository
@@ -48,7 +54,7 @@ spec:
         - name: snapshotPath
           value: snapshot_spec.json
         - name: dataPath
-          value: ""
+          value: mydata.json
         - name: resultsDirPath
           value: results
       workspaces:

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -3,9 +3,12 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: test-publish-pyxis-repository-no-data-json
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
     Run the publish-pyxis-repository task with a single component and no data JSON.
+    The pipeline should fail.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -52,29 +55,3 @@ spec:
           workspace: tests-workspace
       runAfter:
         - setup
-    - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      taskSpec:
-        workspaces:
-          - name: data
-        steps:
-          - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
-            script: |
-              #!/usr/bin/env sh
-              set -eux
-
-              if [ $(cat $(workspaces.data.path)/mock_curl.txt | wc -l) != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
-                  cat $(workspaces.data.path)/mock_curl.txt
-                  exit 1
-              fi
-
-              [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 1) \
-                  == *"/my-product/my-image1 "* ]]
-              [[ $(cat $(workspaces.data.path)/mock_curl.txt | tail -n 1) \
-                  == *"/id/1 "* ]]
-      runAfter:
-        - run-task

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-publish-pyxis-repository
+  name: test-publish-pyxis-repository-no-terms-required
 spec:
   description: |
-    Run the publish-pyxis-repository task with multiple components and verify catalog URLs.
+    Run the publish-pyxis-repository task with multiple components where some of them
+    don't require terms, so these should be included in the signRegistryAccessPath result.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -34,11 +35,11 @@ spec:
                     "name": "component1"
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image2",
+                    "repository": "quay.io/redhat-prod/my-product----my-image5",
                     "name": "component2"
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image3",
+                    "repository": "quay.io/redhat-prod/my-product----my-image6",
                     "name": "component3"
                   }
                 ]
@@ -102,11 +103,11 @@ spec:
                   },
                   {
                     "name": "component2",
-                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image2/3"
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image5/3"
                   },
                   {
                     "name": "component3",
-                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image3/5"
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image6/5"
                   }
                 ]
               }'
@@ -130,18 +131,24 @@ spec:
               [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 2 | tail -n 1) \
                   == *"/id/1 "* ]]
               [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 3 | tail -n 1) \
-                  == *"/my-product/my-image2 "* ]]
+                  == *"/my-product/my-image5 "* ]]
               [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 4 | tail -n 1) \
                   == *"/id/3 "* ]]
               [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 5 | tail -n 1) \
-                  == *"/my-product/my-image3 "* ]]
+                  == *"/my-product/my-image6 "* ]]
               [[ $(cat $(workspaces.data.path)/mock_curl.txt | head -n 6 | tail -n 1) \
                   == *"/id/5 "* ]]
 
+              EXPECTED_RESULTS='my-product/my-image5
+              my-product/my-image6'
+
               SIGN_ACCESS_FILE="$(workspaces.data.path)/$(params.signRegistryAccessPath)"
-              if [ "$(wc -l < "$SIGN_ACCESS_FILE")" != 0 ]; then
-                echo "Error: The signRegistryAccessPath file was expected to be empty. Instead, it contains:"
+              if [ "$(cat "$SIGN_ACCESS_FILE")" != "$EXPECTED_RESULTS" ]; then
+                echo "Error: The signRegistryAccessPath file was expected to contain:"
+                echo "$EXPECTED_RESULTS"
+                echo "Instead it contains:"
                 cat "$SIGN_ACCESS_FILE"
+                exit 1
               fi
       runAfter:
         - run-task

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -75,8 +75,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              if [ -f $(workspaces.data.path)/mock_curl.txt ]; then
-                  echo Error: curl was not expected to be called. Actual calls:
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_curl.txt")" != 1 ]; then
+                  echo Error: curl was expected to be called once. Actual calls:
                   cat $(workspaces.data.path)/mock_curl.txt
                   exit 1
               fi

--- a/tasks/rh-sign-image-cosign/README.md
+++ b/tasks/rh-sign-image-cosign/README.md
@@ -4,12 +4,23 @@ Tekton task to sign container images in snapshot by cosign.
 
 ## Parameters
 
-| Name           | Description                                                               | Optional | Default value |
-|----------------|---------------------------------------------------------------------------|----------|---------------|
-| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -             |
-| secretName     | Name of secret containing needed credentials                              | No       | -             |
+| Name                   | Description                                                                                                                                                                                                                                       | Optional | Default value |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| snapshotPath           | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                         | No       | -             |
+| secretName             | Name of secret containing needed credentials                                                                                                                                                                                                      | No       | -             |
+| signRegistryAccessPath | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 
-# Changelog
+## Changes in 1.0.0
+* Added mandatory parameter `signRegistryAccessPath`.
+  * The relative path in the workspace to a text file that contains a list of repositories
+    that needs registry.access.redhat.com image references to be signed (i.e.
+    requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
+  * Only components for which the repository is included in the file will get
+    the registry.access.redhat.com references signed.
+* `skopeo inspect` call is now done on the source image (`containerImage` in snapshot), rather
+  than on the target location (`repository` in mapped snapshot). This puts it in line
+  with what's done in `rh-sign-image`, but also, we might want to sign the images before
+  they're actually pushed.
 
 ## Changes in 0.3.0
 * Make rekor url configurable

--- a/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image-cosign
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -18,6 +18,12 @@ spec:
     - name: secretName
       description: Name of secret containing needed credentials
       type: string
+    - name: signRegistryAccessPath
+      type: string
+      description: |
+        The relative path in the workspace to a text file that contains a list of repositories
+        that needs registry.access.redhat.com image references to be signed (i.e.
+        requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
   workspaces:
     - name: data
       description: Workspace to read and save files
@@ -56,21 +62,36 @@ spec:
         set -eux
 
         SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
-        COMPONENTS_LENGTH=$(jq '.components |length' ${SNAPSHOT_PATH})
+        COMPONENTS_LENGTH=$(jq '.components |length' "${SNAPSHOT_PATH}")
+
+        SIGN_REGISTRY_ACCESS_FILE=$(workspaces.data.path)/$(params.signRegistryAccessPath)
+        if [ ! -f "${SIGN_REGISTRY_ACCESS_FILE}" ] ; then
+            echo "No valid file was provided as signRegistryAccessPath."
+            exit 1
+        fi
 
         for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
-            COMPONENT_NAME=$(jq -r ".components[${COMPONENTS_INDEX}].name" ${SNAPSHOT_PATH})
+            COMPONENT_NAME=$(jq -r ".components[${COMPONENTS_INDEX}].name" "${SNAPSHOT_PATH}")
             echo "Processing component ${COMPONENT_NAME}"
 
             # Get public image references
-            INTERNAL_CONTAINER_REF=$(jq -r ".components[${COMPONENTS_INDEX}].repository" ${SNAPSHOT_PATH})
-            PUB_CONTAINER_REFS=$(translate-delivery-repo $INTERNAL_CONTAINER_REF | jq -r ".[].url")
+            INTERNAL_CONTAINER_REF=$(jq -r ".components[${COMPONENTS_INDEX}].repository" "${SNAPSHOT_PATH}")
+            rh_registry_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"rh-registry-repo\"]" "${SNAPSHOT_PATH}")
+            registry_access_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"registry-access-repo\"]" \
+              "${SNAPSHOT_PATH}")
+            repository="${rh_registry_repo#*/}"
+
+            # Sign rh-registry-repo references (always) and registry-access-repo references
+            # (only if signatures for this registry are required)
+            REGISTRY_REFERENCES=("${rh_registry_repo}")
+            if grep -q "^${repository}$" "${SIGN_REGISTRY_ACCESS_FILE}"; then
+              REGISTRY_REFERENCES+=("${registry_access_repo}")
+            fi
 
             # Check if image is manifest list
-            BUILD_CONTAINER_IMAGE=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" ${SNAPSHOT_PATH})
+            BUILD_CONTAINER_IMAGE=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" "${SNAPSHOT_PATH}")
             DIGEST="${BUILD_CONTAINER_IMAGE/*@}"
-            INTERNAL_CONTAINER_IMAGE="${INTERNAL_CONTAINER_REF}@${DIGEST}"
-            IMAGE=$(skopeo inspect --raw "docker://${INTERNAL_CONTAINER_IMAGE}")
+            IMAGE=$(skopeo inspect --raw "docker://${BUILD_CONTAINER_IMAGE}")
             MEDIA_TYPE=$(echo "$IMAGE" | jq -r '.mediaType')
             TAGS=$(jq -r ".components[${COMPONENTS_INDEX}].tags|.[]" "${SNAPSHOT_PATH}")
             LIST=0
@@ -86,13 +107,13 @@ spec:
 
             # Sign each manifest in manifest list
             if [ $LIST -eq 1 ]; then
-                for PUB_CONTAINER_REF in $PUB_CONTAINER_REFS; do
+                for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                     for MDIGEST in $(echo "$IMAGE" | jq -r '.manifests[]|.digest'); do
                         for TAG in $TAGS; do
                             echo "Signing manifest ${INTERNAL_CONTAINER_REF}:${TAG} (${MDIGEST})"
                             cosign -t 3m0s sign\
                             ${COSIGN_COMMON_ARGS}\
-                            --sign-container-identity "${PUB_CONTAINER_REF}:${TAG}"\
+                            --sign-container-identity "${REGISTRY_REF}:${TAG}"\
                             "${INTERNAL_CONTAINER_REF}@${MDIGEST}"
                         done
                     done
@@ -100,12 +121,12 @@ spec:
             fi
 
             # Sign manifest list itself or manifest if it's not list
-            for PUB_CONTAINER_REF in $PUB_CONTAINER_REFS; do
+            for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                 for TAG in $TAGS; do
                     echo "Signing manifest ${INTERNAL_CONTAINER_REF}:${TAG} (${DIGEST})"
                     cosign -t 3m0s sign\
                     ${COSIGN_COMMON_ARGS}\
-                    --sign-container-identity "${PUB_CONTAINER_REF}:${TAG}"\
+                    --sign-container-identity "${REGISTRY_REF}:${TAG}"\
                     "${INTERNAL_CONTAINER_REF}@${DIGEST}"
                 done
             done

--- a/tasks/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/rh-sign-image-cosign/tests/mocks.sh
@@ -4,9 +4,9 @@ set -eux
 echo "MOCK SETUP"
 
 
-_TEST_MANIFEST_LIST_OCI_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:0000"
-_TEST_MANIFEST_LIST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:1111"
-_TEST_MANIFEST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:2222"
+_TEST_MANIFEST_LIST_OCI_REFERENCE="quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000"
+_TEST_MANIFEST_LIST_REFERENCE="quay.io/redhat-user-workloads/test-product/test-image1@sha256:1111"
+_TEST_MANIFEST_REFERENCE="quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222"
 
 _DOCKER_MANIFEST_LIST=$(cat << EOF
 {

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -31,18 +31,26 @@ spec:
                 "components": [
                   {
                     "name": "comp0",
-                    "containerImage": "$_TEST_MANIFEST_LIST_REFERENCE",
-                    "repository": "$_TEST_REPO",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000",
+                    "repository": "quay.io/redhat-pending/test-product----test-image0",
+                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0",
+                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0",
                     "tags": ["t1", "t2"]
                   },
                   {
                     "name": "comp1",
-                    "containerImage": "$_TEST_MANIFEST_LIST_OCI_REFERENCE",
-                    "repository": "$_TEST_REPO",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image1@sha256:1111",
+                    "repository": "quay.io/redhat-pending/test-product----test-image1",
+                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image1",
+                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image1",
                     "tags": ["t1", "t2"]
                   }
                 ]
               }
+              EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              test-product/test-image0
               EOF
     - name: run-task
       taskRef:
@@ -52,6 +60,8 @@ spec:
           value: snapshot_spec.json
         - name: secretName
           value: 'test-cosign-secret-rekor'
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -71,11 +81,13 @@ spec:
               echo "check results"
               _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
               _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
-              _TEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+              _TEST_PUB_REPO3="registry.stage.redhat.io/test-product/test-image1"
+              _TEST_REPO1="quay.io/redhat-pending/test-product----test-image0"
+              _TEST_REPO2="quay.io/redhat-pending/test-product----test-image1"
 
               EXPECTED=$(cat <<EOF
-              inspect --raw docker://${_TEST_REPO}@sha256:1111
-              inspect --raw docker://${_TEST_REPO}@sha256:0000
+              inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000
+              inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image1@sha256:1111
               EOF
               )
               CALLS=$(cat "$(workspaces.data.path)/mock_skopeo_calls")
@@ -85,38 +97,30 @@ spec:
               COSIGN_COMMON="-t 3m0s sign -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
               --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111
               EOF
               )
               test "$CALLS" = "$EXPECTED"

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -21,20 +21,24 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-              _TEST_MANIFEST_REFERENCE="quay.io/redhat-pending/test-product----test-image0@sha256:2222"
-              _TEST_MANIFEST_REPO="quay.io/redhat-pending/test-product----test-image0"
               cat > $(workspaces.data.path)/snapshot_spec.json << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp0",
-                    "containerImage": "$_TEST_MANIFEST_REFERENCE",
-                    "repository": "$_TEST_MANIFEST_REPO",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
+                    "repository": "quay.io/redhat-pending/test-product----test-image2",
+                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
+                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
                     "tags": ["t1", "t2"]
                   }
                 ]
               }
+              EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              test-product/test-image2
               EOF
     - name: run-task
       taskRef:
@@ -44,6 +48,8 @@ spec:
           value: snapshot_spec.json
         - name: secretName
           value: 'test-cosign-secret'
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -61,12 +67,13 @@ spec:
               #!/usr/bin/env bash
               set -eux
               echo "check results"
-              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
-              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
-              _TEST_REPO="quay.io/redhat-pending/test-product----test-image0"
+              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image2"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image2"
+              _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
 
               CALLS=$(cat "$(workspaces.data.path)/mock_skopeo_calls")
-              test "$CALLS" = "inspect --raw docker://${_TEST_REPO}@sha256:2222"
+              EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222"
+              test "$CALLS" = "$EXPECTED"
 
               CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
               COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -4,25 +4,34 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 
 ## Parameters
 
-| Name                     | Description                                                                                          | Optional | Default value |
-|--------------------------|------------------------------------------------------------------------------------------------------|----------|---------------|
-| snapshotPath             | Path to the JSON string of the mapped Snapshot spec in the data workspace                            | No       | -             |
-| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                              | No       | -             |
-| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                            | No       | -             |
-| requester                | Name of the user that requested the signing, for auditing purpose                                    | No       | -             |
-| requestTimeout           | Request timeout                                                                                      | Yes      | 180           |
-| concurrentLimit          | The maximum number of images to be processed at once                                                 | Yes      | 16            |
-| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating a requests                   | No       | -             |
-| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                | No       | -             |
-| taskGitRevision          | The revision in the taskGitUrl repo to be used                                                       | No       | -             |
-| pyxisServer              | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'.  | Yes      | production    |
-| pyxisSecret              | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert    | No       | -             |
+| Name                     | Description                                                                                                                                                                                                                                       | Optional | Default value |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| snapshotPath             | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                         | No       | -             |
+| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                                                                                                                                                                           | No       | -             |
+| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                                                                                                                                                                         | No       | -             |
+| requester                | Name of the user that requested the signing, for auditing purpose                                                                                                                                                                                 | No       | -             |
+| requestTimeout           | Request timeout                                                                                                                                                                                                                                   | Yes      | 180           |
+| concurrentLimit          | The maximum number of images to be processed at once                                                                                                                                                                                              | Yes      | 16            |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating a requests                                                                                                                                                                | No       | -             |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                                                                                                             | No       | -             |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                    | No       | -             |
+| pyxisServer              | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'.                                                                                                                                               | Yes      | production    |
+| pyxisSecret              | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert                                                                                                                                                 | No       | -             |
+| signRegistryAccessPath   | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 
+
+## Changes in 5.0.0
+* Added mandatory parameter `signRegistryAccessPath`.
+  * The relative path in the workspace to a text file that contains a list of repositories
+    that needs registry.access.redhat.com image references to be signed (i.e.
+    requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
+  * Only components for which the repository is included in the file will get
+    the registry.access.redhat.com references signed.
 
 ## Changes in 4.0.0
 * New mandatory parameter `releasePlanAdmissionPath`
 * New `internal-pipelinerun` requestType mode which can be enabled for the case of private, internal clusters.
-  * Use `.data.sign.requestType` to choose between `internal-request` and `internal-pipelinerun` 
+  * Use `.data.sign.requestType` to choose between `internal-request` and `internal-pipelinerun`
 * Attempts to sign are now skipped if the manifest digest for a given repository have already been signed.
 
 ## Changes in 3.4.1

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -49,6 +49,12 @@ spec:
       type: string
       description: |
         The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert
+    - name: signRegistryAccessPath
+      type: string
+      description: |
+        The relative path in the workspace to a text file that contains a list of repositories
+        that needs registry.access.redhat.com image references to be signed (i.e.
+        requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
   workspaces:
     - name: data
       description: workspace to read and save files
@@ -95,6 +101,12 @@ spec:
         RPA_FILE="$(workspaces.data.path)/$(params.releasePlanAdmissionPath)"
         if [ ! -f "${RPA_FILE}" ] ; then
             echo "No valid rpa file was provided."
+            exit 1
+        fi
+
+        SIGN_REGISTRY_ACCESS_FILE=$(workspaces.data.path)/$(params.signRegistryAccessPath)
+        if [ ! -f "${SIGN_REGISTRY_ACCESS_FILE}" ] ; then
+            echo "No valid file was provided as signRegistryAccessPath."
             exit 1
         fi
 
@@ -155,7 +167,6 @@ spec:
 
             rh_registry_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"rh-registry-repo\"]" ${SNAPSHOT_PATH})
             registry_access_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"registry-access-repo\"]" ${SNAPSHOT_PATH})
-
             repository="${rh_registry_repo#*/}"
 
             git_sha=$(jq -r ".components[${COMPONENTS_INDEX}].source.git.revision" ${SNAPSHOT_PATH})
@@ -191,6 +202,13 @@ spec:
               sourceContainerDigest=$(oras resolve --registry-config "$AUTH_FILE" "${sourceContainer}")
             fi
 
+            # Sign rh-registry-repo references (always) and registry-access-repo references
+            # (only if signatures for this registry are required)
+            REGISTRY_REFERENCES=("${rh_registry_repo}")
+            if grep -q "^${repository}$" "${SIGN_REGISTRY_ACCESS_FILE}"; then
+              REGISTRY_REFERENCES+=("${registry_access_repo}")
+            fi
+
             for manifest_digest in $manifest_digests; do
 
               find_signatures --pyxis-graphql-api "${PYXIS_GRAPHQL_URL}" \
@@ -199,7 +217,7 @@ spec:
                   --output_file "/tmp/${manifest_digest}"
 
               # Iterate over both rh-registry-repo and registry-access-repo
-              for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
+              for registry_reference in "${REGISTRY_REFERENCES[@]}"; do
 
                 for tag in ${TAGS}; do
 
@@ -245,7 +263,7 @@ spec:
                     --repository "${repository}" \
                     --output_file "/tmp/${sourceContainerDigest}"
 
-                for registry_reference in ${rh_registry_repo} ${registry_access_repo}; do
+                for registry_reference in "${REGISTRY_REFERENCES[@]}"; do
 
                   for tag in ${TAGS}; do
                     sourceTag=${tag}-source

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -32,6 +32,8 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "quay.io/redhat-prod/myproduct----myrepo",
+                    "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+                    "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
                     "tags": [
                       "some-prefix-12345",
                       "some-prefix"
@@ -75,6 +77,8 @@ spec:
                 }
               }
               EOF
+
+              touch "$(workspaces.data.path)/signRegistryAccess.txt"
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -95,6 +99,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -97,6 +97,12 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              prod/repo0
+              prod/repo1
+              prod/repo2
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -117,6 +123,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Test creating an internal request to sign an image with the pushSourceContainer
-    values set in the mapping and components
+    values set in the mapping and components. This also tests a combination of some repos
+    requiring registry.access* signatures and others not requiring them.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -121,6 +122,11 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct0/myrepo0
+              myproduct1/myrepo1
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -141,6 +147,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -158,15 +166,11 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # Just checking source container IRs because the others are checked in the single
-              # component test. There should be 8 IRs for the first component (two tags * one for
+              # There should be 8 IRs for the first component (two tags * one for
               # registry.access.redhat.com and one for registry.redhat.io, * one for the image, one for
-              # the source image), 4 for the second component (same 4 as above but only half as 
-              # pushSourceContainer is false), and 8 for the final (same as first component).
-              #
-              # Just checking the first source one for each (IRs 5 and 17, but also ensuring IR
-              # 13 isn't for the comp1 source container. These will use registry.redhat.io and the
-              # first commonTag which is some-prefix-12345
+              # the source image), 4 for the second component (same 4 as above but only half as
+              # pushSourceContainer is false), and 4 for the final (same 4 as first component,
+              # but only half as registry.access.redhat.com signatures are not required).
 
               internalRequests="$(kubectl get internalrequest -o json --sort-by=.metadata.creationTimestamp | jq -c)"
               irsLength=$(jq ".items | length" <<< "${internalRequests}" )
@@ -174,14 +178,18 @@ spec:
               expectedReferences=()
               for((i=0; i<3; i++)); do
                 expectedReferences+=("registry.redhat.io/myproduct${i}/myrepo${i}:some-prefix-12345")
-                expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-12345")
                 expectedReferences+=("registry.redhat.io/myproduct${i}/myrepo${i}:some-prefix")
-                expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix")
+                if [ "${i}" != "2" ] ; then
+                  expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-12345")
+                  expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix")
+                fi
                 if [ "${i}" != "1" ] ; then
                   expectedReferences+=("registry.redhat.io/myproduct${i}/myrepo${i}:some-prefix-12345-source")
-                  expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-12345-source")
                   expectedReferences+=("registry.redhat.io/myproduct${i}/myrepo${i}:some-prefix-source")
-                  expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-source")
+                  if [ "${i}" != "2" ] ; then
+                    expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-12345-source")
+                    expectedReferences+=("registry.access.redhat.com/myproduct${i}/myrepo${i}:some-prefix-source")
+                  fi
                 fi
               done
 

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -75,6 +75,10 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -95,6 +99,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -85,6 +85,10 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -105,6 +109,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -85,6 +85,10 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -105,6 +109,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -122,7 +128,6 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              
               internalPipelineruns="$(kubectl get pr \
                 -l "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)" \
                 -o json --sort-by=.metadata.creationTimestamp | jq -c)"

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -85,6 +85,10 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -105,6 +109,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -81,6 +81,10 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
     - name: run-task
       taskRef:
         name: rh-sign-image
@@ -103,6 +107,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
`rh-sign-image` and `rh-sign-image-cosign` will now only sign registry.access.redhat.com references if requires_terms is false in the corresponding repository object in Pyxis.

If require_terms is true (the vast majority of repos), signing of registry.access references will be skipped which will result in 50 % reduction of signing
requests.

Several changes are included:

* `publish-pyxis-repository` provides a new result that points to a file that contains a list of repos where signing of registry.access references is needed.
* `rh-sign-image` and `rh-sign-image-cosign` take this result as a new mandatory parameter and will skip registry.access signing unless the given repo is included in the file.
* `rh-advisories` and `rh-push-to-registry-redhat-io` pipelines were modified for this. The order of tasks was also slightly modified so that `publish-pyxis-repository` runs earlier in the pipeline.