### PR TITLE
fix: allow additional properties in schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": true,
   "properties": {
     "systems": {
       "type": "array",
@@ -13,7 +12,6 @@
     },
     "fbc": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "request": {
           "type": "string",
@@ -101,7 +99,6 @@
     },
     "releaseNotes": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "product_id": {
           "type": "integer",
@@ -152,38 +149,12 @@
             "type": "string"
           }
         },
-        "cves": {
-          "type": "array",
-          "items": {
-            "additionalProperties": false,
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "description": "The key of the CVE e.g. CVE-3414"
-              },
-              "component": {
-                "type": "string",
-                "description": "The name of the component"
-              },
-              "packages": {
-                "type": "array",
-                "description": "A list of packages that fixed the CVE e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
         "issues": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "fixed": {
               "type": "array",
               "items": {
-                "additionalProperties": false,
                 "type": "object",
                 "properties": {
                   "id": {
@@ -201,13 +172,11 @@
         },
         "content": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "images": {
               "type": "array",
               "items": {
                 "type": "object",
-                "additionalProperties": false,
                 "properties": {
                   "containerImage": {
                     "type": "string",
@@ -242,7 +211,6 @@
                   },
                   "cves": {
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
                       "fixed": {
                         "type": "object",
@@ -271,7 +239,6 @@
     },
     "sign": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "cosignSecretName": {
           "type": "string",
@@ -298,7 +265,6 @@
     },
     "github": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "githubSecret": {
           "type": "string",
@@ -308,7 +274,6 @@
     },
     "pyxis": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "secret": {
           "type": "string",
@@ -332,7 +297,6 @@
     },
     "slack": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "slack-notification-secret": {
           "type": "string",
@@ -354,13 +318,11 @@
     },
     "mapping": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "components": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string",
@@ -396,7 +358,6 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "additionalProperties": false,
                       "properties": {
                         "filename": {
                           "type": "string",
@@ -445,7 +406,6 @@
         },
         "defaults": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "tags": {
               "type": "array",
@@ -472,7 +432,6 @@
     },
     "cdn": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "env": {
           "type": "string",
@@ -483,7 +442,6 @@
     },
     "mrrc": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "release": {
           "type": "string",


### PR DESCRIPTION
This update removes `"additionalProperties": false` from the schema, allowing extra keys to be included in `data.json`
without causing schema validation to fail.

Slack: [Link to Thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1731934464613269?thread_ts=1731665042.843589&cid=C04PZ7H0VA8)