### PR TITLE
feat(RELEASE-1374): add extract-artifacts task for push-artifacts-to-cdn

### DIFF
--- a/internal/resources/push-artifacts-to-cdn-task.yaml
+++ b/internal/resources/push-artifacts-to-cdn-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml

--- a/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -41,7 +41,25 @@ spec:
     - name: taskGitRevision
       description: The revision in the taskGitUrl repo to be used
       type: string
+  workspaces:
+    - name: pipeline
   tasks:
+    - name: pull-artifacts
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/pull-artifacts/pull-artifacts.yaml
+      params:
+        - name: snapshot_json
+          value: $(params.snapshot_json)
+      workspaces:
+        - name: data
+          workspace: pipeline
     - name: push-artifacts-to-cdn-task
       timeout: "24h00m0s"
       taskRef:
@@ -68,6 +86,11 @@ spec:
           value: $(params.cgwHostname)
         - name: cgwSecret
           value: $(params.cgwSecret)
+      workspaces:
+        - name: data
+          workspace: pipeline
+      runAfter:
+        - pull-artifacts
   results:
     - name: result
       value: $(tasks.push-artifacts-to-cdn-task.results.result)

--- a/tasks/internal/extract-artifacts/README.md
+++ b/tasks/internal/extract-artifacts/README.md
@@ -1,0 +1,10 @@
+# extract-artifacts
+
+Tekton task that extracts binaries using oras and saves them in a workspace
+
+## Parameters
+
+| Name            | Description                                                       | Optional | Default value                                            |
+|-----------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
+| snapshot_json   | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
+| concurrentLimit | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |

--- a/tasks/internal/extract-artifacts/extract-artifacts.yaml
+++ b/tasks/internal/extract-artifacts/extract-artifacts.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-artifacts
+  labels:
+    app.kubernetes.io/version: "0.0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that extracts binaries using oras and saves them in a workspace
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be pulled at once
+      default: 3
+  results:
+    - name: result
+      type: string
+      description: Success if the task succeeds, the error otherwise
+  workspaces:
+    - name: data
+      description: The workspace where pulled binaries are stored
+  steps:
+    - name: extract-artifacts
+      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      env:
+        - name: DOCKER_CONFIG_JSON
+          valueFrom:
+            secretKeyRef:
+              name: redhat-workloads-token
+              key: .dockerconfigjson
+        - name: "SNAPSHOT_JSON"
+          value: "$(params.snapshot_json)"
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        STDERR_FILE=/tmp/stderr.txt
+
+        exitfunc() {
+            local err=$1
+            local line=$2
+            local command="$3"
+            if [ "$err" -eq 0 ] ; then
+                echo -n "Success" > "$(results.result.path)"
+            else
+                echo "$0: ERROR '$command' failed at line $line - exited with status $err" \
+                  > "$(results.result.path)"
+                if [ -f "$STDERR_FILE" ] ; then
+                    tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"
+                fi
+            fi
+            exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
+        }
+        # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        DISK_IMAGE_DIR="$(workspaces.data.path)/artifacts"
+        export DISK_IMAGE_DIR
+        mkdir -p "$DISK_IMAGE_DIR"
+
+        process_component() { # Expected argument is [component json]
+            COMPONENT=$1
+            PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}")
+            DESTINATION="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "${COMPONENT}")/FILES" \
+              || (echo "Missing staged.destination value for component. This should be an existing pulp repo. \
+                  Failing" && exit 1)
+            mkdir -p "${DESTINATION}"
+            DOWNLOAD_DIR=$(mktemp -d)
+            cd "$DOWNLOAD_DIR"
+            # oras has very limited support for selecting the right auth entry,
+            # so create a custom auth file with just one entry
+            AUTH_FILE=$(mktemp)
+            select-oci-auth "${PULLSPEC}" > "$AUTH_FILE"
+            oras pull --registry-config "$AUTH_FILE" "$PULLSPEC"
+            NUM_MAPPED_FILES=$(jq '.staged.files | length' <<< "${COMPONENT}")
+            for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
+                FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT")
+                SOURCE=$(jq -er '.source' <<< "$FILE")
+                FILENAME=$(jq -er '.filename' <<< "$FILE")
+                # The .qcow2 images are not zipped
+                if [ -f "${SOURCE}.gz" ] ; then
+                    gzip -d "${SOURCE}.gz"
+                fi
+                DESTINATION_FILE="${DESTINATION}/${FILENAME}"
+                # Albeit a low probability, a race condition can occur since this is run in parallel.
+                # The race condition is if two files have the same $DESTINATION_FILE and both
+                # if checks are run before either mv is run a few lines below.
+                if [ -f "${DESTINATION_FILE}" ] ; then
+                    echo -n "Multiple files use the same destination value: $DESTINATION" >&2
+                    echo " and filename value: $FILENAME. Failing..." >&2
+                    exit 1
+                fi
+                mv "$SOURCE" "${DESTINATION_FILE}" || echo "didn't find mapped file: ${SOURCE}"
+            done
+
+        }
+
+        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+
+        # use the 1st component's version
+        VERSION=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
+        if [ "${VERSION}" == "" ] ; then
+          echo "Error: version not specified in .components[0].staged.version. Needed to publish to customer portal"
+          exit 1
+        fi
+
+        # Pull each component in parallel
+        for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
+            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
+            # Limit batch size to concurrent limit
+            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
+                wait -n
+            done
+            process_component "$COMPONENT" 2> "$STDERR_FILE" &
+        done
+
+        # Wait for remaining processes to finish
+        while (( ${RUNNING_JOBS@P} > 0 )); do
+            wait -n
+        done

