### PR TITLE
fix: select-oci-auth broken in pulp-push-disk-images

### DIFF
--- a/tasks/internal/pulp-push-disk-images/README.md
+++ b/tasks/internal/pulp-push-disk-images/README.md
@@ -14,3 +14,7 @@ Tekton task to push disk images with Pulp
 | udcacheSecret   | Env specific secret containing the udcache credentials            | No       | -                                                        |
 | cgwHostname     | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret       | Env specific secret containing the content gateway credentials    | No       | -                                                        |
+
+## Changes in 0.2.3
+* Base image in task is updated
+  * The new image contains a fix for a missing helper script used in select-oci-auth

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: pulp-push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.2.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+      image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
       env:
         - name: EXODUS_CERT
           valueFrom:

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
The base image needs update as the select-oci-auth script now requires a helper script.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

