### PR TITLE
fix(KFLUXBUGS-1581): force releaseNotes.type when cves defined

### DIFF
--- a/tasks/create-advisory/README.md
+++ b/tasks/create-advisory/README.md
@@ -18,6 +18,10 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                           |
 
+## Changes in 4.4.2
+* If the releaseNotes do not specify any CVEs fixed and the type is RHSA, fail the task
+* If the releaseNotes specify CVEs fixed, proceed with type set to RHSA regardless of the passed type
+
 ## Changes in 4.4.1
 * Fix linting issues in this task.
 

--- a/tasks/create-advisory/create-advisory.yaml
+++ b/tasks/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "4.4.1"
+    app.kubernetes.io/version: "4.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -55,10 +55,10 @@ spec:
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-advisory-results.json"
 
         # Obtain application from snapshot
-        application=$(jq -rc .application "$(workspaces.data.path)/$(params.snapshotPath)")
+        application=$(jq -r .application "$(workspaces.data.path)/$(params.snapshotPath)")
 
         # Obtain origin workspace from releasePlanAdmission
-        origin=$(jq -rc '.spec.origin' "$(workspaces.data.path)/$(params.releasePlanAdmissionPath)")
+        origin=$(jq -r '.spec.origin' "$(workspaces.data.path)/$(params.releasePlanAdmissionPath)")
 
         # Extract the advisory key and signing configMap name from the data JSON file
         advisoryData=$(jq -c "$(params.jsonKey)" "$(workspaces.data.path)/$(params.dataPath)")
@@ -69,6 +69,19 @@ spec:
         if ! [[ "$advisoryType" =~ ^(RHSA|RHBA|RHEA)$ ]]; then
             echo "Error: advisory type must be one of RHSA, RHBA or RHEA"
             exit 1
+        fi
+
+        # Ensure RHSA is only used if CVEs are provided
+        NUM_CVES=$(jq '[.content.images[]?.cves.fixed // [] | length] | add' <<< "$advisoryData")
+        if [[ "$advisoryType" == "RHSA" ]] && [[ "$NUM_CVES" -eq 0 ]] ; then
+            echo "Provided advisory type is RHSA, but no fixed CVEs were listed"
+            echo "RHSA should only be used if CVEs are fixed in the advisory. Failing..."
+            exit 1
+        fi
+
+        # Set type to RHSA if there are fixed CVEs
+        if [[ "$NUM_CVES" -gt 0 ]] ; then
+            advisoryData=$(jq -c '.type = "RHSA"' <<< "$advisoryData")
         fi
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"

--- a/tasks/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-fail-rhsa-no-cve
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-advisory task with releaseNotes.type set to RHSA but no CVEs in releaseNotes.
+    The task should fail.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir "$(workspaces.data.path)"/results
+              
+              cat > "$(workspaces.data.path)"/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
+                  },
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "quay.io/redhat-prod/repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHSA"
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: resultsDirPath
+          value: "results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/create-advisory/tests/test-create-advisory-overwrite-type.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-overwrite-type.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-overwrite-type
+spec:
+  description: |
+    Run the create-advisory task with a releaseNotes.type that is not RHSA, but CVEs present in releaseNotes.
+    The type should be overwritten to RHSA.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir "$(workspaces.data.path)"/results
+              
+              cat > "$(workspaces.data.path)"/test_release_plan_admission.json << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
+                  },
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/test_snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "quay.io/redhat-prod/repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHEA",
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "test_snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: resultsDirPath
+          value: "results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the request field
+              if [ "$(echo "$internalRequest" | jq -r '.spec.request' )" != "create-advisory" ]; then
+                echo "InternalRequest doesn't contain 'create-advisory' in 'request' field"
+                exit 1
+              fi
+
+              # Check the advisory_json parameter
+              if [[ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_json' )" != \
+              '{"type":"RHSA"'* ]]; then
+                echo "The advisory_json should have had its type overwritten to RHSA because there were CVEs"
+                echo "in the releaseNotes. However, it was not"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit modifies the create-advisory task to fail when releaseNotes.type is RHSA but there are no CVEs listed as fixed. Also, if there are CVEs fixed, the type is forced to be RHSA regardless of what type the user provides.