### PR TITLE
fix: ignore gitlint checks for bots

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -13,3 +13,6 @@ line-length=72
 
 [contrib-title-conventional-commits]
 
+[ignore-by-author-name]
+regex=(.*)\[bot\](.*)
+ignore=T1,B1


### PR DESCRIPTION
This commit modifies the gitlint configuration to ignore the max title length and max body line length rules for bot accounts. Now that this repo uses konflux for its PR testing and is onboarded as a konflux component, we get PRs by the konflux bot.