### PR TITLE
Revert "feat(CLOUDDST-25034): run rh-sign-image-cosign signing in par…

### DIFF
--- a/tasks/managed/rh-sign-image-cosign/README.md
+++ b/tasks/managed/rh-sign-image-cosign/README.md
@@ -10,11 +10,6 @@ Tekton task to sign container images in snapshot by cosign.
 | secretName             | Name of secret containing needed credentials                                                                                                                                                                                                      | No       | -             |
 | signRegistryAccessPath | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 | retries                | Retry cosign N times                                                                                                                                                                                                                              | Yes      | 3             |
-| concurrentLimit       | Number of concurrent cosign operations                                                                                                                                                                                                            | Yes      | 5             |
-
-## Changes in 1.3.0
-* Containers are signed only if the signature doesn't exist in the destination image
-* Existing signature validation and signing are done in parallel now controlled by concurrencyLimit paremeter
 
 ## Changes in 1.2.1
 * fix linting issues

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image-cosign
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,10 +28,6 @@ spec:
       description: Retry cosign N times.
       type: string
       default: "3"
-    - name: concurrentLimit
-      type: string
-      default: 5
-      description: The maximum number of concurrent cosign signing jobs
   workspaces:
     - name: data
       description: Workspace to read and save files
@@ -65,11 +61,6 @@ spec:
               name: $(params.secretName)
               key: REKOR_URL
               optional: true
-        - name: PUBLIC_KEY
-          valueFrom:
-            secretKeyRef:
-              name: $(params.secretName)
-              key: PUBLIC_KEY
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -82,77 +73,36 @@ spec:
             echo "No valid file was provided as signRegistryAccessPath."
             exit 1
         fi
-        PUBLIC_KEY_FILE=$(mktemp)
-        echo -n "$PUBLIC_KEY" > "$PUBLIC_KEY_FILE"
-        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
 
-        jobpid(){
-            pid=$(cut -d' ' -f4 < /proc/self/stat)
-            echo "$pid"
-        }
-        echopid(){
-            pid=$(jobpid)
-            echo "${pid}: $*"
-        }
         run_cosign () { # Expected arguments are [digest_reference, tag_reference]
+            # Upload transparency log when rekor url is specified
+            if [ -v REKOR_URL ]; then
+                COSIGN_COMMON_ARGS=(
+                  -y
+                  --rekor-url="$REKOR_URL"
+                  --key
+                  "$SIGN_KEY"
+                )
+            else
+                COSIGN_COMMON_ARGS=(
+                  --tlog-upload=false
+                  --key
+                  "$SIGN_KEY"
+                )
+            fi
+            echo "Signing manifest $1 ($2)"
             attempt=0
-            backoff1=2
-            backoff2=3
             until [ "$attempt" -gt "$(params.retries)" ] ; do # 3 retries by default
-                cosign "$@" && break
-                sleep $backoff2
-
-                # Fibbonaci backoff
-                old_backoff1=$backoff1
-                backoff1=$backoff2
-                backoff2=$((old_backoff1 + backoff2))
+                cosign -t 3m0s sign\
+                "${COSIGN_COMMON_ARGS[@]}" \
+                --sign-container-identity "$2"\
+                "$1" && break
                 attempt=$((attempt+1))
             done
             if [ "$attempt" -gt "$(params.retries)" ] ; then
-              echopid "Max retries exceeded."
+              echo "Max retries exceeded."
               exit 1
             fi
-        }
-        function check_existing_signatures() {
-          local identity=$1
-          local reference=$2
-          local digest=$3
-          if [ -v REKOR_URL ]; then
-              COSIGN_REKOR_ARGS="--rekor-url=$REKOR_URL"
-          else
-              COSIGN_REKOR_ARGS="--insecure-ignore-tlog=true"
-          fi
-          verify_output=$(run_cosign verify "$COSIGN_REKOR_ARGS" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
-        '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
-        '|select(.critical.identity."docker-reference"| contains("'"$identity"'"))'\
-        ']|length')
-          echo "$found_signatures"
-        }
-        function check_and_sign() {
-          local identity=$1
-          local reference=$2
-          local tag=$3
-          local digest=$4
-          found_signatures=$(check_existing_signatures "$identity" "$reference:$tag" "$digest")
-          if [ -z "$found_signatures" ]; then
-            found_signatures=0
-          fi
-          echopid "FOUND SIGNATURES for ${identity} ${digest}: $found_signatures"
-
-          if [ -v REKOR_URL ]; then
-              COSIGN_REKOR_ARGS="-y --rekor-url=$REKOR_URL"
-          else
-              COSIGN_REKOR_ARGS="--tlog-upload=false"
-          fi
-
-          if [ "$found_signatures" -eq 0 ]; then
-            run_cosign -t 3m0s sign "$COSIGN_REKOR_ARGS" \
-              --key "$SIGN_KEY" \
-              --sign-container-identity "$identity" "$reference@$digest"
-          else
-            echopid "Skip signing ${identity} (${digest})"
-          fi
         }
 
         for (( COMPONENTS_INDEX=0; COMPONENTS_INDEX<COMPONENTS_LENGTH; COMPONENTS_INDEX++ )); do
