### PR TITLE
fix: increase requestTimeout in signing tasks to 30 minutes

### DIFF
--- a/tasks/managed/rh-sign-image/README.md
+++ b/tasks/managed/rh-sign-image/README.md
@@ -10,7 +10,7 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | dataPath                 | Path to the JSON string of the merged data to use in the data workspace                                                                                                                                                                           | No       | -             |
 | releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                                                                                                                                                                         | No       | -             |
 | requester                | Name of the user that requested the signing, for auditing purpose                                                                                                                                                                                 | No       | -             |
-| requestTimeout           | Request timeout                                                                                                                                                                                                                                   | Yes      | 180           |
+| requestTimeout           | Request timeout                                                                                                                                                                                                                                   | Yes      | 1800          |
 | concurrentLimit          | The maximum number of images to be processed at once                                                                                                                                                                                              | Yes      | 16            |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating a requests                                                                                                                                                                | No       | -             |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                                                                                                             | No       | -             |
@@ -19,6 +19,11 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | pyxisSecret              | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys: key and cert                                                                                                                                                 | No       | -             |
 | signRegistryAccessPath   | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 
+
+## Changes in 5.0.3
+* Increase `requestTimeout` value to 30 minutes
+  * The internal-request/internal-pipeline is set to a timeout of 30 minutes, but the internal-request/internal-pipeline script
+    was set to timeout after 3 minutes, which didn't make much sense.
 
 ## Changes in 5.0.2
 * fix linting issues

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "5.0.2"
+    app.kubernetes.io/version: "5.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,7 +26,7 @@ spec:
       description: Name of the user that requested the signing, for auditing purposes
     - name: requestTimeout
       type: string
-      default: "180"
+      default: "1800"
       description: InternalRequest timeout
     - name: concurrentLimit
       type: string

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -7,11 +7,11 @@ Creates an InternalRequest to sign an index image
 | Name                     | Description                                                                               | Optional | Default value  |
 |--------------------------|-------------------------------------------------------------------------------------------|----------|----------------|
 | dataPath                 | Path to the JSON string of the merged data to use in the data workspace                   | No       | -              |
-| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -              | 
+| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -              |
 | referenceImage           | The image to be signed                                                                    | No       | -              |
 | manifestListDigests      | The manifest digests for each arch in manifest list                                       | No       | -              |
 | requester                | Name of the user that requested the signing, for auditing purposes                        | No       | -              |
-| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180            |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 1800           |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -              |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -              |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -              |
@@ -28,6 +28,11 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 4.1.1
+* Increase `requestTimeout` value to 30 minutes
+  * The internal-request/internal-pipeline is set to a timeout of 30 minutes, but the internal-request/internal-pipeline script
+    was set to timeout after 3 minutes, which didn't make much sense.
 
 ## Changes in 4.1.0
 * Updated task to support the `internal-pipelinerun` requestType

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,7 +29,7 @@ spec:
       description: Name of the user that requested the signing, for auditing purposes
     - name: requestTimeout
       type: string
-      default: "180"
+      default: "1800"
       description: InternalRequest timeout
     - name: pipelineRunUid
       type: string
@@ -101,7 +101,7 @@ spec:
           echo "- reference=${reference_image}"
           echo "- manifest_digest=${manifest_digest}"
           echo "- requester=$(params.requester)"
-  
+
           ${requestType} -r "${request}" \
             -p pipeline_image="${pipeline_image}" \
             -p reference="${reference_image}" \


### PR DESCRIPTION
The signing pipelinerun that gets created would have a timeout of 30 minutes, but the internal-request/internal-pipelinerun script would timeout after 3 minutes which didn't make sense.

Right now the signing pipeline takes around 20 minutes because of issues with exceeded quota in umb, so this will help users.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

