### PR TITLE
fix: extend timeout for verify-enterprise-contract task

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.5.4
+* Increase task timeout on the verify-enterprise-contract task
+
 ## Changes in 1.5.3
 * Increase enterpriseContractTimeout to a large value, 8 hours.
   * Users don't have control over this, so set it to a large value so that the pipeline timeout will kick in first, if anything.

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.5.3"
+    app.kubernetes.io/version: "1.5.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -193,6 +193,7 @@ spec:
       runAfter:
         - reduce-snapshot
     - name: verify-enterprise-contract
+      timeout: "4h00m0s"
       taskRef:
         resolver: "bundles"
         params:


### PR DESCRIPTION
It is timing out for very large snapshots.

Look for performance improvements in:
https://issues.redhat.com/browse/KONFLUX-3922