### PR TITLE
fix(RELEASE-1304): invalid result value

### DIFF
--- a/internal/pipelines/process-file-updates/README.md
+++ b/internal/pipelines/process-file-updates/README.md
@@ -13,3 +13,8 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                   |
 | application         | Application being released                                                                                                                                                               | No       | -                   |
 | file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret |
+
+## Changes in 0.0.2
+* fix invalid result value
+  - it turns out Tekton only supports passing task results as pipeline results,
+    so we need to pass the PLR name to the task first and then emit it from the task

--- a/internal/pipelines/process-file-updates/process-file-updates.yaml
+++ b/internal/pipelines/process-file-updates/process-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: process-file-updates
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -52,6 +52,8 @@ spec:
           value: $(params.application)
         - name: file_updates_secret
           value: $(params.file_updates_secret)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: pipeline
@@ -61,6 +63,6 @@ spec:
     - name: buildState
       value: $(tasks.process-file-updates.results.fileUpdatesState)
     - name: internalRequestPipelineRunName
-      value: $(context.pipelineRun.name)
+      value: $(tasks.process-file-updates.results.internalRequestPipelineRunName)
     - name: internalRequestTaskRunName
       value: $(tasks.process-file-updates.results.internalRequestTaskRunName)

--- a/internal/tasks/process-file-updates-task/README.md
+++ b/internal/tasks/process-file-updates-task/README.md
@@ -5,12 +5,18 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 
 ## Parameters
 
-| Name                | Description                                                                                                                                                                              | Optional | Default value                              |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------|
-| upstream_repo       | Upstream Git repository                                                                                                                                                                  | No       | -                                          |
-| repo                | Git repository                                                                                                                                                                           | No       | -                                          |
-| ref                 | Git branch                                                                                                                                                                               | No       | -                                          |
-| paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                                          |
-| application         | Application being released                                                                                                                                                               | No       | -                                          |
-| file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret                        |
-| tempDir             | temp dir for cloning and updates                                                                                                                                                         | Yes      | /tmp/$(context.taskRun.uid)/file-updates   |  
+| Name                           | Description                                                                                                                                                                              | Optional | Default value                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------- |
+| upstream_repo                  | Upstream Git repository                                                                                                                                                                  | No       | -                                        |
+| repo                           | Git repository                                                                                                                                                                           | No       | -                                        |
+| ref                            | Git branch                                                                                                                                                                               | No       | -                                        |
+| paths                          | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                                        |
+| application                    | Application being released                                                                                                                                                               | No       | -                                        |
+| file_updates_secret            | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret                      |
+| tempDir                        | temp dir for cloning and updates                                                                                                                                                         | Yes      | /tmp/$(context.taskRun.uid)/file-updates |
+| internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
+
+## Changes in 0.0.2
+* add new `internalRequestPipelineRunName` parameter and result
+  - Tekton only supports passing task results as pipeline results,
+    so we need to pass the PLR name to the task first and then emit it from the task

--- a/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
+++ b/internal/tasks/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,11 +37,16 @@ spec:
       type: string
       default: "/tmp/$(context.taskRun.uid)/file-updates"
       description: temp dir for cloning and updates
+    - name: internalRequestPipelineRunName
+      type: string
+      description: name of the PipelineRun that called this task
   results:
     - name: fileUpdatesInfo
       description: fileUpdates detailed information
     - name: fileUpdatesState
       description: fileUpdates state
+    - name: internalRequestPipelineRunName
+      description: name of the PipelineRun that called this task
     - name: internalRequestTaskRunName
       description: name of this Task Run to be made available to caller
   workspaces:
@@ -77,6 +82,7 @@ spec:
         #!/usr/bin/env bash
         set -eo pipefail
 
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
         echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
 
         # loading git and gitlab functions
@@ -108,7 +114,7 @@ spec:
 
         # updating local branch with the upstream
         git_rebase -n "glab-base" -r "${UPSTREAM_REPO}" -v "${REVISION}"
-        
+
         replacementsUpdateError=
         # getting the files that have replacements
         cat "${updatePathsTmpfile}"
@@ -120,12 +126,12 @@ spec:
           echo "-- end updatePathsTmpfile --"
           targetFile="$(jq -cr ".[${PATH_INDEX}].path" "${updatePathsTmpfile}")"
           echo "targetFile: ${targetFile}"
