### PR TITLE
fix(KONFLUX-4892): supply sha256 prefix for uncompressed layers

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -17,6 +17,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | isLatest    | If set to true, the images will have a latest tag added with their Pyxis entries                                                                                                                                                                                                                                                                                                                            | Yes      | false         |
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
+## Changes in 3.4.1
+* Fixed format of uncompressed layer list, prepending sha256:
+
 ## Changes in 3.4.0
 * Added support for uploading uncompressed layer information to pyxis
 

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "3.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -195,7 +195,7 @@ spec:
                         gunzip "${BLOB_FILE}.gz"
 
                         # Measure it
-                        EXPANDED_DIGEST=$(sha256sum "${BLOB_FILE}" | cut -d " " -f 1)
+                        EXPANDED_DIGEST="sha256:$(sha256sum "${BLOB_FILE}" | cut -d " " -f 1)"
                         EXPANDED_SIZE=$(wc --bytes "${BLOB_FILE}" | awk '{print $1}' | tr -d '\n')
 
                         # Append this information to the parsed_data manifest


### PR DESCRIPTION
Clients that read these values are expecting a sha256: prefix.