### PR TITLE
test: update checkton to fail on renames or copies

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,7 +62,8 @@ jobs:
         # Migrating to the konflux-ci org
         with:
           fail-on-findings: true
-          find-copies-harder: true
+          find-copies: false
+          find-renames: false
   check-jsonschema:
     name: Validate json schema file
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, checkton will not fail if a file with a violation is renamed or is a close copy to another file. If a file in a PR has a violation, we should fail on it. This changes the checkton config to do that.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