@@ -188,10 +138,7 @@ spec:
                 for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                     for MDIGEST in $(echo "$IMAGE" | jq -r '.manifests[]|.digest'); do
                         for TAG in $TAGS; do
-                            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
-                                wait -n
-                            done
-                            check_and_sign "${REGISTRY_REF}:${TAG}" "${INTERNAL_CONTAINER_REF}" "${TAG}" "${MDIGEST}" &
+                            run_cosign "${INTERNAL_CONTAINER_REF}@${MDIGEST}" "${REGISTRY_REF}:${TAG}"
                         done
                     done
                 done
@@ -200,14 +147,8 @@ spec:
             # Sign manifest list itself or manifest if it's not list
             for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
                 for TAG in $TAGS; do
-                    while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
-                        wait -n
-                    done
-                    check_and_sign "${REGISTRY_REF}:${TAG}" "${INTERNAL_CONTAINER_REF}" "${TAG}" "${DIGEST}" &
+                    run_cosign "${INTERNAL_CONTAINER_REF}@${DIGEST}" "${REGISTRY_REF}:${TAG}"
                 done
             done
-        done
-        while (( ${RUNNING_JOBS@P} > 0 )); do
-            wait -n
         done
         echo "done"

--- a/tasks/managed/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
@@ -7,16 +7,14 @@ kubectl create secret generic test-cosign-secret\
   --from-literal=AWS_DEFAULT_REGION=us-test-1\
   --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
   --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
-  --from-literal=SIGN_KEY=aws://arn:mykey\
-  --from-literal=PUBLIC_KEY=public_key
+  --from-literal=SIGN_KEY=aws://arn:mykey
 
 kubectl create secret generic test-cosign-secret-rekor\
   --from-literal=AWS_DEFAULT_REGION=us-test-1\
   --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
   --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
   --from-literal=SIGN_KEY=aws://arn:mykey\
-  --from-literal=REKOR_URL=https://fake-rekor-server\
-  --from-literal=PUBLIC_KEY=public_key
+  --from-literal=REKOR_URL=https://fake-rekor-server
 
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -48,21 +48,6 @@ spec:
                 ]
               }
               EOF
