### PR TITLE
feat(CLDX-189): support pushing to mirror.openshift.com

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -413,7 +413,25 @@
                   "filePrefix": {
                     "type": "string",
                     "description": "filePrefix to use to select files to add to content gateway"
-                  }
+                  },
+                  "mirrorOpenshiftPush": {
+                    "type": "boolean",
+                    "description": "whether or not to push to mirror.openshift.com"
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The component name found in the snapshot e.g. example-component"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Description propogated to Content Gateway"
+                        }
                 }
               },
               "pushSourceContainer": {

--- a/tasks/publish-to-cgw/README.md
+++ b/tasks/publish-to-cgw/README.md
@@ -2,7 +2,7 @@
 
 Tekton task to publish content to Red Hat's Developer portal using pubtools-content-gateway
 
- - This task _expects_ the content is already push to CDN, it _exposes_ the metadata to Developer portal using content-gateway 
+ - This task _expects_ the content is already pushed to CDN, it _exposes_ the metadata to Developer portal using content-gateway
  - This task uses [pubtools-content-gateway](https://github.com/release-engineering/pubtools-content-gateway) to publish content to content-gateway.
 
 
@@ -15,6 +15,9 @@ Tekton task to publish content to Red Hat's Developer portal using pubtools-cont
 | contentDir  | Path where the content to push is stored in the workspace       | No       | -             |
 | cgwHostname | The hostname of the content-gateway to publish the metadata to  | yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret   | The kubernetes secret to use to authenticate to content-gateway | yes      | publish-to-cgw-secret |
+
+## Changes in 0.2.5
+* Support pushes to mirror.openshift.com (ShortUrl)
 
 ## Changes in 0.2.4
 * Raise Exception correctly when `pubtools-content-gateway` fails

--- a/tasks/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/publish-to-cgw.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-cgw
   labels:
-    app.kubernetes.io/version: "0.2.4"
+    app.kubernetes.io/version: "0.2.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -85,10 +85,11 @@ spec:
         productName = data['contentGateway']['productName']
         productCode = data['contentGateway']['productCode']
         productVersionName = data['contentGateway']['productVersionName']
+        mirrorOpenshiftPush = data['contentGateway'].get('mirrorOpenshiftPush')
         components = data['contentGateway']['components']
         content_list = os.listdir(CONTENT_DIR)
 
-        # Default values for each component, 
+        # Default values for each component,
         # values from DATA_FILE takes presedence over these
         default_values_per_component = {
             'type': "FILE",
@@ -98,7 +99,7 @@ spec:
 
         def generate_download_url(file_name):
             """
-            Generate a download URL in this format: 
+            Generate a download URL in this format:
             /content/origin/files/sha256/{checksum[:2]}{checksum}/{file_name}
             """
             prefix = "/content/origin/files/sha256"
@@ -114,7 +115,9 @@ spec:
             Generate metadata for each file in
             content_list that starts with the component name
             """
-            shortURL_base = '/pub/cgw'
+            shortURL_base = '/pub/'
+            if mirrorOpenshiftPush:
+                shortURL_base = '/pub/cgw'
             metadata = []
             shasum_files_processed = []
             for file in content_list:
@@ -199,9 +202,9 @@ spec:
             print(f" ERROR:\n{command_output}")
             raise
 
-        result_data = {"no_of_files_processed": len(metadata), 
-                      "metadata_file_path": METADATA_FILE_PATH, 
-                      "command_output": command_output}
+        result_data = {"no_of_files_processed": len(metadata),
+                        "metadata_file_path": METADATA_FILE_PATH,
+                        "command_output": command_output}
 
         with open(RESULT_FILE_JSON_PATH, 'w') as f:
             json.dump(result_data, f)

--- a/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/tests/test-publish-to-cgw.yaml
@@ -51,6 +51,7 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "contentGateway": {
+                  "mirrorOpenshiftPush": true,
                   "productName": "product_name_1",
                   "productCode": "product_code_1",
                   "productVersionName": "1.1",


### PR DESCRIPTION
- Change the shortUrl for Content Gateway when delivering to mirror openshift.
- Cleaned up trailing whitespaces