### PR TITLE
feat(RELEASE-1191): diferentiate pyxis and umb in signing part1

### DIFF
--- a/pipelines/simple-signing-pipeline/README.md
+++ b/pipelines/simple-signing-pipeline/README.md
@@ -13,3 +13,11 @@ Tekton pipeline for simple signing. It is meant to be used by the rh-sign-image 
 | config_map_name | A config map name with configuration                                                                   | Yes      | hacbs-signing-pipeline-config                             |
 | taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
+
+## Changes in 0.2.0
+* Changed the results used as parameters to `request-and-upload-signature`
+  * Instead of using the same results for both the Pyxis and UMB SSL authentication, the two were split into
+    their own keys. The `request-and-upload-signature` task already had separate parameters for them, but
+    they were using the same values
+    * While it did have separate parameters for them, one set was prefixed `pyxis_` and the other had no
+      prefix, so the prefix was added for the `umb_` ones

--- a/pipelines/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: simple-signing-pipeline
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -77,12 +77,12 @@ spec:
           value: $(tasks.collect-simple-signing-params.results.sig_key_id)
         - name: sig_key_name
           value: $(tasks.collect-simple-signing-params.results.sig_key_name)
-        - name: ssl_cert_secret_name
-          value: $(tasks.collect-simple-signing-params.results.ssl_cert_secret_name)
-        - name: ssl_cert_file_name
-          value: $(tasks.collect-simple-signing-params.results.ssl_cert_file_name)
-        - name: ssl_key_file_name
-          value: $(tasks.collect-simple-signing-params.results.ssl_key_file_name)
+        - name: umb_ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_secret_name)
+        - name: umb_ssl_cert_file_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_file_name)
+        - name: umb_ssl_key_file_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_key_file_name)
         - name: umb_client_name
           value: $(tasks.collect-simple-signing-params.results.umb_client_name)
         - name: umb_listen_topic
@@ -91,12 +91,12 @@ spec:
           value: $(tasks.collect-simple-signing-params.results.umb_publish_topic)
         - name: umb_url
           value: $(tasks.collect-simple-signing-params.results.umb_url)
-        - name: pyxis_ssl_secret_name
-          value: $(tasks.collect-simple-signing-params.results.ssl_cert_secret_name)
-        - name: pyxis_ssl_cert_secret_key
-          value: $(tasks.collect-simple-signing-params.results.ssl_cert_file_name)
-        - name: pyxis_ssl_key_secret_key
-          value: $(tasks.collect-simple-signing-params.results.ssl_key_file_name)
+        - name: pyxis_ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_cert_secret_name)
+        - name: pyxis_ssl_cert_file_name
+          value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_cert_file_name)
+        - name: pyxis_ssl_key_file_name
+          value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_key_file_name)
         - name: pyxis_url
           value: $(tasks.collect-simple-signing-params.results.pyxis_url)
         - name: taskGitUrl

--- a/tasks/collect-simple-signing-params/README.md
+++ b/tasks/collect-simple-signing-params/README.md
@@ -7,3 +7,13 @@ Task to collect parameters for the simple signing pipeline
 | Name             | Description                                                                           | Optional | Default value                                          |
 |------------------|---------------------------------------------------------------------------------------|----------|--------------------------------------------------------|
 | config_map_name  | Name of a configmap with pipeline configuration                                       | No       | -                                                      |
+
+## Changes in 0.2.0
+* Added the `[pyxis,umb]_ssl_cert_file_name`, `[pyxis,umb]_ssl_cert_secret_name` and `[pyxis,umb]_ssl_key_file_name`
+  results
+  * These keys now exist in the configMaps used in this task
+  * They were added to break apart Pyxis and UMB credentials
+  * They take the place of `ssl_cert_file_name`, `ssl_cert_secret_name` and `ssl_key_file_name` respectively, but
+    the old parameters can not be removed yet as the `simple-signing-pipeline` used in E2E will be the one on the stage
+    cluster, not the one from this PR. So, because the current `simple-signing-pipeline` relies on these results, they
+    have to wait for the next PR to be removed

--- a/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-simple-signing-params
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/tags: release
 spec:
@@ -32,6 +32,18 @@ spec:
       description: SSL certificate file name
     - name: ssl_key_file_name
       description: SSL key file name
+    - name: pyxis_ssl_cert_secret_name
+      description: Pyxis SSL secret name
+    - name: pyxis_ssl_cert_file_name
+      description: Pyxis SSL certificate file name
+    - name: pyxis_ssl_key_file_name
+      description: Pyxis SSL key file name
+    - name: umb_ssl_cert_secret_name
+      description: UMB SSL secret name
+    - name: umb_ssl_cert_file_name
+      description: UMB SSL certificate file name
+    - name: umb_ssl_key_file_name
+      description: UMB SSL key file name
   steps:
     - name: collect-simple-signing-params
       image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
@@ -49,10 +61,16 @@ spec:
         SSL_CERT_FILE_NAME=$(jq -er '.data.SSL_CERT_FILE_NAME' <<< "${configMapJson}")
         SSL_CERT_SECRET_NAME=$(jq -er '.data.SSL_CERT_SECRET_NAME' <<< "${configMapJson}")
         SSL_KEY_FILE_NAME=$(jq -er '.data.SSL_KEY_FILE_NAME' <<< "${configMapJson}")
