### PR TITLE
feat: use 4h timeout default rh-advisories and rh-push-to-registry-redhat-io pipelines

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -90,6 +90,7 @@ spec:
         - name: requireInternalServices
           value: "true"
     - name: collect-data
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -118,6 +119,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: reduce-snapshot
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -171,6 +173,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: apply-mapping
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 3
       taskRef:
         resolver: "git"
@@ -227,6 +230,7 @@ spec:
       runAfter:
         - apply-mapping
     - name: populate-release-notes
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -247,6 +251,7 @@ spec:
         - name: data
           workspace: release-workspace
     - name: embargo-check
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -271,6 +276,7 @@ spec:
       runAfter:
         - populate-release-notes
     - name: collect-cosign-params
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -318,6 +324,7 @@ spec:
         - push-snapshot
         - collect-cosign-params
     - name: push-snapshot
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -345,6 +352,7 @@ spec:
       runAfter:
         - rh-sign-image
     - name: collect-pyxis-params
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -408,6 +416,7 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -435,6 +444,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -463,6 +473,7 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -486,6 +497,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: update-component-sbom
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -513,6 +525,7 @@ spec:
         - push-rpm-data-to-pyxis
         - populate-release-notes
     - name: upload-component-sbom
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -541,6 +554,7 @@ spec:
       runAfter:
         - update-component-sbom
     - name: run-file-updates
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -572,6 +586,7 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -598,6 +613,7 @@ spec:
       runAfter:
         - populate-release-notes
     - name: collect-atlas-params
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -616,6 +632,7 @@ spec:
       runAfter:
         - collect-data
     - name: create-product-sbom
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -639,6 +656,7 @@ spec:
         - collect-atlas-params
         - populate-release-notes
     - name: upload-product-sbom
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -667,6 +685,7 @@ spec:
       runAfter:
         - create-product-sbom
     - name: create-advisory
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       params:
         - name: releasePlanAdmissionPath
@@ -703,6 +722,7 @@ spec:
         - rh-sign-image
         - rh-sign-image-cosign
     - name: update-cr-status
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: resource
           value: $(params.release)
@@ -724,6 +744,7 @@ spec:
         - create-advisory
   finally:
     - name: cleanup
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -86,6 +86,7 @@ spec:
         - name: requireInternalServices
           value: "true"
     - name: collect-data
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -114,6 +115,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: check-data-keys
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -139,6 +141,7 @@ spec:
       runAfter:
         - collect-data
     - name: reduce-snapshot
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -192,6 +195,7 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: apply-mapping
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 3
       taskRef:
         resolver: "git"
@@ -215,6 +219,7 @@ spec:
       runAfter:
         - reduce-snapshot
     - name: verify-enterprise-contract
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "bundles"
         params:
@@ -247,6 +252,7 @@ spec:
       runAfter:
         - apply-mapping
     - name: collect-cosign-params
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -293,6 +299,7 @@ spec:
         - push-snapshot
         - collect-cosign-params
     - name: push-snapshot
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -320,6 +327,7 @@ spec:
       runAfter:
         - rh-sign-image
     - name: collect-pyxis-params
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -383,6 +391,7 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -410,6 +419,7 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -438,6 +448,7 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -461,6 +472,7 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: run-file-updates
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -492,6 +504,7 @@ spec:
         - name: data
           workspace: release-workspace
     - name: update-cr-status
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: resource
           value: $(params.release)
@@ -513,6 +526,7 @@ spec:
         - run-file-updates
   finally:
     - name: cleanup
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
By default the task timeout in the release pipelines are 2h. This is especially short for larger applications without having [RELEASE-1291](https://issues.redhat.com/browse/RELEASE-1291) in place and running into konflux-ci/release-service/issues/603.
This PR sets the timeout for the tasks in the rh-advisories pipeline to 4h (what we've done for the OpenShift Serverless release). 
Also updated `rh-push-to-registry-redhat-io` as you try to keep those pipelines in sync.

An alternative would be to set the 4h timeout globally for all tasks in https://github.com/redhat-appstudio/infra-deployments