### PR TITLE
fix: cves should be permitted

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -152,6 +152,30 @@
             "type": "string"
           }
         },
+        "cves": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key of the CVE e.g. CVE-3414"
+              },
+              "component": {
+                "type": "string",
+                "description": "The name of the component"
+              },
+              "packages": {
+                "type": "array",
+                "description": "A list of packages that fixed the CVE e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
         "issues": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
- we should permit .releaseNotes.cves since the docs mention them and populate-release-notes-images requires them