### PR TITLE
feat(ISV-5321): set SPDX doc name in update-component-sbom task

### DIFF
--- a/tasks/update-component-sbom/README.md
+++ b/tasks/update-component-sbom/README.md
@@ -4,7 +4,10 @@ Tekton task to update component-level SBOMs with purls containing release-time i
 
 ## Parameters
 
-| Name                | Description                                                              | Optional | Default value |
-|---------------------|--------------------------------------------------------------------------|----------|---------------|
-| dataJsonPath        | Path to the JSON string of the merged data containing the release notes  | No       | -             |
-| downloadedSbomPath  | Path to the directory holding previously downloaded SBOMs to be updated. | No       | -             |
+| Name               | Description                                                              | Optional | Default value |
+| ------------------ | ------------------------------------------------------------------------ | -------- | ------------- |
+| dataJsonPath       | Path to the JSON string of the merged data containing the release notes  | No       | -             |
+| downloadedSbomPath | Path to the directory holding previously downloaded SBOMs to be updated. | No       | -             |
+
+## Changes in 0.1.1
+- (ISV-5321) Set a `name` of SPDX document to external reference of the component. The name is set to external image pullspec given by the public registry + repository + digest. Example: registry.redhat.io/ubi8/ubi-minimal@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.

--- a/tasks/update-component-sbom/tests/test-update-component-sbom-basic.yaml
+++ b/tasks/update-component-sbom/tests/test-update-component-sbom-basic.yaml
@@ -31,11 +31,11 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+            image: quay.io/konflux-ci/release-service-utils:e15023773e138c7d3449f288c8c16de4e3a8d249
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
               if [ "$(wc -l < "$(workspaces.data.path)/mock_update.txt")" != 1 ]; then
                 echo Error: update_component_sbom was expected to be called 1 time. Actual calls:
                 cat "$(workspaces.data.path)/mock_update.txt"

--- a/tasks/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/update-component-sbom/update-component-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-component-sbom
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,13 +24,13 @@ spec:
       description: The workspace where the SBOM files reside.
   steps:
     - name: update-component-sbom-purls
-      image: quay.io/konflux-ci/release-service-utils:221d71a4f6b1a50b36b685aa20d86d7df9de33fc
+      image: quay.io/konflux-ci/release-service-utils:e15023773e138c7d3449f288c8c16de4e3a8d249
       script: |
         #!/usr/bin/env bash
         set -eux
-        
+
         INPUT_PATH="$(workspaces.data.path)/$(params.downloadedSbomPath)"
-        
+
         #update the SBOM files in place
         update_component_sbom \
           --data-path "$(workspaces.data.path)/$(params.dataJsonPath)" \


### PR DESCRIPTION
The update-component-sbom task has been updated with newer script which sets a name of SPDX document for release time components. The name is set to external image pullspec and it is visible in the Atlas UI.

JIRA: [ISV-5321](https://issues.redhat.com//browse/ISV-5321)