### PR TITLE
fix: change test metata version

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -65,7 +65,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.2/test-metadata.yaml
+            value: common/tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)


### PR DESCRIPTION
Change to use test-metadata v0.1 since the test-metadata version 0.2 doesn't have the "pull-request-author" in results.