### PR TITLE
fix(RELEASE-1339): no longer consult .sign.request

### DIFF
--- a/tasks/sign-base64-blob/README.md
+++ b/tasks/sign-base64-blob/README.md
@@ -7,7 +7,6 @@ Creates an InternalRequest to sign a base64 encoded blob
 | Name                 | Description                                                                               | Optional | Default value         |
 |----------------------|-------------------------------------------------------------------------------------------|----------|-----------------------|
 | dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                     |
-| request              | Signing pipeline name to handle this request                                              | Yes      | blob-signing-pipeline |
 | referenceImage       | The image to be signed                                                                    | No       | -                     |
 | manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                    |
 | requester            | Name of the user that requested the signing, for auditing purposes                        | No       | -                     |
@@ -22,10 +21,12 @@ Creates an InternalRequest to sign a base64 encoded blob
 ```
 data:
     sign:
-        request: <signing pipeline name>
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 2.4.0
+* No longer examine `.data.sign.request` to obtain the Signing pipeline name. Use the default - blob-signing-pipeline
 
 ## Changes in 2.3.0
 * Updated the base image used in this task

--- a/tasks/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.3.0"
+    app.kubernetes.io/version: "2.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -15,10 +15,6 @@ spec:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-    - name: request
-      type: string
-      description: Signing pipeline name to handle this request
-      default: "blob-signing-pipeline"
     - name: blob
       type: string
       description: The base64 encoded blob to be signed.
@@ -54,7 +50,6 @@ spec:
             exit 1
         fi
 
-        request=$(jq -r '.sign.request // "$(params.request)"' ${DATA_FILE})
         default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3"
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' ${DATA_FILE})
@@ -65,7 +60,7 @@ spec:
         echo "- blob=$(params.blob)"
         echo "- requester=$(params.requester)"
 
-        internal-request -r "${request}" \
+        internal-request -r "blob-signing-pipeline" \
             -p pipeline_image=${pipeline_image} \
             -p blob=$(params.blob) \
             -p requester=$(params.requester) \

--- a/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -25,7 +25,6 @@ spec:
               cat > $(workspaces.data.path)/data.json << EOF
               {
                 "sign": {
-                  "request": "blob-signing-pipeline",
                   "configMapName": "signing-config-map"
                 }
               }


### PR DESCRIPTION
## Describe your changes
- use the sign-base64-blob task default for the request pipeline name

## Relevant Jira
- [RELEASE-1339](https://issues.redhat.com//browse/RELEASE-1339)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

