### PR TITLE
refactor: specify branches instead of target branch in promotion script

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -25,12 +25,12 @@ set -e
 ORG="konflux-ci"
 REPO="release-service-catalog"
 
-OPTIONS=$(getopt --long "branches:,force-to-staging:,override:,dry-run:,help" -o "b:,h" -- "$@")
+OPTIONS=$(getopt --long "promotion-type:,force-to-staging:,override:,dry-run:,help" -o "p:,h" -- "$@")
 eval set -- "$OPTIONS"
 while true; do
     case "$1" in
-        -b|--branches)
-            BRANCHES="$2"
+        -p|--promotion-type)
+            PROMOTION_TYPE="$2"
             shift 2
             ;;
         --force-to-staging)
@@ -60,7 +60,7 @@ done
 print_help(){
     echo "Usage: $0 --branches branch1-to-branch2 [--force-to-staging false] [--override false] [--dry-run false]"
     echo
-    echo "  --branches:         Which branch is being promoted where. Either development-to-staging"
+    echo "  --promotion-type:   The type of promotion to perform. Either development-to-staging"
     echo "                      or staging-to-production."
     echo "  --force-to-staging: If passed with value true, allow promotion to staging even"
     echo "                      if staging and production differ."
@@ -69,7 +69,7 @@ print_help(){
     echo "  --dry-run:          If passed with value true, print out the changes that would"
     echo "                      be promoted but do not git push or delete the temp repo."
     echo
-    echo "  --branches has to be specified."
+    echo "  --promotion-type has to be specified."
 }
 
 check_if_branch_differs() {
@@ -90,20 +90,20 @@ check_if_any_commits_in_last_week() {
     fi
 }
 
-if [ -z "${BRANCHES}" ]; then
-    echo -e "Error: missing '--branches' argument\n"
+if [ -z "${PROMOTION_TYPE}" ]; then
+    echo -e "Error: missing '--promotion-type' argument\n"
     print_help
     exit 1
 fi
-if [ "${BRANCHES}" == development-to-staging ]; then
+if [ "${PROMOTION_TYPE}" == development-to-staging ]; then
     SOURCE_BRANCH=development
     TARGET_BRANCH=staging
-elif [ "${BRANCHES}" == staging-to-production ]; then
+elif [ "${PROMOTION_TYPE}" == staging-to-production ]; then
     SOURCE_BRANCH=staging
     TARGET_BRANCH=production
     SRE_DUPLICATE_BRANCH=stable
 else
-    echo "Invalid branches. Only 'development-to-staging' and 'staging-to-production' are allowed"
+    echo "Invalid promotion type. Only 'development-to-staging' and 'staging-to-production' are allowed"
     print_help
     exit 1
 fi

--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -25,12 +25,12 @@ set -e
 ORG="konflux-ci"
 REPO="release-service-catalog"
 
-OPTIONS=$(getopt --long "target-branch:,force-to-staging:,override:,dry-run:,help" -o "tgt:,h" -- "$@")
+OPTIONS=$(getopt --long "branches:,force-to-staging:,override:,dry-run:,help" -o "b:,h" -- "$@")
 eval set -- "$OPTIONS"
 while true; do
     case "$1" in
-        -tgt|--target-branch)
-            TARGET_BRANCH="$2"
+        -b|--branches)
+            BRANCHES="$2"
             shift 2
             ;;
         --force-to-staging)
