### PR TITLE
fix(KONFLUX-4292): update the step image used in this task

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,10 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.0.3
+* Updated the step image used in this task
+  * Added handling for sbom entries that do not explicitly specify the publisher.
+
 ## Changes in 1.0.2
 * Updated the base image used in this task
   * A typo in `upload_rpm_data.py` was fixed and now we should correctly save

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+        quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -95,7 +95,7 @@ spec:
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+        quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7c3e02f9220179c5ffa027d5e7c86bd1aa923428
+            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
This adds handling for sbom entries that do not explicitly specify the publisher.