### PR TITLE
fix: properly expand create-pyxis-image oras args

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -18,6 +18,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
 
+## Changes in 3.3.4
+* Properly expand platform variables for oras args
+
 ## Changes in 3.3.3
 * Fixed linting issues in create-pyxis-image task 
 

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.3.3"
+    app.kubernetes.io/version: "3.3.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -153,7 +153,7 @@ spec:
                 ORAS_ARGS=()
                 if [[ "$MEDIA_TYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]\
                   || [[ "$MEDIA_TYPE" == "application/vnd.oci.image.index.v1+json" ]]; then
-                  ORAS_ARGS+=("--platform $os/$arch")
+                  ORAS_ARGS+=("--platform $OS/$ARCH")
                 fi
 
                 oras manifest fetch \


### PR DESCRIPTION
We were setting the ORAS_ARGS based on variables in all lowercase, but the variables are actually capitalized. The reason why we never hit this until now is because the if statement that sets these variables was never triggered until a typo was fixed in the if condition with the linting fix yesterday.