### PR TITLE
feat(RELEASE-1387): use trusted artifacts

### DIFF
--- a/.github/resources/cert-manager/kustomization.yml
+++ b/.github/resources/cert-manager/kustomization.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+
+patches:
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager-cainjector
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 90m
+            memory: 90Mi
+          limits:
+            cpu: 120m
+            memory: 120Mi
+    target:
+      kind: Deployment
+      name: cert-manager-webhook

--- a/.github/resources/cluster-issuer/kustomization.yml
+++ b/.github/resources/cluster-issuer/kustomization.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - self-signed-cluster-issuer.yaml

--- a/.github/resources/cluster-issuer/self-signed-cluster-issuer.yaml
+++ b/.github/resources/cluster-issuer/self-signed-cluster-issuer.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed-cluster-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: self-signed-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: root-secret

--- a/.github/resources/registry/certificate.yaml
+++ b/.github/resources/registry/certificate.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: registry-cert
+  namespace: kind-registry
+spec:
+  isCA: true
+  subject:
+    organizations:
+      - konflux
+  dnsNames:
+    - localhost
+    - registry-service.kind-registry
+  issuerRef:
+    kind: ClusterIssuer
+    name: ca-issuer
+  secretName: local-registry-tls

--- a/.github/resources/registry/kustomization.yml
+++ b/.github/resources/registry/kustomization.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - registry.yaml
+  - certificate.yaml
+  - trust-bundle.yaml

--- a/.github/resources/registry/registry.yaml
+++ b/.github/resources/registry/registry.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kind-registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: registry
+  name: registry
+  namespace: kind-registry
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This component requires write permissions"
+    ignore-check.kube-linter.io/run-as-non-root: "This component requires root permissions"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: registry
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+        - name: registry
+          image: registry:2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 250Mi
+          ports:
+            - containerPort: 5000
+          env:
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: "/certs/tls.crt"
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: "/certs/tls.key"
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - name: certs
+          secret:
+            secretName: local-registry-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-service
+  namespace: kind-registry
+spec:
+  type: NodePort
+  selector:
+    run: registry
+  ports:
+    - protocol: TCP
+      nodePort: 30001
+      port: 443
+      targetPort: 5000

--- a/.github/resources/registry/trust-bundle.yaml
+++ b/.github/resources/registry/trust-bundle.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: trusted-ca
+spec:
+  sources:
+    - useDefaultCAs: true
+    - secret:
+        name: "root-secret"
+        key: "ca.crt"
+  target:
+    configMap:
+      key: "ca-bundle.crt"
+    namespaceSelector: {}

--- a/.github/resources/trust-manager/kustomization.yml
+++ b/.github/resources/trust-manager/kustomization.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - trust-manager.yaml

