### PR TITLE
fix: run create-advisory late in the rh-advisories pipeline

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,25 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.5.2
+* Make sure `create-advisory` runs late in the pipeline
+  * Task `create-advisory` would run after `publish-pyxis-repository` which
+    would ensure it runs late in the pipeline. But with the changes in 1.5.0,
+    `publish-pyxis-repository` runs much earlier now.
+  * So make `create-advisory`
+    run after `push-rpm-data-to-pyxis` which is what `publish-pyxis-repository`
+    ran after originally.
+  * But also, add a few more `runAfter` entries to make it run as late
+    as possible:
+    * `run-file-updates`
+    * `rh-sign-image`
+    * `rh-sign-image-cosign`
+* Make some other tasks' order more explicit
+  * No functional change, the tasks already depended on the other tasks'
+    results, but this makes it more explicit (and Tekton PLR UI
+    is known to show incorrect order when relying on task results only)
+
+
 ## Changes in 1.5.1
 * Task `publish-pyxis-repository` should only run after `apply-mapping` has completed as it depends on the `repository`
   value

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.5.1"
+    app.kubernetes.io/version: "1.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -309,6 +309,7 @@ spec:
       runAfter:
         - verify-enterprise-contract
         - push-snapshot
+        - collect-cosign-params
     - name: push-snapshot
       retries: 5
       when:
@@ -398,6 +399,7 @@ spec:
         - embargo-check
         - verify-enterprise-contract
         - publish-pyxis-repository
+        - extract-requester-from-release
     - name: create-pyxis-image
       retries: 5
       taskRef:
@@ -548,7 +550,10 @@ spec:
       runAfter:
         - check-data-keys
         - embargo-check
-        - publish-pyxis-repository
+        - push-rpm-data-to-pyxis
+        - run-file-updates
+        - rh-sign-image
+        - rh-sign-image-cosign
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,12 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.5.2
+* Make task order more explicit
+  * No functional change, the tasks already depended on the other tasks'
+    results, but this makes it more explicit (and Tekton PLR UI
+    is known to show incorrect order when relying on task results only)
+
 ## Changes in 4.5.1
 * Task `publish-pyxis-repository` should only run after `apply-mapping` has completed as it depends on the `repository`
   value

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.5.1"
+    app.kubernetes.io/version: "4.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -264,6 +264,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-snapshot
+        - collect-cosign-params
     - name: push-snapshot
       retries: 5
       when:
@@ -349,6 +350,7 @@ spec:
         - verify-enterprise-contract
         - apply-mapping
         - publish-pyxis-repository
+        - extract-requester-from-release
     - name: create-pyxis-image
       retries: 5
       taskRef:


### PR DESCRIPTION
Task `create-advisory` would run after `publish-pyxis-repository` which would ensure it runs late in the pipeline. But with the changes in 1.5.0, `publish-pyxis-repository` runs much earlier now.

So make `create-advisory` run after `push-rpm-data-to-pyxis` which is what `publish-pyxis-repository` ran after originally.