### PR TITLE
Update all image references of release-service-utils

### DIFF
--- a/tasks/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/add-fbc-contribution.yaml
@@ -54,7 +54,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: add-contribution
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         #

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -74,7 +74,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               #
@@ -122,7 +122,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -75,7 +75,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               #
@@ -118,7 +118,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               #
@@ -97,7 +97,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               #
@@ -91,7 +91,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               #
@@ -140,7 +140,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/apply-mapping.yaml
+++ b/tasks/apply-mapping/apply-mapping.yaml
@@ -31,7 +31,7 @@ spec:
       description: A true/false value depicting whether or not the snapshot was mapped.
   steps:
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -24,7 +24,7 @@ spec:
           - name: snapshot
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -22,7 +22,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-multi-component-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -104,7 +104,7 @@ spec:
           - name: config
         steps:
           - name: check-result-multi-component
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -21,7 +21,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -22,7 +22,7 @@ spec:
           - name: snapshot
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-other-formats-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: config
         steps:
           - name: check-result-other-formats
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -20,7 +20,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -111,7 +111,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -20,7 +20,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -121,7 +121,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/apply-mapping/tests/test-apply-mapping.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -102,7 +102,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/check-data-keys.yaml
+++ b/tasks/check-data-keys/check-data-keys.yaml
@@ -29,7 +29,7 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       args: ["$(params.systems[*])"]
       script: |
         #!/usr/bin/env bash

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/check-fbc-packages/check-fbc-packages.yaml
@@ -23,7 +23,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: check-contribution
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         #

--- a/tasks/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
+++ b/tasks/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
+++ b/tasks/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/cleanup-workspace/cleanup-workspace.yaml
@@ -28,7 +28,7 @@ spec:
       description: Workspace where the directory to cleanup exists
   steps:
     - name: cleanup
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -20,7 +20,7 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/cleanup-workspace/tests/test-cleanup-workspace.yaml
+++ b/tasks/cleanup-workspace/tests/test-cleanup-workspace.yaml
@@ -19,7 +19,7 @@ spec:
           - name: input
         steps:
           - name: put-content-in-workspace
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -52,7 +52,7 @@ spec:
           - name: input
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collect-collectors-resources/collect-collectors-resources.yaml
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the results directory
   steps:
     - name: collect-collectors-resources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: "PREVIOUS_RELEASE"
           value: '$(params.previousRelease)'

--- a/tasks/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
+++ b/tasks/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -80,7 +80,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collect-collectors-resources/tests/test-collect-collectors-data.yaml
+++ b/tasks/collect-collectors-resources/tests/test-collect-collectors-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -129,7 +129,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/collect-cosign-params/collect-cosign-params.yaml
@@ -26,7 +26,7 @@ spec:
         SIGN_KEY and REKOR_URL
   steps:
     - name: collect-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
+++ b/tasks/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -48,7 +48,7 @@ spec:
           - name: cosign-secret-name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SECRET"
                 value: '$(params.cosign-secret-name)'

--- a/tasks/collect-cosign-params/tests/test-collect-cosign-params.yaml
+++ b/tasks/collect-cosign-params/tests/test-collect-cosign-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -50,7 +50,7 @@ spec:
           - name: cosign-secret-name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SECRET"
                 value: '$(params.cosign-secret-name)'

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -71,7 +71,7 @@ spec:
       description: namespace where Snapshot is located
   steps:
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: "RELEASE"
           value: '$(params.release)'
@@ -141,7 +141,7 @@ spec:
         echo -n "$DATA_PATH" > "$(results.data.path)"
         echo "$merged_output" | tee "$(workspaces.data.path)/$DATA_PATH"
     - name: collect-single-component-mode-data
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: "SNAPSHOT"
           value: '$(params.snapshot)'
