### PR TITLE
fix: set rh-sign-image-cosign timeout to 6 hrs

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.8.1
+* Set timeout for rh-sign-image-cosign task to be 6 hrs
+
 ## Changes in 1.8.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 
@@ -35,7 +38,7 @@ the rh-push-to-registry-redhat-io pipeline.
 * Add upload-component-sbom task to push the component-level SBOMs to Atlas.
 
 ## Changes in 1.6.0
-* Add new parameter `schema` to the `check-data-keys` task. 
+* Add new parameter `schema` to the `check-data-keys` task.
 * Add new systems pyxis,mapping & signing to the task.
 
 ## Changes in 1.5.7

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.8.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -285,6 +285,7 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image-cosign
+      timeout: "6h00m0s"
       when:
         - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
           operator: notin

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.7.1
+* Set timeout for rh-sign-image-cosign task to be 6 hrs
+
 ## Changes in 4.7.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.7.0"
+    app.kubernetes.io/version: "4.7.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -120,7 +120,7 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value: 
+          value:
             - pyxis
             - mapping
             - sign
@@ -265,6 +265,7 @@ spec:
       runAfter:
         - collect-data
     - name: rh-sign-image-cosign
+      timeout: "6h00m0s"
       when:
         - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
           operator: notin


### PR DESCRIPTION
## Describe your changes

A user reported timeouts in this task. The timeout happened due to the task waiting for access to the shared PV which should eventually be improved in [RELEASE-1291](https://issues.redhat.com//browse/RELEASE-1291) but for now the increased timeout should help.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

