### PR TITLE
fix: gitlint installation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_REFNAME: ${{ github.ref_name }}
   gitlint:
     name: Run gitlint checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -40,9 +40,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install gitlint into container
-        run: python -m pip install gitlint
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install gitlint
       - name: Run gitlint check
-        run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+        run: |
+          source venv/bin/activate
+          gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
   checkton:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Latest ubuntu does not allow system wide pip install. It can be overriden with `--break-system-packages`, but it's better to create a virtual env.

Note: This [came up](https://github.com/hacbs-release/app-interface-deployments/pull/198) in another repo where we use ubuntu-latest. Here were using an older version of ubuntu, but we it's probably best we switch to ubuntu-latest as well.