+        PYXIS_SSL_CERT_FILE_NAME=$(jq -er '.data.PYXIS_SSL_CERT_FILE_NAME' <<< "${configMapJson}")
+        PYXIS_SSL_CERT_SECRET_NAME=$(jq -er '.data.PYXIS_SSL_CERT_SECRET_NAME' <<< "${configMapJson}")
+        PYXIS_SSL_KEY_FILE_NAME=$(jq -er '.data.PYXIS_SSL_KEY_FILE_NAME' <<< "${configMapJson}")
         UMB_CLIENT_NAME=$(jq -er '.data.UMB_CLIENT_NAME' <<< "${configMapJson}")
         UMB_LISTEN_TOPIC=$(jq -er '.data.UMB_LISTEN_TOPIC' <<< "${configMapJson}")
         UMB_PUBLISH_TOPIC=$(jq -er '.data.UMB_PUBLISH_TOPIC' <<< "${configMapJson}")
         UMB_URL=$(jq -er '.data.UMB_URL' <<< "${configMapJson}")
+        UMB_SSL_CERT_FILE_NAME=$(jq -er '.data.UMB_SSL_CERT_FILE_NAME' <<< "${configMapJson}")
+        UMB_SSL_CERT_SECRET_NAME=$(jq -er '.data.UMB_SSL_CERT_SECRET_NAME' <<< "${configMapJson}")
+        UMB_SSL_KEY_FILE_NAME=$(jq -er '.data.UMB_SSL_KEY_FILE_NAME' <<< "${configMapJson}")
 
         echo -n "$PYXIS_URL" | tee "$(results.pyxis_url.path)"
         echo -n "$SIG_KEY_ID" | tee "$(results.sig_key_id.path)"
@@ -60,7 +78,13 @@ spec:
         echo -n "$SSL_CERT_FILE_NAME" | tee "$(results.ssl_cert_file_name.path)"
         echo -n "$SSL_CERT_SECRET_NAME" | tee "$(results.ssl_cert_secret_name.path)"
         echo -n "$SSL_KEY_FILE_NAME" | tee "$(results.ssl_key_file_name.path)"
+        echo -n "$PYXIS_SSL_CERT_FILE_NAME" | tee "$(results.pyxis_ssl_cert_file_name.path)"
+        echo -n "$PYXIS_SSL_CERT_SECRET_NAME" | tee "$(results.pyxis_ssl_cert_secret_name.path)"
+        echo -n "$PYXIS_SSL_KEY_FILE_NAME" | tee "$(results.pyxis_ssl_key_file_name.path)"
         echo -n "$UMB_CLIENT_NAME" | tee "$(results.umb_client_name.path)"
         echo -n "$UMB_LISTEN_TOPIC" | tee "$(results.umb_listen_topic.path)"
         echo -n "$UMB_PUBLISH_TOPIC" | tee "$(results.umb_publish_topic.path)"
         echo -n "$UMB_URL" | tee "$(results.umb_url.path)"
+        echo -n "$UMB_SSL_CERT_FILE_NAME" | tee "$(results.umb_ssl_cert_file_name.path)"
+        echo -n "$UMB_SSL_CERT_SECRET_NAME" | tee "$(results.umb_ssl_cert_secret_name.path)"
+        echo -n "$UMB_SSL_KEY_FILE_NAME" | tee "$(results.umb_ssl_key_file_name.path)"

--- a/tasks/collect-simple-signing-params/tests/pre-apply-task-hook.sh
+++ b/tasks/collect-simple-signing-params/tests/pre-apply-task-hook.sh
@@ -17,10 +17,16 @@ cat > "/tmp/configMap.json" << EOF
         "SSL_CERT_FILE_NAME": "hacbs-signing-pipeline.pem",
         "SSL_CERT_SECRET_NAME": "hacbs-signing-pipeline-certs",
         "SSL_KEY_FILE_NAME": "hacbs-signing-pipeline.key",
+        "PYXIS_SSL_CERT_FILE_NAME": "hacbs-signing-pipeline.pem",
+        "PYXIS_SSL_CERT_SECRET_NAME": "hacbs-signing-pipeline-certs",
+        "PYXIS_SSL_KEY_FILE_NAME": "hacbs-signing-pipeline.key",
         "UMB_CLIENT_NAME": "hacbs-signing-pipeline-nonprod",
         "UMB_LISTEN_TOPIC": "VirtualTopic.eng.robosignatory.hacbs.sign",
         "UMB_PUBLISH_TOPIC": "VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign",
-        "UMB_URL": "umb.stage.api.redhat.com"
+        "UMB_URL": "umb.stage.api.redhat.com",
+        "UMB_SSL_CERT_FILE_NAME": "hacbs-signing-pipeline.pem",
+        "UMB_SSL_CERT_SECRET_NAME": "hacbs-signing-pipeline-certs",
+        "UMB_SSL_KEY_FILE_NAME": "hacbs-signing-pipeline.key"
     },
     "kind": "ConfigMap",
     "metadata": {


### PR DESCRIPTION
This commit modifies the `simple-signing-pipeline` and its tasks to use separate credentials for Pyxis and UMB authentication. Prior to this commit, both were pulled from the same configMap values so it was impossible to use stage for one system and prod for the other.

Because e2e uses the `simple-signing-pipeline` on the stage sre cluster vs a git resolver (for now), the `request-and-upload-signature` changes can't be part of this commit, nor can the older parameters be removed from the `simple-signing-pipeline` just yet.