### PR TITLE
fix: support dash in label name in tag expansion

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -29,6 +29,10 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
 
+## Changes in 1.7.2
+* Support dash in label name in tag expansion
+  * Image labels can include `-` in their names, so we should support that.
+
 ## Changes in 1.7.1
 * Tweaked processing of tags to automatically remove any duplicate tags in a component
 

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.7.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -95,7 +95,7 @@ spec:
                 tag="$(jq -r --argjson i "$i" '.[$i]' <<< "${tags}")"
 
                 # Repeatedly translate {{}} references until none are left
-                while [[ $tag =~ \{\{\ *([[:alnum:]_\.]+)\ *\}\} ]]; do
+                while [[ $tag =~ \{\{\ *([[:alnum:]_\.-]+)\ *\}\} ]]; do
                   # Extract the variable name (e.g., timestamp), trimming any surrounding spaces
                   var_name="${BASH_REMATCH[1]}"
 

--- a/tasks/apply-mapping/tests/mocks.sh
+++ b/tasks/apply-mapping/tests/mocks.sh
@@ -39,7 +39,7 @@ function skopeo() {
     return
   elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
   then
-    echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Badlabel": "label with space"}}'
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Goodlabel-with-dash": "labelvalue-with-dash", "Badlabel": "label with space"}}'
     return
   elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
   then

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -43,6 +43,7 @@ spec:
                         "foo-{{digest_sha}}",
                         "{{ digest_sha }}",
                         "tag-{{ labels.Goodlabel }}",
+                        "tag-{{ labels.Goodlabel-with-dash }}",
                         "tag1-2024-07-29"
                       ]
                     },
@@ -135,7 +136,7 @@ spec:
               test "$(
                 jq -c '.components[] | select(.name=="comp1") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
-              )" == '["defaultTag","foo-123456","tag-labelvalue",'\
+              )" == '["defaultTag","foo-123456","tag-labelvalue","tag-labelvalue-with-dash",'\
               '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","123456",'\
               '"testrevision-abc","testrev-bar","testrevision","testrev"]'
 


### PR DESCRIPTION
Image labels can include `-` in their names, so
we should support that.