### PR TITLE
fix(RELEASE-1268): publish-pyxis-repository after apply-mapping

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.5.1
+* Task `publish-pyxis-repository` should only run after `apply-mapping` has completed as it depends on the `repository`
+  value
+
 ## Changes in 1.5.0
 * Only sign `registry.access*` references if required
   * Task `publish-pyxis-repository` has a new `signRegistryAccessPath` result that is passed

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.5.0"
+    app.kubernetes.io/version: "1.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -450,6 +450,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-pyxis-params
+        - apply-mapping
     - name: push-rpm-data-to-pyxis
       retries: 5
       taskRef:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.5.1
+* Task `publish-pyxis-repository` should only run after `apply-mapping` has completed as it depends on the `repository`
+  value
+
 ## Changes in 4.5.0
 * Only sign `registry.access*` references if required
   * Task `publish-pyxis-repository` has a new `signRegistryAccessPath` result that is passed

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.5.0"
+    app.kubernetes.io/version: "4.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -401,6 +401,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-pyxis-params
+        - apply-mapping
     - name: push-rpm-data-to-pyxis
       retries: 5
       taskRef:


### PR DESCRIPTION
This commit changes the rh-advisories and rh-push-to-registry-redhat-io pipelines to only execute the publish-pyxis-repository task after the apply-mapping task has completed. The publish-pyxis-repository task depends on the repository value that apply-mapping adds, so prior to this commit we had a race condition.