--- a/tasks/internal/extract-artifacts/tests/mocks.sh
+++ b/tasks/internal/extract-artifacts/tests/mocks.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function select-oci-auth() {
+    echo Mock select-oci-auth called with: $*
+}
+
+function oras() {
+    echo Mock oras called with: $*
+
+    if [[ "$*" != "pull --registry-config"* ]]; then
+        echo Error: Unexpected call to oras
+        exit 1
+    fi
+
+    if [[ "$*" == *"nonexistent-disk-image"* ]]; then
+        echo Simulating failing oras pull call
+        exit 1
+    fi
+
+    touch disk.qcow2
+    touch disk.raw.gz
+    touch fail_gzip.raw.gz
+}
+
+# We aren't going to pull real files that can be unzipped, so just remove the .gz suffix on them
+function gzip() {
+    if [ $2 == "fail_gzip.raw.gz" ] ; then
+        echo gzip failed
+        exit 1
+    fi
+    mv $2 ${2::-3}
+}
+
+function pulp_push_wrapper() {
+    echo Mock pulp_push_wrapper called with: $*
+
+    if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
+        printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
+    fi
+}
+
+function developer_portal_wrapper() {
+  echo Mock developer_portal_wrapper called with: $*
+
+  /home/developer-portal-wrapper/developer_portal_wrapper "$@" --dry-run
+
+  if ! [[ "$?" -eq 0 ]]; then
+      echo Unexpected call to developer_portal_wrapper
+      exit 1
+  fi
+}

--- a/tasks/internal/extract-artifacts/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/extract-artifacts/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy workloads secret (and delete it first if it exists)
+# The secret name here is hardcoded in the task
+kubectl delete secret redhat-workloads-token --ignore-not-found
+kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}

--- a/tasks/internal/extract-artifacts/tests/test-extract-artifacts.yaml
+++ b/tasks/internal/extract-artifacts/tests/test-extract-artifacts.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-artifacts
+spec:
+  description: |
+    Run the extract-artifacts task with everything set up properly to pass
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: extract-artifacts
+      params:
+        - name: snapshot_json
+          value: >-
+            {"application":"amd-bootc-1-3-qcow2-disk-image","artifacts":{},"components":[{
+            "containerImage":"quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+            "contentGateway":{"filePrefix":"amd-1.3","productCode":"DISK","productName":"Disk Image for Linux",
+            "productVersionName":"1.3-staging"},"staged":{"destination":"x86_64-isos","files":[{
+            "filename":"amd-1.3-x86_64-kvm.qcow2","source":"disk.qcow2"},{"filename":"amd-1.3-x86_64-kvm.raw",
+            "source":"disk.raw"}],"version":"1.3"}}]}
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                exit 1
+              fi

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -7,7 +7,6 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 | Name            | Description                                                       | Optional | Default value                                            |
 |-----------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
 | snapshot_json   | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
-| concurrentLimit | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
 | exodusGwSecret  | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
 | exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
 | pulpSecret      | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -15,10 +15,6 @@ spec:
     - name: snapshot_json
       type: string
       description: String containing a JSON representation of the snapshot spec
-    - name: concurrentLimit
-      type: string
-      description: The maximum number of images to be pulled at once
-      default: 3
     - name: exodusGwSecret
       type: string
       description: Env specific secret containing the Exodus Gateway configs