-              REF11="quay.io/redhat-pending/test-product----test-image0:t1"
-              REF12="quay.io/redhat-pending/test-product----test-image0:t2"
-              REF21="quay.io/redhat-pending/test-product----test-image1:t1"
-              REF22="quay.io/redhat-pending/test-product----test-image1:t2"
-
-              # create empty cosign verify mock files
-              touch "$(workspaces.data.path)/$(echo $REF11 | tr '/' '-')"
-              touch "$(workspaces.data.path)/$(echo $REF12 | tr '/' '-')"
-              touch "$(workspaces.data.path)/$(echo $REF21 | tr '/' '-')"
-              touch "$(workspaces.data.path)/$(echo $REF22 | tr '/' '-')"
-
-              # setup cosign success calls - all calls should pass
-              for _ in $(seq 1 48); do
-                  echo "1" >> "$(workspaces.data.path)/mock_cosign_success_calls"
-              done
 
               cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
               test-product/test-image0
@@ -77,8 +62,6 @@ spec:
           value: 'test-cosign-secret-rekor'
         - name: signRegistryAccessPath
           value: signRegistryAccess.txt
-        - name: concurrentLimit
-          value: 1
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -110,7 +93,7 @@ spec:
               CALLS=$(cat "$(workspaces.data.path)/mock_skopeo_calls")
               test "$CALLS" = "$EXPECTED"
 
-              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_sign_calls")
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
               COSIGN_COMMON="-t 3m0s sign -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
               --sign-container-identity"
               EXPECTED=$(cat <<EOF
@@ -140,15 +123,6 @@ spec:
               $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111
               EOF
               )
-              echo "TESTING"
-              if [ "$CALLS" != "$EXPECTED" ]; then
-                echo "Diff:"
-                CALLS_FILE=$(mktemp XXXXX.calls)
-                EXPECTED_FILE=$(mktemp XXXXX.expected)
-                echo "$CALLS" > "$CALLS_FILE"
-                echo "$EXPECTED" > "$EXPECTED_FILE"
-                diff -Naur "$EXPECTED_FILE" "$CALLS_FILE"
-                exit 1
-              fi
+              test "$CALLS" = "$EXPECTED"
       runAfter:
         - run-task

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -31,27 +31,11 @@ spec:
                     "repository": "quay.io/redhat-pending/test-product----test-image2",
                     "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
                     "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
-                    "tags": ["t1", "t2"]
+                    "tags": ["retry-tag"]
                   }
                 ]
               }
               EOF
-
-              # create empty cosign verify mock files
-              REF1="quay.io/redhat-pending/test-product----test-image2:t1"
-              touch "$(workspaces.data.path)/$(echo $REF1 | tr '/' '-')"
-              REF2="quay.io/redhat-pending/test-product----test-image2:t2"
-              touch "$(workspaces.data.path)/$(echo $REF2 | tr '/' '-')"
-
-              # first 3 cosign calls should end with success
-              for _ in $(seq 1 3); do
-                  echo "1" >> "$(workspaces.data.path)/mock_cosign_success_calls"
-              done
-              # simulate cosign failure on 6th call
-              echo "0" >> "$(workspaces.data.path)/mock_cosign_success_calls"
-
-              # after retrying, it should pass
-              echo "1" >> "$(workspaces.data.path)/mock_cosign_success_calls"
 
               cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
               test-product/test-image0
@@ -68,8 +52,6 @@ spec:
           value: signRegistryAccess.txt
         - name: retries
           value: 3
-        - name: concurrentLimit
-          value: 1
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -90,24 +72,15 @@ spec:
               _TEST_PUB_REPO="registry.stage.redhat.io/test-product/test-image2"
               _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
 
-              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_sign_calls")
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
               COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
-              - SIMULATED ERROR -
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:retry-tag ${_TEST_REPO}@sha256:2222
               EOF
               )
-              echo "TESTING"
-              if [ "$CALLS" != "$EXPECTED" ]; then
-                echo "Diff:"
-                CALLS_FILE=$(mktemp XXXXX.calls)
-                EXPECTED_FILE=$(mktemp XXXXX.expected)
-                echo "$CALLS" > "$CALLS_FILE"
-                echo "$EXPECTED" > "$EXPECTED_FILE"
-                diff -Naur "$EXPECTED_FILE" "$CALLS_FILE"
-                exit 1
-              fi
+              test "$CALLS" = "$EXPECTED"
       runAfter:
         - run-task

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -36,16 +36,6 @@ spec:
                 ]
               }
               EOF
