### PR TITLE
feat(RELEASE-1246): make `publish-to-cgw` task idempotent

### DIFF
--- a/tasks/managed/publish-to-cgw/README.md
+++ b/tasks/managed/publish-to-cgw/README.md
@@ -1,11 +1,9 @@
 # publish-to-cgw
 
-Tekton task to publish content to Red Hat's Developer portal using pubtools-content-gateway
+Tekton task to publish content to Red Hat's Developer portal using content-gateway API.
 
  - This task _expects_ the content is already pushed to CDN, it _exposes_ the metadata to Developer portal using content-gateway
- - This task uses [pubtools-content-gateway](https://github.com/release-engineering/pubtools-content-gateway) to publish content to content-gateway.
-
-
+ - This task is idempotent; it will not push new files if a file with the same label, short URL, and download URL already exists in the product version.
 
 ## Parameters
 
@@ -15,6 +13,12 @@ Tekton task to publish content to Red Hat's Developer portal using pubtools-cont
 | contentDir  | Path where the content to push is stored in the workspace       | No       | -             |
 | cgwHostname | The hostname of the content-gateway to publish the metadata to  | yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret   | The kubernetes secret to use to authenticate to content-gateway | yes      | publish-to-cgw-secret |
+
+## Changes in 1.0.0
+* Make the task idempotent by checking if files are
+  already present in the product name and version.
+  * Removal of the 'pubtools-content-gateway' command
+    and calling the content-gateway API directly.
 
 ## Changes in 0.2.6
 * Invoke Content Gateway without password in command

--- a/tasks/managed/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/managed/publish-to-cgw/publish-to-cgw.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-cgw
   labels:
-    app.kubernetes.io/version: "0.2.6"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
       description: Workspace to save the CR jsons to
   steps:
     - name: run-push-cgw-metadata
-      image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+      image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
       env:
         - name: CGW_USERNAME
           valueFrom:
@@ -54,160 +54,9 @@ spec:
               key: token
       script: |
         #!/usr/bin/env bash
-        python3 <<EOF
-        """
-        Run push-cgw-metadata command to push metadata to CGW:
-        1. Extract all components under contentGateway key from dataPath
-        2. Find all the files in contentDir that starts with the component name
-        4. Generate necessary metadata for each file
-        5. Dump the metadata to a YAML file
-        6. Run push-cgw-metadata to push the metadata
-        """
-        import os
-        import json
-        import yaml
-        import hashlib
-        import subprocess
-
-        DATA_FILE = "$(workspaces.data.path)/$(params.dataPath)"
-        CONTENT_DIR = "$(workspaces.data.path)/$(params.contentDir)"
-
-        # Grab the path of datafile and use that as workspace directory
-        WORKSPACE_DIR = os.path.dirname(DATA_FILE)
-        METADATA_FILE_PATH = f"{WORKSPACE_DIR}/cgw_metadata.yaml"
-        RESULT_FILE_JSON_PATH=f"{WORKSPACE_DIR}/results.json"
-
-        with open(DATA_FILE, 'r') as file:
-            data = json.load(file)
-
-        os.makedirs(WORKSPACE_DIR, exist_ok=True)
-
-        productName = data['contentGateway']['productName']
-        productCode = data['contentGateway']['productCode']
-        productVersionName = data['contentGateway']['productVersionName']
-        mirrorOpenshiftPush = data['contentGateway'].get('mirrorOpenshiftPush')
-        components = data['contentGateway']['components']
-        content_list = os.listdir(CONTENT_DIR)
-
-        # Default values for each component,
-        # values from DATA_FILE takes presedence over these
-        default_values_per_component = {
-            'type': "FILE",
-            "hidden": False,
-            "invisible": False
-        }
-
-        def generate_download_url(file_name):
-            """
-            Generate a download URL in this format:
-            /content/origin/files/sha256/{checksum[:2]}{checksum}/{file_name}
-            """
-            prefix = "/content/origin/files/sha256"
-            sha256_hash = hashlib.sha256()
-            with open(CONTENT_DIR + "/" + file_name, "rb") as f:
-                for byte_block in iter(lambda: f.read(4096), b""):
-                    sha256_hash.update(byte_block)
-            checksum = sha256_hash.hexdigest()
-            return f"{prefix}/{checksum[:2]}/{checksum}/{file_name}"
-
-        def generate_metadata(content_list, components):
-            """
-            Generate metadata for each file in
-            content_list that starts with the component name
-            """
-            shortURL_base = '/pub/'
-            if mirrorOpenshiftPush:
-                shortURL_base = '/pub/cgw'
-            metadata = []
-            shasum_files_processed = []
-            for file in content_list:
-                matching_component = None
-                for component in components:
-                    if file.startswith(component['name']):
-                        matching_component = component.copy()
-                        break
-
-                if matching_component:
-                    print("Processing file: ", file)
-                    matching_component.update({
-                        'productName': productName,
-                        'productCode': productCode,
-                        'productVersionName': productVersionName,
-                        'downloadURL': generate_download_url(file),
-                        'shortURL': f"{shortURL_base}/{productCode}/{productVersionName}/{file}",
-                        'label': file,
-                    })
-                    del matching_component['name']
-                    metadata.append({
-                        'type': 'file',
-                        'action': 'create',
-                        'metadata': {**default_values_per_component, **matching_component}
-                    })
-                else:
-                    if file.startswith('sha256') and file not in shasum_files_processed:
-                        shasum_files_processed.append(file)
-                        print("Processing file: ", file)
-                        if file.endswith(".gpg"):
-                            label = "Checksum - GPG"
-                        elif file.endswith(".sig"):
-                            label = "Checksum - Signature"
-                        elif file.endswith(".txt"):
-                            label = "Checksum"
-
-                        metadata.append({
-                            'type': 'file',
-                            'action': 'create',
-                            'metadata': {
-                                'productName': productName,
-                                'productCode': productCode,
-                                'productVersionName': productVersionName,
-                                'downloadURL': generate_download_url(file),
-                                'shortURL': f"{shortURL_base}/{productCode}/{productVersionName}/{file}",
-                                'label': label,
-                                **default_values_per_component
-                            }
-                        })
-                    else:
-                        # Skip files that do not start with any component name or
-                        # sha256
-                        print(f"Skipping file: {file} as it does not start with any \
-                            component name")
-                        continue
-
-            return metadata
-
-        metadata = generate_metadata(content_list, components)
-        print(len(metadata), "Files will be publised to CGW")
-
-        with open(METADATA_FILE_PATH, 'w') as file:
-            yaml.dump(metadata, file, default_flow_style=False, sort_keys=False)
-
-        print(f"YAML content dumped to {METADATA_FILE_PATH}")
-
-        command = [
-            'push-cgw-metadata',
-            '--CGW_hostname', '$(params.cgwHostname)',
-            '--CGW_username', '${CGW_USERNAME}',
-            '--CGW_filepath', METADATA_FILE_PATH
-        ]
-
-        try:
-            result = subprocess.run(command, capture_output=True, text=True, check=True)
-            command_output = result.stderr # using stderr to capture logged output
-            print(f"Command succeeded with {command_output}")
-        except subprocess.CalledProcessError as error:
-            print(f"Command failed with return code {error.returncode}\n")
-            print(f"CGW metadata that was passed: {metadata}\n")
-            command_output = error.stderr
-            print(f" ERROR:\n{command_output}")
-            raise
-
-        result_data = {"no_of_files_processed": len(metadata),
-                        "metadata_file_path": METADATA_FILE_PATH,
-                        "command_output": command_output}
-
-        with open(RESULT_FILE_JSON_PATH, 'w') as f:
-            json.dump(result_data, f)
-        with open('$(results.resultDataPath.path)', 'w') as f:
-            f.write(RESULT_FILE_JSON_PATH)
-        EOF
+        
+        publish_to_cgw_wrapper \
+            --cgw_host "$(params.cgwHostname)" \
+            --data_file "$(workspaces.data.path)/$(params.dataPath)" \
+            --content_dir "$(workspaces.data.path)/$(params.contentDir)" \
+            --output_file "$(results.resultDataPath.path)"

--- a/tasks/managed/publish-to-cgw/tests/mocks.sh
+++ b/tasks/managed/publish-to-cgw/tests/mocks.sh
@@ -1,11 +1,173 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-mkdir -p /tmp/mock-bin
+MOCK_SERVER_SCRIPT="/tmp/mock_server.py"
 
-cat << 'EOF' > /tmp/mock-bin/push-cgw-metadata
-#!/bin/bash
-echo "push-cgw-metadata mock called with: $@" >&2
+cat << 'EOF' > "$MOCK_SERVER_SCRIPT"
+import http.server
+import logging
+import socketserver
+import json
+
+
+class MockHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    all_files = [
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.2/skip",
+            "productVersionId": 4156076,
+            "downloadURL": "/content/origin/files/sha256/78/786a963eabcce0ee12fa1d36030db869a20e87b5f37477d929fb49b54a555593/skip",
+            "label": "skip",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.2/skip-darwin-amd64.gz",
+            "productVersionId": 4156076,
+            "downloadURL": "/content/origin/files/sha256/dd/ddaa38ae71199c268580b50adaefab359db7b7bae6ba8318570af33e550170d2/skip-darwin-amd64.gz",
+            "label": "skip-darwin-amd64.gz",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.2/skip-darwin-arm64.gz",
+            "productVersionId": 4156076,
+            "downloadURL": "/content/origin/files/sha256/0a/0a2f78e827c2d24c96f3e964b196e96528404329076c8635d4542bbfd9674a8a/skip-darwin-arm64.gz",
+            "label": "skip-darwin-arm64.gz",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.2/skip-linux-amd64.gz",
+            "productVersionId": 4156076,
+            "downloadURL": "/content/origin/files/sha256/e9/e9b0965f5e76e6b9f784c96c87afc44f2d61434447bceacc669e776c8a8bad61/skip-linux-amd64.gz",
+            "label": "skip-linux-amd64.gz",
+        },
+        {
+            "type": "FILE",
+            "hidden": False,
+            "invisible": False,
+            "description": "Red Hat OpenShift Local Sandbox Test",
+            "shortURL": "/pub/cgw/product_code_1/1.2/skip-linux-arm64.gz",
+            "productVersionId": 4156076,
+            "downloadURL": "/content/origin/files/sha256/3c/3ceafc6b478a52c63c48ee5dfa08737b149c0a3b01035870b3be48098c9b4cf6/skip-linux-arm64.gz",
+            "label": "skip-linux-arm64.gz",
+        },
+    ]
+
+    logging.basicConfig(level=logging.INFO, format="Mock Call: %(message)s")
+
+    def log_message(self, format, *args):
+        logging.info(format % args)
+
+    def _send_json(self, data, status=200):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode("utf-8"))
+
+    def do_GET(self):
+        """
+        GET requests:
+        /products
+        /products/<product_id>/versions
+        /products/<product_id>/versions/<version_id>/files
+        Else return 404
+        """
+        if self.path == "/products":
+            response = [
+                {
+                    "id": 4010399,
+                    "name": "product_name_1",
+                    "productCode": "product_code_1",
+                },
+                {
+                    "id": 5010399,
+                    "name": "product_name_2",
+                    "productCode": "product_code_2",
+                },
+            ]
+            self._send_json(response)
+
+        elif self.path == "/products/4010399/versions":
+            response = [
+                {
+                    "id": 4156075,
+                    "productId": 4010399,
+                    "versionName": "1.1",
+                },
+                {
+                    "id": 4156076,
+                    "productId": 5010399,
+                    "versionName": "1.2",
+                },
+            ]
+            self._send_json(response)
+
+        elif self.path.startswith("/products/") and self.path.endswith("/files"):
+            self._send_json(self.all_files)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        """
+        POST requests:
+        /products/<product_id>/versions/<version_id>/files
+        Create a new file and return the new file ID
+        if a short url or download url is present it returns an error
+        """
+        if "/versions/" in self.path and self.path.endswith("/files"):
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            file_metadata = json.loads(body.decode("utf-8"))
+
+            for existing in self.all_files:
+                if any(
+                    file_metadata.get(key) == existing[key]
+                    for key in ["shortURL", "downloadURL"]
+                ):
+                    self.send_response(409)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(
+                        json.dumps({"File already exists!"}).encode("utf-8")
+                    )
+                    return
+
+            file_id = len(self.all_files) + 100
+            file_metadata["id"] = file_id
+            self.all_files.append(file_metadata)
+            self._send_json(file_id, status=201)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_DELETE(self):
+        """
+        DELETE requests:
+        /products/<product_id>/versions/<version_id>/files/<file_id>
+        Delete a file by id.
+        """
+        if "/versions/" in self.path and "/files/" in self.path:
+            self.send_response(200)
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+with socketserver.TCPServer(("0.0.0.0", 8080), MockHTTPRequestHandler) as httpd:
+    httpd.serve_forever()
 EOF
 