@@ -40,8 +36,11 @@ spec:
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
+  workspaces:
+    - name: data
+      description: The workspace where pulled binaries are stored
   steps:
-    - name: pull-and-push-images
+    - name: push-images
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
       env:
         - name: EXODUS_CERT
@@ -155,45 +154,8 @@ spec:
         echo "$DOCKER_CONFIG_JSON" | sed -r 's/(^|\})[^{}]+(\{|$)/\1\2/g' > ~/.docker/config.json
         set -x
 
-        DISK_IMAGE_DIR="$(mktemp -d)"
+        DISK_IMAGE_DIR="$(workspaces.data.path)/artifacts"
         export DISK_IMAGE_DIR
-
-        process_component() { # Expected argument is [component json]
-            COMPONENT=$1
-            PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}")
-            DESTINATION="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "${COMPONENT}")/FILES" \
-              || (echo "Missing staged.destination value for component. This should be an existing pulp repo. \
-                  Failing" && exit 1)
-            mkdir -p "${DESTINATION}"
-            DOWNLOAD_DIR=$(mktemp -d)
-            cd "$DOWNLOAD_DIR"
-            # oras has very limited support for selecting the right auth entry,
-            # so create a custom auth file with just one entry
-            AUTH_FILE=$(mktemp)
-            select-oci-auth "${PULLSPEC}" > "$AUTH_FILE"
-            oras pull --registry-config "$AUTH_FILE" "$PULLSPEC"
-            NUM_MAPPED_FILES=$(jq '.staged.files | length' <<< "${COMPONENT}")
-            for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
-                FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT")
-                SOURCE=$(jq -er '.source' <<< "$FILE")
-                FILENAME=$(jq -er '.filename' <<< "$FILE")
-                # The .qcow2 images are not zipped
-                if [ -f "${SOURCE}.gz" ] ; then
-                    gzip -d "${SOURCE}.gz"
-                fi
-                DESTINATION_FILE="${DESTINATION}/${FILENAME}"
-                # Albeit a rare one, this is a race condition since this is run in parallel.
-                # The race condition is if two files have the same $DESTINATION_FILE and both
-                # if checks are run before either mv is run a few lines below.
-                if [ -f "${DESTINATION_FILE}" ] ; then
-                    echo -n "Multiple files use the same destination value: $DESTINATION" >&2
-                    echo " and filename value: $FILENAME. Failing..." >&2
-                    exit 1
-                fi
-                mv "$SOURCE" "${DESTINATION_FILE}" || echo "didn't find mapped file: ${SOURCE}"
-            done
-
-        }
 
         process_component_for_developer_portal() { # Expected argument are [component json], [content_directory]
           COMPONENT=$1
@@ -230,30 +192,12 @@ spec:
 
         }
 
-        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
-        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
-
         # use the 1st component's version
         VERSION=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
         if [ "${VERSION}" == "" ] ; then
           echo "Error: version not specified in .components[0].staged.version. Needed to publish to customer portal"
           exit 1
         fi
-
-        # Process each component in parallel
-        for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
-            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
-            # Limit batch size to concurrent limit
-            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
-                wait -n
-            done
-            process_component "$COMPONENT" 2> "$STDERR_FILE" &
-        done
-
-        # Wait for remaining processes to finish
-        while (( ${RUNNING_JOBS@P} > 0 )); do
-            wait -n
-        done
 
         # Change to the subdir with the images
         cd "${DISK_IMAGE_DIR}"
@@ -266,7 +210,7 @@ spec:
         while IFS= read -r -d '' file ; do
             STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
               --arg version "$VERSION" \
-              '.payload.files[.payload.files | length] = 
+              '.payload.files[.payload.files | length] =
               {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$STAGED_JSON")
         done < <(find * -type f -print0)
 
@@ -283,6 +227,8 @@ spec:
           parent_dir=$(dirname "$path")
           component_destinations+=("${DISK_IMAGE_DIR}/$parent_dir")
         done
+
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
 
         ## Process Files for Developer Portal / CGW
         ##


### PR DESCRIPTION
## Describe your changes

This change splits the pulling part of the push-artifacts-to-cdn-task task into a new extract-artifacts task. There is now a workspace that the tasks share and where the artifacts are stored.

This will enable us to add a new signing task between the pulling and pushing later.

**Note:** This is a Draft, tests haven't been added yet.

## Relevant Jira

https://issues.redhat.com/browse/RELEASE-1374

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

