### PR TITLE
fix: contributing doc to say task tests are required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,8 +130,7 @@ script will install the task CR locally. For example:
       name: apply-mapping
 ```
 
-Currently task tests are not required, so if a task version directory is modified
-in a PR and there are no tests, that directory will be skipped.
+Task tests are required for all new tasks. For task updates, if the task doesn't currently have tests, adding them is not strictly required, but is recommended.
 
 ##### Testing scenarios where the Task is expected to fail
 


### PR DESCRIPTION
This recently came up in a PR:
https://github.com/konflux-ci/release-service-catalog/pull/656

We definitely do require tests for all new tasks. For existing tasks, we mostly do as well, but there are still three tasks without tests:

- base64-encode-checksum
- create-internal-request
- prepare-validation