### PR TITLE
feat: use trusted artifacts

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -59,10 +59,19 @@ jobs:
         if: |
           steps.changed-dirs.outputs.any_changed == 'true'
         uses: ./.github/actions/install-tkn
+      - name: Prepare docker config json
+        env:
+          TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON: ${{ secrets.TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON }}
+        run: |
+          echo $TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON > /tmp/.dockerconfig.json
+          echo "cat /tmp/.dockerconfig.json"
+          cat /tmp/.dockerconfig.json
       - name: Test Tekton tasks
         if: |
           steps.changed-dirs.outputs.any_changed == 'true'
         run: .github/scripts/test_tekton_tasks.sh
         env:
+          TRUSTED_ARTIFACT_OCI_DOCKER_CONFIG_JSON_PATH: /tmp/.dockerconfig.json
+          TRUSTED_ARTIFACT_OCI_STORAGE: ${{ secrets.TRUSTED_ARTIFACT_OCI_STORAGE }}
           TEST_ITEMS: >-
             ${{ steps.changed-dirs.outputs.all_changed_files }}

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -28,13 +28,17 @@ spec:
     - name: snapshot
       type: string
       description: The namespaced name of the Snapshot
-    - name: subdirectory
-      description: Subdirectory inside the workspace to be used
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
-      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
   workspaces:
     - name: data
-      description: Workspace to save the CR jsons to
+      description: Workspace to save the CR jsons to (ws needs to be rw since it updates data files)
   results:
     - name: release
       type: string
@@ -72,6 +76,9 @@ spec:
     - name: releasePipelineMetadata
       type: string
       description: json object containing git resolver metadata about the running release pipeline
+    - description: Produced trusted data artifact
+      name: SOURCE_DATA_ARTIFACT
+      type: string
   steps:
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -91,34 +98,29 @@ spec:
         set -eo pipefail
 
         RESULTS_DIR_PATH="results"
-        if [ -n "$(params.subdirectory)" ]; then
-          mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
-          RESULTS_DIR_PATH="$(params.subdirectory)/results"
-        fi
-
-        mkdir "$(workspaces.data.path)/$RESULTS_DIR_PATH"
+        mkdir -p "$(workspaces.data.path)/$RESULTS_DIR_PATH"
         echo -n "$RESULTS_DIR_PATH" > "$(results.resultsDir.path)"
 
-        RELEASE_PATH="$(params.subdirectory)/release.json"
+        RELEASE_PATH="release.json"
         echo -n "$RELEASE_PATH" > "$(results.release.path)"
         get-resource "release" "${RELEASE}" | tee "$(workspaces.data.path)/$RELEASE_PATH"
 
-        RELEASEPLAN_PATH="$(params.subdirectory)/release_plan.json"
+        RELEASEPLAN_PATH="release_plan.json"
         echo -n "$RELEASEPLAN_PATH" > "$(results.releasePlan.path)"
         get-resource "releaseplan" "${RELEASE_PLAN}" | tee "$(workspaces.data.path)/$RELEASEPLAN_PATH"
 
-        RELEASEPLANADMISSION_PATH="$(params.subdirectory)/release_plan_admission.json"
+        RELEASEPLANADMISSION_PATH="release_plan_admission.json"
         echo -n "$RELEASEPLANADMISSION_PATH" > "$(results.releasePlanAdmission.path)"
         get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
           | tee "$(workspaces.data.path)/$RELEASEPLANADMISSION_PATH"
 
-        RELEASESERVICECONFIG_PATH="$(params.subdirectory)/release_service_config.json"
+        RELEASESERVICECONFIG_PATH="release_service_config.json"
         echo -n "$RELEASESERVICECONFIG_PATH" > "$(results.releaseServiceConfig.path)"
         get-resource "releaseserviceconfig" "${RELEASE_SERVICE_CONFIG}" \
           | tee "$(workspaces.data.path)/$RELEASESERVICECONFIG_PATH"
 
         echo -e "\nFetching Snapshot Spec"
-        SNAPSHOTSPEC_PATH="$(params.subdirectory)/snapshot_spec.json"
+        SNAPSHOTSPEC_PATH="snapshot_spec.json"
         echo -n "$SNAPSHOTSPEC_PATH" > "$(results.snapshotSpec.path)"
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" | tee "$(workspaces.data.path)/$SNAPSHOTSPEC_PATH"
 
@@ -140,7 +142,7 @@ spec:
         # Merge now with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
         merged_output=$(merge-json "$merged_output" "$release_plan_admission_result")
 
-        DATA_PATH="$(params.subdirectory)/data.json"
+        DATA_PATH="data.json"
         echo -n "$DATA_PATH" > "$(results.data.path)"
         echo "$merged_output" | tee "$(workspaces.data.path)/$DATA_PATH"
     - name: collect-single-component-mode-data
@@ -153,7 +155,7 @@ spec:
         set -ex
 
         # check if RP/RPA has a single-component mode
-        DATA_PATH="$(params.subdirectory)/data.json"
+        DATA_PATH="data.json"
         SINGLE_COMPONENT_MODE=$(jq -r '.singleComponentMode // "false"' "$(workspaces.data.path)/$DATA_PATH")
         SNAPSHOT_NAME=$(echo "${SNAPSHOT}" | cut -f2 -d/)
         SNAPSHOT_NAMESPACE=$(echo "${SNAPSHOT}" | cut -f1 -d/)
@@ -198,10 +200,10 @@ spec:
             done
         }
 
