### PR TITLE
fix: check for existing github releases

### DIFF
--- a/tasks/create-github-release/README.md
+++ b/tasks/create-github-release/README.md
@@ -15,8 +15,13 @@ a `release` dir.
 | content_directory | The directory inside the workspace to find files for release      | No       | -             |
 | resultsDirPath    | Path to results directory in the data workspace                   | No       | -             |
 
+## Changes in 2.2.1
+* Fix check for existing release
+  * The grep was inadequate, because it would also match for substrings. Now we'll
+    use github api and check the string directly
+
 ## Changes in 2.2.0
-* make task idempotent
+* Make task idempotent
 
 ## Changes in 2.1.1
 * Fixed shellcheck linting issues

--- a/tasks/create-github-release/create-github-release.yaml
+++ b/tasks/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,15 +42,17 @@ spec:
         set -ex
 
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-github-release-results.json"
-        
+
         cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
         set -o pipefail
         shopt -s failglob
 
-        if gh release list --repo "$REPOSITORY" | grep -q "$RELEASE_VERSION"; then
+        OWNER_REPO=${REPOSITORY#https://github.com/}
+        RELEASE="$(gh api "repos/${OWNER_REPO}/releases" --jq ".[] | select(.tag_name == \"v${RELEASE_VERSION}\")")"
+        if [ -n "$RELEASE" ]; then
           echo "Release v${RELEASE_VERSION} exists"
-          echo "https://github.com/$REPOSITORY/releases/tag/v${RELEASE_VERSION}" > "$(results.url.path)"
-        else 
+          echo "$REPOSITORY/releases/tag/v${RELEASE_VERSION}" > "$(results.url.path)"
+        else
           gh release create "v${RELEASE_VERSION}" ./*.zip ./*.json ./*SHA256SUMS ./*.sig \
           --repo "$REPOSITORY" --title "Release $RELEASE_VERSION" | tee "$(results.url.path)"
         fi

--- a/tasks/create-github-release/tests/mocks.sh
+++ b/tasks/create-github-release/tests/mocks.sh
@@ -4,14 +4,14 @@ set -eux
 # mocks to be injected into task step scripts
 
 function gh() {
-  echo "Mock gh called with: $*"
+  echo "Mock gh called with: $*" >&2
   echo "$*" >> $(workspaces.data.path)/mock_gh.txt
-  if [[ "$*" == "release list --repo foo/repo_with_release" ]]; then
-    echo "v1.2.3"
+  if [[ "$*" == "api repos/foo/repo_with_release/releases"* ]]; then
+    echo "{"repodata": "lotsofdata"}"
     exit 0
   elif
-    [[ "$*" == "release create v1.2.3 ./foo.zip ./foo.json ./foo_SHA256SUMS ./foo_SHA256SUMS.sig --repo foo/bar --title Release 1.2.3" ]] || \
-    [[ "$*" == "release list --repo foo/bar" ]]; then
+    [[ "$*" == "release create v1.2.3 ./foo.zip ./foo.json ./foo_SHA256SUMS ./foo_SHA256SUMS.sig --repo https://github.com/foo/bar --title Release 1.2.3" ]] || \
+    [[ "$*" == "api repos/foo/bar/releases"* ]]; then
     exit 0
   else
     echo Error: Unexpected call

--- a/tasks/create-github-release/tests/test-create-github-exist-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-exist-release.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-create-github-exist-release
 spec:
   description: |
-    Run the create-github-release task to create an existing release. 
+    Run the create-github-release task to create an existing release.
     It will not be recreated.
   workspaces:
     - name: tests-workspace
@@ -39,7 +39,7 @@ spec:
         - name: githubSecret
           value: test-create-github-release-token
         - name: repository
-          value: foo/repo_with_release
+          value: https://github.com/foo/repo_with_release
         - name: release_version
           value: 1.2.3
         - name: content_directory

--- a/tasks/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/create-github-release/tests/test-create-github-release.yaml
@@ -38,7 +38,7 @@ spec:
         - name: githubSecret
           value: test-create-github-release-token
         - name: repository
-          value: foo/bar
+          value: https://github.com/foo/bar
         - name: release_version
           value: 1.2.3
         - name: content_directory


### PR DESCRIPTION
It would print https://githu.com/https://github.com/...

That's because the $REPOSITORY variable has the full repo url, so there's no need to add it again.