### PR TITLE
fix(KFLUXSPRT-794): pass content-gateway token as env var

### DIFF
--- a/tasks/publish-to-cgw/README.md
+++ b/tasks/publish-to-cgw/README.md
@@ -16,6 +16,9 @@ Tekton task to publish content to Red Hat's Developer portal using pubtools-cont
 | cgwHostname | The hostname of the content-gateway to publish the metadata to  | yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret   | The kubernetes secret to use to authenticate to content-gateway | yes      | publish-to-cgw-secret |
 
+## Changes in 0.2.6
+* Invoke Content Gateway without password in command
+
 ## Changes in 0.2.5
 * Support pushes to mirror.openshift.com (ShortUrl)
 

--- a/tasks/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/publish-to-cgw/publish-to-cgw.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-cgw
   labels:
-    app.kubernetes.io/version: "0.2.5"
+    app.kubernetes.io/version: "0.2.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,7 +47,7 @@ spec:
             secretKeyRef:
               name: $(params.cgwSecret)
               key: username
-        - name: CGW_TOKEN
+        - name: CGW_PASSWORD
           valueFrom:
             secretKeyRef:
               name: $(params.cgwSecret)
@@ -183,11 +183,11 @@ spec:
             yaml.dump(metadata, file, default_flow_style=False, sort_keys=False)
 
         print(f"YAML content dumped to {METADATA_FILE_PATH}")
+
         command = [
             'push-cgw-metadata',
             '--CGW_hostname', '$(params.cgwHostname)',
             '--CGW_username', '${CGW_USERNAME}',
-            '--CGW_password', '${CGW_TOKEN}',
             '--CGW_filepath', METADATA_FILE_PATH
         ]
 


### PR DESCRIPTION
- Change name of CGW_TOKEN to CGW_PASSWORD
  - This is actually a token, not pw, but the pubtools library expects this environment variable name
- No longer pass token with command invocation
- Relevant PR to pubtools: https://github.com/release-engineering/pubtools-content-gateway/pull/38/