### PR TITLE
refactor(RELEASE-1191): use simple-signing-pipeline for irs

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.0.3
+* The `sign-index-image` task now receives new mandatory parameters `taskGitUrl` and `taskGitRevision
+
 ## Changes in 4.0.2
 * Drop the `binaryImage` param from the task `add-fbc-contribution-to-index-image`, so IIB can auto resolve it.
 

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.0.2"
+    app.kubernetes.io/version: "4.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -308,6 +308,10 @@ spec:
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       when:
         - input: "$(tasks.add-fbc-contribution-to-index-image.results.mustSignIndexImage)"
           operator: in

--- a/tasks/rh-sign-image/README.md
+++ b/tasks/rh-sign-image/README.md
@@ -20,6 +20,10 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | signRegistryAccessPath   | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 
 
+## Changes in 5.0.1
+* The default for `sign.request` is now always `simple-signing-pipeline` instead of being `hacbs-signing-pipeline`
+  if using InternalRequests
+
 ## Changes in 5.0.0
 * Added mandatory parameter `signRegistryAccessPath`.
   * The relative path in the workspace to a text file that contains a list of repositories

--- a/tasks/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -114,7 +114,6 @@ spec:
         service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
         if [ "${REQUESTTYPE}" == "internal-pipelinerun" ] ; then
           requestType=internal-pipelinerun
-          defaultRequest="simple-signing-pipeline"
           EXTRA_ARGS=(
           --task-git-url "$(params.taskGitUrl)"
           --task-git-revision "$(params.taskGitRevision)"
@@ -122,10 +121,9 @@ spec:
           )
         else
           requestType=internal-request
-          defaultRequest="hacbs-signing-pipeline"
           EXTRA_ARGS=()
         fi
-        request=$(jq --arg defaultRequest "${defaultRequest}" -r '.sign.request // $defaultRequest' "${DATA_FILE}")
+        request=$(jq -r '.sign.request // "simple-signing-pipeline"' "${DATA_FILE}")
 
         default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
 

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -46,7 +46,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -66,7 +66,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -91,7 +91,6 @@ spec:
                   }
                 },
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -44,7 +44,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -54,7 +54,6 @@ spec:
                   }
                 },
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -50,7 +50,6 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -12,6 +12,8 @@ Creates an InternalRequest to sign an index image
 | requester            | Name of the user that requested the signing, for auditing purposes                        | No       | -                      |
 | requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
 | pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                      |
+| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                      |
+| taskGitRevision      | The revision in the taskGitUrl repo to be used                                            | No       | -                      |
 
 ## Signing data parameters
 
@@ -25,6 +27,11 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 4.0.0
+* Added new task parameters `taskGitRevision` and `taskGitUrl`
+  * These are passed to the InternalRequest as they are required parameters of the `simple-signing-pipeline`
+* The default for `sign.request` is now `simple-signing-pipeline` instead of being `hacbs-signing-pipeline`
 
 ## Changes in 3.4.0
 * Removed the `request` parameter and references of `fbc.request` from the task and set the default

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "3.4.0"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,6 +31,16 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: |
+        The url to the git repo where the release-service-catalog tasks to be used are stored. This is passed to
+        the InternalRequest as it is needed by the simple-signing-pipeline
+    - name: taskGitRevision
+      type: string
+      description: |
+        The revision in the taskGitUrl repo to be used. This is passed to the InternalRequest as it is needed by the
+        simple-signing-pipeline
   workspaces:
     - name: data
       description: workspace to read and save files
@@ -48,7 +58,7 @@ spec:
             exit 1
         fi
 
-        request=$(jq -r '.sign.request // "hacbs-signing-pipeline"' "${DATA_FILE}")
+        request=$(jq -r '.sign.request // "simple-signing-pipeline"' "${DATA_FILE}")
         default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
         pipeline_image=$(jq -r --arg default_pipeline_image "${default_pipeline_image}" \
             '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
@@ -75,6 +85,8 @@ spec:
               -p manifest_digest="${manifest_digest}" \
               -p requester="$(params.requester)" \
               -p config_map_name="${config_map_name}" \
+              -p taskGitUrl="$(params.taskGitUrl)" \
+              -p taskGitRevision="$(params.taskGitRevision)" \
               -t "$(params.requestTimeout)" \
               -l "${pipelinerun_label}"="$(params.pipelineRunUid)"
           echo "done"

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -25,7 +25,6 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }
@@ -42,6 +41,10 @@ spec:
           value: "sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
         - name: dataPath
           value: data.json
       workspaces:

--- a/tasks/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image.yaml
@@ -25,7 +25,6 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "sign": {
-                  "request": "hacbs-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }
@@ -42,6 +41,10 @@ spec:
           value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
         - name: dataPath
           value: data.json
       workspaces:


### PR DESCRIPTION
This commit modifies the signing tasks that create InternalRequests. It changes them to use `simple-signing-pipeline` instead of `hacbs-signing-pipeline`. The former is our copy of the latter. This gives us more control over the pipeline.