### PR TITLE
fix(CLOUDDST-24922): retry cosign in signing task

### DIFF
--- a/tasks/rh-sign-image-cosign/README.md
+++ b/tasks/rh-sign-image-cosign/README.md
@@ -5,10 +5,14 @@ Tekton task to sign container images in snapshot by cosign.
 ## Parameters
 
 | Name                   | Description                                                                                                                                                                                                                                       | Optional | Default value |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
 | snapshotPath           | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                         | No       | -             |
 | secretName             | Name of secret containing needed credentials                                                                                                                                                                                                      | No       | -             |
 | signRegistryAccessPath | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
+| retries                | Retry cosign N times                                                                                                                                                                                                                              | Yes      | 3             |
+
+## Changes in 1.2.0
+* Retry failed cosign
 
 ## Changes in 1.1.0
 * Bump release-service-utils to upgrade cosign version to 2.4.0 which includes the fix of an issue the osci team is having when trying to release.

--- a/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image-cosign
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,6 +24,10 @@ spec:
         The relative path in the workspace to a text file that contains a list of repositories
         that needs registry.access.redhat.com image references to be signed (i.e.
         requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
+    - name: retries
+      description: Retry cosign N times.
+      type: string
+      default: "3"
   workspaces:
     - name: data
       description: Workspace to read and save files
@@ -70,6 +74,28 @@ spec:
             exit 1
         fi
 
+        run_cosign () { # Expected arguments are [digest_reference, tag_reference]
+            # Upload transparency log when rekor url is specified
+            if [ -v REKOR_URL ]; then
+                COSIGN_COMMON_ARGS="-y --rekor-url=$REKOR_URL --key $SIGN_KEY"
+            else
+                COSIGN_COMMON_ARGS="--tlog-upload=false --key $SIGN_KEY"
+            fi
+            echo "Signing manifest $1 ($2)"
+            attempt=0
+            until [ "$attempt" -gt "$(params.retries)" ] ; do # 3 retries by default
+                cosign -t 3m0s sign\
+                ${COSIGN_COMMON_ARGS}\
+                --sign-container-identity "$2"\
+                "$1" && break
+                attempt=$((attempt+1))
+            done
+            if [ "$attempt" -gt "$(params.retries)" ] ; then
+              echo "Max retries exceeded."
+              exit 1
+            fi
+        }
+
         for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
             COMPONENT_NAME=$(jq -r ".components[${COMPONENTS_INDEX}].name" "${SNAPSHOT_PATH}")
             echo "Processing component ${COMPONENT_NAME}"
@@ -98,23 +124,12 @@ spec:
             if [ "$MEDIA_TYPE" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then LIST=1; fi
             if [ "$MEDIA_TYPE" = "application/vnd.oci.image.index.v1+json" ]; then LIST=1; fi
 
-            # Upload transparency log when rekor url is specified
-            if [ -v REKOR_URL ]; then
-                COSIGN_COMMON_ARGS="-y --rekor-url=$REKOR_URL --key $SIGN_KEY"
-            else
-                COSIGN_COMMON_ARGS="--tlog-upload=false --key $SIGN_KEY"
-            fi
-
             # Sign each manifest in manifest list
             if [ $LIST -eq 1 ]; then
                 for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                     for MDIGEST in $(echo "$IMAGE" | jq -r '.manifests[]|.digest'); do
                         for TAG in $TAGS; do
-                            echo "Signing manifest ${INTERNAL_CONTAINER_REF}:${TAG} (${MDIGEST})"
-                            cosign -t 3m0s sign\
-                            ${COSIGN_COMMON_ARGS}\
-                            --sign-container-identity "${REGISTRY_REF}:${TAG}"\
-                            "${INTERNAL_CONTAINER_REF}@${MDIGEST}"
+                            run_cosign "${INTERNAL_CONTAINER_REF}@${MDIGEST}" "${REGISTRY_REF}:${TAG}"
                         done
                     done
                 done
@@ -123,11 +138,7 @@ spec:
             # Sign manifest list itself or manifest if it's not list
             for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                 for TAG in $TAGS; do
-                    echo "Signing manifest ${INTERNAL_CONTAINER_REF}:${TAG} (${DIGEST})"
-                    cosign -t 3m0s sign\
-                    ${COSIGN_COMMON_ARGS}\
-                    --sign-container-identity "${REGISTRY_REF}:${TAG}"\
-                    "${INTERNAL_CONTAINER_REF}@${DIGEST}"
+                    run_cosign "${INTERNAL_CONTAINER_REF}@${DIGEST}" "${REGISTRY_REF}:${TAG}"
                 done
             done
         done

--- a/tasks/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/rh-sign-image-cosign/tests/mocks.sh
@@ -139,4 +139,13 @@ function skopeo() {
 function cosign () {
   echo "$@" >> $(workspaces.data.path)/mock_cosign_calls
   echo "running cosign: $@"
+  # mock cosign failing the first 3 calls for the retry test
+  if [[ "$@" == *":retry-tag"* ]]
+  then
+    if [[ $(cat $(workspaces.data.path)/mock_cosign_calls | wc -l) -le 3 ]]
+    then
+      echo "expected cosign call failure for retry test"
+      return 1
+    fi
+  fi
 }

--- a/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-cosign-retries
+spec:
+  description: Run rh-sign-image-cosign with retries
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
+                    "repository": "quay.io/redhat-pending/test-product----test-image2",
+                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
+                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
+                    "tags": ["retry-tag"]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
+              test-product/test-image0
+              EOF
+    - name: run-task
+      taskRef:
+        name: rh-sign-image-cosign
+      params:
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: secretName
+          value: 'test-cosign-secret'
+        - name: signRegistryAccessPath
+          value: signRegistryAccess.txt
+        - name: retries
+          value: 3
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              echo "check results"
+              _TEST_PUB_REPO="registry.stage.redhat.io/test-product/test-image2"
+              _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
+
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
+              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              EXPECTED=$(cat <<EOF
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              EOF
+              )
+              test "$CALLS" = "$EXPECTED"
+      runAfter:
+        - run-task


### PR DESCRIPTION
Retry failed cosign so that signing doesn't fail with temporary issues on pushing to quay.io.