### PR TITLE
fix(RELEASE-1310): add update-cr-status to push-disk-images

### DIFF
--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -223,8 +223,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/push-disk-images/push-disk-images.yaml
-          - name: resultsDirPath
-            value: "$(tasks.collect-data.results.resultsDir)"
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -232,6 +230,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
this commit moves the parameter outside the task section. this will resolve errors that currently happen:
```
[User error] Validation failed for pipelinerun managed-wrb8t with error invalid input params for task push-disk-images: missing values for these params which have no default values: [resultsDirPath]
```
this issue was introduced in #717

example: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/rhtap-releng/applications/amd-bootc-1-3-raw-disk-image/pipelineruns/managed-wrb8t/logs

related to: https://issues.redhat.com/browse/RELEASE-1310
