### PR TITLE
refactor(RELEASE-1267): rename cve field in populate release notes

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -226,9 +226,9 @@
                         "additionalProperties": {
                           "type": "object",
                           "properties": {
-                            "components": {
+                            "packages": {
                               "type": "array",
-                              "description": "A list of CVEs fixed e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
+                              "description": "A list of packages that fixed the CVE e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
                               "items": {
                                 "type": "string"
                               }

--- a/tasks/populate-release-notes-images/README.md
+++ b/tasks/populate-release-notes-images/README.md
@@ -10,6 +10,9 @@ in place so that downstream tasks relying on the releaseNotes data can use it.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 2.2.3
+* Rename `components` in the CVE struct to `packages`
+
 ## Changes in 2.2.2
 * Add component association information
 

--- a/tasks/populate-release-notes-images/populate-release-notes-images.yaml
+++ b/tasks/populate-release-notes-images/populate-release-notes-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes-images
   labels:
-    app.kubernetes.io/version: "2.2.2"
+    app.kubernetes.io/version: "2.2.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,7 +67,7 @@ spec:
                 cveJson=$(jq -n \
                     --arg id $(jq -r '.key' <<< $cve) \
                     --argjson packages $(jq -c '.packages' <<< $cve) \
-                    '{($id): {"components": $packages}}')
+                    '{($id): {"packages": $packages}}')
                 CVEsJson=$(jq --argjson cve "$cveJson" '.cves.fixed += $cve' <<< $CVEsJson)
             done
             # Add one entry per arch (amd64 for example)


### PR DESCRIPTION
This commit changes the CVE struct generated in
populate-release-notes-images to switch from the components key to packages.