### PR TITLE
fix(MMENG-4284): fix charon bug of a product bundle deletion issue

### DIFF
--- a/tasks/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/publish-to-mrrc/publish-to-mrrc.yaml
@@ -45,7 +45,7 @@ spec:
         - name: workdir
           mountPath: "/workdir"
     - name: upload-maven-repo
-      image: quay.io/konflux-ci/charon:b99585182f6750b3f6352889fe9c2222b57833ef
+      image: quay.io/konflux-ci/charon@sha256:95b22f4f0fc1d6bb984a2f63334c3f66a539e433d79cde4eafa7731d8924377f
       script: |
         #!/usr/bin/env bash
         set -eux


### PR DESCRIPTION
Charon has reported a bug of npm product tarball deleting issue([MMENG-4284](https://issues.redhat.com//browse/MMENG-4284)). We had a fix of the bug and pushed a new release of the image. This PR just updated the image in the related task for the release pipeline.