### PR TITLE
feat: support tenant releases in some tasks

### DIFF
--- a/tasks/collect-data/README.md
+++ b/tasks/collect-data/README.md
@@ -22,10 +22,13 @@ should not be present in the Release data section).
 |----------------------|----------------------------------------------------|----------|---------------|
 | release              | Namespaced name of the Release                     | No       | -             |
 | releasePlan          | Namespaced name of the ReleasePlan                 | No       | -             |
-| releasePlanAdmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
-| releaseServiceConfig | Namespaced name of the ReleaseServiceConfig        | No       | -             |
+| releasePlanAdmission | Namespaced name of the ReleasePlanAdmission        | Yes      | -             |
+| releaseServiceConfig | Namespaced name of the ReleaseServiceConfig        | Yes      | -             |
 | snapshot             | Namespaced name of the Snapshot                    | No       | -             |
 | subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
+
+## Changes in 4.6.0
+* `releasePlanAdmission` and `releaseServiceConfig` parameters are now optional to account for tenant release workflow
 
 ## Changes in 4.5.3
 * Introduce new step to collect, print and record information about the git resolver metadata for the

--- a/tasks/collect-data/collect-data.yaml
+++ b/tasks/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.5.3"
+    app.kubernetes.io/version: "4.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,9 +22,11 @@ spec:
     - name: releasePlanAdmission
       type: string
       description: The namespaced name of the ReleasePlanAdmission
+      default: ""
     - name: releaseServiceConfig
       type: string
       description: The namespaced name of the ReleaseServiceConfig
+      default: ""
     - name: snapshot
       type: string
       description: The namespaced name of the Snapshot
@@ -107,15 +109,14 @@ spec:
         echo -n "$RELEASEPLAN_PATH" > "$(results.releasePlan.path)"
         get-resource "releaseplan" "${RELEASE_PLAN}" | tee "$(workspaces.data.path)/$RELEASEPLAN_PATH"
 
-        RELEASEPLANADMISSION_PATH="$(params.subdirectory)/release_plan_admission.json"
-        echo -n "$RELEASEPLANADMISSION_PATH" > "$(results.releasePlanAdmission.path)"
-        get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-          | tee "$(workspaces.data.path)/$RELEASEPLANADMISSION_PATH"
-
-        RELEASESERVICECONFIG_PATH="$(params.subdirectory)/release_service_config.json"
-        echo -n "$RELEASESERVICECONFIG_PATH" > "$(results.releaseServiceConfig.path)"
-        get-resource "releaseserviceconfig" "${RELEASE_SERVICE_CONFIG}" \
-          | tee "$(workspaces.data.path)/$RELEASESERVICECONFIG_PATH"
+        if [[ -n "${RELEASE_SERVICE_CONFIG}" ]]; then
+          RELEASESERVICECONFIG_PATH="$(params.subdirectory)/release_service_config.json"
+          echo -n "$RELEASESERVICECONFIG_PATH" > "$(results.releaseServiceConfig.path)"
+          get-resource "releaseserviceconfig" "${RELEASE_SERVICE_CONFIG}" \
+            | tee "$(workspaces.data.path)/$RELEASESERVICECONFIG_PATH"
+        else
+          touch "$(results.releaseServiceConfig.path)"
+        fi
 
         echo -e "\nFetching Snapshot Spec"
         SNAPSHOTSPEC_PATH="$(params.subdirectory)/snapshot_spec.json"
@@ -131,14 +132,23 @@ spec:
 
         release_plan_result=$(get-resource "releaseplan" "${RELEASE_PLAN}" "{.spec.data}")
 
-        release_plan_admission_result=$(get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
-            "{.spec.data}")
-
         # Merge Release and ReleasePlan keys. ReleasePlan has higher priority
         merged_output=$(merge-json "$release_result" "$release_plan_result")
 
-        # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
-        merged_output=$(merge-json "$merged_output" "$release_plan_admission_result")
+        if [[ -n "${RELEASE_PLAN_ADMISSION}" ]]; then
+          RELEASEPLANADMISSION_PATH="$(params.subdirectory)/release_plan_admission.json"
+          echo -n "$RELEASEPLANADMISSION_PATH" > "$(results.releasePlanAdmission.path)"
+          get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
+            | tee "$(workspaces.data.path)/$RELEASEPLANADMISSION_PATH"
+
+          release_plan_admission_result=$(get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
+              "{.spec.data}")
+
+          # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
+          merged_output=$(merge-json "$merged_output" "$release_plan_admission_result")
+        else
+          touch "$(results.releasePlanAdmission.path)"
+        fi
 
         DATA_PATH="$(params.subdirectory)/data.json"
         echo -n "$DATA_PATH" > "$(results.data.path)"
