### PR TITLE
fix: avoid duplicates in component tags

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -29,6 +29,9 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
 
+## Changes in 1.7.1
+* Tweaked processing of tags to automatically remove any duplicate tags in a component
+
 ## Changes in 1.7.0
 * Added support for image labels in tag variables,
   e.g. `{{ labels.mylabel }}`

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.7.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -123,7 +123,11 @@ spec:
                   exit 1
                 fi
 
-                translated_tags="$(jq -c --arg tag "$tag" '. + [$tag]' <<< "$translated_tags")"
+                # Avoid duplicate tags - only add a tag if not already present
+                if [ "$(jq -c --arg tag "$tag" 'index($tag)' <<< "$translated_tags")" = null ]
+                then
+                  translated_tags="$(jq -c --arg tag "$tag" '. + [$tag]' <<< "$translated_tags")"
+                fi
             done
 
             echo "$translated_tags"

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -42,7 +42,8 @@ spec:
                         "{{ git_short_sha }}-bar",
                         "foo-{{digest_sha}}",
                         "{{ digest_sha }}",
-                        "tag-{{ labels.Goodlabel }}"
+                        "tag-{{ labels.Goodlabel }}",
+                        "tag1-2024-07-29"
                       ]
                     },
                     {


### PR DESCRIPTION
- Tweaked processing of tags to automatically remove any duplicate tags in a component

This came up in a discussion with the osci team.
The idea is that they might want to have e.g.:

```
tags:
  - 9.5
  - {{ labels.release }}
```

In most cases, these will be different, but they might be the same. The pipeline would probably still work, but we should really remove any duplicates.