### PR TITLE
feat(RELEASE-400): adds check-data-keys task in release pipeline

### DIFF
--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -19,6 +19,8 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.1.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
 
 ## Changes in 4.0.4
 * The `sign-index-image` task now receives new mandatory parameter `releasePlanAdmissionPath`

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.0.4"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -122,6 +122,30 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - fbc
+            - sign
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: validate-single-component
       taskRef:
         resolver: "git"

--- a/pipelines/managed/push-binaries-to-dev-portal/README.md
+++ b/pipelines/managed/push-binaries-to-dev-portal/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to sign and release Red Hat binaries to the Red Hat Developer Po
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
 
+## Changes in 1.5.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 1.4.0
 * Use results from `sign-binaries` task for `push-to-cdn` and `publish-to-cgw` instead of `extract-binaries-from-image`
 

--- a/pipelines/managed/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/managed/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-binaries-to-dev-portal
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,30 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - cdn
+            - contentGateway
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/pipelines/managed/push-disk-images-to-cdn/README.md
+++ b/pipelines/managed/push-disk-images-to-cdn/README.md
@@ -20,6 +20,9 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -               |
 
+## Changes in 1.3.0
+* Add new parameter `schema` to the `check-data-keys` task.
+
 ## Changes in 1.2.0
 * The `push-disk-images` task now gets the `resultsDir` parameter from `collect-data` results
 * Add the task `update-cr-status` at the end of the pipeline to save all pipeline results

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -191,6 +191,8 @@ spec:
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
           value:
             - cdn
@@ -207,7 +209,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - verify-enterprise-contract
+        - collect-data
     - name: push-disk-images
       timeout: "2h00m0s"
       when:

--- a/pipelines/managed/push-to-addons-registry/README.md
+++ b/pipelines/managed/push-to-addons-registry/README.md
@@ -19,5 +19,8 @@ Tekton pipeline to release a single FBC component to the Addons Registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 0.1.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 0.0.1
 * Initially forked from push-to-external-registry v5.2.1

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-addons-registry
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,29 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - mapping
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/pipelines/managed/push-to-external-registry/README.md
+++ b/pipelines/managed/push-to-external-registry/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
 
+
+## Changes in 5.3.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 5.2.1
 * Add retries for some tasks
 

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.2.1"
+    app.kubernetes.io/version: "5.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,29 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - mapping
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/pipelines/managed/release-to-github/README.md
+++ b/pipelines/managed/release-to-github/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl                | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision           | The revision in the taskGitUrl repo to be used                        | No        | -            |
 
+## Changes in 4.1.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 4.0.0
 * Drop the `enterpriseContractPublicKey` param. The verify task will take the value from the policy.
 

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -110,6 +110,30 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - github
+            - sign
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: validate-single-component
       taskRef:
         resolver: "git"

--- a/pipelines/managed/release-to-mrrc/README.md
+++ b/pipelines/managed/release-to-mrrc/README.md
@@ -18,3 +18,7 @@ Tekton release pipeline to release maven artifacts extracted from the maven repo
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                                          | No       | -                                                         |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | Yes      | production                                                |
+
+
+## Changes in 0.2.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-mrrc
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -107,6 +107,29 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - mrrc
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: verify-enterprise-contract
       taskRef:
         resolver: "bundles"

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.6.0
+* Add new parameter `schema` to the `check-data-keys` task. 
+* Add new systems pyxis,mapping & signing to the task.
+
 ## Changes in 1.5.7
 * new mandatory parameter `dataPath` added to `create-pyxis-image` task
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.5.7"
+    app.kubernetes.io/version: "1.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -511,9 +511,14 @@ spec:
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
           value:
             - releaseNotes
+            - pyxis
+            - mapping
+            - sign
       taskRef:
         params:
           - name: url

--- a/pipelines/managed/rh-push-to-external-registry/README.md
+++ b/pipelines/managed/rh-push-to-external-registry/README.md
@@ -19,6 +19,10 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                       | No        | -            |
 
+
+## Changes in 5.4.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 5.3.3
 * new mandatory parameter `dataPath` added to `create-pyxis-image` task
 

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.3.3"
+    app.kubernetes.io/version: "5.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,30 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - pyxis
+            - mapping
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.6.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 4.5.6
 * new mandatory parameter `dataPath` added to `create-pyxis-image` task
 

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.5.6"
+    app.kubernetes.io/version: "4.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -113,6 +113,31 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - pyxis
+            - mapping
+            - sign
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/pipelines/managed/rhtap-service-push/README.md
+++ b/pipelines/managed/rhtap-service-push/README.md
@@ -21,6 +21,9 @@
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored   | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                          | No       | -             |
 
