### PR TITLE
fix(KFLUXSPRT-1471): ensure proper handling of incrementer substitution

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -31,6 +31,10 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
 
+## Changes in 1.9.1
+* Fixed handling of {{ incrementer }} substitution to ensure accurate
+  tag generation and prevent incomplete replacements.
+
 ## Changes in 1.9.0
 * support defaults for `contentGateway`
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.9.0"
+    app.kubernetes.io/version: "1.9.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -141,17 +141,18 @@ spec:
                   if [[ "$var_name" == "incrementer" ]]; then
                       repo=$(jq -r '.repository' <<< "$component")
                       tag=$(increment_tag "$tag" "$repo")
-                  else
-                      replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
-                      if [ -z "$replacement" ]; then
-                          echo Error: Substitution variable unknown or empty: "$var_name" >&2
-                          exit 1
-                      fi
-                      # Shellcheck suggests ${var//find/replace}, but
-                      # that won't work here - we need to match arbitrary amount of spaces
-                      # shellcheck disable=SC2001
-                      tag="$(sed "s/{{ *$var_name *}}/$replacement/" <<< "$tag")"
+                      continue  # Skip substitution fallback for incrementer
                   fi
+
+                  replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
+                  if [ -z "$replacement" ]; then
+                      echo "Error: Substitution variable unknown or empty: $var_name" >&2
+                      exit 1
+                  fi
+                  # Shellcheck suggests ${var//find/replace}, but
+                  # that won't work here - we need to match arbitrary amount of spaces
+                  # shellcheck disable=SC2001
+                  tag="$(sed "s/{{ *$var_name *}}/$replacement/" <<< "$tag")"
                 done
 
                 # Sanity check of the resulting tag value


### PR DESCRIPTION
## Describe your changes
This PR fixes the substitution logic for the {{ incrementer }} variable in the apply-mapping task. It ensures proper handling and replacement of the incrementer placeholder during tag translation, addressing scenarios where substitution would previously fail. The issue observed by the user here: [Slack-THREAD](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1737741140734749)

## Relevant Jira

[KFLUXSPRT-1471](https://issues.redhat.com/browse/KFLUXSPRT-1471)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

