### PR TITLE
Update image for create-product-sbom task

### DIFF
--- a/tasks/create-product-sbom/README.md
+++ b/tasks/create-product-sbom/README.md
@@ -5,7 +5,9 @@ releaseNotes content.
 
 ## Parameters
 
-| Name             | Description                                                              | Optional | Default value |
-|------------------|--------------------------------------------------------------------------|----------|---------------|
-| dataJsonPath     | Path to the JSON string of the merged data containing the release notes  | No       | -             |
+| Name         | Description                                                             | Optional | Default value |
+| ------------ | ----------------------------------------------------------------------- | -------- | ------------- |
+| dataJsonPath | Path to the JSON string of the merged data containing the release notes | No       | -             |
 
+## Changes in 0.1.1
+* The release-service-utils image was updated to include a fix when generating name of product level SBOM - it should be based on "{product name} {product version}"

--- a/tasks/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/create-product-sbom/create-product-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-product-sbom
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,7 +23,7 @@ spec:
       description: Relative path to the created product-level SBOM in the data workspace.
   steps:
     - name: create-sbom
-      image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+      image: quay.io/konflux-ci/release-service-utils:8684920ccae6c73bd9f3f23367490a9c04653a09
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-basic.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:8684920ccae6c73bd9f3f23367490a9c04653a09
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,14 +67,14 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:8684920ccae6c73bd9f3f23367490a9c04653a09
             script: |
               #!/usr/bin/env sh
               set -eux
 
               cp "$(workspaces.data.path)/$(params.sbom)" sbom.json
 
-              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product"
+              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product 123"
 
               # Check product SPDX package and relationship
               test "$(jq -r '.packages[0].SPDXID' sbom.json)" == "SPDXRef-product"

--- a/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
+++ b/tasks/create-product-sbom/tests/test-create-product-sbom-multiple-purls.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:8684920ccae6c73bd9f3f23367490a9c04653a09
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -71,14 +71,14 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7e14c3521e37e99f407e11d6f7f1b15f1b3ec01
+            image: quay.io/konflux-ci/release-service-utils:8684920ccae6c73bd9f3f23367490a9c04653a09
             script: |
               #!/usr/bin/env sh
               set -eux
 
               cp "$(workspaces.data.path)/$(params.sbom)" sbom.json
 
-              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product"
+              test "$(jq -r '.name' sbom.json)" == "Red Hat Openstack Product 123"
 
               # Check product SPDX package and relationship
               test "$(jq -r '.packages[0].SPDXID' sbom.json)" == "SPDXRef-product"


### PR DESCRIPTION
There is an update of the image that contains naming fixes of product level SBOM. This image references the latest image containing the fixes.

JIRA: [ISV-5314](https://issues.redhat.com//browse/ISV-5314)