@@ -160,7 +160,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -96,7 +96,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -86,7 +86,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data-with-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -139,7 +139,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -156,7 +156,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-data/tests/test-collect-data.yaml
+++ b/tasks/collect-data/tests/test-collect-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -201,7 +201,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-gh-params/tests/test-collect-gh-params.yaml
+++ b/tasks/collect-gh-params/tests/test-collect-gh-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/collect-mrrc-params/collect-mrrc-params.yaml
+++ b/tasks/collect-mrrc-params/collect-mrrc-params.yaml
@@ -25,7 +25,7 @@ spec:
       description: the secret name for charon aws credential file
   steps:
     - name: collect-mrrc-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
+++ b/tasks/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
+++ b/tasks/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
+++ b/tasks/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: charonAWSSecret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-pyxis-params/tests/test-collect-pyxis-params-default-server.yaml
+++ b/tasks/collect-pyxis-params/tests/test-collect-pyxis-params-default-server.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -50,7 +50,7 @@ spec:
           - name: server
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SERVER"
                 value: '$(params.server)'

--- a/tasks/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-secret.yaml
+++ b/tasks/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-secret.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collect-pyxis-params/tests/test-collect-pyxis-params.yaml
+++ b/tasks/collect-pyxis-params/tests/test-collect-pyxis-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -54,7 +54,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SERVER"
                 value: '$(params.server)'

--- a/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
+++ b/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
+++ b/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
+++ b/tasks/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -34,7 +34,7 @@ spec:
       description: SSL key file name
   steps:
     - name: collect-simple-signing-params
-      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: config_map_name
           value: $(params.config_map_name)

--- a/tasks/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
+++ b/tasks/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
           - name: sig_key_name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "sig_key_name"
                 value: '$(params.sig_key_name)'

--- a/tasks/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -41,7 +41,7 @@ spec:
       description: Name of key within secret which contains webhook URL
   steps:
     - name: create-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
+++ b/tasks/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -95,7 +95,7 @@ spec:
           - name: message
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
+++ b/tasks/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -105,7 +105,7 @@ spec:
           - name: slack-notification-secret-keyname
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/create-advisory/create-advisory.yaml
+++ b/tasks/create-advisory/create-advisory.yaml
@@ -47,7 +47,7 @@ spec:
       description: The advisory url if one was created
   steps:
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/bin/bash
         set -ex

--- a/tasks/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-orphan.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-overwrite-type.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-overwrite-type.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -132,7 +132,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -166,7 +166,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -120,7 +120,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/bin/sh
               set -ex
@@ -172,7 +172,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -122,7 +122,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/bin/sh
               set -ex
@@ -187,7 +187,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -36,7 +36,7 @@ spec:
       description: URL to inspect the created release
   steps:
     - name: create-release-from-binaries
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-release.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -59,7 +59,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/create-product-sbom/create-product-sbom.yaml
@@ -23,7 +23,7 @@ spec:
       description: Relative path to the created product-level SBOM in the data workspace.
   steps:
     - name: create-sbom
-      image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,7 +67,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -71,7 +71,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -68,7 +68,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/embargo-check/embargo-check.yaml
+++ b/tasks/embargo-check/embargo-check.yaml
@@ -29,7 +29,7 @@ spec:
       description: The workspace where the snapshot spec json file resides
   steps:
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -x
@@ -73,7 +73,7 @@ spec:
 
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
 

--- a/tasks/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -60,7 +60,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -36,7 +36,7 @@ spec:
       description: The workspace where the snapshot is stored. The extracted binaries will be stored here as well.
   steps:
     - name: extract-binaries-from-image
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -87,7 +87,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -109,7 +109,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
+++ b/tasks/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -97,7 +97,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/extract-index-image/tests/test-extract-index-image.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -91,7 +91,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/get-ocp-version/get-ocp-version.yaml
@@ -21,7 +21,7 @@ spec:
       description: Store OCP version number from given Image
   steps:
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -27,7 +27,7 @@ spec:
           - name: stored-version
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -28,7 +28,7 @@ spec:
           - name: stored-version
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/make-repo-public/make-repo-public.yaml
+++ b/tasks/make-repo-public/make-repo-public.yaml
@@ -23,7 +23,7 @@ spec:
       description: The workspace where the data json file resides
   steps:
     - name: make-repo-public
