### PR TITLE
feat(RELEASE-1342): support internal-pipelinerun in sign-index-image

### DIFF
--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -19,8 +19,12 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+
+## Changes in 4.0.4
+* The `sign-index-image` task now receives new mandatory parameter `releasePlanAdmissionPath`
+
 ## Changes in 4.0.3
-* The `sign-index-image` task now receives new mandatory parameters `taskGitUrl` and `taskGitRevision
+* The `sign-index-image` task now receives new mandatory parameters `taskGitUrl` and `taskGitRevision`
 
 ## Changes in 4.0.2
 * Drop the `binaryImage` param from the task `add-fbc-contribution-to-index-image`, so IIB can auto resolve it.

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.0.3"
+    app.kubernetes.io/version: "4.0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -300,6 +300,8 @@ spec:
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: referenceImage
           value: $(tasks.add-fbc-contribution-to-index-image.results.requestTargetIndex)
         - name: manifestListDigests

--- a/tasks/sign-index-image/README.md
+++ b/tasks/sign-index-image/README.md
@@ -4,16 +4,17 @@ Creates an InternalRequest to sign an index image
 
 ## Parameters
 
-| Name                 | Description                                                                               | Optional | Default value          |
-|----------------------|-------------------------------------------------------------------------------------------|----------|------------------------|
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                      |
-| referenceImage       | The image to be signed                                                                    | No       | -                      |
-| manifestListDigests  | The manifest digests for each arch in manifest list                                       | No       | -                      |
-| requester            | Name of the user that requested the signing, for auditing purposes                        | No       | -                      |
-| requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                    |
-| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                      |
-| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                      |
-| taskGitRevision      | The revision in the taskGitUrl repo to be used                                            | No       | -                      |
+| Name                     | Description                                                                               | Optional | Default value  |
+|--------------------------|-------------------------------------------------------------------------------------------|----------|----------------|
+| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                   | No       | -              |
+| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -              | 
+| referenceImage           | The image to be signed                                                                    | No       | -              |
+| manifestListDigests      | The manifest digests for each arch in manifest list                                       | No       | -              |
+| requester                | Name of the user that requested the signing, for auditing purposes                        | No       | -              |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180            |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -              |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -              |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -              |
 
 ## Signing data parameters
 
@@ -27,6 +28,12 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 4.1.0
+* Updated task to support the `internal-pipelinerun` requestType
+* New mandatory parameter `releasePlanAdmissionPath`
+  * It is needed in order to obtain the serviceAccount so it can be used in the PipelineRun definition for the
+  internal-pipelinerun
 
 ## Changes in 4.0.0
 * Added new task parameters `taskGitRevision` and `taskGitUrl`

--- a/tasks/sign-index-image/sign-index-image.yaml
+++ b/tasks/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -14,6 +14,9 @@ spec:
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+    - name: releasePlanAdmissionPath
+      description: Path to the JSON string of the releasePlanAdmission in the data workspace
       type: string
     - name: referenceImage
       type: string
@@ -46,11 +49,14 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-index-image
-      image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -e
+
+        TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
+        TASK_ID=$(context.taskRun.uid)
+        PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -58,14 +64,30 @@ spec:
             exit 1
         fi
 
+        requestType=$(jq -r '.sign.requestType // "internal-request"' "${DATA_FILE}")
+        if [ "${requestType}" == "internal-pipelinerun" ] ; then
+          RPA_FILE="$(workspaces.data.path)/$(params.releasePlanAdmissionPath)"
+          if [ ! -f "${RPA_FILE}" ] ; then
+              echo "No valid rpa file was provided."
+              exit 1
+          fi
+          service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
+          EXTRA_ARGS=(
+          --task-git-url "$(params.taskGitUrl)"
+          --task-git-revision "$(params.taskGitRevision)"
+          --service-account "${service_account_name}"
+          )
+        else
+          requestType=internal-request
+          EXTRA_ARGS=()
+        fi
         request=$(jq -r '.sign.request // "simple-signing-pipeline"' "${DATA_FILE}")
+
         default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:released"
         pipeline_image=$(jq -r --arg default_pipeline_image "${default_pipeline_image}" \
             '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
         config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' "${DATA_FILE}")
         reference_image="$(params.referenceImage)"
-
-        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         # Translate direct quay.io reference to public facing registry reference
         # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
@@ -74,20 +96,24 @@ spec:
         # get all digests from manifest list
         for manifest_digest in $(params.manifestListDigests)
         do
-          echo "Creating InternalRequest to sign image:"
+
+          echo "Creating ${requestType} to sign image:"
           echo "- reference=${reference_image}"
           echo "- manifest_digest=${manifest_digest}"
           echo "- requester=$(params.requester)"
+  
+          ${requestType} -r "${request}" \
+            -p pipeline_image="${pipeline_image}" \
+            -p reference="${reference_image}" \
+            -p manifest_digest="${manifest_digest}" \
+            -p requester="$(params.requester)" \
+            -p config_map_name="${config_map_name}" \
+            -p taskGitUrl="$(params.taskGitUrl)" \
+            -p taskGitRevision="$(params.taskGitRevision)" \
+            -l ${TASK_LABEL}="${TASK_ID}" \
+            -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+            -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
+            "${EXTRA_ARGS[@]}" -s true
 
-          internal-request -r "${request}" \
-              -p pipeline_image="${pipeline_image}" \
-              -p reference="${reference_image}" \
-              -p manifest_digest="${manifest_digest}" \
-              -p requester="$(params.requester)" \
-              -p config_map_name="${config_map_name}" \
-              -p taskGitUrl="$(params.taskGitUrl)" \
-              -p taskGitRevision="$(params.taskGitRevision)" \
-              -t "$(params.requestTimeout)" \
-              -l "${pipelinerun_label}"="$(params.pipelineRunUid)"
           echo "done"
         done

--- a/tasks/sign-index-image/tests/mocks.sh
+++ b/tasks/sign-index-image/tests/mocks.sh
@@ -13,3 +13,15 @@ function internal-request() {
   echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
   sleep 2
 }
+
+function internal-pipelinerun() {
+  echo Mock internal-request called with: $*
+  echo $* >> $(workspaces.data.path)/mock_internal-request.txt
+
+  # set to async
+  /home/utils/internal-pipelinerun $@ -s false
+
+  # mimic the sync output
+  echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
+  sleep 2
+}

--- a/tasks/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -2,9 +2,9 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-sign-index-image
+  name: test-sign-index-image-plr
 spec:
-  description: Test creating a internal request to sign an image
+  description: Test creating a internal pipelinerun to sign an image using the simple-signing-pipeline request
   workspaces:
     - name: tests-workspace
   tasks:
@@ -19,13 +19,15 @@ spec:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
-              cat > $(workspaces.data.path)/data.json << EOF
+              cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "sign": {
-                  "configMapName": "signing-config-map"
+                  "configMapName": "signing-config-map",
+                  "request": "simple-signing-pipeline",
+                  "requestType": "internal-pipelinerun"
                 }
               }
               EOF
@@ -92,62 +94,70 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              counter=0
-              testValues=('sha256:6f9a420f660e73a' \
-                          'sha256:6f9a420f660e73b')
-              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
-              internalRequestsCount=$(echo $internalRequests | wc -w)
+              internalPipelineruns="$(kubectl get pr \
+                -l "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)" \
+                -o json --sort-by=.metadata.creationTimestamp | jq -c)"
+              plrsLength=$(jq ".items | length" <<< "${internalPipelineruns}" )
 
-              if [ $internalRequestsCount != "2" ] ; then
-                echo "incorrect number of internalRequests created. Expected 2"
-                exit 1
-              fi
+              expectedReferences=()
+              expectedReferences+=("quay.io/testrepo/testimage:tag")
+              expectedReferences+=("quay.io/testrepo/testimage:tag")
 
-              for internalRequest in ${internalRequests};
-              do
-                params=$(kubectl get internalrequest ${internalRequest} -o jsonpath="{.spec.params}")
+              expectedDigests=()
+              expectedDigests+=("sha256:6f9a420f660e73a")
+              expectedDigests+=("sha256:6f9a420f660e73b")
 
-                if [ $(jq -r '.reference' <<< "${params}") != "quay.io/testrepo/testimage:tag" ]; then
-                  echo "reference image does not match"
-                  exit 1
-                fi
+              foundReferences=()
+              foundDigests=()
+              for((iplr=0; iplr<plrsLength; iplr++)); do
+                params=$(jq -r ".items[$iplr].spec.params" <<< "${internalPipelineruns}")
+                refValue=$(jq -r '.[1].value' <<< "${params}")
+                manifestDigest=$(jq -r '.[2].value' <<< "${params}")
+                foundReferences+=("${refValue}")
+                foundDigests+=("${manifestDigest}")
 
-                if [ $(jq -r '.manifest_digest' <<< "${params}") != "${testValues[$counter]}" ]; then
-                  echo "manifest_digest does not match"
-                  exit 1
-                fi
-
-                if [ $(jq -r '.config_map_name' <<< "${params}") != "signing-config-map" ]
-                then
+                if [ "$(jq -r '.[4].value' <<< "${params}")" != "signing-config-map" ]; then
                   echo "config_map_name does not match"
                   exit 1
                 fi
 
-                if [ $(jq -r '.requester' <<< "${params}") != "testuser" ]
-                then
+                if [ "$(jq -r '.[3].value' <<< "${params}")" != "testuser" ]; then
                   echo "requester does not match"
                   exit 1
                 fi
 
-                if [ $(jq -r '.pipeline_image' <<< "${params}") != \
-                   "quay.io/redhat-isv/operator-pipelines-images:released" ]
-                then
+                if [ "$(jq -r '.[0].value' <<< "${params}")" != \
+                   "quay.io/redhat-isv/operator-pipelines-images:released" ]; then
                   echo "pipeline_image does not match"
                   exit 1
                 fi
-
-                counter=$((counter+1))
               done
+
+              differenceReferences=$(echo "${expectedReferences[@]}" "${foundReferences[@]}" | tr ' ' '\n' \
+                | sort | uniq -u)
+              differenceDigests=$(echo "${expectedDigests[@]}" "${foundDigests[@]}" | tr ' ' '\n' | sort | uniq -u)
+
+              if [ -n "${differenceReferences}" ] ; then
+                echo "error: references expected compared to found do not match"
+                echo ""
+                echo "${differenceReferences}"
+                exit 1
+              fi
+              if [ -n "${differenceDigests}" ] ; then
+                echo "error: digests expected compared to found do not match"
+                echo ""
+                echo "${differenceDigests}"
+                exit 1
+              fi
       runAfter:
         - run-task
   finally:
     - name: cleanup
       taskSpec:
         steps:
-          - name: delete-crs
+          - name: delete-plrs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
-
-              kubectl delete internalrequests --all
+              kubectl delete pr -l "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)"

--- a/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -29,6 +29,32 @@ spec:
                 }
               }
               EOF
+              cat > "$(workspaces.data.path)/release_plan_admission.json" << EOF
+              {
+                "spec": {
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "https://localhost.git"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipelines/abc/abc.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "release-service-account"
+                  }
+                }
+              }
+              EOF
     - name: run-task
       taskRef:
         name: sign-index-image
@@ -47,6 +73,8 @@ spec:
           value: "main"
         - name: dataPath
           value: data.json
+        - name: releasePlanAdmissionPath
+          value: release_plan_admission.json
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -61,7 +89,7 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"


### PR DESCRIPTION
## Describe your changes
- Updated the sign-index-image task to support the
   `internal-pipelinerun` requestType
- New mandatory parameter `releasePlanAdmissionPath`
   - It is needed in order to obtain the serviceAccount so
     it can be used in the PipelineRun definition for the
     internal-pipelinerun

## Relevant Jira
- [RELEASE-1342](https://issues.redhat.com//browse/RELEASE-1342)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

