### PR TITLE
feat(RELEASE-1324): file-updates internal task uses git resolver

### DIFF
--- a/internal/pipelines/process-file-updates/README.md
+++ b/internal/pipelines/process-file-updates/README.md
@@ -5,14 +5,19 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 
 ## Parameters
 
-| Name                | Description                                                                                                                                                                              | Optional | Default value       |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------------|
-| upstream_repo       | Upstream Git repository                                                                                                                                                                  | No       | -                   |
-| repo                | Git repository                                                                                                                                                                           | No       | -                   |
-| ref                 | Git branch                                                                                                                                                                               | No       | -                   |
-| paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                   |
-| application         | Application being released                                                                                                                                                               | No       | -                   |
-| file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret |
+| Name                | Description                                                                                                                                                                              | Optional | Default value                         |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------------------------------|
+| upstream_repo       | Upstream Git repository                                                                                                                                                                  | No       | -                                                         |
+| repo                | Git repository                                                                                                                                                                           | No       | -                                                         |
+| ref                 | Git branch                                                                                                                                                                               | No       | -                                                         |
+| paths               | String containing a JSON array of file paths and its updates and/or replacements E.g. '[{"path":"file1.yaml","replacements":[{"key":".yamlkey1,","replacement":"\|regex\|replace\|"}]}]' | No       | -                                                         |
+| application         | Application being released                                                                                                                                                               | No       | -                                                         |
+| file_updates_secret | The credentials used to update the git repo                                                                                                                                              | Yes      | file-updates-secret                                       |
+| taskGitUrl          | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                                                    | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision     | The revision in the taskGitUrl repo to be used                                                                                                                                           | No       | -                                                         |
+
+## Changes in 1.0.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers
 
 ## Changes in 0.0.2
 * fix invalid result value

--- a/internal/pipelines/process-file-updates/process-file-updates.yaml
+++ b/internal/pipelines/process-file-updates/process-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: process-file-updates
   labels:
-    app.kubernetes.io/version: "0.0.2"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -33,12 +33,26 @@ spec:
       type: string
       default: "file-updates-secret"
       description: The credentials used to update the git repo
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: pipeline
   tasks:
     - name: process-file-updates
       taskRef:
-        name: process-file-updates-task
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/process-file-updates-task/process-file-updates-task.yaml
       params:
         - name: upstream_repo
           value: $(params.upstream_repo)

--- a/internal/resources/process-file-updates-task.yaml
+++ b/internal/resources/process-file-updates-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/process-file-updates-task/process-file-updates-task.yaml

--- a/pipelines/managed/push-to-addons-registry/README.md
+++ b/pipelines/managed/push-to-addons-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release a single FBC component to the Addons Registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 0.2.1
+* Pass taskGitUrl and taskGitRevision to run-file-updates task
+
 ## Changes in 0.2.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-addons-registry
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -297,6 +297,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       runAfter:
         - push-snapshot
       taskRef:

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.8.3
+* Pass taskGitUrl and taskGitRevision to run-file-updates task
+
 ## Changes in 1.8.2
 * Pass taskGitUrl and taskGitRevision to embargo-check task
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.8.2"
+    app.kubernetes.io/version: "1.8.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -552,6 +552,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       runAfter:
         - push-rpm-data-to-pyxis
       taskRef:

--- a/pipelines/managed/rh-push-to-external-registry/README.md
+++ b/pipelines/managed/rh-push-to-external-registry/README.md
@@ -19,6 +19,9 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                       | No        | -            |
 
+## Changes in 5.5.1
+* Pass taskGitUrl and taskGitRevision to run-file-updates task
+
 ## Changes in 5.5.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.5.0"
+    app.kubernetes.io/version: "5.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -370,6 +370,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       runAfter:
         - push-rpm-data-to-pyxis
       taskRef:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.7.2
