### PR TITLE
chore: bump image in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,10 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.3.0
+* Updated the base image used in this task
+  * The new image ignores the `gpg-pubkey` rpm package
+
 ## Changes in 1.2.0
 * Change SBOM download location to a subdir of the data workspace, so that other tasks can
   access the downloaded SBOMs. A new result `sbomPath` is added to store the path the SBOMs

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+        quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -92,12 +92,12 @@ spec:
           echo "ERROR: Expected to fetch sbom for $PYXIS_IMAGES images, but only $SBOM_COUNT were saved"
           exit 1
         fi
-        
+
         echo -n "${SBOM_PATH}" > "$(results.sbomPath.path)"
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+        quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
           - name: sbomPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fb3aab1684422e897c2bac5acd57d5ecf42615ae
+            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
The new image ignores the `gpg-pubkey` rpm package.

See here:
https://github.com/konflux-ci/release-service-utils/pull/312