### PR TITLE
fix: let apply-mapping retry a few times

### DIFF
--- a/pipelines/rh-advisories/README.md
+++ b/pipelines/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.5.5
+* Add retries to apply-mapping task in case of transient errors
+
 ## Changes in 1.5.4
 * Increase task timeout on the verify-enterprise-contract task
 

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.5.4"
+    app.kubernetes.io/version: "1.5.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -171,6 +171,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: apply-mapping
+      retries: 3
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.5.4
+* Add retries to apply-mapping task in case of transient errors
+
 ## Changes in 4.5.3
 * Fix the missing pyxis error on rh-push-to-registry-redhat-io
   * Missing the pyxisServer and pyxisSecret when calling rh-sign-image task.

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.5.3"
+    app.kubernetes.io/version: "4.5.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -167,6 +167,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: apply-mapping
+      retries: 3
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
I just saw a run fail with a 502 bad gateway error while trying to skopeo inspect some content in apply-mapping. It was a transient error, but I had to restart my whole release pipeline. A retry or two would be nice here.