### PR TITLE
feat(RELEASE-987): add schema validator to pipelines via `check-data-keys task`

### DIFF
--- a/tasks/check-data-keys/README.md
+++ b/tasks/check-data-keys/README.md
@@ -1,10 +1,9 @@
 # check-data-keys
 
-Tekton task to check that all required information is present in the data file in order to use the
-specified system(s). If any required keys are missing, the task will fail.
+Tekton task that validates data keys against a schema to ensure that all required keys for a system(s) are present and correctly formatted. The system(s) passed into the `systems` parameter become required. The schema validation also applies to all data passed into the `dataPath` parameter, meaning all the data keys must be allowed and formatted correctly.
 
 For example, if `releaseNotes` is passed as a system and the data file does not have all the required
-releaseNotes keys, the task will fail.
+releaseNotes keys, the schema will give validation errors, and the task will fail.
 
 Currently, `releaseNotes`, and `cdn` are the only supported systems.
 
@@ -14,6 +13,10 @@ Currently, `releaseNotes`, and `cdn` are the only supported systems.
 |----------|---------------------------------------------------------|----------|---------------|
 | dataPath | Path to the JSON string of the merged data to use       | No       |               |
 | systems  | The systems to check that all data keys are present for | Yes      | []            |
+| schema   | The URl to the schema                                   | Yes      | https://github.com/konflux-ci/release-service-catalog/blob/production/schema/dataKeys.json |
+
+## Changes in 1.0.0
+* Replacing the check with a schema validator
 
 ## Changes in 0.9.2
 * Fixing checkton/shellcheck linting issues in the task and test

--- a/tasks/check-data-keys/check-data-keys.yaml
+++ b/tasks/check-data-keys/check-data-keys.yaml
@@ -4,17 +4,22 @@ kind: Task
 metadata:
   name: check-data-keys
   labels:
-    app.kubernetes.io/version: "0.9.2"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task to check that all required information is present to use the specified system(s)
+    Tekton task to check that all required information is present to use the specified system(s) 
+    and the data is valid against the schema.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use
       type: string
+    - name: schema 
+      description: URL to the JSON schema file to validate the data against
+      type: string
+      default: https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/development/schema/dataKeys.json
     - name: systems
       description: The systems to check that all data keys are present for
       type: array
@@ -24,52 +29,26 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
       args: ["$(params.systems[*])"]
       script: |
         #!/usr/bin/env bash
         set -ex
-
-        KEYS_JSON='{
-            "releaseNotes": [
-                "product_id",
-                "product_name",
-                "product_version",
-                "product_stream",
-                "cpe",
-                "type",
-                "content.images",
-                "synopsis",
-                "topic",
-                "description",
-                "solution",
-                "references"
-            ],
-            "cdn": [
-                "env"
-            ]
-        }'
 
         if [ ! -f "$(workspaces.data.path)/$(params.dataPath)" ] ; then
             echo "No data JSON was provided."
             exit 1
         fi
 
-        RC=0
+        if ! curl -s --fail-with-body "$(params.schema)" -o /tmp/schema ; then
+            echo "Failed to download schema file: $(params.schema)"
+            exit 1
+        fi
 
-        for SYSTEM in "$@" ; do
-            if [[ $(jq -r ".$SYSTEM" <<< "$KEYS_JSON") == null ]] ; then
-                echo "Unsupported system value: $SYSTEM"
-                RC=1
-            fi
+        systemsJSON=$(echo "$@" | jq -R 'split(" ")')
 
-            echo "Checking all required keys exist for: $SYSTEM"
-            for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON") ; do
-                if [[ $(jq ".$SYSTEM.$KEY" "$(workspaces.data.path)/$(params.dataPath)") == "null" ]] ; then
-                    echo "Missing required $SYSTEM key: $KEY"
-                    RC=1
-                fi
-            done
-        done
+        jq --argjson systems "$systemsJSON" '.systems += $systems' \
+            "$(workspaces.data.path)/$(params.dataPath)" > "/tmp/systems" 
+        mv "/tmp/systems" "$(workspaces.data.path)/$(params.dataPath)"
 
