### PR TITLE
fix: fail build timestamp expansion for oci artifacts with no labels

### DIFF
--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -232,8 +232,8 @@ spec:
             image_metadata="$(skopeo inspect --no-tags --override-os "${os}" --override-arch "${arch}" \
               docker://"${IMAGE_REF}" | jq -c)"
             # For timestamp, use Labels.build-date and fallback to Created
-            build_date="$(jq -r '.Labels."build-date" // .Created' <<< "$image_metadata")"
-            if [ "${build_date}" = "null" ] ; then
+            build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
+            if [ "${build_date}" = "" ] ; then
               timestamp=""
             else
               timestamp="$(date -d "${build_date}" "+$passedTimestampFormat")"


### PR DESCRIPTION
There is no build timestamp or created field for some artifacts (like 
disk-image OCI artifacts and models).                                 
                                                                      
When "build_date" was equal to the empty string, this would cause the 
build timestamp to be produced like this:                             
                                                                      
  ❯ date -d "" '+%s'                                                  
  1728532800                                                          
                                                                      
... which is always rounded to midnight on the given day.             
                                                                      
This would cause multiple releases in a row to incorrectly assign the 
same timestamp, even if the artifacts were different, had different   
digests, and had really been built at different times.                
                                                                      
The new check here will cause the behavior for date-less OCI artifacts
to align with the behavior for date-less images. It will fail the     
release if the user attempts to use `{{ timestamp }}` and no build    
timestamp can be found.                                               