### PR TITLE
chore(KFLUXBUGS-1741): bump release-service-utils in push-snapshot

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -13,6 +13,9 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
 | caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
 
+## Changes in 6.4.0
+* Bump release-service-utils to upgrade the get-image-architecture script which can properly handle a Tekton bundle
+
 ## Changes in 6.3.0
 * Add support for custom CA cert in push-snapshot task
 

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.3.0"
+    app.kubernetes.io/version: "6.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,7 +67,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
The new image brings a new version of the get-image-architecture script which can properly handle a Tekton bundle. This update was previously done to the apply-mapping Task, but the push-snapshot Task also relies on it.