@@ -200,8 +210,11 @@ spec:
 
         check_source "Release" "$(workspaces.data.path)/$(params.subdirectory)/release.json"
         check_source "ReleasePlan" "$(workspaces.data.path)/$(params.subdirectory)/release_plan.json"
-        check_source "ReleasePlanAdmission" \
-            "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json"
+
+        if [[ -n "${RELEASE_PLAN_ADMISSION}" ]]; then
+          check_source "ReleasePlanAdmission" \
+              "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json"
+        fi
 
         exit $RC
     - name: print-pipeline-ref-info
@@ -210,8 +223,13 @@ spec:
         #!/usr/bin/env bash
         set -eu
 
-        pipelineref=$(jq -c '.spec.pipeline.pipelineRef' \
-          "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json")
+        if [[ -f "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json" ]]; then
+          pipelineref=$(jq -c '.spec.pipeline.pipelineRef' \
+            "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json")
+        else
+          pipelineref=$(jq -c '.spec.pipeline.pipelineRef' \
+            "$(workspaces.data.path)/$(params.subdirectory)/release_plan.json")
+        fi
         resolver=$(jq -r '.resolver // ""' <<< "${pipelineref}")
         if [ "${resolver}" == "git" ] ; then
           url=$(jq -r '.params[] | select(.name=="url") | .value' <<< "${pipelineref}")

