### PR TITLE
fix: tweak github actions

### DIFF
--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -13,20 +13,20 @@ on:
           - production
       force-to-staging:
         description: |
-          If passed with value true, allow promotion to staging even if staging and production differ
+          Force to staging: Allow promotion to staging even if staging and production differ
         type: boolean
         required: true
         default: false
       override:
         description: |
-          If passed with value true, allow promotion to production even if the change has not been in staging for one
+          Override: Allow promotion to production even if the change has not been in staging for one
           week
         type: boolean
         required: true
         default: false
       dry-run:
         description: |
-          If passed with value true, print out the changes that would be promoted but do not perform the git push
+          Dry run: Print out the changes that would be promoted but do not perform the git push
         type: boolean
         required: true
         default: false

--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run branch promotion script
         run: |
           .github/scripts/promote_branch.sh --target-branch $TARGET --force-to-staging $FORCE \

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get changed dirs
         id: changed-dirs
         uses: tj-actions/changed-files@v41


### PR DESCRIPTION
- update checkout action to v4
  - Some places were already on version 4. Move the rest as well.
  - v3 would print this warning:
    > The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.
- tweak Promote branch inputs
  - When you trigger the workflow via Github UI, it will
    not show you the name of those inputs. It just shows
    checkboxes and the description next to them.

    So let's add the input names to the descriptions
    and also remove the "If set to true" part, as it doesn't
    make sense in the UI.

<img width="330" alt="Screenshot 2024-10-09 at 9 28 32" src="https://github.com/user-attachments/assets/585e1fd6-f8fd-49a8-af78-8b28360a240c">
