### PR TITLE
fix(RELEASE-1306): dir already exists error in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,9 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.3.1
+* Avoid "dir already exists" error in case the task is retried in a pipelinerun
+
 ## Changes in 1.3.0
 * Updated the base image used in this task
   * The new image ignores the `gpg-pubkey` rpm package

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -54,7 +54,9 @@ spec:
         NUM_COMPONENTS=$(jq '.components | length' "${PYXIS_FILE}")
 
         SBOM_PATH="$(dirname "$(params.pyxisJsonPath)")/downloaded-sboms"
-        mkdir "$(workspaces.data.path)/${SBOM_PATH}"
+        # The dir might already exist in case of retries of the task.
+        # No need for a cleanup - we will just override the files.
+        mkdir -p "$(workspaces.data.path)/${SBOM_PATH}"
         cd "$(workspaces.data.path)/${SBOM_PATH}"
         DOCKER_CONFIG="$(mktemp -d)"
         export DOCKER_CONFIG


### PR DESCRIPTION
This happened when the task was retried in the PipelineRun.