### PR TITLE
chore: add test to confirm references is an array

### DIFF
--- a/tasks/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-fail-invalid-releasenotes-key
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the check-data-keys task with the releaseNotes key with a references
+    field that is a string, not an array and verify that the task fails as
+    expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_id": 123,
+                  "product_version": "1.2.3",
+                  "product_stream": "rhtas-tp1",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "quay.io/example/openstack@sha256:abcde",
+                        "repository": "rhosp16-rhel8/openstack",
+                        "tags": [
+                          "latest"
+                        ],
+                        "architecture": "amd64",
+                        "signingKey": "abcde",
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
+                        "cves": {
+                          "fixed": {
+                            "CVE-2022-1234": {
+                              "components": [
+                                "pkg:golang/golang.org/x/net/http2@1.11.1"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": "this should be an array"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: systems
+          value:
+            - releaseNotes
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup


### PR DESCRIPTION
The schema already checks this, but I wanted to make sure we are guarding against this for the future.