### PR TITLE
feat(RELEASE-1322): embargo-check internal task uses git resolver

### DIFF
--- a/internal/pipelines/check-embargoed-cves/README.md
+++ b/internal/pipelines/check-embargoed-cves/README.md
@@ -6,6 +6,11 @@ result will be the list of embargoed CVEs.
 
 ## Parameters
 
-| Name | Description                                                                                | Optional | Default value |
-|------|--------------------------------------------------------------------------------------------|----------|---------------|
-| cves | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |
+| Name            | Description                                                                                | Optional | Default value                                             |
+|-----------------|--------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| cves            | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -                                                         |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored      | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                             | No       | -                                                         |
+
+## Changes in 1.0.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/internal/pipelines/check-embargoed-cves/check-embargoed-cves.yaml
+++ b/internal/pipelines/check-embargoed-cves/check-embargoed-cves.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: check-embargoed-cves
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -16,10 +16,24 @@ spec:
       type: string
       description: |
           String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345')
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: check-embargoed-cves-task
       taskRef:
-        name: check-embargoed-cves-task
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
       params:
         - name: cves
           value: $(params.cves)

--- a/internal/resources/check-embargoed-cves-task.yaml
+++ b/internal/resources/check-embargoed-cves-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.8.2
+* Pass taskGitUrl and taskGitRevision to embargo-check task
+
 ## Changes in 1.8.1
 * Set timeout for rh-sign-image-cosign task to be 6 hrs
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/version: "1.8.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -252,6 +252,10 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       taskRef:
         params:
           - name: url

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -10,6 +10,11 @@ by server using curl and checks the CVEs via an InternalRequest. If any issue or
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
 | requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180           |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 0.5.0
+* Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 
 ## Changes in 0.4.1
 * fix linting issues in embargo-check task 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,6 +24,12 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -97,6 +103,8 @@ spec:
 
         internal-request -r "check-embargoed-cves" \
             -p cves="${CVES}" \
+            -p taskGitUrl="$(params.taskGitUrl)" \
+            -p taskGitRevision="$(params.taskGitRevision)" \
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" \
             -s true \

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -66,6 +66,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -50,6 +50,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
@@ -18,6 +18,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -66,6 +66,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -35,6 +35,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -64,6 +64,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -48,6 +48,10 @@ spec:
           value: data.json
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace


### PR DESCRIPTION
This commit updates the embargo-check internal pipeline to call its one task via git resolver. The pipeline itself still uses a cluster resolver, which will be changed in a separate commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

