### PR TITLE
feat(RELEASE-1239): print pipeline ref info

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -27,6 +27,10 @@ should not be present in the Release data section).
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
 
+## Changes in 4.5.3
+* Introduce new step to collect, print and record information about the git resolver metadata for the
+  running release pipeline.
+
 ## Changes in 4.5.2
 * Introduce new step to collect information needed for reduce-snapshot task
 

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.5.2"
+    app.kubernetes.io/version: "4.5.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -69,6 +69,9 @@ spec:
     - name: snapshotNamespace
       type: string
       description: namespace where Snapshot is located
+    - name: releasePipelineMetadata
+      type: string
+      description: json object containing git resolver metadata about the running release pipeline
   steps:
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -148,7 +151,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -ex
-      
+
         # check if RP/RPA has a single-component mode
         DATA_PATH="$(params.subdirectory)/data.json"
         SINGLE_COMPONENT_MODE=$(jq -r '.singleComponentMode // "false"' "$(workspaces.data.path)/$DATA_PATH")
@@ -201,3 +204,45 @@ spec:
             "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json"
 
         exit $RC
+    - name: print-pipeline-ref-info
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        pipelineref=$(jq -c '.spec.pipeline.pipelineRef' \
+          "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json")
+        resolver=$(jq -r '.resolver // ""' <<< "${pipelineref}")
+        if [ "${resolver}" == "git" ] ; then
+          url=$(jq -r '.params[] | select(.name=="url") | .value' <<< "${pipelineref}")
+          revision=$(jq -r '.params[] | select(.name=="revision") | .value' <<< "${pipelineref}")
+          pathinrepo=$(jq -r '.params[] | select(.name=="pathInRepo") | .value' <<< "${pipelineref}")
+          orgrepo="${url#*/*/*/}"
+          org=$(echo "${orgrepo}" | cut -f1 -d/)
+          repo=$(echo "${orgrepo}" | cut -f2 -d/ | cut -d. -f1)
+
+          sha=$(curl -s "https://api.github.com/repos/${org}/${repo}/commits/${revision}" | jq -r '.sha // ""')
+
+        fi
+
+        org="${org:-unknown}"
+        repo="${repo:-unknown}"
+        revision="${revision:-unknown}"
+        pathinrepo="${pathinrepo:-unknown}"
+        sha="${sha:-unknown}"
+
+        echo ""
+        echo "Release Pipeline Ref Info:"
+        echo "--------------------------"
+
+        json=$(jq -n -c \
+          --arg org "${org}" \
+          --arg repo "${repo}" \
+          --arg revision "${revision}" \
+          --arg pathinrepo "${pathinrepo}" \
+          --arg sha "${sha}" \
+          '$ARGS.named')
+
+        echo "${json}" > "$(results.releasePipelineMetadata.path)"
+        # pretty print for log message
+        jq . <<< "$json"

--- a/tasks/collect-data/tests/mocks.sh
+++ b/tasks/collect-data/tests/mocks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+curl() {
+  # Output the call to stderr
+  echo "Mock curl called with:" "$@" >&2
+  echo "$@" >> "$(workspaces.data.path)/mock_curl.txt"
+  echo '{ "sha": "12345"}'
+}

--- a/tasks/collect-data/tests/pre-apply-task-hook.sh
+++ b/tasks/collect-data/tests/pre-apply-task-hook.sh
@@ -5,3 +5,9 @@
 
 # Add RBAC so that the SA executing the tests can retrieve CRs
 kubectl apply -f .github/resources/crd_rbac.yaml
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"

