### PR TITLE
fix(RELEASE-1345): bump image in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/push-rpm-data-to-pyxis/README.md
+++ b/tasks/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,10 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.3.2
+* Updated the base image used in this task
+  * The new image avoids failing on invalid purl strings
+
 ## Changes in 1.3.1
 * Avoid "dir already exists" error in case the task is retried in a pipelinerun
 

--- a/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.3.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+        quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -99,7 +99,7 @@ spec:
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+        quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
           - name: sbomPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f7adbd837f43941f161b6da830b2091267889e34
+            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -105,7 +105,7 @@ spec:
                 cat "$(workspaces.data.path)/mock_select-oci-auth.txt"
                 exit 1
               fi
-              
+
               test "$(params.sbomPath)" == "./downloaded-sboms"
       runAfter:
         - run-task


### PR DESCRIPTION
The new image contains a fix to avoid failing on invalid purl strings.

See this related PR:
https://github.com/konflux-ci/release-service-utils/pull/343

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

