### PR TITLE
feat(RELEASE-1283): correct workspace

### DIFF
--- a/internal/pipelines/process-file-updates/process-file-updates.yaml
+++ b/internal/pipelines/process-file-updates/process-file-updates.yaml
@@ -33,6 +33,8 @@ spec:
       type: string
       default: "file-updates-secret"
       description: The credentials used to update the git repo
+  workspaces:
+    - name: pipeline
   tasks:
     - name: process-file-updates
       taskRef:

--- a/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
+++ b/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
@@ -43,7 +43,7 @@ spec:
     - name: fileUpdatesState
       description: fileUpdates state
   workspaces:
-    - name: data
+    - name: pipeline
       description: workspace to read and save files
   steps:
     - name: perform-updates

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,8 +24,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git config --global init.defaultBranch main
@@ -51,9 +51,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -66,7 +66,7 @@ spec:
         - name: fileUpdatesState
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: fileUpdatesInfo
@@ -104,13 +104,13 @@ spec:
               echo "Testing that file present in working directory is what we expect"
               diff -q "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
   finally:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -124,5 +124,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,8 +24,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git config --global init.defaultBranch main
@@ -58,9 +58,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -73,7 +73,7 @@ spec:
         - name: fileUpdatesState
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: fileUpdatesInfo
@@ -99,13 +99,13 @@ spec:
               test "$(jq -r .error <<< "${fileUpdatesInfo:?}")" == "\"no replacements were performed\""
 
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
   finally:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -119,5 +119,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
@@ -13,11 +13,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -25,8 +25,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git config --global init.defaultBranch main
@@ -60,9 +60,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -70,7 +70,7 @@ spec:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -84,5 +84,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,8 +24,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git config --global init.defaultBranch main
@@ -58,9 +58,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -73,7 +73,7 @@ spec:
         - name: fileUpdatesState
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: fileUpdatesInfo
@@ -99,13 +99,13 @@ spec:
               test "$(jq -r .error <<< "${fileUpdatesInfo:?}")" == "\"no replacements were performed\""
 
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
   finally:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -119,5 +119,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,8 +24,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git config --global init.defaultBranch main
@@ -59,9 +59,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -74,7 +74,7 @@ spec:
         - name: fileUpdatesState
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: fileUpdatesInfo
@@ -112,13 +112,13 @@ spec:
               echo "Testing that file present in working directory is what we expect"
               diff -q "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
   finally:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -132,5 +132,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
@@ -13,11 +13,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -25,8 +25,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               git init .
     - name: run-task
@@ -47,9 +47,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -57,7 +57,7 @@ spec:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -71,5 +71,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -12,11 +12,11 @@ spec:
   tasks:
     - name: setup
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       taskSpec:
         workspaces:
-          - name: data
+          - name: pipeline
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,8 +24,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
-              cd "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
               mkdir one-update
               cd one-update
               git init .
@@ -47,9 +47,9 @@ spec:
         - name: file_updates_secret
           value: "file-updates-secret"
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
       runAfter:
         - setup
@@ -62,7 +62,7 @@ spec:
         - name: fileUpdatesState
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: fileUpdatesInfo
@@ -92,13 +92,13 @@ spec:
               test "${changedFiles}" == "test/one-update.yaml"
 
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace
   finally:
     - name: cleanup
       params:
         - name: tempDir
-          value: "$(workspaces.data.path)/$(context.pipelineRun.uid)/file-updates"
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
         params:
           - name: tempDir
@@ -112,5 +112,5 @@ spec:
 
               rm -rf "$(params.tempDir)"
       workspaces:
-        - name: data
+        - name: pipeline
           workspace: tests-workspace


### PR DESCRIPTION
- since the process-file-updates runs on internal private cluster, it must have a workspace with the name '**pipeline**' for one to be bound by the internal services controller.