### PR TITLE
fix: update `releaseNotes.product_version` regex pattern

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -114,7 +114,7 @@
         "product_version": {
           "type": "string",
           "description": "The product version e.g v1.0.0",
-          "pattern": "^(fbc|[vV]?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)|[vV]?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)|[vV]?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*) ([Aa]lpha|[Bb]eta|fast|tech preview)|[vV]?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*) ([Aa]lpha|[Bb]eta|fast|tech preview))$"
+          "pattern": "^(fbc[-]|[vV])?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*))?([-\\s]?([Aa]lpha|[Bb]eta|fast|tech[-\\s]preview)?)$"
         },
         "product_stream": {
           "type": "string",


### PR DESCRIPTION
This fix updates the releaseNotes.product_version regex pattern to correctly support all required version formats.
See here for the conversation: [link](https://gitlab.cee.redhat.com/releng/advisories/-/merge_requests/19#note_13413066)

