### PR TITLE
hack: workaround for bootc

### DIFF
--- a/tasks/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/create-pyxis-image/create-pyxis-image.yaml
@@ -48,7 +48,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+      image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
       env:
         - name: pyxisCert
           valueFrom:
@@ -163,6 +163,12 @@ spec:
                   "${ORAS_ARGS[@]}" \
                   "${PULLSPEC}" \
                       | tee "${MANIFEST_FILE}"
+
+                # Temporary - do not merge
+                # As a side-effect of the way they build without squashing, their final layer is always bit-wise identical. This causes upload to pyxis to fail which cannot tolerate duplicate "top_layer_id" values. Here - just delete the layers so that no layer information is uploaded. Requires https://github.com/konflux-ci/release-service-utils/pull/311
+                echo "Delete the layers, just for rhel-bootc"
+                jq '.layers = []' "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
+                mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
 
                 # Augment that manifest with further information about the layers, decompressed
                 # This requires pulling the layers to decompress and then measure them

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -63,7 +63,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -68,7 +68,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:f00c49df232d477ba843b4c48343d745dfebe747
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
Do not merge. This is a temporary pipeline to for rpm-ostree images.

The image update here pulls in this change:
https://github.com/konflux-ci/release-service-utils/pull/311

It makes it so that in the event that the layer data is absent, a `null` value won't be sent to pyxis which would be rejected by pyxis' input validation.