### PR TITLE
chore(RELEASE-1191): add simple-signing-pipeline to internal clusters

### DIFF
--- a/internal/resources/collect-simple-signing-params.yaml
+++ b/internal/resources/collect-simple-signing-params.yaml
@@ -1,0 +1,1 @@
+../../tasks/collect-simple-signing-params/collect-simple-signing-params.yaml

--- a/internal/resources/simple-signing-pipeline.yaml
+++ b/internal/resources/simple-signing-pipeline.yaml
@@ -1,0 +1,1 @@
+../../pipelines/simple-signing-pipeline/simple-signing-pipeline.yaml

--- a/tasks/collect-simple-signing-params/README.md
+++ b/tasks/collect-simple-signing-params/README.md
@@ -6,5 +6,4 @@ Task to collect parameters for the simple signing pipeline
 
 | Name             | Description                                                                           | Optional | Default value                                          |
 |------------------|---------------------------------------------------------------------------------------|----------|--------------------------------------------------------|
-| pipeline_image   | An image of operator-pipeline-images for the steps to run in.                         | Yes      | quay.io/redhat-isv/operator-pipelines-images:released  |
 | config_map_name  | Name of a configmap with pipeline configuration                                       | No       | -                                                      |


### PR DESCRIPTION
This commit adds the simple-signing-pipeline and its
collect-simple-signing-params task to the `internal/resources` dir so
they will be on the internal clusters.