### PR TITLE
feat(RELEASE-1323): create-advisory internal task uses git resolver

### DIFF
--- a/internal/pipelines/create-advisory/README.md
+++ b/internal/pipelines/create-advisory/README.md
@@ -6,11 +6,16 @@ advisory URL as well as a result to show the error message if one occurred.
 
 ## Parameters
 
-| Name                 | Description                                                                                            | Optional | Default value |
-|----------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
-| advisory_json        | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -             |
-| application          | Application being released                                                                             | No       | -             |
-| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -             |
-| config_map_name      | The name of the configMap that contains the signing key                                                | No       | -             |
-| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
-| errata_secret_name   | The name of the secret that contains the errata service account metadata                               | No       | -             |
+| Name                 | Description                                                                                            | Optional | Default value                                             |
+|----------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| advisory_json        | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -                                                         |
+| application          | Application being released                                                                             | No       | -                                                         |
+| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
+| config_map_name      | The name of the configMap that contains the signing key                                                | No       | -                                                         |
+| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
+| errata_secret_name   | The name of the secret that contains the errata service account metadata                               | No       | -                                                         |
+| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
+
+## Changes in 1.0.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/internal/pipelines/create-advisory/create-advisory.yaml
+++ b/internal/pipelines/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -33,10 +33,24 @@ spec:
     - name: errata_secret_name
       type: string
       description: The name of the secret that contains the errata service account metadata
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: create-advisory-task
       taskRef:
-        name: create-advisory-task
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/create-advisory-task/create-advisory-task.yaml
       params:
         - name: advisory_json
           value: $(params.advisory_json)

--- a/internal/resources/create-advisory-task.yaml
+++ b/internal/resources/create-advisory-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/create-advisory-task/create-advisory-task.yaml

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.8.4
+* Pass taskGitUrl and taskGitRevision to create-advisory task
+
 ## Changes in 1.8.3
 * Pass taskGitUrl and taskGitRevision to run-file-updates task
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.8.3"
+    app.kubernetes.io/version: "1.8.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -679,6 +679,10 @@ spec:
           value: "$(tasks.collect-data.results.resultsDir)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       taskRef:
         params:
           - name: url

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -17,6 +17,11 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | request                  | Type of request to be created                                                             | Yes      | create-advisory             |
 | synchronously            | Whether the task should wait for InternalRequests to complete                             | Yes      | true                        |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                           |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                           |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -                           |
+
+## Changes in 5.0.0
+* Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 
 ## Changes in 4.4.3
 * Pass the errata service account secret name to the InternalRequest based on stage or prod

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "4.4.3"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,6 +39,12 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: data
       description: Workspace where the json files are stored
@@ -166,6 +172,8 @@ spec:
                          -p config_map_name="${configMapName}" \
                          -p advisory_secret_name="${advisorySecretName}" \
                          -p errata_secret_name="${errataSecretName}" \
+                         -p taskGitUrl="$(params.taskGitUrl)" \
+                         -p taskGitRevision="$(params.taskGitRevision)" \
                          -s "$(params.synchronously)" \
                          -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
                          > "$(workspaces.data.path)"/ir-result.txt || \

--- a/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
@@ -106,6 +106,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -149,6 +153,18 @@ spec:
               if [ "$(jq -r '.type' <<< "$advisoryJson")" != "RHBA" ]; then
                 echo "The advisory_json should have had its type overwritten to RHBA because there were no CVEs"
                 echo "and no type was initially provided in the releaseNotes."
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
                 exit 1
               fi
   finally:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
@@ -118,6 +118,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -90,6 +90,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
@@ -106,6 +106,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -63,6 +63,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -89,6 +89,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-orphan.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-orphan.yaml
@@ -110,6 +110,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -102,6 +102,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -106,6 +106,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-overwrite-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-overwrite-type.yaml
@@ -116,6 +116,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -159,6 +163,18 @@ spec:
               '{"type":"RHSA"'* ]]; then
                 echo "The advisory_json should have had its type overwritten to RHSA because there were CVEs"
                 echo "in the releaseNotes. However, it was not"
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
                 exit 1
               fi
   finally:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -104,6 +104,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -172,6 +176,18 @@ spec:
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.errata_secret_name' )" != \
                 "errata-stage-service-account" ]; then
                 echo "InternalRequest has the wrong errata_secret_name parameter"
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
                 exit 1
               fi
   finally:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -100,6 +100,10 @@ spec:
           value: "false"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -166,6 +170,18 @@ spec:
               # Check the config_map_name parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.config_map_name' )" != "cm" ]; then
                 echo "InternalRequest has the wrong config_map_name parameter"
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
                 exit 1
               fi
 


### PR DESCRIPTION
This commit updates the create-advisory internal pipeline to call its one task via git resolver. The pipeline itself still uses a cluster resolver, which will be changed in a separate commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

