### PR TITLE
feat(RELEASE-1283): process-file-updates resources

### DIFF
--- a/internal/pipelines/process-file-updates/README.md
+++ b/internal/pipelines/process-file-updates/README.md
@@ -1,0 +1,15 @@
+# process-file-updates
+
+Tekton Pipeline to update files in Git repositories. It is possible to seed a file with initial content and/or apply
+replacements to a yaml file that already exists. It will attempt to create a Merge Request in Gitlab.
+
+## Parameters
+
+| Name                | Description                                                                                                                                                                              | Optional | Default value       |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------------|
+| upstream_repo       | Upstream Git repository                                                                                                                                                                  | No       | -                   |
+| repo                | Git repository                                                                                                                                                                           | No       | -                   |
+| ref                 | Git branch                                                                                                                                                                               | No       | -                   |
+| paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                   |
+| application         | Application being released                                                                                                                                                               | No       | -                   |
+| file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret |

--- a/internal/pipelines/process-file-updates/process-file-updates.yaml
+++ b/internal/pipelines/process-file-updates/process-file-updates.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: process-file-updates
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Tekton Pipeline to update files in Git repositories
+  params:
+    - name: upstream_repo
+      type: string
+      description: Upstream Git repository
+    - name: repo
+      type: string
+      description: Git repository
+    - name: ref
+      type: string
+      description: Git branch
+    - name: paths
+      type: string
+      description: |
+          String containing a JSON array of file paths and its updates and/or replacements
+          E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"|regex|replace|"}]}]'
+    - name: application
+      type: string
+      description: Application being released
+    - name: file_updates_secret
+      type: string
+      default: "file-updates-secret"
+      description: The credentials used to update the git repo
+  tasks:
+    - name: process-file-updates
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: $(params.upstream_repo)
+        - name: repo
+          value: $(params.repo)
+        - name: ref
+          value: $(params.ref)
+        - name: paths
+          value: $(params.paths)
+        - name: application
+          value: $(params.application)
+        - name: file_updates_secret
+          value: $(params.file_updates_secret)
+  results:
+    - name: jsonBuildInfo
+      value: $(tasks.process-file-updates.results.fileUpdatesInfo)
+    - name: buildState
+      value: $(tasks.process-file-updates.results.fileUpdatesState)

--- a/internal/resources/process-file-updates-task.yaml
+++ b/internal/resources/process-file-updates-task.yaml
@@ -1,0 +1,1 @@
+../tasks/process-file-updates-task/process-file-updates-task.yaml

--- a/internal/resources/process-file-updates.yaml
+++ b/internal/resources/process-file-updates.yaml
@@ -1,0 +1,1 @@
+../pipelines/process-file-updates/process-file-updates.yaml

--- a/internal/tasks/process-file-updates-task/README.md
+++ b/internal/tasks/process-file-updates-task/README.md
@@ -1,0 +1,16 @@
+# process-file-updates-task
+
+Tekton Task to update files in Git repositories. It is possible to seed a file with initial content and/or apply
+replacements to a yaml file that already exists. It will attempt to create a Merge Request in Gitlab.
+
+## Parameters
+
+| Name                | Description                                                                                                                                                                              | Optional | Default value                              |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------|
+| upstream_repo       | Upstream Git repository                                                                                                                                                                  | No       | -                                          |
+| repo                | Git repository                                                                                                                                                                           | No       | -                                          |
+| ref                 | Git branch                                                                                                                                                                               | No       | -                                          |
+| paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                                          |
+| application         | Application being released                                                                                                                                                               | No       | -                                          |
+| file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret                        |
+| tempDir             | temp dir for cloning and updates                                                                                                                                                         | Yes      | /tmp/$(context.taskRun.uid)/file-updates   |  