-      image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: REGISTRY_TOKEN
           valueFrom:

--- a/tasks/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
+++ b/tasks/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/make-repo-public/tests/test-make-repo-public.yaml
+++ b/tasks/make-repo-public/tests/test-make-repo-public.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -23,7 +23,7 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-cves-added.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -117,7 +117,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-data.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-snapshot.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-fail-missing-snapshot.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-multiple-images.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -106,7 +106,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-no-overwrite.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -101,7 +101,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
+++ b/tasks/populate-release-notes-images/tests/test-populate-release-notes-images-single-image.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -94,7 +94,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/prepare-exodus-params/prepare-exodus-params.yaml
+++ b/tasks/prepare-exodus-params/prepare-exodus-params.yaml
@@ -33,7 +33,7 @@ spec:
         The kubernetes secret to use to authenticate to exodus-gateway. It needs to contain two keys: key and cert
   steps:
     - name: collect-exodus-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env sh
         set -x

--- a/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-live.yaml
+++ b/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-live.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
           - name: exodusGwEnv
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "exodusGwSecret"
                 value: '$(params.exodusGwSecret)'

--- a/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-qa.yaml
+++ b/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-qa.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
           - name: exodusGwEnv
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "exodusGwSecret"
                 value: '$(params.exodusGwSecret)'

--- a/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-stage.yaml
+++ b/tasks/prepare-exodus-params/tests/test-prepare-exodus-params-cdn-stage.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
           - name: exodusGwEnv
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "exodusGwSecret"
                 value: '$(params.exodusGwSecret)'

--- a/tasks/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/prepare-fbc-release.yaml
@@ -28,7 +28,7 @@ spec:
       description: Workspace where the snapshot and data json is stored
   steps:
     - name: prepare-fbc-release
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -96,7 +96,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -84,7 +84,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -94,7 +94,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/publish-index-image/tests/test-publish-index-image.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -110,7 +110,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -50,7 +50,7 @@ spec:
         requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
   steps:
     - name: publish-pyxis-repository
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -82,7 +82,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/publish-to-cgw.yaml
@@ -40,7 +40,7 @@ spec:
       description: Workspace to save the CR jsons to
   steps:
     - name: run-push-cgw-metadata
-      image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: CGW_USERNAME
           valueFrom:

--- a/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -98,7 +98,7 @@ spec:
           - name: resultDataPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               python3 <<EOF

--- a/tasks/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/publish-to-mrrc/publish-to-mrrc.yaml
@@ -21,7 +21,7 @@ spec:
       type: string
   steps:
     - name: prepare-repo
-      image: quay.io/konflux-ci/release-service-utils:4576e1e2a30439129cb69c8a4f39f7ced2d44376
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
+++ b/tasks/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
+++ b/tasks/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
+++ b/tasks/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -57,7 +57,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-disk-images/push-disk-images.yaml
+++ b/tasks/push-disk-images/push-disk-images.yaml
@@ -27,7 +27,7 @@ spec:
       description: Workspace where the json files are stored
   steps:
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -81,7 +81,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -84,7 +84,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -141,7 +141,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -84,7 +84,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -141,7 +141,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -84,7 +84,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -141,7 +141,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,7 +67,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-to-cdn/push-to-cdn.yaml
+++ b/tasks/push-to-cdn/push-to-cdn.yaml
@@ -38,7 +38,7 @@ spec:
         The relative path in the workspace to the stored json of source:destination paths
   steps:
     - name: execute-exodus-rsync
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: exodusGwCert
           valueFrom:

