### PR TITLE
feat(RELEASE-993): add support for incrementing rebuild numbers

### DIFF
--- a/tasks/apply-mapping/README.md
+++ b/tasks/apply-mapping/README.md
@@ -18,6 +18,8 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
 * "{{ git_short_sha }}" -> The git sha reduced to 7 characters
 * "{{ digest_sha }}" -> The image digest of the respective component
+* "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the   
+  repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 
@@ -28,6 +30,11 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
+
+## Changes in 1.8.0
+* Enhanced tag generation by adding support for the {{ incrementer }} variable:
+  * The {{ incrementer }} variable automatically finds the highest existing incremented tag
+    in the repository (e.g., v1.0.0-2) and generates the next sequential tag (e.g., v1.0.0-3)
 
 ## Changes in 1.7.3
 * Added verbosity to error message when 0 components are mapped, as many users are hitting this

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.7.3"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,6 +62,38 @@ spec:
             exit 0
         fi
 
+        # Function to handle incrementer logic
+        increment_tag() {
+            local tag_template="$1"
+            local repo="$2"
+
+            # Use `skopeo list-tags` to fetch all tags from the repository
+            existing_tags=$(skopeo list-tags docker://"${repo}" | jq -r '.Tags[]')
+            
+            # Remove `{{ incrementer }}` placeholder to get the version prefix for regex pattern
+            # shellcheck disable=SC2001
+            version_prefix=$(echo "${tag_template}" | sed 's/{{ incrementer }}//g')
+            tag_pattern="^${version_prefix}[0-9]+$"  # Build regex pattern dynamically
+
+            # Extract the numeric part of existing tags and find the max increment
+            max_increment=$(echo "${existing_tags}" | grep -E "${tag_pattern}" | sed -E "s/${version_prefix}//" \
+            | sort -nr | head -n1)
+
+            # Calculate the next increment (default to 1 if max_increment is empty or unset)
+            increment=$((max_increment + 1))
+
+            # Substitute `{{ incrementer }}` in the tag template with the calculated increment
+            tag="${tag_template//\{\{ incrementer \}\}/${increment}}"
+
+            # Validate the final tag format to avoid malformed tags
+            if [[ ! "${tag}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                echo "Error: Invalid tag format after substitution: ${tag}"
+                exit 1
+            fi
+
+            echo "$tag"  # Return the final tag
+        }
+
         # Expected arguments are: [variable, substitute_map, labels_map]
         substitute() {
             variable=$1
@@ -105,7 +137,15 @@ spec:
                     exit 1
                   fi
 
-                  replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
+                  # Handle incrementer logic
+                  if [[ "$var_name" == "incrementer" ]]; then
+                      repo=$(jq -r '.repository' <<< "$component")
+                      tag=$(increment_tag "$tag" "$repo")
+                  else
+                      replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
+                      tag="${tag//"{{ *$var_name *}}"/$replacement}"
+                  fi
+
                   if [ -z "$replacement" ]; then
                       echo Error: Substitution variable unknown or empty: "$var_name" >&2
                       exit 1

--- a/tasks/apply-mapping/tests/mocks.sh
+++ b/tasks/apply-mapping/tests/mocks.sh
@@ -33,6 +33,21 @@ function skopeo() {
   echo Mock skopeo called with: $* >&2
   echo $* >> $(workspaces.config.path)/mock_skopeo.txt
 
+  if [[ "$*" =~ list-tags\ docker://repo1 ]]; then
+      echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
+      return
+  fi
+
+  if [[ "$*" =~ inspect\ --no-tags\ docker://repo1 ]]; then
+      echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
+      return
+  fi
+
+  if [[ "$*" =~ inspect\ --no-tags\ docker://repo2 ]]; then
+      echo '{"Tags": []}'
+      return
+  fi
+
   if [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -7,7 +7,7 @@ spec:
   description: |
     Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
     the data file with tags per component and verify that the resulting json
-    contains the expected values with tags expanded.
+    contains the expected values with tags expanded, including incrementer logic.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -42,6 +42,7 @@ spec:
                         "{{ git_short_sha }}-bar",
                         "foo-{{digest_sha}}",
                         "{{ digest_sha }}",
+                        "v2.0.0-{{ incrementer }}",
                         "tag-{{ labels.Goodlabel }}",
                         "tag-{{ labels.Goodlabel.with-dash }}",
                         "tag1-2024-07-29"
@@ -53,7 +54,9 @@ spec:
                       "tags": [
                         "tag1-{{timestamp}}",
                         "tag2-{{ release_timestamp }}",
-                        "tag4-{{release_timestamp}}"
+                        "tag4-{{release_timestamp}}",
+                        "v1.0.0-{{ incrementer }}",
+                        "v1-{{ incrementer }}-release"
                       ],
                       "timestampFormat": "%Y-%m"
                     },
@@ -137,7 +140,7 @@ spec:
                 jq -c '.components[] | select(.name=="comp1") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
               )" == '["defaultTag","foo-123456","tag-labelvalue","tag-labelvalue-with-dash",'\
-              '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","123456",'\
+              '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","v2.0.0-5","123456",'\
               '"testrevision-abc","testrev-bar","testrevision","testrev"]'
 
               echo Test that SNAPSHOT contains component comp2
@@ -150,7 +153,7 @@ spec:
               test "$(
                 jq -c '.components[] | select(.name=="comp2") | .tags' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
-              )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01"]'
+              )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01","v1-1-release","v1.0.0-1"]'
 
               echo Test that repository of component comp3 was overridden by mapping file
               test "$(


### PR DESCRIPTION
 Added functionality to apply-mapping task to auto-increment
 rebuild numbers in tags (e.g., X.Y.Z-1 to X.Y.Z-2).
 
 The `translate_tags` function now handles `{{ incrementer }}` substitutions by checking for the highest existing increment in the target repo and adding +1 if found or starting with -1 if none exists