-chmod +x /tmp/mock-bin/push-cgw-metadata
-export PATH=/tmp/mock-bin:$PATH
+python3 "$MOCK_SERVER_SCRIPT" &
+MOCK_SERVER_PID=$!

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-all.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-all.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-cgw-create-all
+spec:
+  description: |
+    Run the publish-to-cgw task and verify that all files are created
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+            script: |
+              #!/bin/bash
+              set -eux
+
+              CONTENT_DIR="$(workspaces.data.path)/contentDir"
+              mkdir -p "$CONTENT_DIR"
+
+              # binaries to be created
+              cosign_binaries=(
+                "cosign"
+                "cosign-darwin-amd64.gz"
+                "cosign-darwin-arm64.gz"
+                "cosign-linux-amd64.gz"
+                "cosign-linux-arm64.gz"
+                "fake-name-linux-amd64.gz" # should be ignored
+                "checksum.txt" # should be ignored
+              )  
+              
+              # binaries to be created
+              gitsign_binaries=(
+                "gitsign-darwin-amd64.gz"
+                "gitsign-darwin-arm64.gz"
+                "gitsign-linux-amd64.gz"
+                "gitsign-linux-arm64.gz"
+                "checksum.txt" # should be ignored
+              )   
+              
+              all_binaries=("${cosign_binaries[@]}" "${gitsign_binaries[@]}")
+              
+              for binary in "${all_binaries[@]}"; do
+                echo "$binary content" > "$CONTENT_DIR/$binary"
+              done
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "contentGateway": {
+                  "mirrorOpenshiftPush": true,
+                  "productName": "product_name_1",
+                  "productCode": "product_code_1",
+                  "productVersionName": "1.2",
+                  "components": [
+                    {
+                      "name": "cosign",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "shortURL": "/cgw/product_code_1/1.1",
+                      "hidden": false
+                    },
+                    {
+                      "name": "gitsign",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "shortURL": "/cgw/product_code_1/1.1",
+                      "hidden": false
+                    }
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-to-cgw
+      params:
+        - name: cgwHostname
+          value: "http://0.0.0.0:8080"
+        - name: dataPath
+          value: "data.json"
+        - name: contentDir
+          value: "contentDir"
+        - name: cgwSecret
+          value: "test-publish-to-cgw-secret"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: resultDataPath
+          value: $(tasks.run-task.results.resultDataPath)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: resultDataPath
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            script: |
+              #!/usr/bin/env bash
+              python3 <<EOF
+              import json
+
+              with open("$(params.resultDataPath)", "r") as file:
+                  data = json.load(file)
+
+              no_of_files_processed = data.get("no_of_files_processed")
+              no_of_files_created = data.get("no_of_files_created")
+              no_of_files_skipped = data.get("no_of_files_skipped")
+
+              assert (
+                  no_of_files_processed == 9
+              ), f"Expected 9 files to be processed, got {no_of_files_processed}"
+              assert (
+                  no_of_files_created == 9
+              ), f"Expected 9 files to be created, got {no_of_files_created}"
+              assert (
+                  no_of_files_skipped == 0
+              ), f"Expected 0 files to be skipped, got {no_of_files_skipped}"
+
+              print("All checks passed")
+              EOF

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-and-skip.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-and-skip.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-cgw-create-skip
+spec:
+  description: |
+    Run the publish-to-cgw task and verify that 5 files are 
+    created and 5 files are skipped, ensuring that only new files are
+    created and existing files are skipped before pushing to CGW.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+            script: |
+              #!/bin/bash
+              set -eux
+
+              CONTENT_DIR="$(workspaces.data.path)/contentDir"
+              mkdir -p "$CONTENT_DIR"
+
+              # binaries to be skipped
+              skip_binaries=(
+                skip
+                skip-darwin-amd64.gz
+                skip-darwin-arm64.gz
+                skip-linux-amd64.gz
+                skip-linux-arm64.gz
+                fake-name-linux-amd64.gz # should be ignored
+                checksum.txt # should be ignored
+              )
+
+              # binaries to be created
+              cosign_binaries=(
+                cosign
+                cosign-darwin-amd64.gz
+                cosign-darwin-arm64.gz
+                cosign-linux-amd64.gz
+                cosign-linux-arm64.gz
+                fake-name-linux-amd64.gz # should be ignored
+                checksum.txt # should be ignored
+              )
+
+              all_binaries=("${cosign_binaries[@]}" "${skip_binaries[@]}")
+
+              for binary in "${all_binaries[@]}"; do
+                echo "$binary content" > "$CONTENT_DIR/$binary"
+              done    
+              
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "contentGateway": {
+                  "mirrorOpenshiftPush": true,
+                  "productName": "product_name_1",
+                  "productCode": "product_code_1",
+                  "productVersionName": "1.2",
+                  "components": [
+                    {
+                      "name": "skip",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "shortURL": "/cgw/product_code_1/1.1",
+                      "hidden": false
+                    },
+                    { 
+                      "name": "cosign",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "shortURL": "/cgw/product_code_1/1.1",
+                      "hidden": false
+                    }
+                  ]
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: publish-to-cgw
+      params:
+        - name: cgwHostname
+          value: "http://0.0.0.0:8080"
+        - name: dataPath
+          value: "data.json"
+        - name: contentDir
+          value: "contentDir"
+        - name: cgwSecret
+          value: "test-publish-to-cgw-secret"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: resultDataPath
+          value: $(tasks.run-task.results.resultDataPath)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: resultDataPath
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            script: |
+              #!/usr/bin/env bash
+              python3 <<EOF
+              import json
+
+              with open("$(params.resultDataPath)", "r") as file:
+                  data = json.load(file)
+
+              no_of_files_processed = data.get("no_of_files_processed")
+              no_of_files_created = data.get("no_of_files_created")
+              no_of_files_skipped = data.get("no_of_files_skipped")
+
+              assert (
+                  no_of_files_processed == 10
+              ), f"Expected 10 files to be processed, got {no_of_files_processed}"
+              assert (
+                  no_of_files_created == 5
+              ), f"Expected 5 files to be created, got {no_of_files_created}"
+              assert (
+                  no_of_files_skipped == 5
+              ), f"Expected 5 files to be skipped, got {no_of_files_skipped}"
+
+              print("All checks passed")
+              EOF

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-skip-all.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-skip-all.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-publish-to-cgw
+  name: test-publish-to-cgw-skip-all
 spec:
   description: |
-    Run the publish-to-cgw task and verify the results
+   Run the publish-to-cgw task and confirm that every file is skipped
+   since all files already exist in the CGW.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -18,52 +19,39 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
             script: |
-              #!/usr/bin/env sh
+              #!/bin/bash
               set -eux
 
               CONTENT_DIR="$(workspaces.data.path)/contentDir"
               mkdir -p "$CONTENT_DIR"
 
-              cosign_binaries="\
-              cosign \
-              cosign-darwin-amd64.gz \
-              cosign-darwin-arm64.gz \
-              cosign-linux-amd64.gz \
-              cosign-linux-arm64.gz \
-              fake-name-linux-amd64.gz \ # should be ignored
-              checksum.txt" # should be ignored
+              # binaries to be skipped
+              skip_binaries=(
+                "skip"
+                "skip-darwin-amd64.gz"
+                "skip-darwin-arm64.gz"
+                "skip-linux-amd64.gz"
+                "skip-linux-arm64.gz"
+                "fake-name-linux-amd64.gz" # should be ignored 
+                "checksum.txt" # should be ignored
+              )
 
-              gitsign_binaries="\
-              gitsign-darwin-amd64.gz \
-              gitsign-darwin-arm64.gz \
-              gitsign-linux-amd64.gz \
-              gitsign-linux-arm64.gz \
-              checksum.txt" # should be ignored
-
-              all_binaries="$cosign_binaries $gitsign_binaries"
-
-              for binary in $all_binaries; do
+              for binary in "${skip_binaries[@]}"; do
                 echo "$binary content" > "$CONTENT_DIR/$binary"
-              done
-
+              done    
+              
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "contentGateway": {
                   "mirrorOpenshiftPush": true,
                   "productName": "product_name_1",
                   "productCode": "product_code_1",
-                  "productVersionName": "1.1",
+                  "productVersionName": "1.2",
                   "components": [
                     {
-                      "name": "cosign",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
-                    },
-                    {
-                      "name": "gitsign",
+                      "name": "skip",
                       "description": "Red Hat OpenShift Local Sandbox Test",
                       "shortURL": "/cgw/product_code_1/1.1",
                       "hidden": false
@@ -76,6 +64,8 @@ spec:
       taskRef:
         name: publish-to-cgw
       params:
+        - name: cgwHostname
+          value: "http://0.0.0.0:8080"
         - name: dataPath
           value: "data.json"
         - name: contentDir
@@ -105,16 +95,22 @@ spec:
               python3 <<EOF
               import json
 
-              with open('$(params.resultDataPath)', 'r') as file:
+              with open("$(params.resultDataPath)", "r") as file:
                   data = json.load(file)
 
-              no_of_files_processed = data.get('no_of_files_processed')
-              cmd_output = data.get('command_output')
-              metadata_file_path = data.get('metadata_file_path')
+              no_of_files_processed = data.get("no_of_files_processed")
+              no_of_files_created = data.get("no_of_files_created")
+              no_of_files_skipped = data.get("no_of_files_skipped")
 
-              assert no_of_files_processed == 9, f'Expected 9 files to be processed, got {no_of_files_processed}'
-              assert cmd_output.startswith('push-cgw-metadata mock called with')
-              assert metadata_file_path.endswith('/cgw_metadata.yaml')
+              assert (
+                  no_of_files_processed == 5
+              ), f"Expected 5 files to be processed, got {no_of_files_processed}"
+              assert (
+                  no_of_files_created == 0
+              ), f"Expected 0 files to be created, got {no_of_files_created}"
+              assert (
+                  no_of_files_skipped == 5
+              ), f"Expected 5 files to be skipped, got {no_of_files_skipped}"
 
-              print('All checks passed')
+              print("All checks passed")
               EOF


### PR DESCRIPTION
## Describe your changes
This update makes the `publish-to-cgw` task  idempotent by checking if files already exist under the specified product name and version before processing. If files are present, they are skipped to avoid errors. Additionally, the pubtools-content-gateway command has been removed and we are now calling the CGW api directly.

## Relevant Jira
[CGW Docs](https://source.redhat.com/groups/public/dxd/middleware_engineering_services_mwes_wiki/redhat_developersjboss_download_manager_administration_ui)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [* ] My commit message includes `Signed-off-by: My name <email>`
- [ *] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ *] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