+## Changes in 4.3.0
+* Add the `check-data-keys` task to validate the `data.json` file using the JSON schema.
+
 ## Changes in 4.2.1
 * new mandatory parameter `dataPath` added to `create-pyxis-image` task
 

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "4.2.1"
+    app.kubernetes.io/version: "4.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,30 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-access-to-resources
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: 
+            - mapping
+            - pyxis
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/check-data-keys/check-data-keys.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-data
     - name: reduce-snapshot
       taskRef:
         resolver: "git"

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -6,7 +6,17 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["releaseNotes", "cdn"],
+        "enum": [
+          "releaseNotes",
+          "cdn",
+          "fbc",
+          "sign",
+          "mrrc",
+          "github",
+          "contentGateway",
+          "pyxis",
+          "mapping"
+        ],
         "description": "List of systems that are supported to be required in the data"
       }
     },
@@ -49,8 +59,7 @@
         },
         "productName": {
           "type": "string",
-          "description": "The product name e.g. exampleproduct ",
-          "pattern": "^[a-z]+$"
+          "description": "The product name e.g. exampleproduct"
         },
         "productVersion": {
           "type": "string",
@@ -426,7 +435,6 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "additionalProperties": false,
                       "properties": {
                         "name": {
                           "type": "string",
@@ -577,9 +585,7 @@
         }
       },
       "then": {
-        "required": [
-          "releaseNotes"
-        ],
+        "required": ["releaseNotes"],
         "properties": {
           "releaseNotes": {
             "required": [
@@ -597,9 +603,7 @@
             ],
             "properties": {
               "content": {
-                "required": [
-                  "images"
-                ]
+                "required": ["images"]
               }
             }
           }
@@ -617,14 +621,256 @@
         }
       },
       "then": {
-        "required": [
-          "cdn"
-        ],
+        "required": ["cdn"],
         "properties": {
           "cdn": {
+            "required": ["env"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "fbc"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["fbc"],
+        "properties": {
+          "fbc": {
             "required": [
-              "env"
+              "fromIndex",
+              "publishingCredentials",
+              "allowedPackages"
             ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "fbc"
+            }
+          },
+          "fbc": {
+            "properties": {
+              "preGA": {
+                "enum": [true]
+              }
+            },
+            "required": ["preGA"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": ["targetIndex", "productName", "productVersion"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "fbc"
+            }
+          },
+          "fbc": {
+            "properties": {
+              "hotfix": {
+                "enum": [true]
+              }
+            },
+            "required": ["hotfix"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": ["targetIndex", "issueId"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "fbc"
+            }
+          },
+          "fbc": {
+            "properties": {
+              "stagedIndex": {
+                "not": {
+                  "enum": [true]
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fbc": {
+            "required": ["targetIndex"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "sign"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["sign"],
+        "properties": {
+          "sign": {
+            "required": ["configMapName"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "mrrc"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["mrrc"],
+        "properties": {
+          "mrrc": {
+            "required": ["environment", "release", "awsSecret", "charonConfig"]
+          },
+          "releaseNotes": {
+            "required": ["product_name", "product_version"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "github"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["github"],
+        "properties": {
+          "github": {
+            "required": ["githubSecret"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "contentGateway"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "items": {
+                  "properties": {
+                    "contentGateway": {
+                      "required": [
+                        "productName",
+                        "productCode",
+                        "productVersionName",
+                        "mirrorOpenshiftPush",
+                        "components"
+                      ],
+                      "properties": {
+                        "components": {
+                          "items": {
+                            "required": ["name", "description"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "pyxis"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["pyxis"],
+        "properties": {
+          "pyxis": {
+            "required": ["server", "secret"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "mapping"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "items": {
+                  "required": ["name", "repository"]
+                }
+              }
+            }
           }
         }
       }

--- a/tasks/check-data-keys/README.md
+++ b/tasks/check-data-keys/README.md
@@ -13,7 +13,11 @@ Currently, `releaseNotes`, and `cdn` are the only supported systems.
 |----------|---------------------------------------------------------|----------|---------------|
 | dataPath | Path to the JSON string of the merged data to use       | No       |               |
 | systems  | The systems to check that all data keys are present for | Yes      | []            |
-| schema   | The URl to the schema                                   | Yes      | https://github.com/konflux-ci/release-service-catalog/blob/production/schema/dataKeys.json |
+| schema   | The URl to the schema                                   | Yes      | https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/development/schema/dataKeys.json |
+
+## Changes in 1.0.1
+* Add `-L` option to curl command to follow redirects for schema download.
+* Fixes README.md `schema` parameter description.
 
 ## Changes in 1.0.0
 * Replacing the check with a schema validator

--- a/tasks/check-data-keys/check-data-keys.yaml
+++ b/tasks/check-data-keys/check-data-keys.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-data-keys
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
             exit 1
         fi
 
-        if ! curl -s --fail-with-body "$(params.schema)" -o /tmp/schema ; then
+        if ! curl -sL --fail-with-body "$(params.schema)" -o /tmp/schema ; then
             echo "Failed to download schema file: $(params.schema)"
             exit 1
         fi


### PR DESCRIPTION
This commit adds the check-data-keys task into the release pipelines to ensure validation of required data keys.
[Link](https://issues.redhat.com/browse/RELEASE-400)