+* Pass taskGitUrl and taskGitRevision to run-file-updates task
+
 ## Changes in 4.7.1
 * Set timeout for rh-sign-image-cosign task to be 6 hrs
 

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "4.7.1"
+    app.kubernetes.io/version: "4.7.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -472,6 +472,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       runAfter:
         - push-rpm-data-to-pyxis
       taskRef:

--- a/tasks/managed/run-file-updates/README.md
+++ b/tasks/managed/run-file-updates/README.md
@@ -14,6 +14,11 @@ the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 | synchronously      | Whether the task should wait for InternalRequests to complete                             | Yes      | true                     |
 | pipelineRunUid     | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                        |
 | resultsDirPath     | Path to results directory in the data workspace                                           | No       | -                        |
+| taskGitUrl         | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                        |
+| taskGitRevision    | The revision in the taskGitUrl repo to be used                                            | No       | -                        |
+
+## Changes in 3.0.0
+* Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 
 ## Changes in 2.0.2
 * fix linting issues

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -36,6 +36,12 @@ spec:
     - name: resultsDirPath
       description: Path to the results directory in the data workspace
       type: string
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   results:
     - name: mergeRequestUrl
       description: URL of MR that was created
@@ -94,6 +100,8 @@ spec:
                            -p paths="${updatedPaths}" \
                            -p application="${application}" \
                            -p file_updates_secret="${file_updates_secret}" \
+                           -p taskGitUrl="$(params.taskGitUrl)" \
+                           -p taskGitRevision="$(params.taskGitRevision)" \
                            -s "$(params.synchronously)" \
                            -l ${TASK_LABEL}="${TASK_ID}" \
                            -l ${REQUEST_LABEL}="${requestId}" \

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
@@ -81,6 +81,10 @@ spec:
           value: ""
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -168,6 +172,18 @@ spec:
                 # Check if the 'ref' field matches
                 if [ "$(echo "$requestRepo" | jq -r '.spec.params.ref')" != "$ref" ]; then
                   echo "InternalRequest for repo: $repo has different 'ref'. Expected: $ref"
+                  exit 1
+                fi
+
+                # Check if the 'taskGitUrl' field matches
+                if [ "$(echo "$requestRepo" | jq -r '.spec.params.taskGitUrl')" != "http://localhost" ]; then
+                  echo "InternalRequest for repo: $repo has different 'taskGitUrl'. Expected: http://localhost"
+                  exit 1
+                fi
+
+                # Check if the 'taskGitRevision' field matches
+                if [ "$(echo "$requestRepo" | jq -r '.spec.params.taskGitRevision')" != "main" ]; then
+                  echo "InternalRequest for repo: $repo has different 'taskGitRevision'. Expected: main"
                   exit 1
                 fi
 

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
@@ -93,6 +93,10 @@ spec:
           value: ""
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
@@ -93,6 +93,10 @@ spec:
           value: ""
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
@@ -89,6 +89,10 @@ spec:
           value: ""
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -174,6 +178,18 @@ spec:
                 # Check if the 'ref' field matches
                 if [ "$(echo "$requestRepo" | jq -r '.spec.params.ref')" != "$ref" ]; then
                   echo "InternalRequest for repo: $repo has different 'ref'. Expected: $ref"
+                  exit 1
+                fi
+
+                # Check if the 'taskGitUrl' field matches
+                if [ "$(echo "$requestRepo" | jq -r '.spec.params.taskGitUrl')" != "http://localhost" ]; then
+                  echo "InternalRequest for repo: $repo has different 'taskGitUrl'. Expected: http://localhost"
+                  exit 1
+                fi
+
+                # Check if the 'taskGitRevision' field matches
+                if [ "$(echo "$requestRepo" | jq -r '.spec.params.taskGitRevision')" != "main" ]; then
+                  echo "InternalRequest for repo: $repo has different 'taskGitRevision'. Expected: main"
                   exit 1
                 fi
 


### PR DESCRIPTION
This commit updates the process-file-updates internal pipeline to call its one task via git resolver. The pipeline itself still uses a cluster resolver, which will be changed in a separate commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

