### PR TITLE
chore(RELEASE-1042): add publish-index-image internal task and pipeline

### DIFF
--- a/internal/pipelines/publish-index-image-pipeline/README.md
+++ b/internal/pipelines/publish-index-image-pipeline/README.md
@@ -1,0 +1,13 @@
+# publish-index-image-pipeline
+
+Tekton pipeline to publish a built FBC index image using skopeo
+
+## Parameters
+
+| Name                  | Description                                   | Optional | Default value |
+|-----------------------|-----------------------------------------------|----------|---------------|
+| sourceIndex           | sourceIndex signing image                     | No       | -             |
+| targetIndex           | targetIndex signing image                     | No       | -             |
+| retries               | Number of skopeo retries                      | Yes      | 0             |
+| publishingCredentials | The credentials used to access the registries | No       | -             |
+| requestUpdateTimeout  | Max seconds waiting for the status update     | Yes      | 360           |

--- a/internal/pipelines/publish-index-image-pipeline/publish-index-image-pipeline.yaml
+++ b/internal/pipelines/publish-index-image-pipeline/publish-index-image-pipeline.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: publish-index-image-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Pipeline to publish a built FBC index image using skopeo
+  params:
+    - name: sourceIndex
+      type: string
+      description: sourceIndex signing image
+    - name: targetIndex
+      type: string
+      description: targetIndex signing image
+    - name: retries
+      type: string
+      default: "0"
+      description: Number of skopeo retries
+    - name: publishingCredentials
+      type: string
+      description: The credentials used to access the registries
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  tasks:
+    - name: publish-index-image-task
+      taskRef:
+        name: publish-index-image-task
+      params:
+        - name: sourceIndex
+          value: $(params.sourceIndex)
+        - name: targetIndex
+          value: $(params.targetIndex)
+        - name: retries
+          value: $(params.retries)
+        - name: publishingCredentials
+          value: $(params.publishingCredentials)
+        - name: requestUpdateTimeout
+          value: $(params.requestUpdateTimeout)
+  results:
+    - name: requestMessage
+      value: $(tasks.publish-index-image-task.results.requestMessage)

--- a/internal/resources/publish-index-image-pipeline.yaml
+++ b/internal/resources/publish-index-image-pipeline.yaml
@@ -1,0 +1,1 @@
+../pipelines/publish-index-image-pipeline/publish-index-image-pipeline.yaml

--- a/internal/resources/publish-index-image-task.yaml
+++ b/internal/resources/publish-index-image-task.yaml
@@ -1,0 +1,1 @@
+../tasks/publish-index-image-task/publish-index-image-task.yaml

--- a/internal/tasks/publish-index-image-task/README.md
+++ b/internal/tasks/publish-index-image-task/README.md
@@ -1,0 +1,13 @@
+# publish-index-image-task
+
+Tekton task to publish a built FBC index image using skopeo
+
+## Parameters
+
+| Name                  | Description                                   | Optional | Default value |
+|-----------------------|-----------------------------------------------|----------|---------------|
+| sourceIndex           | sourceIndex signing image                     | No       | -             |
+| targetIndex           | targetIndex signing image                     | No       | -             |
+| retries               | Number of skopeo retries                      | Yes      | 0             |
+| publishingCredentials | The credentials used to access the registries | No       | -             |
+| requestUpdateTimeout  | Max seconds waiting for the status update     | Yes      | 360           |

--- a/internal/tasks/publish-index-image-task/publish-index-image-task.yaml
+++ b/internal/tasks/publish-index-image-task/publish-index-image-task.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-index-image-task
+  labels:
+    app.kubernetes.io/version: "0.1.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Task to publish a built FBC index image using skopeo
+  params:
+    - name: sourceIndex
+      type: string
+      description: sourceIndex signing image
+    - name: targetIndex
+      type: string
+      description: targetIndex signing image
+    - name: retries
+      type: string
+      default: "0"
+      description: Number of skopeo retries
+    - name: publishingCredentials
+      type: string
+      default: "fbc-publishing-credentials"
+      description: The credentials used to access the registries
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  results:
+    - name: requestMessage
+  steps:
+    - name: publish-index-image
+      env:
+        - name: SOURCE_INDEX_CREDENTIAL
+          valueFrom:
+            secretKeyRef:
+              key: sourceIndexCredential
+              name: $(params.publishingCredentials)
+        - name: TARGET_INDEX_CREDENTIAL
+          valueFrom:
+            secretKeyRef:
+              key: targetIndexCredential
+              name: $(params.publishingCredentials)
+      image: >-
+        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        PATH=/bin:/usr/bin:/usr/local/bin
+        export PATH
+
+        # do not authenticate if the source is redhat's "registry-proxy" which is unauthenticated.
+        if [[ ! "$(params.sourceIndex)" =~ ^registry-proxy(\-stage)?.engineering.redhat.com ]]; then
+            AUTH_PARAM=("--src-creds" "${SOURCE_INDEX_CREDENTIAL}")
+        fi
+
+        (skopeo copy \
+        --all \
+        --preserve-digests \
+        --retry-times "$(params.retries)" \
+        --src-tls-verify=false "${AUTH_PARAM[@]}" \
+        "docker://$(params.sourceIndex)" \
+        --dest-creds "${TARGET_INDEX_CREDENTIAL}" \
+        "docker://$(params.targetIndex)" && \
+        echo -n "Index Image Published successfully" || \
+        echo -n "Failed publishing Index Image" ) | tee "$(results.requestMessage.path)"
+
+        # trick to get the proper exit status
+        grep "success" "$(results.requestMessage.path)" >/dev/null

