### PR TITLE
chore(RELEASE-1038): add embargoed-cves internal task and pipeline

### DIFF
--- a/internal/pipelines/check-embargoed-cves/README.md
+++ b/internal/pipelines/check-embargoed-cves/README.md
@@ -1,0 +1,11 @@
+# check-embargoed-cves pipeline
+
+Tekton pipeline to execute the check-embargoed-cves task. The goal of the task is to ensure none of the provided
+CVEs are marked as embargoed. If so, the pipeline result `result` will be the error and check `embargoed_cves`
+result will be the list of embargoed CVEs.
+
+## Parameters
+
+| Name | Description                                                                                | Optional | Default value |
+|------|--------------------------------------------------------------------------------------------|----------|---------------|
+| cves | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |

--- a/internal/pipelines/check-embargoed-cves/check-embargoed-cves.yaml
+++ b/internal/pipelines/check-embargoed-cves/check-embargoed-cves.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: check-embargoed-cves
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Pipeline to check if any CVEs passed are embargoed
+  params:
+    - name: cves
+      type: string
+      description: |
+          String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345')
+  tasks:
+    - name: check-embargoed-cves-task
+      taskRef:
+        name: check-embargoed-cves-task
+      params:
+        - name: cves
+          value: $(params.cves)
+  results:
+    - name: result
+      value: $(tasks.check-embargoed-cves-task.results.result)
+    - name: embargoed_cves
+      value: $(tasks.check-embargoed-cves-task.results.embargoed_cves)

--- a/internal/resources/check-embargoed-cves-task.yaml
+++ b/internal/resources/check-embargoed-cves-task.yaml
@@ -1,0 +1,1 @@
+../tasks/check-embargoed-cves-task/check-embargoed-cves-task.yaml

--- a/internal/resources/check-embargoed-cves.yaml
+++ b/internal/resources/check-embargoed-cves.yaml
@@ -1,0 +1,1 @@
+../pipelines/check-embargoed-cves/check-embargoed-cves.yaml

--- a/internal/tasks/check-embargoed-cves-task/README.md
+++ b/internal/tasks/check-embargoed-cves-task/README.md
@@ -1,0 +1,11 @@
+# check-embargoed-cves-task
+
+Checks if any passed CVEs are embargoed. The task will always exit 0 even if something fails. This is because the task result
+will not be set if the task fails, and the task result should always be set and propagated back to the cluster that creates the
+internal request. The success/failure is handled in the task creating the internal request.
+
+## Parameters
+
+| Name | Description                                                                                | Optional | Default value |
+|------|--------------------------------------------------------------------------------------------|----------|---------------|
+| cves | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |

--- a/internal/tasks/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/internal/tasks/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-embargoed-cves-task
+  labels:
+    app.kubernetes.io/version: "0.1.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+      Checks if any passed CVEs are embargoed.
+      The task will always exit 0 even if something fails. This is because the task result will not be
+      set if the task fails, and the task result should always be set and propagated back to the cluster
+      that creates the internal request. The success/failure is handled in the task creating the internal
+      request.
+  params:
+    - name: cves
+      type: string
+      description: |
+          String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345')
+  results:
+    - name: result
+      description: Success if the task succeeds, the error otherwise
+    - name: embargoed_cves
+      description: Space separated string of embargoed CVEs if any are found, empty string otherwise
+  steps:
+    - name: check-embargoed-cves
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      env:
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: name
+        - name: SERVICE_ACCOUNT_KEYTAB
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: base64_keytab
+        - name: OSIDB_URL
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: osidb_url
+      script: |
+          #!/usr/bin/env bash
+          set -eo pipefail
+
+          # shellcheck disable=SC2317 # shellcheck calls all the commands in exitfunc unreachable because it is called
+          # via trap
+          exitfunc() {
+              local err="$1"
+              local line="$2"
+              local command="$3"
+              if [ "$err" -eq 0 ] ; then
+                  echo -n "Success" > "$(results.result.path)"
+              else
+                  echo -n \
+                    "$0: ERROR '$command' failed at line $line - exited with status $err" > "$(results.result.path)"
+              fi
+              exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
+          }
+          # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+          trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+          echo -n "" > "$(results.embargoed_cves.path)"
+
+          # write keytab to file
+          echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
+          # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
+          KRB5CCNAME=$(mktemp)
+          export KRB5CCNAME
+          KRB5_CONFIG=$(mktemp)
+          export KRB5_CONFIG
+          export KRB5_TRACE=/dev/stderr
+          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
+          kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+
+          RC=0
+          for CVE in $(params.cves); do
+              echo "Checking CVE ${CVE}"
+              # Get token. They are short lived, so get one for before each request
+              TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
+              EMBARGOED=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
+                  "${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${CVE}&include_fields=cve_id,embargoed" \
+                  | jq .results[0].embargoed)
+              # null would mean no access to the CVE, which may mean embargoed, and true means embargoed
+              if [ "$EMBARGOED" != "false" ] ; then
+                  echo "CVE ${CVE} is embargoed"
+                  echo -n "${CVE} " >> "$(results.embargoed_cves.path)"
+                  RC=1
+              fi
+          done
+          exit $RC

