### PR TITLE
chore: allow promotion after 6 days

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -82,10 +82,10 @@ check_if_branch_differs() {
 }
 
 check_if_any_commits_in_last_week() {
-    NEW_COMMITS=$(git log --oneline --since="$(date --date="7 days ago" +%Y-%m-%d)" | wc -l)
+    NEW_COMMITS=$(git log --oneline --since="$(date --date="6 days ago" +%Y-%m-%d)" | wc -l)
     if [ $NEW_COMMITS -ne 0 ] ; then
         echo "There are commits in staging that are less than a week old. Blocking promotion to production"
-        echo "Commits less than a week old: $(git log --oneline --since="$(date --date="7 days ago" +%Y-%m-%d)")"
+        echo "Commits less than a week old: $(git log --oneline --since="$(date --date="6 days ago" +%Y-%m-%d)")"
         exit 1
     fi
 }


### PR DESCRIPTION
Without checking the checkbox to override this, we don't allow promotion from staging to production unless it's been sitting there for a week at least.

Let's relax this a little bit, so that it's ok to run it one week later in the day and another week earlier.

BTW, I intentionally kept the message saying "a week" because it's still meant to be more or less a week. Let me know if you think it should say "6 days".