--- a/tasks/push-to-cdn/tests/test-push-to-cdn.yaml
+++ b/tasks/push-to-cdn/tests/test-push-to-cdn.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
           - name: srcDestPaths
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "srcDestPaths"
                 value: '$(params.srcDestPaths)'

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -72,7 +72,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,7 +87,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -88,7 +88,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -84,7 +84,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -89,7 +89,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -88,7 +88,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -72,7 +72,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -91,7 +91,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/request-and-upload-signature/tests/test-request-and-upload-signature-retries.yaml
+++ b/tasks/request-and-upload-signature/tests/test-request-and-upload-signature-retries.yaml
@@ -58,7 +58,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -29,7 +29,7 @@ spec:
       description: Workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: AWS_DEFAULT_REGION
           valueFrom:

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -74,7 +74,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -60,7 +60,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -111,7 +111,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -137,7 +137,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -161,7 +161,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -216,7 +216,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -113,7 +113,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,7 +123,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -144,7 +144,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,7 +123,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -190,7 +190,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,7 +123,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -23,7 +23,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/run-collectors.yaml
+++ b/tasks/run-collectors/run-collectors.yaml
@@ -26,7 +26,7 @@ spec:
       description: Workspace where the CRs are stored
   steps:
     - name: run-collectors
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -xeo pipefail

--- a/tasks/run-collectors/tests/test-run-collectors-fail-timeout.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors-fail-timeout.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/tests/test-run-collectors-no-crs.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors-no-crs.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -48,7 +48,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/tests/test-run-collectors-parallel.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors-parallel.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -127,7 +127,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/tests/test-run-collectors-rp-only.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors-rp-only.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -113,7 +113,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/tests/test-run-collectors-rpa-only.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors-rpa-only.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -113,7 +113,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-collectors/tests/test-run-collectors.yaml
+++ b/tasks/run-collectors/tests/test-run-collectors.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -126,7 +126,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/run-file-updates/run-file-updates.yaml
+++ b/tasks/run-file-updates/run-file-updates.yaml
@@ -38,7 +38,7 @@ spec:
       description: Workspace where the file updates to apply are defined
   steps:
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/bin/sh
         #

--- a/tasks/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/run-file-updates/tests/test-run-file-updates.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -103,7 +103,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/save-collectors-results/save-collectors-results.yaml
@@ -34,7 +34,7 @@ spec:
       description: Workspace where the results directory is stored
   steps:
     - name: save-collectors-results
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/save-collectors-results/tests/test-save-collectors-results.yaml
+++ b/tasks/save-collectors-results/tests/test-save-collectors-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/send-slack-notification/send-slack-notification.yaml
@@ -29,7 +29,7 @@ spec:
         optional: true
   steps:
     - name: send-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       volumeMounts:
         - name: slack-token
           mountPath: "/etc/secrets"

--- a/tasks/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -33,7 +33,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/send-slack-notification/tests/test-send-slack-notification.yaml
+++ b/tasks/send-slack-notification/tests/test-send-slack-notification.yaml
@@ -33,7 +33,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -59,7 +59,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -112,7 +112,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/sign-binaries/sign-binaries.yaml
+++ b/tasks/sign-binaries/sign-binaries.yaml
@@ -108,7 +108,7 @@ spec:
         Path where the final signed content is stored in the workspace
   steps:
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       env:
         - name: QUAY_USER
           valueFrom:
@@ -173,7 +173,7 @@ spec:
         echo "Digest for windows content: $windows_digest"
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       volumeMounts:
         - name: mac-ssh-key-vol
           mountPath: "/etc/secrets"
@@ -305,7 +305,7 @@ spec:
         # shellcheck disable=SC2029
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(params.pipelineRunUid)"
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       volumeMounts:
         - name: windows-ssh-key-vol
           mountPath: "/etc/secrets"