-        check_source "Release" "$(workspaces.data.path)/$(params.subdirectory)/release.json"
-        check_source "ReleasePlan" "$(workspaces.data.path)/$(params.subdirectory)/release_plan.json"
+        check_source "Release" "$(workspaces.data.path)/release.json"
+        check_source "ReleasePlan" "$(workspaces.data.path)/release_plan.json"
         check_source "ReleasePlanAdmission" \
-            "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json"
+            "$(workspaces.data.path)/release_plan_admission.json"
 
         exit $RC
     - name: print-pipeline-ref-info
@@ -211,7 +213,7 @@ spec:
         set -eu
 
         pipelineref=$(jq -c '.spec.pipeline.pipelineRef' \
-          "$(workspaces.data.path)/$(params.subdirectory)/release_plan_admission.json")
+          "$(workspaces.data.path)/release_plan_admission.json")
         resolver=$(jq -r '.resolver // ""' <<< "${pipelineref}")
         if [ "${resolver}" == "git" ] ; then
           url=$(jq -r '.params[] | select(.name=="url") | .value' <<< "${pipelineref}")
@@ -246,3 +248,14 @@ spec:
         echo "${json}" > "$(results.releasePipelineMetadata.path)"
         # pretty print for log message
         jq . <<< "$json"
+    - name: create-trusted-artifact
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_DATA_ARTIFACT.path)=$(workspaces.data.path)
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task with the disallowed key product_id in the Release data.
   workspaces:
@@ -124,8 +128,8 @@ spec:
           value: default/releaseserviceconfig-disallowed-release-sample
         - name: snapshot
           value: default/snapshot-disallowed-release-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task with the disallowed key product_id in the ReleasePlan data.
   workspaces:
@@ -124,8 +128,8 @@ spec:
           value: default/releaseserviceconfig-disallowed-rp-sample
         - name: snapshot
           value: default/snapshot-disallowed-rp-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task without a ReleasePlanAdmission cr and verify that the task fails as expected.
     This test cannot rely on the snapshot not existing as the snapshot is retrieved with a jsonpath added
@@ -84,8 +88,8 @@ spec:
           value: default/releaseserviceconfig-missing-cr-sample
         - name: snapshot
           value: default/snapshot-missing-cr-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   description: |
     Run the collect-data task without a ReleaseServiceConfig cr and verify that the task fails as expected.
     This test cannot rely on the snapshot not existing as the snapshot is retrieved with a jsonpath added
@@ -74,8 +78,8 @@ spec:
           value: default/releaseserviceconfig-missing-rsc-sample
         - name: snapshot
           value: default/snapshot-missing-rsc-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -9,6 +9,10 @@ spec:
     git resolver
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -111,8 +115,8 @@ spec:
           value: default/releaseserviceconfig-sample
         - name: snapshot
           value: default/snapshot-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -122,6 +126,8 @@ spec:
       params:
         - name: releasePipelineMetadata
           value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.run-task.results.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that the pipeline ref info is made available
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -106,8 +110,8 @@ spec:
           value: default/releaseserviceconfig-sample
         - name: snapshot
           value: default/snapshot-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -117,6 +121,8 @@ spec:
       params:
         - name: releasePipelineMetadata
           value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.run-task.results.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -126,9 +132,17 @@ spec:
         params:
           - name: releasePipelineMetadata
             type: string
+          - name: SOURCE_DATA_ARTIFACT
+            type: string
         workspaces:
           - name: data
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             env:

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that data task result is accurate.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -15,7 +19,7 @@ spec:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               cat > release << EOF
@@ -113,8 +117,8 @@ spec:
           value: default/releaseserviceconfig-with-data-sample
         - name: snapshot
           value: default/snapshot-with-data-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -126,6 +130,8 @@ spec:
           value: $(tasks.run-task.results.data)
         - name: singleComponentMode
           value: $(tasks.run-task.results.singleComponentMode)
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.run-task.results.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -137,7 +143,15 @@ spec:
             type: string
           - name: singleComponentMode
             type: string
+          - name: SOURCE_DATA_ARTIFACT
+            type: string
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -8,6 +8,10 @@ spec:
     Run the collect-data task and verify that all resources are stored in the workspace.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: setup
       taskSpec:
@@ -103,8 +107,8 @@ spec:
           value: default/releaseserviceconfig-sample
         - name: snapshot
           value: default/snapshot-sample
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
       runAfter:
         - setup
       workspaces:
@@ -132,6 +136,10 @@ spec:
           value: $(tasks.run-task.results.snapshotName)
         - name: snapshotNamespace
           value: $(tasks.run-task.results.snapshotNamespace)
+        - name: releasePipelineMetadata
+          value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.run-task.results.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -159,9 +167,17 @@ spec:
             type: string
           - name: snapshotNamespace
             type: string
+          - name: SOURCE_DATA_ARTIFACT
+            type: string
         workspaces:
           - name: data
         steps:
+          - name: use-trusted-artifact
+            args:
+              - use
+              - $(params.SOURCE_DATA_ARTIFACT)=$(workspaces.data.path)
+            computeResources: {}
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |


### PR DESCRIPTION
- in an effort to move away from PVCs, we are trying trusted artifacts.
- this PR makes the following changes:
  - PipelineRun uses an EmptyDir now for the workspace
  - the subDirectory parameter is removed
  - the data path is now saved as an artifact in quay
  - the check-result task then uses it for testing
- If we go ahead with this, then we would create a new task called `collect-data-oci-ta` alongside `collect-data` and gradually build up new `-oci-ta` pipelines.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

