### PR TITLE
feat(RELEASE-1350): internal push-artifacts-to-cdn

### DIFF
--- a/internal/resources/push-artifacts-to-cdn-task.yaml
+++ b/internal/resources/push-artifacts-to-cdn-task.yaml
@@ -1,0 +1,1 @@
+../../tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml

--- a/internal/resources/push-artifacts-to-cdn.yaml
+++ b/internal/resources/push-artifacts-to-cdn.yaml
@@ -1,0 +1,1 @@
+../../pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml

--- a/pipelines/internal/push-artifacts-to-cdn/README.md
+++ b/pipelines/internal/push-artifacts-to-cdn/README.md
@@ -1,0 +1,17 @@
+# push-artifacts-to-cdn
+
+Tekton Pipeline to push artifacts to CDN and/or Dev Portal
+
+## Parameters
+
+| Name            | Description                                                                            | Optional    | Default value                                              |
+|-----------------|----------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|
+| snapshot_json   | String containing a JSON representation of the snapshot spec                           | No          | -                                                          |
+| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                              | No          | -                                                          |
+| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                      | No          | -                                                          |
+| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                               | No          | -                                                          |
+| udcacheSecret   | Env specific secret containing the udcache credentials                                 | No          | -                                                          |
+| cgwHostname     | The hostname of the content-gateway to publish the metadata to                         | Yes         | https://developers.redhat.com/content-gateway/rest/admin   |
+| cgwSecret       | Env specific secret containing the content gateway credentials                         | No          | -                                                          |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored  | Yes         | https://github.com/konflux-ci/release-service-catalog.git  |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                         | No          | -                                                          |

