### PR TITLE
fix(KONFLUX-4292): bump image in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,11 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.0.2
+* Updated the base image used in this task
+  * A typo in `upload_rpm_data.py` was fixed and now we should correctly save
+    the gpg field in Pyxis
+
 ## Changes in 1.0.1
 * Updated the base image used in this task
 

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+        quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -95,7 +95,7 @@ spec:
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+        quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
A typo in `upload_rpm_data.py` was fixed and now
we should correctly save the gpg field in Pyxis.