--- a/internal/tasks/check-embargoed-cves-task/tests/mocks.sh
+++ b/internal/tasks/check-embargoed-cves-task/tests/mocks.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function kinit() {
+  echo "kinit $*"
+}
+
+function curl() {
+  echo Mock curl called with: $* >&2
+
+  if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
+  then
+    echo '{"access": "dummy-token"}'
+  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-embargo"* ]]
+  then
+    echo '{"results": [{"embargoed": true}]}'
+  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-noaccess"* ]]
+  then
+    echo '{}'
+  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id="* ]]
+  then
+    echo '{"results": [{"embargoed": false}]}'
+  else
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/internal/tasks/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
+++ b/internal/tasks/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy osidb secret (and delete it first if it exists)
+# The secret name is hardcoded in the task so the mock secret name can't have the task name in it
+kubectl delete secret osidb-service-account --ignore-not-found
+kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=OWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0Cg== --from-literal=osidb_url=myurl

--- a/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-embargoed-cves-task-embargoed-cve
+spec:
+  description: |
+    Run the check-embargoed-cves task with an embargoed CVE. The result
+    task result should be an error and the embargoed_cves result should be the cve id
+  tasks:
+    - name: run-task
+      taskRef:
+        name: check-embargoed-cves-task
+      params:
+        - name: cves
+          value: "CVE-123 CVE-embargo"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: embargoed_cves
+          value: $(tasks.run-task.results.embargoed_cves)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: embargoed_cves
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != *"ERROR"*"failed at line"*"exited with status"* ]]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.embargoed_cves)" != "CVE-embargo " ]; then
+                echo Error: embargoed_cves task result is not correct
+                exit 1
+              fi

--- a/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-embargoed-cves-task-no-access-cve
+spec:
+  description: |
+    Run the check-embargoed-cves task with a CVE that can't be accessed. This is treated as embargoed, as if it
+    can't be accessed, it could be embargoed. The result task result should be an error and the embargoed_cves
+    result should be the cve id
+  tasks:
+    - name: run-task
+      taskRef:
+        name: check-embargoed-cves-task
+      params:
+        - name: cves
+          value: "CVE-noaccess"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: embargoed_cves
+          value: $(tasks.run-task.results.embargoed_cves)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: embargoed_cves
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != *"ERROR"*"failed at line"*"exited with status"* ]]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.embargoed_cves)" != "CVE-noaccess " ]; then
+                echo Error: embargoed_cves task result is not correct
+                exit 1
+              fi

--- a/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/internal/tasks/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-embargoed-cves-task-no-embargo
+spec:
+  description: |
+    Run the check-embargoed-cves task with no embargoed CVEs. The result
+    task result should be Success and the embargoed_cves result should be empty
+  tasks:
+    - name: run-task
+      taskRef:
+        name: check-embargoed-cves-task
+      params:
+        - name: cves
+          value: "CVE-123 CVE-456"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: embargoed_cves
+          value: $(tasks.run-task.results.embargoed_cves)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: embargoed_cves
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(params.result)" != Success ]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.embargoed_cves)" != "" ]; then
+                echo Error: embargoed_cves task result is not correct
+                exit 1
+              fi


### PR DESCRIPTION
This commit moves the embargoed-cves pipeline and task from the app-interface repo to the internal directory of this repo. It also adds tests and a README with it.