### PR TITLE
fix: make it more clear that the user needs to set fbc_opt_in

### DIFF
--- a/tasks/add-fbc-contribution/README.md
+++ b/tasks/add-fbc-contribution/README.md
@@ -13,6 +13,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
 | resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
 
+## Changes in 3.4.2
+* Improve clarity of log statements when fbc_opt_in is not set to True.
+
 ## Changes in 3.4.1
 * Removed references to data parameters `iibServiceConfigSecret` and `iibOverwriteFromIndexCredential` as
   they should not be changed by users.

--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.4.1"
+    app.kubernetes.io/version: "3.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -165,17 +165,6 @@ spec:
         echo -n "${mustPublishIndexImage}" | tee "$(results.mustPublishIndexImage.path)"
         echo -n "${fbc_opt_in}" | tee "$(results.isFbcOptIn.path)"
 
-        # Whether the index image will be published
-        if [ "$mustPublishIndexImage" = "true" ]; then
-          echo "Index image will be published."
-        elif [ "$fbc_opt_in" = "false" ]; then
-          echo "Index image will not be published because FBC opt-in is set to false in Pyxis."
-        elif [ "${staged_index}" = "true" ]; then
-          echo "Index image will not be published because this is a staging release."
-        else
-          echo "Index image will not be published for an unspecified reason."
-        fi
-
         jq '.reason // "Unset"'  <<< "${conditions}" | tee "$(results.requestReason.path)"
         jq '.message // "Unset"' <<< "${conditions}" | tee "$(results.requestMessage.path)"
 
@@ -183,4 +172,17 @@ spec:
 
         jq -r '.iibLog' <<< "${results}"
         RC="$(jq -r '.exitCode' <<< "${results}")"
+
+        # Summarize what happened for the human user.
+        if [ "$mustPublishIndexImage" = "true" ]; then
+          echo "Index image will be published."
+        elif [ "$fbc_opt_in" = "false" ]; then
+          echo "Index image will not be published because fbc_opt_in is set to false in Pyxis."
+          echo "If this is the first time you are releasing, make sure you request fbc_opt_in in Pyxis."
+        elif [ "${staged_index}" = "true" ]; then
+          echo "Index image will not be published because this is a staging release."
+        else
+          echo "Index image will not be published for an unspecified reason."
+        fi
+
         exit "$RC"


### PR DESCRIPTION
Try to print out a more clear and instructive message for the user in the event that the fbc_opt_in flag is not set to true.