--- a/tasks/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-data-print-pipeline-ref-nongit
+spec:
+  description: |
+    Run the collect-data task and verify that the pipeline ref info is not available when not using a
+    git resolver
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                applications:
+                  - foo
+                origin: foo
+                data:
+                  singleComponentMode: true
+                  one:
+                    two: three
+                    four:
+                      - five
+                      - six
+                policy: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                      - name: name
+                        value: release-pipeline
+                      - name: namespace
+                        value: default
+                      - name: kind
+                        value: pipeline
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releaseserviceconfig << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseServiceConfig
+              metadata:
+                name: releaseserviceconfig-sample
+                namespace: default
+              spec:
+              EOF
+              kubectl apply -f releaseserviceconfig
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: releasePlanAdmission
+          value: default/releaseplanadmission-sample
+        - name: releaseServiceConfig
+          value: default/releaseserviceconfig-sample
+        - name: snapshot
+          value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: releasePipelineMetadata
+          value: "$(tasks.run-task.results.releasePipelineMetadata)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: releasePipelineMetadata
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: PIPELINE_METADATA
+                value: '$(params.releasePipelineMetadata)'
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              touch "$(workspaces.data.path)/mock_curl.txt"
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_curl.txt")" != 0 ]; then
+                echo Error: curl was expected to be called 0 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_curl.txt"
+                exit 1
+              fi
+              
+              org=$(jq -r '.org' <<< "$PIPELINE_METADATA")
+              repo=$(jq -r '.repo' <<< "$PIPELINE_METADATA")
+              revision=$(jq -r '.revision' <<< "$PIPELINE_METADATA")
+              pathinrepo=$(jq -r '.pathinrepo' <<< "$PIPELINE_METADATA")
+              sha=$(jq -r '.sha' <<< "$PIPELINE_METADATA")
+              
+              test "${org}" == 'unknown'
+              test "${repo}" == 'unknown'
+              test "${revision}" == 'unknown'
+              test "${pathinrepo}" == 'unknown'
+              test "${sha}" == 'unknown'
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releaseserviceconfig releaseserviceconfig-sample
+              kubectl delete snapshot snapshot-sample

--- a/tasks/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-data-print-pipeline-ref
+spec:
+  description: |
+    Run the collect-data task and verify that the pipeline ref info is made available
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                applications:
+                  - foo
+                origin: foo
+                policy: foo
+                pipeline:
+                  pipelineRef:
+                    params:
+                      - name: url
+                        value: 'https://github.com/some-catalog/some-service-catalog.git'
+                      - name: revision
+                        value: development
+                      - name: pathInRepo
+                        value: pipelines/rh-advisories/rh-advisories.yaml
+                    resolver: git
+                  serviceAccountName: release-service-account
+                  timeouts:
+                    pipeline: 5h0m0s
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releaseserviceconfig << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseServiceConfig
+              metadata:
+                name: releaseserviceconfig-sample
+                namespace: default
+              spec:
+              EOF
+              kubectl apply -f releaseserviceconfig
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: releasePlanAdmission
+          value: default/releaseplanadmission-sample
+        - name: releaseServiceConfig
+          value: default/releaseserviceconfig-sample
+        - name: snapshot
+          value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: releasePipelineMetadata
+          value: "$(tasks.run-task.results.releasePipelineMetadata)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: releasePipelineMetadata
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: PIPELINE_METADATA
+                value: '$(params.releasePipelineMetadata)'
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_curl.txt")" != 1 ]; then
+                echo Error: curl was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_curl.txt"
+                exit 1
+              fi
+
+              org=$(jq -r '.org' <<< "$PIPELINE_METADATA")
+              repo=$(jq -r '.repo' <<< "$PIPELINE_METADATA")
+              revision=$(jq -r '.revision' <<< "$PIPELINE_METADATA")
+              pathinrepo=$(jq -r '.pathinrepo' <<< "$PIPELINE_METADATA")
+              sha=$(jq -r '.sha' <<< "$PIPELINE_METADATA")
+
+              test "${org}" == 'some-catalog'
+              test "${repo}" == 'some-service-catalog'
+              test "${revision}" == 'development'
+              test "${pathinrepo}" == 'pipelines/rh-advisories/rh-advisories.yaml'
+              test "${sha}" == '12345'
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete releaseplanadmission releaseplanadmission-sample
+              kubectl delete releaseserviceconfig releaseserviceconfig-sample
+              kubectl delete snapshot snapshot-sample


### PR DESCRIPTION
- collect, print and record info about git resolver metadata for running
  pipeline.
- data can be obtained from the result 'releasePipelineMetadata'
- an example of usage of this data can be seen here:
  https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2460/diffs