### PR TITLE
fix(KFLUXBUGS-1848): associate existing images with a new repo

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -17,6 +17,15 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | isLatest    | If set to true, the images will have a latest tag added with their Pyxis entries                                                                                                                                                                                                                                                                                                                            | Yes      | false         |
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
+
+## Changes in 3.4.2
+* Updated the base image used in this task
+  * The new image supports adding a new repository entry to the ContainerImage
+    object in Pyxis if it already exists, but doesn't contain the repository
+    entry yet
+    * The use case is that an image was already released to one repository,
+      but we may want to release it to another repository
+
 ## Changes in 3.4.1
 * Fixed format of uncompressed layer list, prepending sha256:
 
@@ -27,7 +36,7 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 * Properly expand platform variables for oras args
 
 ## Changes in 3.3.3
-* Fixed linting issues in create-pyxis-image task 
+* Fixed linting issues in create-pyxis-image task
 
 ## Changes in 3.3.2
 * Fixed fetching of Dockerfile oci artifact

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.4.1"
+    app.kubernetes.io/version: "3.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:0feab5b3d54d450b6fcb4dbc73db0c78f27e6164
+      image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -63,7 +63,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:65d8db844c008e7736ec8dff307868525279484d
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -68,7 +68,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:31c0a95a9604fd16b002b4969cfd74753d9c5e77
+            image: quay.io/konflux-ci/release-service-utils:6963f58c2e87b9162e6de874f6097695e0c36e87
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
Updated the base image used in this task.

- The new image supports adding a new repository entry to the ContainerImage object in Pyxis if it already exists, but doesn't contain the repository entry yet