--- a/internal/tasks/publish-index-image-task/tests/mocks.sh
+++ b/internal/tasks/publish-index-image-task/tests/mocks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -x
+
+# mocks to be injected into task step scripts
+
+function skopeo() {
+  echo Mock skopeo called with: $* >&2
+
+  if [[ "$*" == *"--src-tls-verify=false --src-creds source docker://quay.io/source"* ]]
+  then
+    return 0
+  elif [[ "$*" == *"--src-tls-verify=false docker://registry-proxy.engineering.redhat.com/foo"* ]]
+  then
+    return 0
+  elif [[ "$*" == *"--src-tls-verify=false docker://registry-proxy.engineering.redhat.com/fail"* ]]
+  then
+    return 1
+  else
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/internal/tasks/publish-index-image-task/tests/pre-apply-task-hook.sh
+++ b/internal/tasks/publish-index-image-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy secret (and delete it first if it exists)
+kubectl delete secret publish-index-image-secret --ignore-not-found
+kubectl create secret generic publish-index-image-secret --from-literal=sourceIndexCredential=source --from-literal=targetIndexCredential=target

--- a/internal/tasks/publish-index-image-task/tests/test-publish-index-image-fail.yaml
+++ b/internal/tasks/publish-index-image-task/tests/test-publish-index-image-fail.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image-fail
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-index-image task with a failing sourceIndex. The grep at the end of the task sets the task
+    status to that of the skopeo command, and here the mock will make the skopeo command fail due to the sourceIndex
+  tasks:
+    - name: run-task
+      taskRef:
+        name: publish-index-image-task
+      params:
+        - name: sourceIndex
+          value: "registry-proxy.engineering.redhat.com/fail"
+        - name: targetIndex
+          value: "quay.io/target"
+        - name: publishingCredentials
+          value: "publish-index-image-secret"

--- a/internal/tasks/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
+++ b/internal/tasks/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image-registry-proxy
+spec:
+  description: |
+    Run the publish-index-image task with a registry-proxy sourceIndex. Ensure the task succeeds, which can
+    only happen if --src-creds is properly added (due to the mocks.sh)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: publish-index-image-task
+      params:
+        - name: sourceIndex
+          value: "registry-proxy.engineering.redhat.com/foo"
+        - name: targetIndex
+          value: "quay.io/target"
+        - name: publishingCredentials
+          value: "publish-index-image-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: requestMessage
+          value: $(tasks.run-task.results.requestMessage)
+      taskSpec:
+        params:
+          - name: requestMessage
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.requestMessage)" != "Index Image Published successfully" ]]; then
+                echo Error: requestMessage task result is not correct
+                exit 1
+              fi

--- a/internal/tasks/publish-index-image-task/tests/test-publish-index-image.yaml
+++ b/internal/tasks/publish-index-image-task/tests/test-publish-index-image.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image
+spec:
+  description: |
+    Run the publish-index-image task with a non registry-proxy sourceIndex
+  tasks:
+    - name: run-task
+      taskRef:
+        name: publish-index-image-task
+      params:
+        - name: sourceIndex
+          value: "quay.io/source"
+        - name: targetIndex
+          value: "quay.io/target"
+        - name: publishingCredentials
+          value: "publish-index-image-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: requestMessage
+          value: $(tasks.run-task.results.requestMessage)
+      taskSpec:
+        params:
+          - name: requestMessage
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.requestMessage)" != "Index Image Published successfully" ]]; then
+                echo Error: requestMessage task result is not correct
+                exit 1
+              fi


### PR DESCRIPTION
This commit moves the publish-index-image pipeline and task from the app-interface repo to the internal directory of this repo. It also adds tests and a README with it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