@@ -58,10 +58,10 @@ while true; do
 done
 
 print_help(){
-    echo "Usage: $0 --target-branch branch [--force-to-staging false] [--override false] [--dry-run false]"
+    echo "Usage: $0 --branches branch1-to-branch2 [--force-to-staging false] [--override false] [--dry-run false]"
     echo
-    echo "  --target-branch:    The name of the branch to be promoted. Options are staging"
-    echo "                      and production."
+    echo "  --branches:         Which branch is being promoted where. Either development-to-staging"
+    echo "                      or staging-to-production."
     echo "  --force-to-staging: If passed with value true, allow promotion to staging even"
     echo "                      if staging and production differ."
     echo "  --override:         If passed with value true, allow promotion to production"
@@ -69,7 +69,7 @@ print_help(){
     echo "  --dry-run:          If passed with value true, print out the changes that would"
     echo "                      be promoted but do not git push or delete the temp repo."
     echo
-    echo "  --target-branch has to be specified."
+    echo "  --branches has to be specified."
 }
 
 check_if_branch_differs() {
@@ -90,18 +90,20 @@ check_if_any_commits_in_last_week() {
     fi
 }
 
-if [ -z "${TARGET_BRANCH}" ]; then
-    echo -e "Error: missing 'target-branch' argument\n"
+if [ -z "${BRANCHES}" ]; then
+    echo -e "Error: missing '--branches' argument\n"
     print_help
     exit 1
 fi
-if [ "${TARGET_BRANCH}" == "staging" ]; then
-    SOURCE_BRANCH="development"
-elif [ "${TARGET_BRANCH}" == "production" ]; then
-    SOURCE_BRANCH="staging"
-    SRE_DUPLICATE_BRANCH="stable"
+if [ "${BRANCHES}" == development-to-staging ]; then
+    SOURCE_BRANCH=development
+    TARGET_BRANCH=staging
+elif [ "${BRANCHES}" == staging-to-production ]; then
+    SOURCE_BRANCH=staging
+    TARGET_BRANCH=production
+    SRE_DUPLICATE_BRANCH=stable
 else
-    echo "Invalid target-branch. Only 'staging' and 'production' are allowed"
+    echo "Invalid branches. Only 'development-to-staging' and 'staging-to-production' are allowed"
     print_help
     exit 1
 fi

--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -3,14 +3,14 @@ name: Promote branch
 on:
   workflow_dispatch:
     inputs:
-      target-branch:
-        description: The name of the branch to be promoted
+      branches:
+        description: Which branch is being promoted where
         type: choice
         required: true
-        default: staging
+        default: development-to-staging
         options:
-          - staging
-          - production
+          - development-to-staging
+          - staging-to-production
       force-to-staging:
         description: |
           Force to staging: Allow promotion to staging even if staging and production differ
@@ -39,10 +39,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Run branch promotion script
         run: |
-          .github/scripts/promote_branch.sh --target-branch $TARGET --force-to-staging $FORCE \
+          .github/scripts/promote_branch.sh --branches $BRANCHES --force-to-staging $FORCE \
             --override $OVERRIDE --dry-run $DRY
         env:
-          TARGET: ${{ inputs.target-branch }}
+          BRANCHES: ${{ inputs.branches }}
           FORCE: ${{ inputs.force-to-staging }}
           OVERRIDE: ${{ inputs.override }}
           DRY: ${{ inputs.dry-run }}

--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -3,8 +3,8 @@ name: Promote branch
 on:
   workflow_dispatch:
     inputs:
-      branches:
-        description: Which branch is being promoted where
+      promotion-type:
+        description: The type of promotion to perform
         type: choice
         required: true
         default: development-to-staging
@@ -39,10 +39,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Run branch promotion script
         run: |
-          .github/scripts/promote_branch.sh --branches $BRANCHES --force-to-staging $FORCE \
+          .github/scripts/promote_branch.sh --promotion-type $PROMOTION_TYPE --force-to-staging $FORCE \
             --override $OVERRIDE --dry-run $DRY
         env:
-          BRANCHES: ${{ inputs.branches }}
+          PROMOTION_TYPE: ${{ inputs.promotion-type }}
           FORCE: ${{ inputs.force-to-staging }}
           OVERRIDE: ${{ inputs.override }}
           DRY: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Describe your changes

Previously what was being promoted was potentially confusing because the description said "which branch to promote", but it was actually the target branch, not the source branch. And we promote the source branch to the target branch.

I propose to specify both branches at once, i.e. development-to-staging or staging-to-production to make it clearer.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

