### PR TITLE
feat(RELEASE-1310): add update-cr-status to push-disk-images

### DIFF
--- a/pipelines/push-disk-images-to-cdn/README.md
+++ b/pipelines/push-disk-images-to-cdn/README.md
@@ -20,6 +20,10 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -               |
 
+## Changes in 1.2.0
+* The `push-disk-images` task now gets the `resultsDir` parameter from `collect-data` results
+* Add the task `update-cr-status` at the end of the pipeline to save all pipeline results
+
 ## Changes in 1.1.0
 * Add new reduce-snapshot task
 

--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -223,6 +223,8 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-disk-images/push-disk-images.yaml
+          - name: resultsDirPath
+            value: "$(tasks.collect-data.results.resultsDir)"
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -235,6 +237,26 @@ spec:
           workspace: release-workspace
       runAfter:
         - check-data-keys
+    - name: update-cr-status
+      params:
+        - name: resource
+          value: $(params.release)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/update-cr-status/update-cr-status.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - push-disk-images
   finally:
     - name: cleanup
       taskRef:

--- a/tasks/push-disk-images/README.md
+++ b/tasks/push-disk-images/README.md
@@ -10,6 +10,10 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | No       | -             |
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| resultsDirPath           | Path to results directory in the data workspace                                           | No       | -             |
+
+## Changes in 0.3.0
+* The task now writes pushed file names to a results json file in the workspace
 
 ## Changes in 0.2.2
 * Increase the InternalRequest PipelineRun timeout to 24 hours in total

--- a/tasks/push-disk-images/push-disk-images.yaml
+++ b/tasks/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,9 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: resultsDirPath
+      description: Path to the results directory in the data workspace
+      type: string
   workspaces:
     - name: data
       description: Workspace where the json files are stored
@@ -36,6 +39,10 @@ spec:
         snapshot=$(jq -c '.' "$(workspaces.data.path)/$(params.snapshotPath)")
         # .cdn.env is likely to change in the future. This is just for POC
         env=$(jq -r '.cdn.env' "$(workspaces.data.path)/$(params.dataPath)")
+
+        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/push-disk-images-results.json"
+        FILES=$(jq -c '{"disk-image-files": [.components[].staged?.files[]?.filename]}' <<< "$snapshot")
+        echo "$FILES" > "$RESULTS_FILE"
 
         # There are three envs supported...production, stage, and qa
         exodusGwSecret=""

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -21,6 +21,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
               {
                 "application": "disk-images",
@@ -71,6 +72,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
@@ -19,7 +19,8 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "cdn": {
@@ -40,6 +41,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -19,7 +19,8 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/test_snapshot_spec.json" << EOF
               {
                 "application": "disk-images",
@@ -50,6 +51,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -19,7 +19,8 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "contentGateway": {
@@ -52,6 +53,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -18,6 +18,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
               {
                 "application": "disk-images",
@@ -68,6 +69,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -18,6 +18,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
               {
                 "application": "disk-images",
@@ -68,6 +69,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:

--- a/tasks/push-disk-images/tests/test-push-disk-images-results.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-results.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-disk-images-results
+spec:
+  description: |
+    Run the push-disk-images task with and verify the proper file names are reported as task results
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "nvidia-aws-disk-image-1-3",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/redhat-user-workloads/rhel-ai-tenant/nvidia-aws-disk-image-1-3/nvidia-aws-disk-image-1-3@sha256:c866ff5e773045580c3f3025610c82c653685db9914712ed2713dfea8ec13e05",
+                    "name": "nvidia-aws-disk-image-1-3",
+                    "source": {
+                      "git": {
+                        "revision": "534fa8a78f4587ccca254eec71eab26677f29090",
+                        "url": "https://gitlab.com/redhat/rhel-ai/disk-images/nvidia-aws"
+                      }
+                    },
+                    "contentGateway": {
+                      "filePrefix": "rhel-ai-nvidia-aws-1.3",
+                      "productCode": "RHELAI",
+                      "productName": "Binary_RL_Red Hat Enterprise Linux AI",
+                      "productVersionName": "1.3-staging"
+                    },
+                    "staged": {
+                      "destination": "rhelai-1_DOT_3-for-rhel-9-x86_64-isos",
+                      "files": [
+                        {
+                          "filename": "rhel-ai-nvidia-aws-1.3-1732915588-x86_64.ami",
+                          "source": "disk.raw"
+                        }
+                      ],
+                      "version": "1.3"
+                    }
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "contentGateway": {
+                  "productName": "Konflux test product",
+                  "productCode": "KTestProduct",
+                  "productVersionName": "KTestProduct 1",
+                  "components": [
+                    {
+                      "name": "test-component",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "label": "Checksum File Sandbox Test"
+                    }
+                  ]
+                },
+                "cdn": {
+                  "env": "stage"
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: dataPath
+          value: "data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:6a7ca9ba0ddd70404fe2267551409925cf513132
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              results=$(cat "$(workspaces.data.path)/results/push-disk-images-results.json")
+
+              # Check the results file
+              expected="rhel-ai-nvidia-aws-1.3-1732915588-x86_64.ami"
+              if [ "$(jq -r '."disk-image-files"[]' <<< "$results")" != "$expected" ]; then
+                echo "push-disk-images results do not contain expected file names"
+                exit 1
+              fi

--- a/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -18,6 +18,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              mkdir "$(workspaces.data.path)/results"
               cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
               {
                 "application": "disk-images",
@@ -68,6 +69,8 @@ spec:
           value: "data.json"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
       runAfter:
         - setup
       workspaces:


### PR DESCRIPTION
this commit adds the `update-cr-status` task to the `push-disk-images` pipeline.

related to: https://issues.redhat.com/browse/RELEASE-1310