### PR TITLE
Don't fail cleanup if internalrequests not installed

### DIFF
--- a/tasks/cleanup-workspace/README.md
+++ b/tasks/cleanup-workspace/README.md
@@ -10,6 +10,9 @@ Tekton task to delete a given directory in a passed workspace and cleanup Intern
 | delay          | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
 | pipelineRunUid | The uid of the current pipelineRun. It is only available at the pipeline level                                   | Yes      | ""            |
 
+## Changes in 0.8.2
+* Fix error if internalrequests are not installed on cluster
+
 ## Changes in 0.8.1
 * Fix linting issues in this task
 

--- a/tasks/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/cleanup-workspace/cleanup-workspace.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: cleanup-workspace
   labels:
-    app.kubernetes.io/version: "0.8.1"
+    app.kubernetes.io/version: "0.8.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,9 +34,13 @@ spec:
         set -eux
 
         if [ -n "$(params.pipelineRunUid)" ] ; then
-            # Cleanup all internalrequests
-            kubectl delete internalrequest \
-                -l internal-services.appstudio.openshift.io/pipelinerun-uid="$(params.pipelineRunUid)"
+            # Cleanup all internalrequests, but only if internalrequests exist on cluster
+            if kubectl api-resources | grep InternalRequest | grep appstudio.redhat.com ; then
+              kubectl delete internalrequest \
+                  -l internal-services.appstudio.openshift.io/pipelinerun-uid="$(params.pipelineRunUid)"
+            else
+              echo "CRD internalrequests.appstudio.redhat.com not found on cluster"
+            fi
         fi
 
         if [ -z "$(params.subdirectory)" ] ; then


### PR DESCRIPTION
This is the case on the new Fedora Cluster run by the [Konflux+Fedora SIG](https://github.com/konflux-ci/community/blob/main/sigs/fedora.md)