### PR TITLE
fix(RELEASE-1065): fix linting issues in create-github-release task

### DIFF
--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -15,6 +15,9 @@ a `release` dir.
 | content_directory | The directory inside the workspace to find files for release      | No       | -             |
 | resultsDirPath    | Path to results directory in the data workspace                   | No       | -             |
 
+## Changes in 2.1.1
+* Fixed shellcheck linting issues
+
 ## Changes in 2.1.0
 * Updated the base image used in this task
 

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
     - name: create-release-from-binaries
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -ex
 
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-github-release-results.json"
@@ -46,10 +46,10 @@ spec:
         cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
         set -o pipefail
         shopt -s failglob
-        gh release create v$RELEASE_VERSION *.zip *.json *SHA256SUMS *.sig \
-          --repo $REPOSITORY --title "Release $RELEASE_VERSION" | tee $(results.url.path)
+        gh release create "v${RELEASE_VERSION}" ./*.zip ./*.json ./*SHA256SUMS ./*.sig \
+          --repo "$REPOSITORY" --title "Release $RELEASE_VERSION" | tee "$(results.url.path)"
 
-        jq -n --arg release "$(cat $(results.url.path))" '{"github-release": {"url": $release}}' | tee $RESULTS_FILE
+        jq -n --arg release "$(cat "$(results.url.path)")" '{"github-release": {"url": $release}}' | tee "$RESULTS_FILE"
       env:
         - name: GH_TOKEN
           valueFrom:

--- a/tasks/create-github-release/tests/mocks.sh
+++ b/tasks/create-github-release/tests/mocks.sh
@@ -7,7 +7,7 @@ function gh() {
   echo "Mock gh called with: $*"
   echo "$*" >> $(workspaces.data.path)/mock_gh.txt
 
-  if [[ "$*" != "release create v1.2.3 foo.zip foo.json foo_SHA256SUMS foo_SHA256SUMS.sig --repo foo/bar --title Release 1.2.3" ]]
+  if [[ "$*" != "release create v1.2.3 ./foo.zip ./foo.json ./foo_SHA256SUMS ./foo_SHA256SUMS.sig --repo foo/bar --title Release 1.2.3" ]]
   then
     echo Error: Unexpected call
     exit 1


### PR DESCRIPTION
this commit fixes the shellcheck linting issue in the task create-github-release.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>