### PR TITLE
chore: bump image in create-pyxis-image

### DIFF
--- a/tasks/create-pyxis-image/README.md
+++ b/tasks/create-pyxis-image/README.md
@@ -18,6 +18,10 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | rhPush      | If set to true, an additional entry will be created in ContainerImage.repositories with the registry and repository fields converted to use Red Hat's official registry. E.g. a mapped repository of "quay.io/redhat-pending/product---my-image" will be converted to use registry "registry.access.redhat.com" and repository "product/my-image". Also, this repository entry will be marked as published. | Yes      | false         |
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
 
+## Changes in 3.4.4
+* Bumped the utils image used in this task
+  * The updated image contains refactoring of the create_container_image python script
+
 ## Changes in 3.4.3
 * Updated the base image used in this task
   * The previous update changed the output of the create_container_image script

--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.4.3"
+    app.kubernetes.io/version: "3.4.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+      image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -63,7 +63,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -68,7 +68,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
The updated image contains refactoring
of the create_container_image python script.

Related PR:
https://github.com/konflux-ci/release-service-utils/pull/305

This will also contain these:
- https://github.com/konflux-ci/release-service-utils/pull/310/files
  - a fix for saving the correct manifest list digest
- https://github.com/konflux-ci/release-service-utils/pull/311
  - a fix to handle null values for top_layer_id and uncompressed_top_layer_id properly