--- a/tasks/collect-data/tests/test-collect-data-tenant-release.yaml
+++ b/tasks/collect-data/tests/test-collect-data-tenant-release.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-data-tenant-release
+spec:
+  description: >
+    Run the collect-data task without ReleasePlanAdmissiong and ReleaseConfig parameters and verify
+    that all resources are stored in the workspace.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              spec:
+                application: foo
+                components:
+                  - name: name
+                    containerImage: newimage
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: snapshot
+          value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: resultsDir
+          value: $(tasks.run-task.results.resultsDir)
+        - name: release
+          value: $(tasks.run-task.results.release)
+        - name: releasePlan
+          value: $(tasks.run-task.results.releasePlan)
+        - name: releasePlanAdmission
+          value: $(tasks.run-task.results.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(tasks.run-task.results.releaseServiceConfig)
+        - name: snapshotSpec
+          value: $(tasks.run-task.results.snapshotSpec)
+        - name: fbcFragment
+          value: $(tasks.run-task.results.fbcFragment)
+        - name: singleComponentMode
+          value: $(tasks.run-task.results.singleComponentMode)
+        - name: snapshotName
+          value: $(tasks.run-task.results.snapshotName)
+        - name: snapshotNamespace
+          value: $(tasks.run-task.results.snapshotNamespace)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: resultsDir
+            type: string
+          - name: release
+            type: string
+          - name: releasePlan
+            type: string
+          - name: releasePlanAdmission
+            type: string
+          - name: releaseServiceConfig
+            type: string
+          - name: snapshotSpec
+            type: string
+          - name: fbcFragment
+            type: string
+          - name: singleComponentMode
+            type: string
+          - name: snapshotName
+            type: string
+          - name: snapshotNamespace
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that the results directory was created
+              test -d "$(workspaces.data.path)/$(resultsDir)"
+
+              echo Test that Release CR was saved to workspace
+              test "$(jq -r '.metadata.name' < "$(workspaces.data.path)/$(params.release)")" == release-sample
+
+              echo Test that ReleasePlan CR was saved to workspace
+              test "$(jq -r '.metadata.name' < "$(workspaces.data.path)/$(params.releasePlan)")" == releaseplan-sample
+
+              echo Test that ReleasePlanAdmission CR was skipped
+              test "$(params.releasePlanAdmission)" == ""
+
+              echo Test that ReleaseServiceConfig CR was skipped
+              test "$(params.releaseServiceConfig)" == ""
+
+              echo Test that Snapshot spec was saved to workspace
+              test "$(jq -r '.application' < "$(workspaces.data.path)/$(params.snapshotSpec)")" == foo
+
+              echo Test the fbcFragment result was properly set
+              test "$(params.fbcFragment)" == "newimage"
+
+              echo Test that the snapshotName result was properly set
+              test "$(params.snapshotName)" == "snapshot-sample"
+
+              echo Test that the snapshotNamespace result was properly set
+              test "$(params.snapshotNamespace)" == "default"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete snapshot snapshot-sample

--- a/tasks/verify-access-to-resources/README.md
+++ b/tasks/verify-access-to-resources/README.md
@@ -8,10 +8,13 @@ This Tekton task is used to verify access to various resources in the pipelines.
 |-------------------------|---------------------------------------------------------|----------|---------------|
 | release                 | Namespace/name of the Release                           | No       | -             |
 | releasePlan             | Namespace/name of the ReleasePlan                       | No       | -             |
-| releasePlanAdmission    | Namespace/name of the ReleasePlanAdmission              | No       | -             |
-| releaseServiceConfig    | Namespace/name of the ReleaseServiceConfig              | No       | -             |
+| releasePlanAdmission    | Namespace/name of the ReleasePlanAdmission              | Yes      | -             |
+| releaseServiceConfig    | Namespace/name of the ReleaseServiceConfig              | Yes      | -             |
 | snapshot                | Namespace/name of the Snapshot                          | No       | -             |
 | requireInternalServices | Whether to check if internal requests can be created    | Yes      | false         |
+
+## Changes in 0.4.0
+* `releasePlanAdmission` and `releaseServiceConfig` parameters are now optional to account for tenant release workflow
 
 ## Changes in 0.3.1
 * Fix shellcheck/checkton linting issues in the task

--- a/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-tenant-release.yaml
+++ b/tasks/verify-access-to-resources/tests/test-verify-access-to-resources-tenant-release.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-access-to-resources-tenant-release
+spec:
+  description: >
+    Run the verify-access-to-resources task without a ReleasePlanAdmission and Releaseconfig to
+    verify these are not required checks.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: verify-access-to-resources
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: snapshot
+          value: default/snapshot-sample
+        - name: requireInternalServices
+          value: "true"
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample
+              kubectl delete releaseplan releaseplan-sample
+              kubectl delete snapshot snapshot-sample

--- a/tasks/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/verify-access-to-resources/verify-access-to-resources.yaml
@@ -2,9 +2,9 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: verify-access-to-resources  
+  name: verify-access-to-resources
   labels:
-    app.kubernetes.io/version: "0.3.1"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -21,9 +21,11 @@ spec:
     - name: releasePlanAdmission
       description: Namespace/name of the ReleasePlanAdmission
       type: string
+      default: ""
     - name: releaseServiceConfig
       description: Namespace/name of the ReleaseServiceConfig
       type: string
+      default: ""
     - name: snapshot
       description: Namespace/name of the Snapshot
       type: string
@@ -31,7 +33,7 @@ spec:
       description: Whether internal services are required
       type: string
       default: "false"
-  steps: 
+  steps:
     - name: verify-access-to-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
@@ -39,6 +41,9 @@ spec:
 
           ORIGIN_NAMESPACE="$(cut -f1 -d/ <<< "$(params.release)")"
           TARGET_NAMESPACE="$(cut -f1 -d/ <<< "$(params.releasePlanAdmission)")"
+          if [[ -z "${TARGET_NAMESPACE}" ]]; then
+            TARGET_NAMESPACE="${ORIGIN_NAMESPACE}"
+          fi
           RSC_NAMESPACE="$(cut -f1 -d/ <<< "$(params.releaseServiceConfig)")"
 
           RELEASE_NAME="$(cut -f2 -d/ <<< "$(params.release)")"
@@ -50,10 +55,21 @@ spec:
           CAN_I_READ_RELEASES="$(kubectl auth can-i get release/"${RELEASE_NAME}" -n "${ORIGIN_NAMESPACE}")"
           CAN_I_READ_RELEASEPLANS="$(kubectl auth can-i get releaseplan/"${RELEASEPLAN_NAME}"\
               -n "${ORIGIN_NAMESPACE}")"
-          CAN_I_READ_RELEASEPLANADMISSIONS="$(kubectl auth can-i get\
-              releaseplanadmission/"${RELEASEPLANADMISSION_NAME}" -n "${TARGET_NAMESPACE}")"
-          CAN_I_READ_RELEASESERVICECONFIG="$(kubectl auth can-i get\
-              releaseserviceconfig/"${RELEASESERVICECONFIG_NAME}" -n "${RSC_NAMESPACE}")"
+
+          if [[ -n "${RELEASEPLANADMISSION_NAME}" ]]; then
+            CAN_I_READ_RELEASEPLANADMISSIONS="$(kubectl auth can-i get\
+                releaseplanadmission/"${RELEASEPLANADMISSION_NAME}" -n "${TARGET_NAMESPACE}")"
+          else
+            CAN_I_READ_RELEASEPLANADMISSIONS="skipped"
+          fi
+
+          if [[ -n "${RELEASESERVICECONFIG_NAME}" ]]; then
+            CAN_I_READ_RELEASESERVICECONFIG="$(kubectl auth can-i get\
+                releaseserviceconfig/"${RELEASESERVICECONFIG_NAME}" -n "${RSC_NAMESPACE}")"
+          else
+            CAN_I_READ_RELEASESERVICECONFIG="skipped"
+          fi
+
           CAN_I_READ_SNAPSHOTS="$(kubectl auth can-i get snapshot/"${SNAPSHOT_NAME}" -n "${ORIGIN_NAMESPACE}")"
 
           if [ "$(params.requireInternalServices)" = "true" ]; then


### PR DESCRIPTION
Update `collect-data` and `verify-access-to-resources` tasks to no longer require ReleasePlanAdmission and ReleaseConfig references. When performing a tenant release, these are not available.