--- a/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
+++ b/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: process-file-updates-task
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Update files in a Git repository
+  params:
+    - name: upstream_repo
+      type: string
+      description: Upstream Git repository
+    - name: repo
+      type: string
+      description: Git repository
+    - name: ref
+      type: string
+      description: Git branch
+    - name: paths
+      type: string
+      description: |
+          String containing a JSON array of file paths and its replacements or updates
+          E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"|regex|replace|"}]}]'
+    - name: application
+      type: string
+      description: Application being released
+    - name: file_updates_secret
+      type: string
+      default: "file-updates-secret"
+      description: The credentials used to update the git repo
+    - name: tempDir
+      type: string
+      default: "/tmp/$(context.taskRun.uid)/file-updates"
+      description: temp dir for cloning and updates
+  results:
+    - name: fileUpdatesInfo
+      description: fileUpdates detailed information
+    - name: fileUpdatesState
+      description: fileUpdates state
+  workspaces:
+    - name: data
+      description: workspace to read and save files
+  steps:
+    - name: perform-updates
+      image: quay.io/konflux-ci/release-service-utils@sha256:504e93b6435a6f10f825bacdbac9ac3da9be4cdfffdae10c0607cb8362928e50
+      env:
+        - name: GITLAB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: $(params.file_updates_secret)
+              key: gitlab_host
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.file_updates_secret)
+              key: gitlab_access_token
+        - name: GIT_AUTHOR_NAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.file_updates_secret)
+              key: git_author_name
+        - name: GIT_AUTHOR_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.file_updates_secret)
+              key: git_author_email
+        - name: TEMP
+          value: "$(params.tempDir)"
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        # loading git and gitlab functions
+        # shellcheck source=/dev/null
+        . /home/utils/gitlab-functions
+        # shellcheck source=/dev/null
+        . /home/utils/git-functions
+
+        echo "Temp Dir: $TEMP"
+        mkdir -p "$TEMP"
+
+        gitlab_init
+        git_functions_init
+
+        # saves the params.paths json to a file
+        updatePathsTmpfile="${TEMP}/updatePaths.json"
+        cat > "${updatePathsTmpfile}" << JSON
+        $(params.paths)
+        JSON
+
+        UPSTREAM_REPO="$(params.upstream_repo)"
+        REPO="$(params.repo)"
+        REVISION="$(params.ref)"
+
+        echo -e "=== UPDATING ${REPO} ON BRANCH ${REVISION} ===\n"
+
+        cd "${TEMP}"
+        git_clone_and_checkout --repository "${REPO}" --revision "${REVISION}"
+
+        # updating local branch with the upstream
+        git_rebase -n "glab-base" -r "${UPSTREAM_REPO}" -v "${REVISION}"
+        
+        replacementsUpdateError=
+        # getting the files that have replacements
+        cat "${updatePathsTmpfile}"
+        PATHS_LENGTH="$(jq '. | length' "${updatePathsTmpfile}")"
+        for (( PATH_INDEX=0; PATH_INDEX < PATHS_LENGTH; PATH_INDEX++ )); do
+          # getting the replacements for the file
+          cat "${updatePathsTmpfile}"
+          targetFile="$(jq -cr ".[${PATH_INDEX}].path" "${updatePathsTmpfile}")"
+    
+          seed=$(jq -cr ".[${PATH_INDEX}].seed // \"\"" "${updatePathsTmpfile}")
+                      
+          if [ -n "${seed}" ] ; then
+            echo "seed operation to perform"
+            targetDir=$(dirname "${targetFile}")
+            mkdir -p "${targetDir}"
+            echo "${seed}" > "${targetFile}"
+            git add "${targetFile}"
+            git status
+          fi
+    
+          REPLACEMENTS_LENGTH="$(jq -cr ".[${PATH_INDEX}].replacements | length" "${updatePathsTmpfile}")"
+          echo "Replacements to perform: ${REPLACEMENTS_LENGTH}"
+          REPLACEMENTS_PERFORMED=
+          if [ "${REPLACEMENTS_LENGTH}" -gt 0 ] ; then
+            REPLACEMENTS_PERFORMED=0
+            # we need to know how many empty newlines and `---` the file has before
+            # the actual yaml data starts excluding comments
+            blankLinesBeforeYaml="$(awk '/[[:alpha:]]+/{ if(! match($0, "^#")) { print NR-1; exit } }' "${targetFile}")"
+        
+            # check if the targetFile is a valid yaml file
+            if ! yq "${targetFile}" >/dev/null 2>&1; then
+              echo "fileUpdates: the targetFile ${targetFile} is not a yaml file" | \
+              tee "$(results.fileUpdatesInfo.path)"
+              exit 1
+            fi
+        
+            for (( REPLACEMENT_INDEX=0; REPLACEMENT_INDEX < REPLACEMENTS_LENGTH; REPLACEMENT_INDEX++ )); do
+              echo "REPLACEMENT: #${REPLACEMENT_INDEX}"
+              key="$(jq -cr ".[${PATH_INDEX}].replacements[${REPLACEMENT_INDEX}].key" "${updatePathsTmpfile}")"
+              replacement="$(jq -cr ".[${PATH_INDEX}].replacements[${REPLACEMENT_INDEX}].replacement" \
+                "${updatePathsTmpfile}")"
+      
+              # getting the key's position
+              echo -en "Searching for key \`${key}\`: "
+              yq "${key} | (line, .)" "${targetFile}" > "${TEMP}/found.txt"
+              cat "${TEMP}/found.txt"
+              foundAt=$(head -n 1 "${TEMP}/found.txt")
+              if (( foundAt == 0 )); then
+                  echo "NOT FOUND"
+                  continue
+              fi
+              echo "FOUND"
+      
+              sed -i '1d' "${TEMP}/found.txt"
+              # getting the value size (in number of lines)
+              valueSize=$(yq "${key}" "${targetFile}" | wc -l)
+              startBlock=$(( foundAt + blankLinesBeforeYaml ))
+      
+              # the replacement should be a sed expression using "|" as separator
+              if [[ $(tr -dc "|" <<< "${replacement}" | wc -m ) != 3 ]]; then
+                  replacementsUpdateError="Replace expression should be in '|search|replace|' format"
+                  break
+              fi
+      
+              # run the replace
+              cat "${targetFile}"
+              echo ""
+              sed -i "${startBlock},+${valueSize}s${replacement}" "${targetFile}"
+      
+              # get the replace part of "|search|replace|"
+              replaceStr=$(awk -F"|" '{print $3}' <<< "${replacement}")
+      
+              # when the value is a text block we must make sure
+              # only a single line was replaced and that the result
+              # block has the same number of lines as before
+              sed -ne "${startBlock},+${valueSize}p" "${targetFile}" > "${TEMP}/result.txt"
+              diff -u "${TEMP}/{found,result}.txt" > "${TEMP}/diff.txt" || true
+      
+              replacedBlockLines=$(wc -l < "${TEMP}/result.txt")
+              if [[ $replacedBlockLines != $(( valueSize +1 )) ]]; then
+                  replacementsUpdateError="Text block size differs from the original"
+                  break
+              fi
+      
+              # check if only a single line was replaced
+              replacedCount=$(sed -ne "${startBlock},+${valueSize}p" "${targetFile}" | grep -c "${replaceStr}")
+              if [[ $replacedCount != 1 ]]; then
+                  replacementsUpdateError="Too many lines replaced. Check if the replace expression isn't too greedy"
+                  break
+              fi
+              REPLACEMENTS_PERFORMED=$((REPLACEMENTS_PERFORMED + 1))
+            done
+          fi
+        done
+
+        if [ -n "${replacementsUpdateError}" ]; then
+            tempdiff=$(cat "${TEMP}/diff.txt")
+            # we need to limit the size to due to the max result buffer
+            diff=${tempdiff:1:3700} \
+            error="${replacementsUpdateError}" \
+            yq -o json --null-input '.str = strenv(diff), .error = strenv(error)' \
+            | tee "$(results.fileUpdatesInfo.path)"
+            echo -n "Failed" |tee "$(results.fileUpdatesState.path)"
+            # it should exit 0 otherwise the task does not set the results
+            # this way the InternalRequest can see what was wrong
+            exit 0
+        fi
+        if [ "${REPLACEMENTS_PERFORMED}" == 0 ] ;then
+            error="\"no replacements were performed\"" \
+            yq -o json --null-input '.str = strenv(error), .error = strenv(error)' \
+            | tee "$(results.fileUpdatesInfo.path)"
+            echo -n "Failed" |tee "$(results.fileUpdatesState.path)"
+            # it should exit 0 otherwise the task does not set the results
+            # this way the InternalRequest can see what was wrong
+            exit 0
+        fi
+
+        echo -e "\n*** START LOCAL CHANGES ***\n"
+        git diff
+        echo -e "\n*** END LOCAL CHANGES ***\n"
+
+        WORKING_BRANCH=$(uuidgen |awk '{print substr($1, 1, 8)}')
+        git_commit_and_push --branch "$WORKING_BRANCH" --message "fileUpdates changes"
+
+        echo "Creating Pull Request..."
+        GITLAB_MR_MSG="[Konflux release] $(params.application): fileUpdates changes ${WORKING_BRANCH}"
+        gitlab_create_mr --head "$WORKING_BRANCH" --target-branch "$REVISION" --title "${GITLAB_MR_MSG}" \
+            --description "${GITLAB_MR_MSG}" --upstream-repo "${UPSTREAM_REPO}" | jq '. | tostring' \
+            |tee -a "$(results.fileUpdatesInfo.path)"
+
+        echo -n "Success" |tee "$(results.fileUpdatesState.path)"
+
+        echo -e "=== FINISHED ===\n"

