### PR TITLE
feat(RELEASE-1214): add support for spdx sbom format

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,12 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.1.0
+* Added support for SPDX sbom format
+  * If sbom format is SPDX, call `upload_rpm_data`, if it's CycloneDX, call
+    `upload_rpm_data_cyclonedx`
+  * The image is updated to include the new functionality
+
 ## Changes in 1.0.3
 * Updated the step image used in this task
   * Added handling for sbom entries that do not explicitly specify the publisher.

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.0.3"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+        quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
       volumeMounts:
         - mountPath: /workdir
           name: workdir
@@ -95,7 +95,7 @@ spec:
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+        quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
       env:
         - name: pyxisCert
           valueFrom:
@@ -151,8 +151,27 @@ spec:
 
         for FILE in *.json; do
           IMAGEID=$(echo $FILE | cut -d '.' -f 1)
-          echo Uploading RPM data to Pyxis for IMAGE: "$IMAGEID" with SBOM: "$FILE"
-          upload_rpm_data --retry --image-id "$IMAGEID" --sbom-path "$FILE" --verbose > "${IMAGEID}.out" 2>&1 &
+
+          # Extract the format information using jq
+          UPLOAD_SCRIPT=$(
+            jq -r '
+              if .bomFormat == "CycloneDX" then
+                "upload_rpm_data_cyclonedx"
+              else if .spdxVersion then
+                "upload_rpm_data"
+              else
+                empty
+              end end' "$FILE"
+          )
+
+          # If UPLOAD_SCRIPT is empty, it's not a valid SBOM (CycloneDX or SPDX)
+          if [ -z "$UPLOAD_SCRIPT" ]; then
+            echo "Error: ${FILE}: not a valid SBOM (CycloneDX or SPDX)"
+            exit 1
+          fi
+
+          echo Uploading RPM data to Pyxis for IMAGE: "$IMAGEID" with SBOM: "$FILE using script: $UPLOAD_SCRIPT"
+          $UPLOAD_SCRIPT --retry --image-id "$IMAGEID" --sbom-path "$FILE" --verbose > "${IMAGEID}.out" 2>&1 &
 
           jobs+=($!)  # Save the background process ID
           images+=($IMAGEID)

--- a/tasks/push-rpm-data-to-pyxis/tests/mocks.sh
+++ b/tasks/push-rpm-data-to-pyxis/tests/mocks.sh
@@ -14,7 +14,13 @@ function cosign() {
     exit 1
   fi
 
-  touch /workdir/sboms/${4}
+  if [[ "$4" == *cyclonedx.json ]]; then
+    SBOM_JSON='{"bomFormat": "CycloneDX"}'
+  else
+    SBOM_JSON='{"spdxVersion": "SPDX-2.3"}'
+  fi
+
+  echo "$SBOM_JSON" > /workdir/sboms/${4}
 }
 
 function upload_rpm_data() {
@@ -42,6 +48,17 @@ function upload_rpm_data() {
     echo $LOCK_FILE_COUNT > $(workspaces.data.path)/${3}.count
     sleep 2
     rm $LOCK_FILE
+  fi
+}
+
+function upload_rpm_data_cyclonedx() {
+  echo Mock upload_rpm_data_cyclonedx called with: $*
+  echo $* >> "$(workspaces.data.path)/mock_upload_rpm_data_cyclonedx.txt"
+
+  if [[ "$*" != "--retry --image-id "*" --sbom-path "*".json --verbose" ]]
+  then
+    echo Error: Unexpected call
+    exit 1
   fi
 }
 

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -2,11 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-rpm-data-to-pyxis-single-arch
+  name: test-push-rpm-data-to-pyxis-cyclonedx
 spec:
   description: |
     Run the push-rpm-data-to-pyxis task with required parameters and single arch
-    images - a happy path scenario.
+    images - a happy path scenario. The sboms are in cyclonedx format, so
+    upload_rpm_data_cyclonedx script will be used.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -32,7 +33,7 @@ spec:
                     "pyxisImages": [
                       {
                         "arch": "amd64",
-                        "imageId": "myImageID1",
+                        "imageId": "myImageID1cyclonedx",
                         "digest": "mydigest1",
                         "arch_digest": "mydigest1",
                         "os": "linux"
@@ -44,7 +45,7 @@ spec:
                     "pyxisImages": [
                       {
                         "arch": "amd64",
-                        "imageId": "myImageID3",
+                        "imageId": "myImageID3cyclonedx",
                         "digest": "mydigest2",
                         "arch_digest": "mydigest2",
                         "os": "linux"
@@ -89,9 +90,9 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_upload_rpm_data.txt")" != 2 ]; then
-                echo Error: upload_rpm_data was expected to be called 2 times. Actual calls:
-                cat "$(workspaces.data.path)/mock_upload_rpm_data.txt"
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_upload_rpm_data_cyclonedx.txt")" != 2 ]; then
+                echo Error: upload_rpm_data_cyclonedx was expected to be called 2 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_upload_rpm_data_cyclonedx.txt"
                 exit 1
               fi
 

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e39e8d32c8263474c63fc1e922d7954d37e32374
+            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
Based on the sbom type, we either run `upload_rpm_data` or `upload_rpm_data_cyclonedx`.

This depends on https://github.com/konflux-ci/release-service-utils/pull/307