### PR TITLE
fix(RELEASE-1304): typo when setting default value with jq

### DIFF
--- a/tasks/run-file-updates/README.md
+++ b/tasks/run-file-updates/README.md
@@ -16,6 +16,9 @@ the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 | resultsDirPath     | Path to results directory in the data workspace                                           | No       | -                        |
 
 
+## Changes in 2.0.1
+* fix typo in default value for `jq`
+
 ## Changes in 2.0.0
 * new mandatory parameter resultsDirPath added
 * the task now supplies created merge requests to update Release CR status task.

--- a/tasks/run-file-updates/run-file-updates.yaml
+++ b/tasks/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -53,7 +53,7 @@ spec:
 
         # Obtain application from snapshot
         application=$(jq -rc .application $(workspaces.data.path)/$(params.snapshotPath))
-        
+
         # Extract the key from the JSON file
         fileUpdates=$(jq -rc "$(params.jsonKey)" $(workspaces.data.path)/$(params.fileUpdatesPath))
 
@@ -105,7 +105,7 @@ spec:
 
           results=$(jq -r '.status.results' <<< "${IRjson}")
           internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
-          internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName / ""' <<< "${results}")"
+          internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
 
           echo "** internalRequestPipelineRunName: ${internalRequestPipelineRunName}"
           echo "** internalRequestTaskRunName: ${internalRequestTaskRunName}"


### PR DESCRIPTION
There was `/` instead of `//`, so instead of setting a default value it would be diving the values. And e2e was failing with:

null (null) and string ("") cannot be divided