### PR TITLE
feat(ISV-5571): ignore SBOM-related task errors in rh-advisories

### DIFF
--- a/tasks/managed/upload-sbom-to-atlas/README.md
+++ b/tasks/managed/upload-sbom-to-atlas/README.md
@@ -14,6 +14,9 @@ Supports both CycloneDX and SPDX format.
 | supportedCycloneDxVersion | If the SBOM uses a higher CycloneDX version, `syft convert` in the task will convert all SBOMs to this CycloneDX version before uploading them to Atlas. If the SBOM is already in this version or lower, it will be uploaded as is. | Yes      | 1.4                                                                           |
 | supportedSpdxVersion      | If the SBOM uses a higher SPDX version, `syft convert` in the task will convert all SBOMs to this SPDX version before uploading them to Atlas. If the SBOM is already in this version or lower, it will be uploaded as is.           | Yes      | 2.3                                                                           |
 
+## Changes in 0.2.1
+Ignore error (but output a message) if upload request to Atlas fails.
+
 ## Changes in 0.2.0
 Remove option to skip uploading SBOMs. Skipping will be handled via Tekton.
 Rename productSBOMPath parameter to sbomDir. Use SBOM file names as Atlas IDs.

--- a/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
+++ b/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
@@ -7,4 +7,10 @@ curl() {
   echo "Mock curl called with:" "$@" >&2
   workdir="$(workspaces.data.path)/workdir"
   echo "$@" >> "$workdir/mock_curl.txt"
+
+  # Throw a failure (which should be caught) for Atlas API calls in the curl fail test
+  params="$*"
+  if [[ "$params" =~ "https://sbom.atlas.devshift.net/api/v1/sbom?id=spdx_minimal_curl_fail_2_3" ]]; then
+    return 1
+  fi
 }

--- a/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-curl-fail.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-curl-fail.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-upload-sbom-to-atlas-curl-fail
+spec:
+  description: |
+    Tests that failure in uploading SPDX SBOMs to Atlas should not fail the upload-sbom-to-atlas task.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: sbomDir
+            default: "sboms"
+            description: Directory containing generated SBOM files.
+            type: string
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:3eb493f6b7923e04fbb01b44b24e5491a2bbd1ec
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # creating directory for generated SBOM-s
+              mkdir "$(workspaces.data.path)/$(params.sbomDir)"
+              # creating working directory
+              mkdir "$(workspaces.data.path)/workdir"
+
+              sbomsDir="$(workspaces.data.path)/$(params.sbomDir)"
+              workdir="$(workspaces.data.path)/workdir"
+
+              # minimal SPDX SBOM 2.3 - no need for conversion
+              cat > "$sbomsDir/spdx_minimal_curl_fail_2_3.json" << EOF
+              {
+                "spdxVersion": "SPDX-2.3",
+                "dataLicense": "CC0-1.0",
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "name": "Minimal SPDX SBOM for testing curl failure",
+                "documentNamespace": "http://spdx.org/spdxdocs/minimal-spdx-sbom",
+                "documentDescribes": []
+              }
+              EOF
+              sbom_id_2_3="spdx_minimal_curl_fail_2_3"
+              echo "$sbom_id_2_3" > "$workdir/spdx_minimal_curl_fail_2_3"
+
+    - name: run-task
+      taskRef:
+        name: upload-sbom-to-atlas
+      params:
+        - name: atlasSecretName
+          value: atlas-test-sso-secret
+        - name: sbomDir
+          value: "sboms"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sbomDir
+            default: "sboms"
+            description: Directory containing generated SBOM files.
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:3eb493f6b7923e04fbb01b44b24e5491a2bbd1ec
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              workdir="$(workspaces.data.path)/workdir"
+
+              # Check count of curl calls
+              if [ "$(wc -l < "$workdir/mock_curl.txt")" -ne 2 ]; then
+                echo "TEST FAILED: curl was expected to be called 2 times. Actual calls:"
+                cat "$workdir/mock_curl.txt"
+                exit 1
+              else
+                echo "TEST PASSED: Curl has been called 2 times"
+              fi

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: upload-sbom-to-atlas
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -229,6 +229,7 @@ spec:
             -H "transfer-encoding: chunked" \
             -H "content-type: application/json" \
             --data "@$supported_version_of_sbom" \
-            "$bombasticApiUrl/api/v1/sbom?id=$sbom_id"
+            "$bombasticApiUrl/api/v1/sbom?id=$sbom_id" \
+            || echo "SBOM upload to Atlas has failed!"
 
         done


### PR DESCRIPTION
## Describe your changes
Failing to process or upload SBOMs should not fail the whole rh-advisories pipeline. This change ensures that the pipeline will continue even if there are errors in the SBOM-related tasks.

## Relevant Jira
https://issues.redhat.com/browse/ISV-5571

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR 
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x]  I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