-    
+
           seed=$(jq ".[${PATH_INDEX}].seed // \"\"" "${updatePathsTmpfile}")
           seed="${seed%\"}"
           seed="${seed#\"}"
           echo "${seed}"
-                      
+
           if [ -n "${seed}" ] ; then
             echo "seed operation to perform"
             targetDir=$(dirname "${targetFile}")
@@ -137,7 +143,7 @@ spec:
             git add "${targetFile}"
             git status
           fi
-    
+
           REPLACEMENTS_LENGTH="$(jq -cr ".[${PATH_INDEX}].replacements | length" "${updatePathsTmpfile}")"
           echo "Replacements to perform: ${REPLACEMENTS_LENGTH}"
           REPLACEMENTS_PERFORMED=
@@ -146,20 +152,20 @@ spec:
             # we need to know how many empty newlines and `---` the file has before
             # the actual yaml data starts excluding comments
             blankLinesBeforeYaml="$(awk '/[[:alpha:]]+/{ if(! match($0, "^#")) { print NR-1; exit } }' "${targetFile}")"
-        
+
             # check if the targetFile is a valid yaml file
             if ! yq "${targetFile}" >/dev/null 2>&1; then
               echo "fileUpdates: the targetFile ${targetFile} is not a yaml file" | \
               tee "$(results.fileUpdatesInfo.path)"
               exit 1
             fi
-        
+
             for (( REPLACEMENT_INDEX=0; REPLACEMENT_INDEX < REPLACEMENTS_LENGTH; REPLACEMENT_INDEX++ )); do
               echo "REPLACEMENT: #${REPLACEMENT_INDEX}"
               key="$(jq -cr ".[${PATH_INDEX}].replacements[${REPLACEMENT_INDEX}].key" "${updatePathsTmpfile}")"
               replacement="$(jq -cr ".[${PATH_INDEX}].replacements[${REPLACEMENT_INDEX}].replacement" \
                 "${updatePathsTmpfile}")"
-      
+
               # getting the key's position
               echo -en "Searching for key \`${key}\`: "
               yq "${key} | (line, .)" "${targetFile}" > "${TEMP}/found.txt"
@@ -170,39 +176,39 @@ spec:
                   continue
               fi
               echo "FOUND"
-      
+
               sed -i '1d' "${TEMP}/found.txt"
               # getting the value size (in number of lines)
               valueSize=$(yq "${key}" "${targetFile}" | wc -l)
               startBlock=$(( foundAt + blankLinesBeforeYaml ))
-      
+
               # the replacement should be a sed expression using "|" as separator
               if [[ $(tr -dc "|" <<< "${replacement}" | wc -m ) != 3 ]]; then
                   replacementsUpdateError="Replace expression should be in '|search|replace|' format"
                   break
               fi
-      
+
               # run the replace
               echo "--start file--"
               cat "${targetFile}"
               echo "--end file--"
               sed -i "${startBlock},+${valueSize}s${replacement}" "${targetFile}"
-      
+
               # get the replace part of "|search|replace|"
               replaceStr=$(awk -F"|" '{print $3}' <<< "${replacement}")
-      
+
               # when the value is a text block we must make sure
               # only a single line was replaced and that the result
               # block has the same number of lines as before
               sed -ne "${startBlock},+${valueSize}p" "${targetFile}" > "${TEMP}/result.txt"
               diff -u "${TEMP}/{found,result}.txt" > "${TEMP}/diff.txt" || true
-      
+
               replacedBlockLines=$(wc -l < "${TEMP}/result.txt")
               if [[ $replacedBlockLines != $(( valueSize +1 )) ]]; then
                   replacementsUpdateError="Text block size differs from the original"
                   break
               fi
-      
+
               # check if only a single line was replaced
               replacedCount=$(sed -ne "${startBlock},+${valueSize}p" "${targetFile}" | grep -c "${replaceStr}")
               if [[ $replacedCount != 1 ]]; then

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -52,6 +52,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace
@@ -67,6 +69,8 @@ spec:
           value: $(tasks.run-task.results.fileUpdatesState)
         - name: internalRequestTaskRunName
           value: $(tasks.run-task.results.internalRequestTaskRunName)
+        - name: internalRequestPipelineRunName
+          value: $(tasks.run-task.results.internalRequestPipelineRunName)
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
       taskSpec:
@@ -76,6 +80,8 @@ spec:
           - name: fileUpdatesState
             type: string
           - name: internalRequestTaskRunName
+            type: string
+          - name: internalRequestPipelineRunName
             type: string
           - name: tempDir
             type: string
@@ -88,13 +94,13 @@ spec:
 
               echo Test that merge_request can be parsed
               test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
-              
+
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)
               echo "Test that only 1 commits is present"
               test "${commits}" == "1"
-              
-              # we can take the last commit since 1st one was done by setup 
+
+              # we can take the last commit since 1st one was done by setup
               commitId=$(git log --oneline | awk '{print $1}' | tail -1)
               changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
               echo "Test that files changed in commit correspond to updates"
@@ -104,12 +110,15 @@ spec:
               indexImage: Tom
 
               EOF
-              
+
               echo "Testing that file present in working directory is what we expect"
               diff "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
 
               echo Test that internalRequestTaskRunName is not empty
-              test "$(params.internalRequestTaskRunName)" != ""
+              test -n "$(params.internalRequestTaskRunName)"
+
+              echo Test that internalRequestPipelineRunName is not empty
+              test -n "$(params.internalRequestPipelineRunName)"
 
       workspaces:
         - name: pipeline

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
@@ -32,10 +32,10 @@ spec:
               git init .
               git config --global user.email "test@test.com"
               git config --global user.name "tester"
-  
+
               mkdir addons
               cat > "addons/my-addon2.yaml" << EOF
-              indexImage: 
+              indexImage:
               name: test
               EOF
               git add addons/my-addon2.yaml
@@ -59,6 +59,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
@@ -33,10 +33,10 @@ spec:
               git init .
               git config --global user.email "test@test.com"
               git config --global user.name "tester"
-  
+
               mkdir addons
               cat > "addons/my-addon2.yaml" << EOF
-              indexImage: 
+              indexImage:
               name: test
               EOF
               git add addons/my-addon2.yaml
@@ -61,6 +61,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
@@ -32,10 +32,10 @@ spec:
               git init .
               git config --global user.email "test@test.com"
               git config --global user.name "tester"
-  
+
               mkdir addons
               cat > "addons/my-addon2.yaml" << EOF
-              indexImage: 
+              indexImage:
               name: test
               EOF
               git add addons/my-addon2.yaml
@@ -59,6 +59,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -32,10 +32,10 @@ spec:
               git init .
               git config --global user.email "test@test.com"
               git config --global user.name "tester"
-  
+
               mkdir addons
               cat > "addons/my-addon2.yaml" << EOF
-              indexImage: 
+              indexImage:
               name: test
               EOF
               git add addons/my-addon2.yaml
@@ -60,6 +60,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace
@@ -92,13 +94,13 @@ spec:
 
               echo Test that merge_request can be parsed
               test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
-              
+
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)
               echo "Test that only 2 commits are present"
               test "${commits}" == "2"
-              
-              # we can take the last commit since 1st one was done by setup 
+
+              # we can take the last commit since 1st one was done by setup
               commitId=$(git log --oneline | awk '{print $1}' | tail -1)
               changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
               echo "Test that files changed in commit correspond to updates"
@@ -108,7 +110,7 @@ spec:
               indexImage: Tom
               name: test
               EOF
-              
+
               echo "Testing that file present in working directory is what we expect"
               diff -q "$(params.tempDir)/one-update/addons/my-addon2.yaml" "/tmp/my-addon2.yaml"
       workspaces:

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
@@ -48,6 +48,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace

--- a/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/internal/tasks/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -48,6 +48,8 @@ spec:
           value: "file-updates-secret"
         - name: tempDir
           value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
       workspaces:
         - name: pipeline
           workspace: tests-workspace
@@ -80,12 +82,12 @@ spec:
 
               echo Test that merge_request can be parsed
               test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
-              
+
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)
               echo "Test that only 1 commit was made"
               test "${commits}" == "1"
-              
+
               commitId=$(git log --oneline | cut -f1 -d" ")
               changedFiles=$(git show -r "${commitId}" --name-only --oneline | tail -1)
               echo "Test that files changed in commit correspond to updates"


### PR DESCRIPTION
It turns out Tekton only supports passing task results as pipeline results, so we need to pass the PLR name to the task first and then emit it from the task.