--- a/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: push-artifacts-to-cdn
+  labels:
+    app.kubernetes.io/version: "0.0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Pipeline to push artifacts to CDN and/or Dev Portal
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: exodusGwSecret
+      type: string
+      description: Env specific secret containing the Exodus Gateway configs
+    - name: exodusGwEnv
+      type: string
+      description: Environment to use in the Exodus Gateway. Options are [live, pre]
+    - name: pulpSecret
+      type: string
+      description: Env specific secret containing the rhsm-pulp credentials
+    - name: udcacheSecret
+      type: string
+      description: Env specific secret containing the udcache credentials
+    - name: cgwHostname
+      type: string
+      description: The hostname of the content-gateway to publish the metadata to
+      default: https://developers.redhat.com/content-gateway/rest/admin
+    - name: cgwSecret
+      type: string
+      description: Env specific secret containing the content gateway credentials
+    - name: taskGitUrl
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+      type: string
+    - name: taskGitRevision
+      description: The revision in the taskGitUrl repo to be used
+      type: string
+  tasks:
+    - name: push-artifacts-to-cdn-task
+      timeout: "24h00m0s"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+      params:
+        - name: snapshot_json
+          value: $(params.snapshot_json)
+        - name: exodusGwSecret
+          value: $(params.exodusGwSecret)
+        - name: exodusGwEnv
+          value: $(params.exodusGwEnv)
+        - name: pulpSecret
+          value: $(params.pulpSecret)
+        - name: udcacheSecret
+          value: $(params.udcacheSecret)
+        - name: cgwHostname
+          value: $(params.cgwHostname)
+        - name: cgwSecret
+          value: $(params.cgwSecret)
+  results:
+    - name: result
+      value: $(tasks.push-artifacts-to-cdn-task.results.result)

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -1,0 +1,16 @@
+# push-artifacts-to-cdn-task
+
+Tekton task to push artifacts to CDN and optionally Dev Portal with optional signing
+
+## Parameters
+
+| Name            | Description                                                       | Optional | Default value                                            |
+|-----------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
+| snapshot_json   | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
+| concurrentLimit | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
+| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
+| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
+| pulpSecret      | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |
+| udcacheSecret   | Env specific secret containing the udcache credentials            | No       | -                                                        |
+| cgwHostname     | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
+| cgwSecret       | Env specific secret containing the content gateway credentials    | No       | -                                                        |

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -1,0 +1,293 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-artifacts-to-cdn-task
+  labels:
+    app.kubernetes.io/version: "0.0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to push artifacts to CDN and optionally Dev Portal with optional signing
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be pulled at once
+      default: 3
+    - name: exodusGwSecret
+      type: string
+      description: Env specific secret containing the Exodus Gateway configs
+    - name: exodusGwEnv
+      type: string
+      description: Environment to use in the Exodus Gateway. Options are [live, pre]
+    - name: pulpSecret
+      type: string
+      description: Env specific secret containing the rhsm-pulp credentials
+    - name: udcacheSecret
+      type: string
+      description: Env specific secret containing the udcache credentials
+    - name: cgwHostname
+      type: string
+      description: Env specific hostname for content gateway
+    - name: cgwSecret
+      type: string
+      description: Env specific secret containing the content gateway credentials
+  results:
+    - name: result
+      description: Success if the task succeeds, the error otherwise
+  steps:
+    - name: pull-and-push-images
+      image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+      env:
+        - name: EXODUS_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: cert
+        - name: EXODUS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: key
+        - name: EXODUS_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: url
+        - name: PULP_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: pulp_url
+        - name: PULP_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: konflux-release-rhsm-pulp.crt
+        - name: PULP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: konflux-release-rhsm-pulp.key
+        - name: UDC_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: url
+        - name: UDC_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: cert
+        - name: UDC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: key
+        - name: DOCKER_CONFIG_JSON
+          valueFrom:
+            secretKeyRef:
+              name: redhat-workloads-token
+              key: .dockerconfigjson
+        - name: "SNAPSHOT_JSON"
+          value: "$(params.snapshot_json)"
+        - name: CGW_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cgwSecret)
+              key: username
+        - name: CGW_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cgwSecret)
+              key: token
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        STDERR_FILE=/tmp/stderr.txt
+
+        exitfunc() {
+            local err=$1
+            local line=$2
+            local command="$3"
+            if [ "$err" -eq 0 ] ; then
+                echo -n "Success" > "$(results.result.path)"
+            else
+                echo "$0: ERROR '$command' failed at line $line - exited with status $err" \
+                  > "$(results.result.path)"
+                if [ -f "$STDERR_FILE" ] ; then
+                    tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"
+                fi
+            fi
+            exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
+        }
+        # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        # Setup required variables
+        export EXODUS_GW_CERT=/tmp/exodus.crt
+        export EXODUS_GW_KEY=/tmp/exodus.key
+        export PULP_CERT_FILE=/tmp/pulp.crt
+        export PULP_KEY_FILE=/tmp/pulp.key
+        export UDCACHE_CERT=/tmp/udc.crt
+        export UDCACHE_KEY=/tmp/udc.key
+        EXODUS_GW_ENV=$(params.exodusGwEnv)
+        export EXODUS_GW_ENV
+        export EXODUS_GW_URL="$EXODUS_URL"
+        export EXODUS_PULP_HOOK_ENABLED=True
+        export EXODUS_GW_TIMEOUT=7200
+        mkdir -p ~/.docker
+
+        set +x
+        echo "$EXODUS_CERT" > "$EXODUS_GW_CERT"
+        echo "$EXODUS_KEY" > "$EXODUS_GW_KEY"
+        echo "$PULP_CERT" > "$PULP_CERT_FILE"
+        echo "$PULP_KEY" > "$PULP_KEY_FILE"
+        echo "$UDC_CERT" > "$UDCACHE_CERT"
+        echo "$UDC_KEY" > "$UDCACHE_KEY"
+        # Quotes are added to the secret so it applies in k8s nicely. But now we have to remove them
+        echo "$DOCKER_CONFIG_JSON" | sed -r 's/(^|\})[^{}]+(\{|$)/\1\2/g' > ~/.docker/config.json
+        set -x
+
+        DISK_IMAGE_DIR="$(mktemp -d)"
+        export DISK_IMAGE_DIR
+
+        process_component() { # Expected argument is [component json]
+            COMPONENT=$1
+            PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}")
+            DESTINATION="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "${COMPONENT}")/FILES" \
+              || (echo "Missing staged.destination value for component. This should be an existing pulp repo. \
+                  Failing" && exit 1)
+            mkdir -p "${DESTINATION}"
+            DOWNLOAD_DIR=$(mktemp -d)
+            cd "$DOWNLOAD_DIR"
+            # oras has very limited support for selecting the right auth entry,
+            # so create a custom auth file with just one entry
+            AUTH_FILE=$(mktemp)
+            select-oci-auth "${PULLSPEC}" > "$AUTH_FILE"
+            oras pull --registry-config "$AUTH_FILE" "$PULLSPEC"
+            NUM_MAPPED_FILES=$(jq '.staged.files | length' <<< "${COMPONENT}")
+            for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
+                FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT")
+                SOURCE=$(jq -er '.source' <<< "$FILE")
+                FILENAME=$(jq -er '.filename' <<< "$FILE")
+                # The .qcow2 images are not zipped
+                if [ -f "${SOURCE}.gz" ] ; then
+                    gzip -d "${SOURCE}.gz"
+                fi
+                DESTINATION_FILE="${DESTINATION}/${FILENAME}"
+                # Albeit a rare one, this is a race condition since this is run in parallel.
+                # The race condition is if two files have the same $DESTINATION_FILE and both
+                # if checks are run before either mv is run a few lines below.
+                if [ -f "${DESTINATION_FILE}" ] ; then
+                    echo -n "Multiple files use the same destination value: $DESTINATION" >&2
+                    echo " and filename value: $FILENAME. Failing..." >&2
+                    exit 1
+                fi
+                mv "$SOURCE" "${DESTINATION_FILE}" || echo "didn't find mapped file: ${SOURCE}"
+            done
+
+        }
+
+        process_component_for_developer_portal() { # Expected argument are [component json], [content_directory]
+          COMPONENT=$1
+
+          contentGatewayConfig="$(jq -c '.contentGateway // {}' <<< "${COMPONENT}")"
+          contentGatewayConfigSize="$(jq  '. | length' <<< "${contentGatewayConfig}")"
+          if [ "${contentGatewayConfigSize}" == "0" ]; then
+            echo "Configuration is not defined for Developer Portal publishing...skipping component"
+            return
+          fi
+
+          productName="$(jq -er '.productName' <<< "${contentGatewayConfig}")" \
+            || (echo "Missing contentGateway.productName value for component. This should be an existing product \
+                  in the Developer Portal. Failing" && exit 1)
+
+          productCode="$(jq -er '.productCode' <<< "${contentGatewayConfig}")" \
+            || (echo "Missing contentGateway.productCode value for component. This should be an existing product \
+                  in the Developer Portal. Failing" && exit 1)
+
+          productVersionName="$(jq -er '.productVersionName' <<< "${contentGatewayConfig}")" \
+            || (echo "Missing contentGateway.productVersionName value for component. This should be an existing \
+                  product in the Developer Portal. Failing" && exit 1)
+
+          filePrefix="$(jq -er '.filePrefix' <<< "${contentGatewayConfig}")" \
+            || (echo "Missing contentGateway.filePrefix value for component. This should be the prefix for files to \
+                  upload to the Developer Portal. Failing" && exit 1)
+
+          developer_portal_wrapper --debug --product-name "${productName}" \
+            --product-code "${productCode}" \
+            --product-version-name "${productVersionName}" \
+            --cgw-hostname "$(params.cgwHostname)" \
+            --content-directory "$2" \
+            --file-prefix "${filePrefix}"
+
+        }
+
+        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+
+        # use the 1st component's version
+        VERSION=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
+        if [ "${VERSION}" == "" ] ; then
+          echo "Error: version not specified in .components[0].staged.version. Needed to publish to customer portal"
+          exit 1
+        fi
+
+        # Process each component in parallel
+        for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
+            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
+            # Limit batch size to concurrent limit
+            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
+                wait -n
+            done
+            process_component "$COMPONENT" 2> "$STDERR_FILE" &
+        done
+
+        # Wait for remaining processes to finish
+        while (( ${RUNNING_JOBS@P} > 0 )); do
+            wait -n
+        done
+
+        # Change to the subdir with the images
+        cd "${DISK_IMAGE_DIR}"
+
+        STAGED_JSON='{"header":{"version": "0.2"},"payload":{"files":[]}}'
+
+        # Add the files to the payload
+        # shell check wants us to find ./* but that adds `./` to the paths which breaks the script
+        # shellcheck disable=SC2035
+        while IFS= read -r -d '' file ; do
+            STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
+              --arg version "$VERSION" \
+              '.payload.files[.payload.files | length] = 
+              {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$STAGED_JSON")
+        done < <(find * -type f -print0)
+
+        echo "$STAGED_JSON" | yq -P -I 4 > staged.yaml
+
+        pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
+          --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
+          2> "$STDERR_FILE"
+
+        relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
+        component_destinations=()
+        for path in $relative_paths:
+        do
+          parent_dir=$(dirname "$path")
+          component_destinations+=("${DISK_IMAGE_DIR}/$parent_dir")
+        done
+
+        ## Process Files for Developer Portal / CGW
+        ##
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+        for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
+            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
+            process_component_for_developer_portal "$COMPONENT" "${component_destinations[$i]}"  2> "$STDERR_FILE"
+        done

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function select-oci-auth() {
+    echo Mock select-oci-auth called with: $*
+}
+
+function oras() {
+    echo Mock oras called with: $*
+
+    if [[ "$*" != "pull --registry-config"* ]]; then
+        echo Error: Unexpected call to oras
+        exit 1
+    fi
+
+    if [[ "$*" == *"nonexistent-disk-image"* ]]; then
+        echo Simulating failing oras pull call
+        exit 1
+    fi
+
+    touch disk.qcow2
+    touch disk.raw.gz
+    touch fail_gzip.raw.gz
+}
+
+# We aren't going to pull real files that can be unzipped, so just remove the .gz suffix on them
+function gzip() {
+    if [ $2 == "fail_gzip.raw.gz" ] ; then
+        echo gzip failed
+        exit 1
+    fi
+    mv $2 ${2::-3}
+}
+
+function pulp_push_wrapper() {
+    echo Mock pulp_push_wrapper called with: $*
+
+    if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
+        printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
+    fi
+}
+
+function developer_portal_wrapper() {
+  echo Mock developer_portal_wrapper called with: $*
+
+  /home/developer-portal-wrapper/developer_portal_wrapper "$@" --dry-run
+
+  if ! [[ "$?" -eq 0 ]]; then
+      echo Unexpected call to developer_portal_wrapper
+      exit 1
+  fi
+}

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy exodus secret (and delete it first if it exists)
+kubectl delete secret pulp-task-exodus-secret --ignore-not-found
+kubectl create secret generic pulp-task-exodus-secret --from-literal=cert=myexoduscert --from-literal=key=myexoduskey --from-literal=url=https://exodus.com
+
+# Create a dummy pulp secret (and delete it first if it exists)
+kubectl delete secret pulp-task-pulp-secret --ignore-not-found
+kubectl create secret generic pulp-task-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://pulp.com
+
+# Create a dummy pulp secret to fail with (and delete it first if it exists)
+# This is used to simulate the pulp_push_wrapper script failing
+kubectl delete secret pulp-task-bad-pulp-secret --ignore-not-found
+kubectl create secret generic pulp-task-bad-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://failing-pulp.com
+
+# Create a dummy udc secret (and delete it first if it exists)
+kubectl delete secret pulp-task-udc-secret --ignore-not-found
+kubectl create secret generic pulp-task-udc-secret --from-literal=cert=myudccert --from-literal=key=myudckey --from-literal=url=https://udc.com
+
+# Create a dummy cgw secret (and delete it first if it exists)
+kubectl delete secret pulp-task-cgw-secret --ignore-not-found
+kubectl create secret generic pulp-task-cgw-secret --from-literal=username=cgwuser --from-literal=token=cgwtoken
+
+# Create a dummy workloads secret (and delete it first if it exists)
+# The secret name here is hardcoded in the task
+kubectl delete secret redhat-workloads-token --ignore-not-found
+kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-gzip
+spec:
+  description: |
+    Run the push-artifacts task with the gzip command failing. This happens because the staged.files.source
+    value here is set up to fail in the mocks.sh file. This should fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"fail_gzip.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*gzip*/} ]] ; then
+                echo "Error: result task result should show failure from gzip but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-cgwfileprefix
+spec:
+  description: |
+    Run the push-artifacts task with the component having no contentGateway.filePrefix. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*contentGateway.filePrefix*/} ]] ; then
+                echo "Error: result task result should show failure from contentGateway.filePrefix but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-cgwproductcode
+spec:
+  description: |
+    Run the push-artifacts task with the component having no contentGateway.productCode. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*contentGateway.productCode*/} ]] ; then
+                echo "Error: result task result should show failure from contentGateway.productCode but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-cgwproductname
+spec:
+  description: |
+    Run the push-artifacts task with the component having no contentGateway.productName. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*contentGateway.productName*/} ]] ; then
+                echo "Error: result task result should show failure from contentGateway.productName but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-cgwproductversionname
+spec:
+  description: |
+    Run the push-artifacts task with the component having no contentGateway.productVersionName. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux"},
+            "staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*contentGateway.productVersionName*/} ]] ; then
+                echo "Error: result task result should show failure from contentGateway.productVersionName but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-containerimage
+spec:
+  description: |
+    Run the push-artifacts task with the component having no containerImage. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*containerImage*/} ]] ; then
+                echo "Error: result task result should show failure from containerImage but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-stageddestination
+spec:
+  description: |
+    Run the push-artifacts task with the component having no staged.destination. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*staged.destination*/} ]] ; then
+                echo "Error: result task result should show failure from staged.destination but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-stagedfilesfilename
+spec:
+  description: |
+    Run the push-artifacts task with the component having a staged.files entry without filename. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*staged*files*filename*/} ]] ; then
+                echo "Error: result task result should show failure from staged.files[].filename but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-stagedfilessource
+spec:
+  description: |
+    Run the push-artifacts task with the component having a staged.files entry without source. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*staged*files*source*/} ]] ; then
+                echo "Error: result task result should show failure from staged.files[].source but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-no-stagedversion
+spec:
+  description: |
+    Run the push-artifacts task with the component having no staged.version. This should
+    fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}]}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # The script echoes then exit 1 if it can't determine the version
+              if [[ ${RESULT/*exit 1*/} ]] ; then
+                echo "Error: result task result should show exit 1 but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-oras-pull
+spec:
+  description: |
+    Run the push-artifacts task with the oras pull command failing. This happens because the containerImage
+    value here is set up to fail in the mocks.sh file. This should fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/nonexistent-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*oras pull*/} ]] ; then
+                echo "Error: result task result should show failure from oras pull but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-pulp-push
+spec:
+  description: |
+    Run the push-artifacts task with the pulp_push_wrapper script failing. This is done by having
+    the mock script call fail based on the pulp-url argument, which comes from the pulpSecret
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-bad-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*Mocked failure of pulp_push_wrapper*/} ]] ; then
+                echo "Error: result task result should show failure on pulp_push_wrapper script but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-same-filename
+spec:
+  description: |
+    Run the push-artifacts task with the component having two files set to be moved to the same location via
+    the filename key. This should fail the task
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.qcow2",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ ${RESULT/*Multiple files use the same destination*/} ]] ; then
+                echo "Error: result task result should show failure from using the same destination but doesn't"
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-only-cdn
+spec:
+  description: |
+    Run the push-artifacts task and only push to CDN since the CGW config data is not present
+    in the snapshot.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{"containerImage":
+            "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345","staged":{"destination":
+            "x86_64-isos","files":[{"filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":
+            "amd-1.3-x86_64-kvm.raw","source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn
+spec:
+  description: |
+    Run the push-artifacts task with everything set up properly to pass
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                exit 1
+              fi


### PR DESCRIPTION
## Describe your changes
- new clone of push-disk-images pipeline and task called `push-artifacts-to-cdn`
- can now be used as an `internal-pipelinerun`
- can now skip components with no CGW data

## Relevant Jira
- [RELEASE-1350](https://issues.redhat.com//browse/RELEASE-1350)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