--- a/.github/resources/trust-manager/trust-manager.yaml
+++ b/.github/resources/trust-manager/trust-manager.yaml
@@ -1,0 +1,799 @@
+---
+# Source: trust-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: 
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: 
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: Sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          ConfigMap is a reference (by name) to a ConfigMap's `data` key, or to a
+                          list of ConfigMap's `data` key using label selector, in the trust Namespace.
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's `data` field to be used.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: |-
+                                  matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, 
+                                    and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". 
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - key
+                        type: object
+                      inLine:
+                        description: InLine is a simple string to append as the source data.
+                        type: string
+                      secret:
+                        description: |-
+                          Secret is a reference (by name) to a Secret's `data` key, or to a
+                          list of Secret's `data` key using label selector, in the trust Namespace.
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's `data` field to be used.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: |-
+                                  matchExpressions is a list of label selector requirements. 
+                                  The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key,
+                                    and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". 
+                                  The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - key
+                        type: object
+                      useDefaultCAs:
+                        description: |-
+                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                          Default CAs are available if trust-manager was installed via Helm
+                          or was otherwise set up to include a package-injecting init container by using the
+                          "--default-package-location" flag when starting the trust-manager controller.
+                          If default CAs were not configured at start-up, any request to use the default
+                          CAs will fail.
+                          The version of the default CA package which is used for a Bundle is stored in the
+                          defaultCAPackageVersion field of the Bundle's status field.
+                        type: boolean
+                    type: object
+                  type: array
+                target:
+                  description: Target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link 
+                            https://cert-manager.io/docs/faq/#keystore-passwords
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                            password:
+                              default: changeit
+                              description: Password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        pkcs12:
+                          description: |-
+                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+                            The bundle is by default created without a password.
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                            password:
+                              default: ""
+                              description: Password for PKCS12 trust store
+                              maxLength: 128
+                              type: string
+                          required:
+                            - key
+                          type: object
+                      type: object
+                    configMap:
+                      description: |-
+                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels matches on the set of labels that must be present on a
+                            Namespace for the Bundle target to be synced there.
+                          type: object
+                      type: object
+                    secret:
+                      description: |-
+                        Secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and 
+                        can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
+                      required:
+                        - key
+                      type: object
+                  type: object
+              required:
+                - sources
+                - target
+              type: object
+            status:
+              description: Status of the Bundle. This is set and managed automatically.
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of the Bundle.
+                    Known condition types are `Bundle`.
+                  items:
+                    description: BundleCondition contains condition information for a Bundle.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human-readable description of the details of the last
+                          transition, complementing reason.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Bundle.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine-readable explanation for the condition's last
+                          transition.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Synced`).
+                        maxLength: 316
+                        pattern: |-
+                          ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)
+                          ?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                    which was retrieved when the set of default CAs was requested in the bundle
+                    source. This should only be set if useDefaultCAs was set to "true" on a source,
+                    and will be the same for the same version of a bundle with identical certificates.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: trust-manager/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+  name: trust-manager
+rules:
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles"
+    # We also need patch here so we can perform migrations from old CSA to SSA.
+    verbs: ["get", "list", "watch", "patch"]
+# Permissions to update finalizers are required for trust-manager to work correctly
+# on OpenShift, even though we don't directly use finalizers at the time of writing
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles/finalizers"
+    verbs: ["update"]
+
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - "bundles/status"
+    verbs: ["patch"]
+
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs: ["get", "list", "create", "patch", "watch", "delete"]
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs: ["create", "patch"]
+---
+# Source: trust-manager/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+  name: trust-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trust-manager
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+---
+# Source: trust-manager/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager:leaderelection
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "watch"
+      - "list"
+---
+# Source: trust-manager/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trust-manager
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trust-manager:leaderelection
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trust-manager:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: trust-manager
+    namespace: cert-manager
+---
+# Source: trust-manager/templates/metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trust-manager-metrics
+  namespace: cert-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9402
+      targetPort: 9402
+      protocol: TCP
+      name: metrics
+  selector:
+    app: trust-manager
+---
+# Source: trust-manager/templates/webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 6443
+      protocol: TCP
+      name: webhook
+  selector:
+    app: trust-manager
+---
+# Source: trust-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/readiness-port: "Keeping upstream configs"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trust-manager
+  template:
+    metadata:
+      labels:
+        app: trust-manager
+        app.kubernetes.io/name: trust-manager
+        helm.sh/chart: trust-manager-v0.12.0
+        app.kubernetes.io/instance: trust-manager
+        app.kubernetes.io/version: "v0.12.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: trust-manager
+      initContainers:
+        - name: cert-manager-package-debian
+          image: "quay.io/jetstack/cert-manager-package-debian:20210119.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "/copyandmaybepause"
+            - "/debian-package"
+            - "/packages"
+          volumeMounts:
+            - mountPath: /packages
+              name: packages
+              readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 250Mi
+      containers:
+        - name: trust-manager
+          image: "quay.io/jetstack/trust-manager:v0.12.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6443
+            - containerPort: 9402
+          readinessProbe:
+            httpGet:
+              port: 6060
+              path: /readyz
+            initialDelaySeconds: 3
+            periodSeconds: 7
+          args:
+            - "--log-format=text"
+            - "--log-level=1"
+            - "--metrics-port=9402"
+            - "--readiness-probe-port=6060"
+            - "--readiness-probe-path=/readyz"
+            - "--leader-election-lease-duration=15s"
+            - "--leader-election-renew-deadline=10s"
+              # trust
+            - "--trust-namespace=cert-manager"
+              # webhook
+            - "--webhook-host=0.0.0.0"
+            - "--webhook-port=6443"
+            - "--webhook-certificate-dir=/tls"
+            - "--default-package-location=/packages/cert-manager-package-debian.json"
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+              readOnly: true
+            - mountPath: /packages
+              name: packages
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 250Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: packages
+          emptyDir:
+            sizeLimit: 50M
+        - name: tls
+          secret:
+            defaultMode: 420
+            secretName: trust-manager-tls
+---
+# Source: trust-manager/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  commonName: "trust-manager.cert-manager.svc"
+  dnsNames:
+    - "trust-manager.cert-manager.svc"
+  secretName: trust-manager-tls
+  revisionHistoryLimit: 1
+  issuerRef:
+    name: trust-manager
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: trust-manager/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selfSigned: {}
+---
+# Source: trust-manager/templates/webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: trust-manager
+  labels:
+    app: trust-manager
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
+
+  annotations:
+    cert-manager.io/inject-ca-from: "cert-manager/trust-manager"
+webhooks:
+  - name: trust.cert-manager.io
+    rules:
+      - apiGroups:
+          - "trust.cert-manager.io"
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 5
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+
+      service:
+        name: trust-manager
+        namespace: cert-manager
+        path: /validate-trust-cert-manager-io-v1alpha1-bundle

--- a/.github/scripts/deploy_registry.sh
+++ b/.github/scripts/deploy_registry.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+script_path="$(dirname -- "${BASH_SOURCE[0]}")"
+
+retry() {
+  for _ in {1..3}; do
+      local ret=0
+      $1 || ret="$?"
+      if [[ "$ret" -eq 0 ]]; then
+          return 0
+      fi
+      sleep 3
+  done
+
+  echo "$1": "$2."
+  return "$ret"
+}
+
+deploy_cert_manager() {
+  kubectl apply -k "${script_path}/../resources/cert-manager"
+  sleep 5
+  retry "kubectl wait --for=condition=Ready --timeout=120s -l app.kubernetes.io/instance=cert-manager -n cert-manager pod" \
+        "Cert manager did not become available within the allocated time"
+}
+
+deploy_trust_manager() {
+  kubectl apply -k "${script_path}/../resources/trust-manager"
+  sleep 5
+  # trust manager is running in the cert-manager namespace
+  retry "kubectl wait --for=condition=Ready --timeout=60s -l app.kubernetes.io/instance=trust-manager -n cert-manager pod" \
+        "Trust manager did not become available within the allocated time"
+}
+
+deploy_registry() {
+  kubectl apply -k "${script_path}/../resources/registry"
+  retry "kubectl wait --for=condition=Ready --timeout=240s -n kind-registry -l run=registry pod" \
+        "The local registry did not become available within the allocated time"
+}
+
+port_forward() {
+  regpid=$(ps -eawwf | grep "30001:443" | grep -v grep | awk '{print $2}')
+  if [ ! -z "$regpid" ] ; then
+    kill -9 $regpid
+  fi
+  sleep 2
+
+  kubectl port-forward -n kind-registry svc/registry-service 30001:443 &
+}
+
+prepare_docker_config() {
+  authString=$(echo -n "root:root" | base64 -w0)
+  cat > "/tmp/.dockerconfig.json" <<EOF
+  {
+    "auths": {
+      "registry-service.kind-registry": {
+        "auth": "${authString}"
+      }
+    }
+  }
+EOF
+  cat "/tmp/.dockerconfig.json"
+}
+
+deploy_cert_manager
+deploy_trust_manager
+kubectl apply -k "${script_path}/../resources/cluster-issuer"
+deploy_registry
+port_forward
+prepare_docker_config

--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -22,6 +22,26 @@ shopt -s nullglob
 
 WORKSPACE_TEMPLATE=${BASH_SOURCE%/*/*}/resources/workspace-template.yaml
 
+if [ -z "${USE_TRUSTED_ARTIFACTS}" ]
+then
+  echo "Defaulting to PVC based workspaces..."
+  # empty is needed since trusted-artifacts needs a non-empty storage
+  # parameter in order to reach the skipping logic
+  export TRUSTED_ARTIFACT_OCI_STORAGE="empty"
+else
+
+  echo "Using Trusted Artifacts for workspaces..."
+  export TRUSTED_ARTIFACT_OCI_STORAGE=registry-service.kind-registry/trusted-artifacts
+  export TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON_PATH=/tmp/.dockerconfig.json
+
+  kubectl create secret generic docker-config \
+    --from-file=.dockerconfigjson="${TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON_PATH}" \
+    --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f -
+  kubectl patch serviceaccount default -p \
+    '{"imagePullSecrets": [{"name": "docker-config"}], "secrets": [{"name": "docker-config"}]}'
+
+fi
+
 if [ $# -gt 0 ]
 then
   TEST_ITEMS=$@
@@ -116,7 +136,13 @@ do
       sleep 5
     done
 
-    PIPELINERUN=$(tkn p start $TEST_NAME -w name=tests-workspace,volumeClaimTemplateFile=$WORKSPACE_TEMPLATE -o json | jq -r '.metadata.name')
+    if [ -z "${USE_TRUSTED_ARTIFACTS}" ]; then
+      workSpaceParams="volumeClaimTemplateFile=$WORKSPACE_TEMPLATE"
+    else
+      workSpaceParams="emptyDir="
+    fi
+    PIPELINERUN=$(tkn p start --use-param-defaults $TEST_NAME -p ociStorage=${TRUSTED_ARTIFACT_OCI_STORAGE} -w "name=tests-workspace,${workSpaceParams}" -o json | jq -r '.metadata.name')
+
     echo "  Started pipelinerun $PIPELINERUN"
     sleep 1  # allow a second for the pr object to appear (including a status condition)
     while [ "$(kubectl get pr $PIPELINERUN -o=jsonpath='{.status.conditions[0].status}')" == "Unknown" ]

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -22,8 +22,29 @@ jobs:
           dir_names: "true"
           dir_names_max_depth: "3"
       - name: Show changed dirs
+        id: show-changed-dirs
+        shell: bash
         run: |
           echo ${{ steps.changed-dirs.outputs.all_changed_files }}
+          trustedArtifactsBasedTasks=()
+          for dir in ${{ steps.changed-dirs.outputs.all_changed_files }}
+          do
+            echo "$dir"
+            taskName=$(basename "${dir}")
+            taskFile="${dir}/${taskName}.yaml"
+            if [ -f "${taskFile}" ] \
+              && [[ $(yq '[.spec.params[] | select(.name == "ociStorage")] | length' \
+              "${taskFile}") -gt 0 ]]
+            then
+              ociStageParam=$(yq '.spec.params[] | select(.name == "ociStorage") | .name' "${taskFile}")
+              if [ -n "${ociStageParam}" ]; then
+                echo "Found a trusted artifacts compatible task: ${taskFile}"
+                trustedArtifactsBasedTasks+=($dir)
+              fi
+            fi
+          done
+          echo "trustedArtifactsBasedTasks: ${trustedArtifactsBasedTasks[@]}"
+          echo "trustedArtifactsBasedTasks=${trustedArtifactsBasedTasks[@]}" >> $GITHUB_OUTPUT
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.10.0
         if: |
@@ -33,6 +54,12 @@ jobs:
           steps.changed-dirs.outputs.any_changed == 'true'
         run: |
           kubectl cluster-info
+      - name: Deploy Local Kind Registry
+        timeout-minutes: 10
+        if: |
+          steps.changed-dirs.outputs.any_changed == 'true'
+        run: |
+          .github/scripts/deploy_registry.sh
       - name: Install Tekton
         timeout-minutes: 10
         if: |
@@ -59,10 +86,18 @@ jobs:
         if: |
           steps.changed-dirs.outputs.any_changed == 'true'
         uses: ./.github/actions/install-tkn
-      - name: Test Tekton tasks
+      - name: Test Tekton tasks using PVC-based workspace
         if: |
           steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/test_tekton_tasks.sh
         env:
           TEST_ITEMS: >-
             ${{ steps.changed-dirs.outputs.all_changed_files }}
+      - name: Test Tekton tasks with Trusted Artifacts
+        if: |
+          steps.show-changed-dirs.outputs.trustedArtifactsBasedTasks != ''
+        run: .github/scripts/test_tekton_tasks.sh
+        env:
+          USE_TRUSTED_ARTIFACTS: true
+          TEST_ITEMS: >-
+            ${{ steps.show-changed-dirs.outputs.trustedArtifactsBasedTasks }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,17 @@ For other images, the reference should always either specify an image by a non-m
 or by its digest (e.g. `registry.access.redhat.com/ubi8/ubi@sha256:c94bc309b197f9fc465052123ead92bf50799ba72055bd040477ded`).
 Floating tags like `latest` or `8.8` in the case of the ubi image should be avoided.
 
+### Modes for Running Pipelines
+
+Note: There are currently 2 modes that may be used when running pipelines:
+- **Legacy/PV** mode involving using a workspace that is backed by a PV (physical volume)
+- **Trusted Artifact** mode that uses an OCI registry as a mean to share data between tasks.
+
+A significant portion of tasks have been converted to support both modes. The CI process analyzes that task under test
+and performs a simple check to verify it supports Trusted Artifacts and if so, tests are executed in both modes.
+
+You can follow this [video](https://miro.com/app/board/uXjVIbidSuI=/?playRecording=5ed2a205-bad5-4f62-a1b1-1dae27ddc65c) for an overview on Trusted Artifacts
+
 ### Tekton Task Testing
 
 When a pull request is opened, Tekton Task tests are run for all the task directories
@@ -281,9 +292,21 @@ Requirements:
 
     ```kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml```
 
+* Local Registry is installed in the Cluster
+
+    ```.github/scripts/deploy_registry.sh```
+
 * tkn cli installed ([docs](https://tekton.dev/docs/cli/))
 
 * jq installed
+
+* Optionally enable **Trusted Artifact** mode by setting the environment variable:
+
+```
+export USE_TRUSTED_ARTIFACTS=true
+```
+
+Note: if a task has not been converted, and you have enable Trusted Artifacts, you will see errors.
 
 Once you have everything ready, you can run the test script and pass task version directories
 as arguments, e.g.

--- a/pipelines/managed/push-artifacts-to-cdn/README.md
+++ b/pipelines/managed/push-artifacts-to-cdn/README.md
@@ -20,3 +20,6 @@ It uses InternalRequests so that it can be run on both public and private cluste
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                              | No       | -               |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -               |
+
+## Changes in 0.1.0
+* Align workspace name with changes in the apply-mapping task

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -154,7 +154,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/push-disk-images-to-cdn/README.md
+++ b/pipelines/managed/push-disk-images-to-cdn/README.md
@@ -20,6 +20,9 @@ Tekton Pipeline to push disk images to a cdn using pulp
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -               |
 
+## Changes in 1.5.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 1.4.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-cdn
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -153,7 +153,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/push-disk-images-to-marketplaces/README.md
+++ b/pipelines/managed/push-disk-images-to-marketplaces/README.md
@@ -19,6 +19,9 @@ Tekton Pipeline to push disk images to various cloud marketplaces
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
 
+## Changes in 0.4.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 0.3.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images-to-marketplaces
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -153,7 +153,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/push-to-addons-registry/README.md
+++ b/pipelines/managed/push-to-addons-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release a single FBC component to the Addons Registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 0.3.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 0.2.1
 * Pass taskGitUrl and taskGitRevision to run-file-updates task
 

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-addons-registry
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,7 +116,7 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value: 
+          value:
             - mapping
       taskRef:
         params:
@@ -176,7 +176,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/push-to-external-registry/README.md
+++ b/pipelines/managed/push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Snapshots to an external registry.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                         | No       | -             |
 
+## Changes in 5.5.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 5.4.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.4.0"
+    app.kubernetes.io/version: "5.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,7 +116,7 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value: 
+          value:
             - mapping
       taskRef:
         params:
@@ -176,7 +176,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.12.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 1.11.1
 * Task `embargo-check` is set to run after `check-data-keys` as it will inject the `public` key to each issue,
   which isn't in the schema

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/version: "1.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -192,7 +192,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/rh-push-to-external-registry/README.md
+++ b/pipelines/managed/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                       | No        | -            |
 
+## Changes in 5.6.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 5.5.1
 * Pass taskGitUrl and taskGitRevision to run-file-updates task
 

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.5.1"
+    app.kubernetes.io/version: "5.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,7 +116,7 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value: 
+          value:
             - pyxis
             - mapping
       taskRef:
@@ -177,7 +177,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.8.0
+* Align workspace name with changes in the apply-mapping task
+
 ## Changes in 4.7.2
 * Pass taskGitUrl and taskGitRevision to run-file-updates task
 

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.7.2"
+    app.kubernetes.io/version: "4.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -214,7 +214,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/pipelines/managed/rhtap-service-push/README.md
+++ b/pipelines/managed/rhtap-service-push/README.md
@@ -21,7 +21,10 @@
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored   | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                          | No       | -             |
 
-## Changes in 4.5.0 
+## Changes in 4.6.0
+* Align workspace name with changes in the apply-mapping task
+
+## Changes in 4.5.0
 * Remove the `gitImage` parameter from the `update-infra-deployments` task
 
 ## Changes in 4.4.0

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rhtap-service-push
   labels:
-    app.kubernetes.io/version: "4.5.0"
+    app.kubernetes.io/version: "4.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,7 +116,7 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value: 
+          value:
             - mapping
             - pyxis
       taskRef:
@@ -177,7 +177,7 @@ spec:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
       workspaces:
-        - name: config
+        - name: data
           workspace: release-workspace
       runAfter:
         - reduce-snapshot

--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -25,11 +25,18 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 
 ## Parameters
 
-| Name              | Description                                                                                  | Optional | Default value |
-|-------------------|----------------------------------------------------------------------------------------------|----------|---------------|
-| snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |
-| dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
-| failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
+| Name                    | Description                                                                                                                 | Optional | Default value |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to                                | No       | -             |
+| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                     | No       | -             |
+| failOnEmptyResult       | Fail the task if the resulting snapshot contains zero components                                                            | Yes      | false         |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                   | Yes      | empty         |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire  | Yes      | 1d            |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                         | Yes      | ""            |
+| subdirectory            | Subdirectory inside the workspace to be used                                                                                | Yes      | ""            |
+
+## Changes in 2.0.0
+* This task now supports Trusted artifacts
 
 ## Changes in 1.9.1
 * Bump the utils image used in this task

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.9.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,22 +22,62 @@ spec:
       type: string
       description: Fail the task if the resulting snapshot contains 0 components
       default: "false"
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: sourceDataArtifact
+      type: string
+      default: ""
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
   workspaces:
-    - name: config
+    - name: data
       description: The workspace where the extra config file containing the mapping and snapshot json reside
   results:
     - name: mapped
       type: string
       description: A true/false value depicting whether or not the snapshot was mapped.
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
   steps:
+    - name: skip-trusted-artifact-operations
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        if [ "$(params.ociStorage)" == "empty" ]; then
+          echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+          touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+        fi
+    - name: use-trusted-artifact
+      args:
+        - use
+        - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+      env:
+        - name: "ORAS_OPTIONS"
+          value: "--insecure"
+        - name: "HOME"
+          value: "/tekton/home"
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     - name: apply-mapping
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -eux
 
-        SNAPSHOT_SPEC_FILE="$(workspaces.config.path)/$(params.snapshotPath)"
-        DATA_FILE="$(workspaces.config.path)/$(params.dataPath)"
+        SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         SNAPSHOT_SPEC_FILE_ORIG="${SNAPSHOT_SPEC_FILE}.orig"
 
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
@@ -353,3 +393,29 @@ spec:
               "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
         done
+    - name: create-trusted-artifact
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+        - name: "ORAS_OPTIONS"
+          value: "--insecure"
+        - name: "HOME"
+          value: "/tekton/home"
+    - name: patch-source-data-artifact-result
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        # this is needed to skip trusted-artifacts tasks
+        # when using PVC based workspaces.
+        if [ "$(params.ociStorage)" == "empty" ]; then
+          echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+        fi

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -4,7 +4,7 @@ set -eux
 # mocks to be injected into task step scripts
 
 function date() {
-  echo $* >> $(workspaces.config.path)/mock_date.txt
+  echo $* >> $(workspaces.data.path)/$(params.subdirectory)/mock_date.txt
 
   case "$*" in
       *"2024-07-29T02:17:29 +%Y-%m-%d")
@@ -31,7 +31,7 @@ function date() {
 
 function skopeo() {
   echo Mock skopeo called with: $* >&2
-  echo $* >> $(workspaces.config.path)/mock_skopeo.txt
+  echo $* >> $(workspaces.data.path)/$(params.subdirectory)/mock_skopeo.txt
 
   if [[ "$*" =~ list-tags\ docker://repo1 ]]; then
       echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'

--- a/tasks/managed/apply-mapping/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/apply-mapping/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -10,14 +10,27 @@ spec:
     for the component.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -25,7 +38,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -37,7 +51,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -54,40 +68,98 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.config.path)/test_snapshot_spec.json"
+              cat "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
 
               echo Test that comp1 has NO contentGateway data
               test "$(
                 jq -c '.components[] | select(.name=="comp1") | has("contentGateway")' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == "false"
-
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -9,14 +9,27 @@ spec:
     validate that the values are overridden if defined in the component or if not defined then the defaults are used.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -24,7 +37,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "defaults": {
@@ -87,7 +101,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -124,51 +138,110 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.config.path)/test_snapshot_spec.json"
+              cat "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
 
               echo Test that comp1 has the correct contentGateway.productVersionName
               test "$(
                 jq -r '.components[] | select(.name=="comp1") | .contentGateway.productVersionName' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == "comp1-1"
 
               echo Test that comp2 has the correct contentGateway.filePrefix
               test "$(
                 jq -r '.components[] | select(.name=="comp2") | .contentGateway.filePrefix' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == "myapp-comp1-1"
 
               echo Test that comp3 has the correct contentGateway defaults
               test "$(
                 jq -c '.components[] | select(.name=="comp3") | .contentGateway' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == '{"productName":"myapp","productCode":"MYAPP","productVersionName":"1.0","filePrefix":"myapp-1.3"}'
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -13,14 +13,27 @@ spec:
     The task should fail on that.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -28,7 +41,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -46,7 +60,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -63,16 +77,56 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -13,14 +13,27 @@ spec:
     The task should fail on that.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -28,7 +41,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -47,7 +61,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -64,16 +78,56 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -13,14 +13,27 @@ spec:
     The task should fail on that.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -28,7 +41,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -46,7 +60,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -63,16 +77,56 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -12,16 +12,27 @@ spec:
     and verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: config
         results:
-          - name: snapshot
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -29,7 +40,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -46,7 +58,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -67,18 +79,58 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: "snapshot_spec.json"
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
         - name: dataPath
-          value: "data.json"
+          value: $(context.pipelineRun.uid)/data.json
         - name: failOnEmptyResult
           value: "true"
-      workspaces:
-        - name: config
-          workspace: tests-workspace
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -12,14 +12,27 @@ spec:
     This will result in a failure.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -27,7 +40,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -48,7 +62,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -67,16 +81,56 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -13,14 +13,27 @@ spec:
     in the tags.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -28,7 +41,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -46,7 +60,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -63,16 +77,56 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -9,14 +9,27 @@ spec:
     and Red Hat specific repository formats. Verify that the resulting json contains the expected transformations.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup-multi-component
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-multi-component-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -24,7 +37,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data_multi_component.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data_multi_component.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -45,7 +59,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec_multi_component.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -82,27 +96,86 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task-multi-component
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec_multi_component.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec_multi_component.json
         - name: dataPath
-          value: test_data_multi_component.json
+          value: $(context.pipelineRun.uid)/test_data_multi_component.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup-multi-component.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup-multi-component
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result-multi-component
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task-multi-component.results.sourceDataArtifact)=$(workspaces.data.path)/work"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result-multi-component
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -112,46 +185,46 @@ spec:
               # Test for comp1
               echo Test that SNAPSHOT contains component comp1
               test "$(jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" -eq 1
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" -eq 1
 
               echo Test that rh-registry-repo for comp1 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo"' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 registry.redhat.io/product-name/image1
 
               echo Test that registry-access-repo for comp1 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo"' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 registry.access.redhat.com/product-name/image1
 
               # Test for comp2
               echo Test that SNAPSHOT contains component comp2
               test "$(jq -r '[ .components[] | select(.name=="comp2") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" -eq 1
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" -eq 1
 
               echo Test that quay.io repository for comp2 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp2") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 quay.io/redhat-prod/product-name----image2
 
               echo Test that registry-access-repo for comp2 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp2") | ."registry-access-repo"' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 registry.access.redhat.com/product-name/image2
 
               # Test for comp3
               echo Test that SNAPSHOT contains component comp3
               test "$(jq -r '[ .components[] | select(.name=="comp3") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" -eq 1
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" -eq 1
 
               echo Test that rh-registry-repo for comp3 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp3") | ."rh-registry-repo"' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 registry.stage.redhat.io/product-name/image3
 
               echo Test that registry-access-repo for comp3 is correctly set
               test "$(jq -r '.components[] | select(.name=="comp3") | ."registry-access-repo"' \
-                < "$(workspaces.config.path)/test_snapshot_spec_multi_component.json")" == \
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_multi_component.json")" == \
                 registry.access.stage.redhat.com/product-name/image3
       runAfter:
         - run-task-multi-component

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -9,16 +9,29 @@ spec:
     provided and verify that the returned json is the same as the one in the input.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
         results:
           - name: snapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -26,7 +39,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/snapshot_spec.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -53,27 +67,84 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: snapshot_spec.json
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
         - name: dataPath
           value: ""
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -82,9 +153,7 @@ spec:
 
               # The resulting JSON is exactly the same as the original one (since no mapping was used)
               test "$(
-                jq --sort-keys . < "$(workspaces.config.path)/snapshot_spec.json"
+                jq --sort-keys . < "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
               )" == "$(
-                jq --sort-keys . < "$(workspaces.config.path)/snapshot_spec.json.orig"
+                jq --sort-keys . < "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json.orig"
               )"
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -10,23 +10,38 @@ spec:
     the input.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: config
         results:
           - name: snapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
-              cat > "$(workspaces.config.path)/data.json" << EOF
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/data.json" << EOF
               {
                 "somekey": {
                   "key": "value",
@@ -35,7 +50,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -56,27 +71,84 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: "snapshot_spec.json"
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
         - name: dataPath
-          value: "data.json"
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -85,9 +157,7 @@ spec:
 
               # The resulting JSON is exactly the same as the original one (since no mapping was used)
               test "$(
-                jq --sort-keys . < "$(workspaces.config.path)/snapshot_spec.json"
+                jq --sort-keys . < "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json"
               )" == "$(
-                jq --sort-keys . < "$(workspaces.config.path)/snapshot_spec.json.orig"
+                jq --sort-keys . < "$(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot_spec.json.orig"
               )"
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -9,14 +9,29 @@ spec:
     handled by the task. Verify that the resulting json remains unchanged in the repository field.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup-other-formats
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: snapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-other-formats-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -24,7 +39,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data_other_formats.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data_other_formats.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -37,7 +53,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec_other_formats.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec_other_formats.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -48,27 +64,82 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task-other-formats
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec_other_formats.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json
         - name: dataPath
-          value: test_data_other_formats.json
+          value: $(context.pipelineRun.uid)/test_data_other_formats.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup-other-formats.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup-other-formats
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result-other-formats
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task-other-formats.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result-other-formats
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -78,25 +149,25 @@ spec:
               echo Test that SNAPSHOT contains component comp1
               test "$(
                 jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec_other_formats.json"
+                < "$(workspaces.data.path)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )" -eq 1
 
               echo Test that repository of component comp1 stayed intact
               test "$(
                 jq -r '.components[] | select(.name=="comp1") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec_other_formats.json"
+                < "$(workspaces.data.path)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )" == quay.io/my-sample/my-image
 
               echo Test that rh-registry-repo for comp1 is not set because it was not in a known format
               test -z "$(
                 jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo" // empty' \
-                < "$(workspaces.config.path)/test_snapshot_spec_other_formats.json"
+                < "$(workspaces.data.path)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )"
 
               echo Test that registry-access-repo for comp1 is not set because it was not in a known format
               test -z "$(
                 jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo" // empty' \
-                < "$(workspaces.config.path)/test_snapshot_spec_other_formats.json"
+                < "$(workspaces.data.path)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )"
       runAfter:
         - run-task-other-formats

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -10,14 +10,27 @@ spec:
     contains the expected values with filenames expanded.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -25,7 +38,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -62,7 +76,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -89,27 +103,88 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -119,13 +194,11 @@ spec:
               echo Test that comp1 has the proper files
               test "$(
                 jq -c '.components[] | select(.name=="comp1") | .staged.files' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == '[{"source":"one.qcow2","filename":"ai-testrevision"},{"source":"one.raw","filename":"ai-testrev"}]'
 
               echo Test that comp2 has the proper files
               test "$(
                 jq -c '.components[] | select(.name=="comp2") | .staged.files' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == '[{"source":"two.qcow2","filename":"ai-123456"}]'
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -10,14 +10,27 @@ spec:
     contains the expected values with tags expanded, including incrementer logic.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -25,7 +38,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -75,7 +89,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -102,27 +116,88 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
@@ -132,13 +207,13 @@ spec:
               echo Test that SNAPSHOT contains component comp1
               test "$(
                 jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 1
 
               echo Test that comp1 has the proper tags
               test "$(
                 jq -c '.components[] | select(.name=="comp1") | .tags' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == '["defaultTag","foo-123456","tag-labelvalue","tag-labelvalue-with-dash",'\
               '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","v2.0.0-5","123456",'\
               '"testrevision-abc","testrev-bar","testrevision","testrev"]'
@@ -146,25 +221,23 @@ spec:
               echo Test that SNAPSHOT contains component comp2
               test "$(
                 jq -r '[ .components[] | select(.name=="comp2") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 1
 
               echo Test that comp2 has the proper tags
               test "$(
                 jq -c '.components[] | select(.name=="comp2") | .tags' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01","v1-1-release","v1.0.0-1"]'
 
               echo Test that repository of component comp3 was overridden by mapping file
               test "$(
                 jq -r '.components[] | select(.name=="comp3") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == repo3a
 
               echo Test that comp3 has the 1 default tag
               test "$(
                 jq -r '.components[] | select(.name=="comp3") | .tags | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 1
-      runAfter:
-        - run-task

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -9,14 +9,27 @@ spec:
     the data json file and verify that the resulting json contains the expected values.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
         workspaces:
-          - name: config
+          - name: data
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
@@ -24,7 +37,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.config.path)/test_data.json" << EOF
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
@@ -49,7 +63,7 @@ spec:
               }
               EOF
 
-              cat > "$(workspaces.config.path)/test_snapshot_spec.json" << EOF
+              cat > "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -80,73 +94,132 @@ spec:
                 ]
               }
               EOF
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+              
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
     - name: run-task
       taskRef:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: test_snapshot_spec.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: test_data.json
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       runAfter:
         - setup
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
     - name: check-result
       workspaces:
-        - name: config
+        - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      runAfter:
+        - run-task
       taskSpec:
         workspaces:
-          - name: config
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               echo Test that SNAPSHOT contains component comp1
               test "$(
                 jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 1
 
               echo Test that SNAPSHOT contains repository from the mapping file
               test "$(
                 jq -r '.components[] | select(.name=="comp1") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == repo1
 
               echo Test that SNAPSHOT does not contain component comp2
               test "$(
                 jq -r '[ .components[] | select(.name=="comp2") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 0
 
               echo Test that repository of component comp3 was overridden by mapping file
               test "$(
                 jq -r '.components[] | select(.name=="comp3") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == repo3a
 
               echo Test that repository of component comp4 stayed intact
               test "$(
                 jq -r '.components[] | select(.name=="comp4") | .repository' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == repo4
 
               echo Test that customfield of component comp4 was added to its snapshot entry
               test "$(
                 jq -r '.components[] | select(.name=="comp4") | .customfield' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" == custom
 
               echo Test that SNAPSHOT does not contain component comp5 as it was not included in the mapping file
               test "$(
                 jq -r '[ .components[] | select(.name=="comp5") ] | length' \
-                < "$(workspaces.config.path)/test_snapshot_spec.json"
+                < "$(workspaces.data.path)/$(params.subdirectory)/test_snapshot_spec.json"
               )" -eq 0
-      runAfter:
-        - run-task

--- a/tasks/managed/collect-data/README.md
+++ b/tasks/managed/collect-data/README.md
@@ -18,14 +18,19 @@ should not be present in the Release data section).
 
 ## Parameters
 
-| Name                 | Description                                        | Optional | Default value |
-|----------------------|----------------------------------------------------|----------|---------------|
-| release              | Namespaced name of the Release                     | No       | -             |
-| releasePlan          | Namespaced name of the ReleasePlan                 | No       | -             |
-| releasePlanAdmission | Namespaced name of the ReleasePlanAdmission        | No       | -             |
-| releaseServiceConfig | Namespaced name of the ReleaseServiceConfig        | No       | -             |
-| snapshot             | Namespaced name of the Snapshot                    | No       | -             |
-| subdirectory         | Subdirectory inside the workspace to be used.      | Yes      | -             |
+| Name                    | Description                                                                                                                 | Optional | Default value |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| release                 | Namespaced name of the Release                                                                                              | No       | -             |
+| releasePlan             | Namespaced name of the ReleasePlan                                                                                          | No       | -             |
+| releasePlanAdmission    | Namespaced name of the ReleasePlanAdmission                                                                                 | No       | -             |
+| releaseServiceConfig    | Namespaced name of the ReleaseServiceConfig                                                                                 | No       | -             |
+| snapshot                | Namespaced name of the Snapshot                                                                                             | No       | -             |
+| subdirectory            | Subdirectory inside the workspace to be used                                                                                | Yes      | ""            |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                   | Yes      | empty         |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire  | Yes      | 1d            |
+
+## Changes in 5.0.0
+* This task now supports Trusted artifacts
 
 ## Changes in 4.5.3
 * Introduce new step to collect, print and record information about the git resolver metadata for the

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "4.5.3"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,6 +32,15 @@ spec:
       description: Subdirectory inside the workspace to be used
       type: string
       default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
   workspaces:
     - name: data
       description: Workspace to save the CR jsons to
@@ -72,6 +81,12 @@ spec:
     - name: releasePipelineMetadata
       type: string
       description: json object containing git resolver metadata about the running release pipeline
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+    - name: subdirectory
+      type: string
+      description: Subdirectory inside the workspace to be used
   steps:
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -90,13 +105,24 @@ spec:
         #!/usr/bin/env bash
         set -eo pipefail
 
+        set -x
+        echo -n "$(params.subdirectory)" > "$(results.subdirectory.path)"
+
         RESULTS_DIR_PATH="results"
         if [ -n "$(params.subdirectory)" ]; then
           mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+          if [ "$(params.ociStorage)" == "empty" ]; then
+            echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+            touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+
+            # this is needed to skip trusted-artifacts tasks
+            # when using PVC based workspaces.
+            echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+          fi
           RESULTS_DIR_PATH="$(params.subdirectory)/results"
         fi
 
-        mkdir "$(workspaces.data.path)/$RESULTS_DIR_PATH"
+        mkdir -p "$(workspaces.data.path)/$RESULTS_DIR_PATH"
         echo -n "$RESULTS_DIR_PATH" > "$(results.resultsDir.path)"
 
         RELEASE_PATH="$(params.subdirectory)/release.json"
@@ -246,3 +272,18 @@ spec:
         echo "${json}" > "$(results.releasePipelineMetadata.path)"
         # pretty print for log message
         jq . <<< "$json"
+    - name: create-trusted-artifact
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+        - name: "ORAS_OPTIONS"
+          value: "--insecure"
+        - name: "HOME"
+          value: "/tekton/home"

--- a/tasks/managed/collect-data/tests/mocks.sh
+++ b/tasks/managed/collect-data/tests/mocks.sh
@@ -5,6 +5,6 @@ set -eux
 curl() {
   # Output the call to stderr
   echo "Mock curl called with:" "$@" >&2
-  echo "$@" >> "$(workspaces.data.path)/mock_curl.txt"
+  echo "$@" >> "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt"
   echo '{ "sha": "12345"}'
 }

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task with the disallowed key product_id in the Release data.
   workspaces:
@@ -124,8 +128,8 @@ spec:
           value: default/releaseserviceconfig-disallowed-release-sample
         - name: snapshot
           value: default/snapshot-disallowed-release-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task with the disallowed key product_id in the ReleasePlan data.
   workspaces:
@@ -124,8 +128,8 @@ spec:
           value: default/releaseserviceconfig-disallowed-rp-sample
         - name: snapshot
           value: default/snapshot-disallowed-rp-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task without a ReleasePlanAdmission cr and verify that the task fails as expected.
     This test cannot rely on the snapshot not existing as the snapshot is retrieved with a jsonpath added
@@ -86,6 +90,8 @@ spec:
           value: default/snapshot-missing-cr-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task without a ReleaseServiceConfig cr and verify that the task fails as expected.
     This test cannot rely on the snapshot not existing as the snapshot is retrieved with a jsonpath added
@@ -76,6 +80,8 @@ spec:
           value: default/snapshot-missing-rsc-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -9,6 +9,10 @@ spec:
     git resolver
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -113,6 +117,8 @@ spec:
           value: default/snapshot-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -122,6 +128,10 @@ spec:
       params:
         - name: releasePipelineMetadata
           value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(tasks.run-task.results.subdirectory)"
+        - name: subdirectory
+          value: $(tasks.run-task.results.subdirectory)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -130,6 +140,8 @@ spec:
       taskSpec:
         params:
           - name: releasePipelineMetadata
+            type: string
+          - name: subdirectory
             type: string
         workspaces:
           - name: data
@@ -143,10 +155,11 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              touch "$(workspaces.data.path)/mock_curl.txt"
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_curl.txt")" != 0 ]; then
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              touch "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt"
+              if [ "$(wc -l < "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt")" != 0 ]; then
                 echo Error: curl was expected to be called 0 times. Actual calls:
-                cat "$(workspaces.data.path)/mock_curl.txt"
+                cat "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt"
                 exit 1
               fi
               

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that the pipeline ref info is made available
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -108,6 +112,8 @@ spec:
           value: default/snapshot-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -117,6 +123,10 @@ spec:
       params:
         - name: releasePipelineMetadata
           value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(tasks.run-task.results.subdirectory)"
+        - name: subdirectory
+          value: $(tasks.run-task.results.subdirectory)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -126,9 +136,22 @@ spec:
         params:
           - name: releasePipelineMetadata
             type: string
+          - name: subdirectory
+            type: string
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             env:
@@ -138,9 +161,9 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(workspaces.data.path)/mock_curl.txt")" != 1 ]; then
+              if [ "$(wc -l < "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt")" != 1 ]; then
                 echo Error: curl was expected to be called 1 time. Actual calls:
-                cat "$(workspaces.data.path)/mock_curl.txt"
+                cat "$(workspaces.data.path)/$(params.subdirectory)/mock_curl.txt"
                 exit 1
               fi
 

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that data task result is accurate.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -15,7 +19,7 @@ spec:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               cat > release << EOF
@@ -115,6 +119,8 @@ spec:
           value: default/snapshot-with-data-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -126,6 +132,10 @@ spec:
           value: $(tasks.run-task.results.data)
         - name: singleComponentMode
           value: $(tasks.run-task.results.singleComponentMode)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(tasks.run-task.results.subdirectory)"
+        - name: subdirectory
+          value: "$(tasks.run-task.results.subdirectory)"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -137,7 +147,20 @@ spec:
             type: string
           - name: singleComponentMode
             type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that all resources are stored in the workspace.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -105,6 +109,8 @@ spec:
           value: default/snapshot-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -132,6 +138,10 @@ spec:
           value: $(tasks.run-task.results.snapshotName)
         - name: snapshotNamespace
           value: $(tasks.run-task.results.snapshotNamespace)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(tasks.run-task.results.subdirectory)"
+        - name: subdirectory
+          value: $(tasks.run-task.results.subdirectory)
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -159,9 +169,22 @@ spec:
             type: string
           - name: snapshotNamespace
             type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         workspaces:
           - name: data
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
@@ -169,7 +192,7 @@ spec:
               set -eux
 
               echo Test that the results directory was created
-              test -d "$(workspaces.data.path)/$(resultsDir)"
+              test -d "$(workspaces.data.path)/$(params.resultsDir)"
 
               echo Test that Release CR was saved to workspace
               test "$(jq -r '.metadata.name' < "$(workspaces.data.path)/$(params.release)")" == release-sample

--- a/tasks/managed/reduce-snapshot/README.md
+++ b/tasks/managed/reduce-snapshot/README.md
@@ -4,10 +4,17 @@ Tekton task to reduce a snapshot to a single component based on the component th
 
 ## Parameters
 
-| Name                                | Description                                              | Optional | Default value |
-|-------------------------------------|----------------------------------------------------------|----------|---------------|
-| SNAPSHOT                            | String representation of Snapshot spec                   | No       | -             |
-| SINGLE_COMPONENT                    | Single mode component enabled                            | No       | -             |
-| SINGLE_COMPONENT_CUSTOM_RESOURCE    | Custom Resource to query for built component in Snapshot | No       | -             |
-| SINGLE_COMPONENT_CUSTOM_RESOURCE_NS | Namespace where Custom Resource is found                 | No       | -             |
-| SNAPSHOT_PATH                       | The location to place the reduced Snapshot               | No       | -             |
+| Name                                | Description                                                                                                                | Optional | Default value |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| SNAPSHOT                            | String representation of Snapshot spec                                                                                     | No       | -             |
+| SINGLE_COMPONENT                    | Single mode component enabled                                                                                              | No       | -             |
+| SINGLE_COMPONENT_CUSTOM_RESOURCE    | Custom Resource to query for built component in Snapshot                                                                   | No       | -             |
+| SINGLE_COMPONENT_CUSTOM_RESOURCE_NS | Namespace where Custom Resource is found                                                                                   | No       | -             |
+| SNAPSHOT_PATH                       | The location to place the reduced Snapshot                                                                                 | No       | -             |
+| ociStorage                          | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty         |
+| ociArtifactExpiresAfter             | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d            |
+| sourceDataArtifact                  | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""            |
+| subdirectory                        | Subdirectory inside the workspace to be used                                                                               | Yes      | ""            |
+
+## Changes in 1.0.0
+* This task now supports Trusted artifacts

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: reduce-snapshot
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,10 +28,51 @@ spec:
     - name: SNAPSHOT_PATH
       type: string
       description: The location to place the reduced Snapshot
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: sourceDataArtifact
+      type: string
+      default: ""
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
+  results:
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
   workspaces:
     - name: data
       description: Workspace to save the CR jsons to
   steps:
+    - name: skip-trusted-artifact-operations
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        if [ "$(params.ociStorage)" == "empty" ]; then
+          echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+          touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+        fi
+    - name: use-trusted-artifact
+      args:
+        - use
+        - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+      env:
+        - name: "ORAS_OPTIONS"
+          value: "--insecure"
+        - name: "HOME"
+          value: "/tekton/home"
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     - name: reduce
       env:
         - name: SNAPSHOT
@@ -47,3 +88,29 @@ spec:
       image: quay.io/enterprise-contract/ec-cli@sha256:913c7dac3d41877b01835d2e55bcd970c6cdbf4944f8176e9e3de9548642a2b4
       command: [reduce-snapshot.sh]
       onError: continue  # progress even if the step fails
+    - name: create-trusted-artifact
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+        - name: "ORAS_OPTIONS"
+          value: "--insecure"
+        - name: "HOME"
+          value: "/tekton/home"
+    - name: patch-source-data-artifact-result
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        # this is needed to skip trusted-artifacts tasks
+        # when using PVC based workspaces.
+        if [ "$(params.ociStorage)" == "empty" ]; then
+          echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+        fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -8,9 +8,22 @@ spec:
     Run the reduce snapshot task with single component mode being false
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -36,9 +49,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
+                "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -47,7 +96,7 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: false
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -55,7 +104,13 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: default
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -65,20 +120,40 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 2 ]; then
                 echo "ERROR: Resulting snapshot does not contain 2 components"
                 exit 1
               fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -9,9 +9,22 @@ spec:
     Therefore, the entire snapshot file is returned instead of being reduced.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -37,9 +50,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
+                "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -48,7 +97,7 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: true
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -56,7 +105,13 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: default
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -66,20 +121,40 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 2 ]; then
                 echo "ERROR: Resulting snapshot does not contain 2 components"
                 exit 1
               fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -8,9 +8,22 @@ spec:
     Run the reduce snapshot task with missing labels
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -33,9 +46,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | \
+                tee "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -44,7 +93,7 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: true
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -52,7 +101,13 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: default
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -62,20 +117,40 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 2 ]; then
                 echo "ERROR: Resulting snapshot does not contain 2 components"
                 exit 1
               fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -8,9 +8,22 @@ spec:
     Run the reduce task to reduce to a single component without the CUSTOM_RESOURCE_NAMESPACE parameter
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -36,9 +49,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
+                "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -47,13 +96,19 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: true
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
           value: snapshot/snapshot-sample
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -63,24 +118,45 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 1 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 1 ]; then
                 echo "ERROR: Resulting snapshot does not contain 1 component"
                 exit 1
               fi
-              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/snapshot.json")" != "tom" ]; then
+              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                != "tom" ]; then
                 echo "ERROR: Resulting snapshot does not contain the 'tom' component"
                 exit 1
               fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -9,9 +9,22 @@ spec:
     Therefore, the entire snapshot should be returned instead of it being reduced
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -37,9 +50,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
+                "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -48,7 +97,7 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: true
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -56,7 +105,13 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: default
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -66,20 +121,40 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 2 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 2 ]; then
                 echo "ERROR: Resulting snapshot does not contain 2 components"
                 exit 1
               fi

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -8,9 +8,22 @@ spec:
     Run the reduce task to reduce to a single component
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
       taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -36,9 +49,45 @@ spec:
                     containerImage: newimage2
               EOF
               kubectl apply -f snapshot
-              
-              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee "$(workspaces.data.path)/snapshot.json"
-              chmod 666 "$(workspaces.data.path)/snapshot.json"
+
+              mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+              kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
+                "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              chmod 666 "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+          - name: skip-trusted-artifact-operations
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eo pipefail
+      
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo "oci storage not detected via params.ociStorage ... skipping trusted artifacts tasks"
+                touch "$(workspaces.data.path)/$(params.subdirectory)/.skip-trusted-artifacts"
+              fi
+          - name: create-trusted-artifact
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.sourceDataArtifact.path)=$(workspaces.data.path)/$(params.subdirectory)
+            computeResources: { }
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+            env:
+              - name: IMAGE_EXPIRES_AFTER
+                value: 1d
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+          - name: patch-source-data-artifact-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+      
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.sourceDataArtifact.path)"
+              fi
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -47,7 +96,7 @@ spec:
         name: reduce-snapshot
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
         - name: SINGLE_COMPONENT
           value: true
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -55,7 +104,13 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: default
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/snapshot.json
+          value: $(workspaces.data.path)/$(context.pipelineRun.uid)/snapshot.json
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
       runAfter:
         - setup
       workspaces:
@@ -65,24 +120,45 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(workspaces.data.path)/$(context.pipelineRun.uid)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
       runAfter:
         - run-task
       taskSpec:
         workspaces:
           - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.sourceDataArtifact)=$(workspaces.data.path)/$(params.subdirectory)
+            env:
+              - name: "ORAS_OPTIONS"
+                value: "--insecure"
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat "$(workspaces.data.path)/snapshot.json"
-              if [ "$(jq '.components | length' < "$(workspaces.data.path)/snapshot.json")" -ne 1 ]; then
+              cat "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json"
+              if [ "$(jq '.components | length' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                -ne 1 ]; then
                 echo "ERROR: Resulting snapshot does not contain 1 component"
                 exit 1
               fi
-              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/snapshot.json")" != "tom" ]; then
+              if [ "$(jq -cr '.components[0].name' < "$(workspaces.data.path)/$(params.subdirectory)/snapshot.json")" \
+                != "tom" ]; then
                 echo "ERROR: Resulting snapshot does not contain the 'tom' component"
                 exit 1
               fi

--- a/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -8,6 +8,10 @@ spec:
     Run the verify-access-to-resources task and verifies access to resources.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -78,6 +82,8 @@ spec:
           value: default/snapshot-sample
         - name: requireInternalServices
           value: "true"
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
   finally:

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: verify-access-to-resources  
+  name: verify-access-to-resources
   labels:
     app.kubernetes.io/version: "0.3.1"
   annotations:
@@ -31,7 +31,7 @@ spec:
       description: Whether internal services are required
       type: string
       default: "false"
-  steps: 
+  steps:
     - name: verify-access-to-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |


### PR DESCRIPTION
## Describe your changes
- in an effort to move away from PVCs, we are trying
  trusted artifacts based on https://github.com/konflux-ci/build-trusted-artifacts/tree/main
- tasks that have been updated now support 2 modes:
  - PVC based workspaces
  - Trusted artifacts with emptyDir workspaces
    
Summary:
- collect-data, reduce-snapshot, apply-mapping now support trusted
  artifacts mode
- pipelines that use apply-mapping have had the workspace used for
  the apply-mapping task renamed to be in line with other tasks.
- CI changes:
   - it now attempts to detect if a Trusted Artifacts based task
     has been changes and runs the tests with trusted artifacts enabled.
  - tests now create an on-local-cluster registry.

requires https://github.com/konflux-ci/release-service/pull/666 for use on real clusters

## Relevant Jira
- [RELEASE-1387](https://issues.redhat.com//browse/RELEASE-1387)

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
