### PR TITLE
fix: allow "fbc" as product_version

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -125,7 +125,7 @@
         "product_version": {
           "type": "string",
           "description": "The product version e.g v1.0.0",
-          "pattern": "^(fbc[-]|[vV])?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*))?([-\\s]?([Aa]lpha|[Bb]eta|fast|tech[-\\s]preview)?)$"
+          "pattern": "^fbc|(fbc[-]|[vV])?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*))?([-\\s]?([Aa]lpha|[Bb]eta|fast|tech[-\\s]preview)?)$"
         },
         "product_stream": {
           "type": "string",


### PR DESCRIPTION
## Describe your changes

It turns out that's what's commonly used in
the konflux-release-data repo and also
what the CI tests in that repo enforce.

I tested this by running `check-jsonschema` manually first to reproduce the issue and then I also ran it with the modified schema and tried "fbc" as well as something like "v1.0.0" or "1.0.0" and it worked.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