@@ -407,7 +407,7 @@ spec:
         # shellcheck disable=SC2029,SC2086
         ssh $SSH_OPTS "rmdir /s /q C:\\Users\\Administrator\\AppData\\Local\\Temp\\$(params.pipelineRunUid)"
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       volumeMounts:
         - name: checksum-fingerprint-vol
           mountPath: "/etc/secrets_fingerprint"

--- a/tasks/sign-binaries/tests/test-sign-binaries-checksum.yaml
+++ b/tasks/sign-binaries/tests/test-sign-binaries-checksum.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/sign-binaries/tests/test-sign-binaries.yaml
+++ b/tasks/sign-binaries/tests/test-sign-binaries.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -123,7 +123,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -99,7 +99,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -56,7 +56,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -114,7 +114,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -65,7 +65,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -99,7 +99,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -82,7 +82,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/update-cr-status/tests/test-update-cr-status.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -71,7 +71,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-cr-status/update-cr-status.yaml
+++ b/tasks/update-cr-status/update-cr-status.yaml
@@ -34,7 +34,7 @@ spec:
       description: Workspace where the results directory is stored
   steps:
     - name: update-cr-status
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/tests/test-update-ocp-tag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/update-ocp-tag/update-ocp-tag.yaml
@@ -31,7 +31,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: update-ocp-tag
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
        #!/usr/bin/env bash
        set -eux

--- a/tasks/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-cyclonedx.yaml
+++ b/tasks/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-cyclonedx.yaml
@@ -23,7 +23,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -112,7 +112,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-spdx.yaml
+++ b/tasks/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-spdx.yaml
@@ -23,7 +23,7 @@ spec:
             type: string
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -104,7 +104,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -64,7 +64,7 @@ spec:
         secretName: $(params.atlasSecretName)
   steps:
     - name: gather-sboms
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash
         set -o errexit -o pipefail -o nounset
@@ -158,7 +158,7 @@ spec:
 
     # Needs syft, which is in a different image => has to be a separate step
     - name: convert-sboms-if-needed
-      image: quay.io/konflux-ci/release-service-utils:80a575e7e12d32f866a6105827804f2f122cea73
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env bash    
         set -o errexit -o pipefail -o nounset
@@ -192,7 +192,7 @@ spec:
         done
 
     - name: upload-sboms
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       volumeMounts:
         - name: atlas-secret
           mountPath: /secrets/

--- a/tasks/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
+++ b/tasks/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/validate-single-component/tests/test-validate-single-component.yaml
+++ b/tasks/validate-single-component/tests/test-validate-single-component.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/validate-single-component/validate-single-component.yaml
+++ b/tasks/validate-single-component/validate-single-component.yaml
@@ -21,7 +21,7 @@ spec:
       description: Workspace where the snapshot is stored
   steps:
     - name: validate-single-component
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
         #!/usr/bin/env sh
         set -eux

--- a/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/verify-access-to-resources/verify-access-to-resources.yaml
@@ -33,7 +33,7 @@ spec:
       default: "false"
   steps: 
     - name: verify-access-to-resources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
       script: |
           #!/usr/bin/env bash
 


### PR DESCRIPTION
@mmalina suggested that these should be in sync over in https://github.com/konflux-ci/release-service-catalog/pull/634#discussion_r1815997246

The different versions in place before this PR were:

```
❯ git grep "image: quay.io/konflux-ci/release-service-utils" | awk '{print $3}' | sort | uniq -c | sort -n
      1 quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
      1 quay.io/konflux-ci/release-service-utils:4576e1e2a30439129cb69c8a4f39f7ced2d44376
      1 quay.io/konflux-ci/release-service-utils:80a575e7e12d32f866a6105827804f2f122cea73
      1 quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
      2 quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
      2 quay.io/konflux-ci/release-service-utils:91d9f4886c57a8b86c3c643ea00617250ac30ff0
      3 quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
      4 quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
      5 quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
      5 quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
      7 quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
     13 quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
     14 quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
     15 quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
    339 quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
```