### PR TITLE
fix: composing oras args in create-pyxis-image

### DIFF
--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -153,7 +153,7 @@ spec:
                 ORAS_ARGS=()
                 if [[ "$MEDIA_TYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]\
                   || [[ "$MEDIA_TYPE" == "application/vnd.oci.image.index.v1+json" ]]; then
-                  ORAS_ARGS+=("--platform $OS/$ARCH")
+                  ORAS_ARGS+=(--platform "$OS/$ARCH")
                 fi
 
                 oras manifest fetch \


### PR DESCRIPTION
This line was just modified earlier today to fix the os and arch variables. But it is still wrong - you want the name of argument and the actual value separate, otherwise the whole thing will be used as one parameter.

Since it's still the same line and the changelog entry still applies to this, I don't think I need to bump the version again.

Here's the previous fix for reference: https://github.com/konflux-ci/release-service-catalog/pull/641