-              # create empty cosign verify mock files
-              REF1="quay.io/redhat-pending/test-product----test-image2:t1"
-              touch "$(workspaces.data.path)/$(echo $REF1 | tr '/' '-')"
-              REF2="quay.io/redhat-pending/test-product----test-image2:t2"
-              touch "$(workspaces.data.path)/$(echo $REF2 | tr '/' '-')"
-
-              # first 8 cosign calls should end with success
-              for _ in $(seq 1 8); do
-                  echo "1" >> "$(workspaces.data.path)/mock_cosign_success_calls"
-              done
 
               cat > "$(workspaces.data.path)/signRegistryAccess.txt" << EOF
               test-product/test-image2
@@ -60,8 +50,6 @@ spec:
           value: 'test-cosign-secret'
         - name: signRegistryAccessPath
           value: signRegistryAccess.txt
-        - name: concurrentLimit
-          value: 2
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -87,25 +75,15 @@ spec:
               EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222"
               test "$CALLS" = "$EXPECTED"
 
-              # call records need to be sorted as concurrentLimit is set to 2
-              CALLS=$(sort "$(workspaces.data.path)/mock_cosign_sign_calls")
+              CALLS=$(cat "$(workspaces.data.path)/mock_cosign_calls")
               COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
               EOF
               )
-              echo "TESTING"
-              if [ "$CALLS" != "$EXPECTED" ]; then
-                echo "Diff:"
-                CALLS_FILE=$(mktemp XXXXX.calls)
-                EXPECTED_FILE=$(mktemp XXXXX.expected)
-                echo "$CALLS" > "$CALLS_FILE"
-                echo "$EXPECTED" > "$EXPECTED_FILE"
-                diff -Naur "$EXPECTED_FILE" "$CALLS_FILE"
-                exit 1
-              fi
+              test "$CALLS" = "$EXPECTED"
       runAfter:
         - run-task


### PR DESCRIPTION
…allel (#701)"

This reverts commit b820c4637ffb5c7af88cdd24f5cad311e79d8767.

It seems the new version doesn't work as expected. A user reported issues.

## Describe your changes

This was found in the taskrun log:

```
+++ cosign verify --rekor-url=https://rekor-server-trusted-artifact-signer.apps.rosa.rekor-stage.ic5w.p3.openshiftapps.com quay.io/redhat-pending/rhtpa----rhtpa-guac-rhel9:1.2.2-1736761596
Error: --certificate-identity or --certificate-identity-regexp is required for verification in keyless mode
main.go:74: error during command execution: --certificate-identity or --certificate-identity-regexp is required for verification in keyless mode
```

And also:
```
+ cosign -t 3m0s sign '-y --rekor-url=https://rekor-server-trusted-artifact-signer.apps.rosa.rekor-stage.ic5w.p3.openshiftapps.com' --key awskms:///arn:aws:kms:us-east-1:095921525512:key/b2c7a225-fe17-464c-b817-56f2c4c97c69 --sign-container-identity registry.stage.redhat.io/rhtpa/rhtpa-guac-rhel9:1.2.2 quay.io/redhat-pending/rhtpa----rhtpa-guac-rhel9@sha256:3f92720dc115a9ecb5ec75188dd776667d44aad98fab7b40ecdc33131f2a4356
WARNING: the -y --rekor-url=https://rekor-server-trusted-artifact-signer.apps.rosa.rekor-stage.ic5w.p3.openshiftapps.com flag is deprecated and will be removed in a future release. Please use the --y --rekor-url=https://rekor-server-trusted-artifact-signer.apps.rosa.rekor-stage.ic5w.p3.openshiftapps.com flag instead.
Error: unknown flag: --y --rekor-url
main.go:74: error during command execution: unknown flag: --y --rekor-url
```

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