--- a/internal/tasks/process-file-updates-task/tests/mocks.sh
+++ b/internal/tasks/process-file-updates-task/tests/mocks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+function git() {
+  echo "git $*"
+  if [[ "$*" == *"clone"* ]]; then
+    gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
+    mkdir -p "$gitRepo"
+  fi
+  if [[ "$*" == "init"* ]]; then
+    /usr/bin/git $*
+  fi
+  if [[ "$*" == "add"* ]]; then
+    if [[ "$*" == *"seed-error"* ]]; then
+      echo "simulating error"
+      exit 1
+    else
+      /usr/bin/git $*
+    fi
+  fi
+  if [[ "$*" == "status"* ]]; then
+    /usr/bin/git $*
+  fi
+  if [[ "$*" == "commit"* ]]; then
+    /usr/bin/git "$@"
+  fi
+  if [[ "$*" == "config"* ]]; then
+    /usr/bin/git "$@"
+  fi
+}
+
+function glab() {
+  if [[ "$*" == *"mr create"* ]]; then
+    gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
+    echo "/merge_request/1"
+  fi
+}

--- a/internal/tasks/process-file-updates-task/tests/pre-apply-task-hook.sh
+++ b/internal/tasks/process-file-updates-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+kubectl delete secret file-updates-secret --ignore-not-found
+kubectl create secret generic file-updates-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-combo
+spec:
+  description: |
+    Run the process-file-updates task with a seed and a replacement. The resulting
+    task result should be provide a merge request url
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git config --global init.defaultBranch main
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+              git init .
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/my-addon2.yaml","seed":"indexImage: \\ntom:",
+            "replacements":[{"key":".indexImage","replacement":"|indexImage:.*|indexImage: Tom|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that merge_request can be parsed
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              
+              cd "$(params.tempDir)/one-update"
+              commits=$(git log --oneline | wc -l)
+              echo "Test that only 1 commits is present"
+              test "${commits}" == "1"
+              
+              # we can take the last commit since 1st one was done by setup 
+              commitId=$(git log --oneline | awk '{print $1}' | tail -1)
+              changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
+              echo "Test that files changed in commit correspond to updates"
+              test "${changedFiles}" == "addons/my-addon2.yaml"
+
+              cat > "/tmp/my-addon2.yaml" << EOF
+              indexImage: Tom
+              tom:
+              EOF
+              
+              echo "Testing that file present in working directory is what we expect"
+              diff -q "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-replacements-error
+spec:
+  description: |
+    Run the process-file-updates task with a replacement for a key that does not exist.
+    The resulting task result should be provide a merge request url
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git config --global init.defaultBranch main
+              git init .
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+  
+              mkdir addons
+              cat > "addons/my-addon2.yaml" << EOF
+              indexImage: 
+              name: test
+              EOF
+              git add addons/my-addon2.yaml
+              git commit -m "prior commit"
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/my-addon2.yaml","replacements":[{"key":".Bundle","replacement":"|Bundle.*|Bundle: Tom|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: fileUpdatesInfo
+                value: "$(params.fileUpdatesInfo)"
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Test that status is Failed"
+              test "$(params.fileUpdatesState)" == "Failed"
+
+              echo "Get the error"
+              test "$(jq -r .error <<< "${fileUpdatesInfo:?}")" == "\"no replacements were performed\""
+
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-replacements-missing-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the process-file-updates task with replacements which contain a non-existent path.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git config --global init.defaultBranch main
+              git init .
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+  
+              mkdir addons
+              cat > "addons/my-addon2.yaml" << EOF
+              indexImage: 
+              name: test
+              EOF
+              git add addons/my-addon2.yaml
+              git commit -m "prior commit"
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/missing.yaml","replacements":[{"key":
+            ".indexImage","replacement":"|indexImage.*|indexImage: Tom|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-replacements-success-one-error
+spec:
+  description: |
+    Run the process-file-updates task with a replacement for a key that does not exist.
+    The resulting task result should be provide a merge request url
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git config --global init.defaultBranch main
+              git init .
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+  
+              mkdir addons
+              cat > "addons/my-addon2.yaml" << EOF
+              indexImage: 
+              name: test
+              EOF
+              git add addons/my-addon2.yaml
+              git commit -m "prior commit"
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/my-addon2.yaml","replacements":[{"key":".Bundle","replacement":"|Bundle.*|Bundle: Tom|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: fileUpdatesInfo
+                value: "$(params.fileUpdatesInfo)"
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Test that status is Failed"
+              test "$(params.fileUpdatesState)" == "Failed"
+
+              echo "Get the error"
+              test "$(jq -r .error <<< "${fileUpdatesInfo:?}")" == "\"no replacements were performed\""
+
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-replacements
+spec:
+  description: |
+    Run the process-file-updates task with replacements. The resulting
+    task result should be provide a merge request url
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git config --global init.defaultBranch main
+              git init .
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+  
+              mkdir addons
+              cat > "addons/my-addon2.yaml" << EOF
+              indexImage: 
+              name: test
+              EOF
+              git add addons/my-addon2.yaml
+              git commit -m "prior commit"
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/my-addon2.yaml","replacements":[{"key":".indexImage",
+            "replacement":"|indexImage.*|indexImage: Tom|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that merge_request can be parsed
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              
+              cd "$(params.tempDir)/one-update"
+              commits=$(git log --oneline | wc -l)
+              echo "Test that only 2 commits are present"
+              test "${commits}" == "2"
+              
+              # we can take the last commit since 1st one was done by setup 
+              commitId=$(git log --oneline | awk '{print $1}' | tail -1)
+              changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
+              echo "Test that files changed in commit correspond to updates"
+              test "${changedFiles}" == "addons/my-addon2.yaml"
+
+              cat > "/tmp/my-addon2.yaml" << EOF
+              indexImage: Tom
+              name: test
+              EOF
+              
+              echo "Testing that file present in working directory is what we expect"
+              diff -q "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-seed-error
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the process-file-updates task with a single seed. Simulate an error
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              git init .
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"test/seed-error.yaml","seed":"indexImage: \\ntom:"}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-seed
+spec:
+  description: |
+    Run the process-file-updates task with a single seed or update. The result
+    task result should be provide a merge request url
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir one-update
+              cd one-update
+              git init .
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: repo
+          value: "https://some.gitlab/test/one-update.git"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"test/one-update.yaml","seed":"indexImage: \\ntom:"}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that merge_request can be parsed
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              
+              cd "$(params.tempDir)/one-update"
+              commits=$(git log --oneline | wc -l)
+              echo "Test that only 1 commit was made"
+              test "${commits}" == "1"
+              
+              commitId=$(git log --oneline | cut -f1 -d" ")
+              changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
+              echo "Test that files changed in commit correspond to updates"
+              test "${changedFiles}" == "test/one-update.yaml"
+
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+  finally:
+    - name: cleanup
+      params:
+        - name: tempDir
+          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: tempDir
+            type: string
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              rm -rf "$(params.tempDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace


### PR DESCRIPTION
- new pipeline and task for internal process-file-updates
- cloned from https://github.com/hacbs-release/app-interface-deployments/blob/main/internal-services/catalog/file-updates-pipeline.yaml and https://github.com/hacbs-release/app-interface-deployments/blob/main/internal-services/catalog/file-updates-process-file-updates-task.yaml with additional seeding feature and added tests