-        exit $RC
+        check-jsonschema --output-format=text --schemafile "/tmp/schema"  "$(workspaces.data.path)/$(params.dataPath)"

--- a/tasks/check-data-keys/tests/mocks.sh
+++ b/tasks/check-data-keys/tests/mocks.sh
@@ -1,0 +1,10 @@
+#mocks.sh
+#!/usr/bin/env bash
+set -eux
+function curl() {
+    if [[ "$*" == *"https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/production/schema/non-existent-schema.json"* ]]; then
+        command curl -s --fail-with-body "$@" -o /tmp/schema
+    else
+        command curl -s --fail-with-body  https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/development/schema/dataKeys.json -o /tmp/schema
+    fi
+}

--- a/tasks/check-data-keys/tests/pre-apply-task-hook.sh
+++ b/tasks/check-data-keys/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Inject mocks.sh into the task's first step
+yq -i '.spec.steps[0].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -30,7 +30,7 @@ spec:
               {
                 "releaseNotes": {
                   "product_name": "Red Hat Openstack Product",
-                  "product_version": "123",
+                  "product_version": "1.2.3",
                   "product_stream": "rhtas-tp1",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -2,10 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-check-data-keys
+  name: test-check-data-keys-fail-missing-schema-key
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with all necessary keys present.
+    Run the check-data-keys task without a schema JSON and verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -26,24 +28,12 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
-                  "product_id": 123,
                   "product_name": "Red Hat Openstack Product",
+                  "product_id": 123,
                   "product_version": "1.2.3",
                   "product_stream": "rhtas-tp1",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
-                  "issues": {
-                    "fixed": [
-                      {
-                        "id": "RHOSP-12345",
-                        "source": "issues.example.com"
-                      },
-                      {
-                        "id": "1234567",
-                        "source": "bugzilla.example.com"
-                      }
-                    ]
-                  },
                   "content": {
                     "images": [
                       {
@@ -74,9 +64,6 @@ spec:
                   "references": [
                     "https://docs.example.com/some/example/release-notes"
                   ]
-                },
-                "cdn": {
-                  "env": "qa"
                 }
               }
               EOF
@@ -86,10 +73,11 @@ spec:
       params:
         - name: dataPath
           value: "data.json"
+        - name: schema
+          value: "https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/production/schema/non-existent-schema.json"
         - name: systems
           value:
             - releaseNotes
-            - cdn
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -29,7 +29,10 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_stream": "rhtas-tp1",
                   "product_id": 123,
+                  "product_version": "1.2.3",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
                   "issues": {
@@ -39,7 +42,7 @@ spec:
                         "source": "issues.example.com"
                       },
                       {
-                        "id": 1234567,
+                        "id": "1234567",
                         "source": "bugzilla.example.com"
                       }
                     ]
@@ -87,6 +90,7 @@ spec:
           value:
             - releaseNotes
             - unsupported
+            - random
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -2,10 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-check-data-keys
+  name: test-check-data-keys-incorrect-type-releasenotes-key
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with all necessary keys present.
+    Run the check-data-keys task with an incorrect type for the releaseNotes product_id key which should be an integer 
+    and verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -26,7 +29,7 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
-                  "product_id": 123,
+                  "product_id": "rh-123",
                   "product_name": "Red Hat Openstack Product",
                   "product_version": "1.2.3",
                   "product_stream": "rhtas-tp1",
@@ -74,9 +77,6 @@ spec:
                   "references": [
                     "https://docs.example.com/some/example/release-notes"
                   ]
-                },
-                "cdn": {
-                  "env": "qa"
                 }
               }
               EOF
@@ -89,7 +89,6 @@ spec:
         - name: systems
           value:
             - releaseNotes
-            - cdn
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
This updates the `check-data-keys` task to now use a schema validator, ensuring data keys adhere to the specified schema.

Jira : [RELEASE-987](https://issues.redhat.com/browse/RELEASE-987)
Open PR for new dependency `check-jsonschema` in utils  [PR](https://github.com/konflux-ci/release-service-utils/pull/275)
