### PR TITLE
fix(KFLUXBUGS-1896): pass errata SA secret when creating advisories

### DIFF
--- a/tasks/create-advisory/README.md
+++ b/tasks/create-advisory/README.md
@@ -18,6 +18,9 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                           |
 
+## Changes in 4.4.3
+* Pass the errata service account secret name to the InternalRequest based on stage or prod
+
 ## Changes in 4.4.2
 * If the releaseNotes do not specify any CVEs fixed and the type is RHSA, fail the task
 * If the releaseNotes specify CVEs fixed, proceed with type set to RHSA regardless of the passed type

--- a/tasks/create-advisory/create-advisory.yaml
+++ b/tasks/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "4.4.2"
+    app.kubernetes.io/version: "4.4.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -99,7 +99,9 @@ spec:
         # these are their secret names
         #
         prodSecretName="create-advisory-prod-secret"
+        prodErrataSecretName="errata-prod-service-account"
         stagingSecretName="create-advisory-stage-secret"
+        stagingErrataSecretName="errata-stage-service-account"
         #
         # detect which one to use based on repositories specified
         #
@@ -150,8 +152,10 @@ spec:
         # is true.
         #
         advisorySecretName="${prodSecretName}"
+        errataSecretName="${prodErrataSecretName}"
         if [ "${foundPendingRepositories}" == "true" ]; then
           advisorySecretName="${stagingSecretName}"
+          errataSecretName="${stagingErrataSecretName}"
         fi
 
         echo "Creating InternalRequest to create advisory..."
@@ -161,6 +165,7 @@ spec:
                          -p advisory_json="${advisoryData}" \
                          -p config_map_name="${configMapName}" \
                          -p advisory_secret_name="${advisorySecretName}" \
+                         -p errata_secret_name="${errataSecretName}" \
                          -s "$(params.synchronously)" \
                          -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
                          > "$(workspaces.data.path)"/ir-result.txt || \

--- a/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -167,6 +167,13 @@ spec:
                 echo "InternalRequest has the wrong advisory_secret_name parameter"
                 exit 1
               fi
+
+              # Check the errata_secret_name parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.errata_secret_name' )" != \
+                "errata-stage-service-account" ]; then
+                echo "InternalRequest has the wrong errata_secret_name parameter"
+                exit 1
+              fi
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -182,6 +182,13 @@ spec:
                 echo "InternalRequest has the wrong advisory_secret_name parameter"
                 exit 1
               fi
+
+              # Check the errata_secret_name parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.errata_secret_name' )" != \
+                "errata-prod-service-account" ]; then
+                echo "InternalRequest has the wrong errata_secret_name parameter"
+                exit 1
+              fi
   finally:
     - name: cleanup
       taskSpec:


### PR DESCRIPTION
Currently, we hardcode the errata service account secret in the internal task. This results in using prod errata credentials when pushing stage advisories from a prod cluster. This commit fixes that.