### PR TITLE
fix(KFLUXBUGS-1846): incomplete image results in push-snapshot

### DIFF
--- a/tasks/push-snapshot/README.md
+++ b/tasks/push-snapshot/README.md
@@ -13,6 +13,11 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
 | caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
 
+## Changes in 6.4.1
+* Bump release-service-utils image
+  * The updated image will fail if skopeo inspect fails
+* Fix authentication for skopeo inspect when running get-image-architectures
+
 ## Changes in 6.4.0
 * Bump release-service-utils to upgrade the get-image-architecture script which can properly handle a Tekton bundle
 

--- a/tasks/push-snapshot/push-snapshot.yaml
+++ b/tasks/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.4.0"
+    app.kubernetes.io/version: "6.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+      image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -73,6 +73,9 @@ spec:
               echo "Max retries exceeded."
               exit 1
             fi
+            # Only the cosign call above needs this custom Docker config. Unset it, so that skopeo call
+            # in get-image-architecture uses the default config in ~/.docker/config.json (this one would break it)
+            unset DOCKER_CONFIG
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
               "$2" "$3"

--- a/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,7 +67,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/push-snapshot/tests/test-push-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5e9ee4c1d6cb3484d227c31557be3f476a4f3d7f
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
- Bump utils image for improved get-image-architectures:
  - https://github.com/konflux-ci/release-service-utils/pull/328
- Fix authentication for skopeo inspect when running get-image-architectures
  - From second component on, it would always use the docker config that was crafted for the previous component, so if the source repo was private, it would fail to fetch the architecture details for that image. As a result, image results would be wrong.