### PR TITLE
fix(RELEASE-1389): update-fbc-catalog need publishingCredentials

### DIFF
--- a/pipelines/internal/update-fbc-catalog/README.md
+++ b/pipelines/internal/update-fbc-catalog/README.md
@@ -7,6 +7,7 @@ Tekton pipeline add/update FBC fragments to the FBC catalog by interacting with 
 | Name                    | Description                                                                           | Optional | Default value                                             |
 |-------------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
 | iibServiceAccountSecret | Secret containing the credentials for IIB service                                     |   yes    | iib-service-account                                       |
+| publishingCredentials   | Secret containing the publishing credentials used to fetch the image config           |   no     |                                                           |
 | fbcFragment             | FBC fragment built by HACBS                                                           |   no     | -                                                         |
 | fromIndex               | Index image (catalog of catalogs) the FBC fragment will be added to                   |   no     | -                                                         |
 | buildTags               | List of additional tags the internal index image copy should be tagged with           |   yes    | '[]'                                                      |
@@ -16,6 +17,9 @@ Tekton pipeline add/update FBC fragments to the FBC catalog by interacting with 
 | buildTimeoutSeconds     | IIB Build Service timeout seconds                                                     |   no     | -                                                         |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored |   yes    | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                        |   no     | -                                                         |
+
+## Changes in 1.1.0
+* adds `publishingCredentials` parameter
 
 ## Changes in 1.0.0
 * Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/pipelines/internal/update-fbc-catalog/update-fbc-catalog.yaml
+++ b/pipelines/internal/update-fbc-catalog/update-fbc-catalog.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: update-fbc-catalog
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -16,6 +16,9 @@ spec:
       type: string
       description: Secret containing the credentials for IIB service
       default: iib-service-account
+    - name: publishingCredentials
+      type: string
+      description: Secret containing the publishing credentials used to fetch the image config
     - name: fbcFragment
       type: string
       description: FBC fragment built by HACBS
@@ -69,6 +72,8 @@ spec:
       params:
         - name: iibServiceAccountSecret
           value: $(params.iibServiceAccountSecret)
+        - name: publishingCredentials
+          value: $(params.publishingCredentials)
         - name: fbcFragment
           value: $(params.fbcFragment)
         - name: fromIndex

--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -10,8 +10,12 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | addArches               | List of arches the index image should be built for.                          | No       | -             |
 | buildTimeoutSeconds     | Timeout seconds to receive the build state                                   | Yes      | "300"         |
 | iibServiceAccountSecret | Secret with IIB credentials to be used                                       | No       | -             |
+| publishingCredentials   | Secret containing the publishing credentials used to fetch the image config  | No       | -             |
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
+
+## Changes in 1.1.0
+* adds new parameter `publishingCredentials`
 
 ## Changes in 1.0.2
 * Fix an issue caused by the `indexImageDigests` result being multi line - now the digests are space-separated on one line

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -24,6 +24,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
     - name: check-result
       params:
         - name: jsonBuildInfo

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -25,6 +25,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
         - name: hotfix
           value: true
     - name: check-result

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
@@ -23,6 +23,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
     - name: check-result
       params:
         - name: jsonBuildInfo

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
@@ -26,6 +26,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
     - name: check-result
       params:
         - name: jsonBuildInfo

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
@@ -26,6 +26,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
     - name: check-result
       params:
         - name: jsonBuildInfo

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
@@ -27,6 +27,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
     - name: check-result
       params:
         - name: jsonBuildInfo

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -24,6 +24,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
         - name: stagedIndex
           value: true
     - name: check-result

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
@@ -23,6 +23,8 @@ spec:
           value: "[]"
         - name: iibServiceAccountSecret
           value: "iib-service-account-secret"
+        - name: publishingCredentials
+          value: "publishing-credentials"
         - name: buildTimeoutSeconds
           value: 1
     - name: check-result

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,6 +38,9 @@ spec:
     - name: iibServiceAccountSecret
       type: string
       description: Secret with IIB credentials to be used
+    - name: publishingCredentials
+      type: string
+      description: Secret containing the publishing credentials used to fetch the image config
     - name: hotfix
       type: string
       default: "false"
@@ -84,6 +87,12 @@ spec:
             secretKeyRef:
               name: iib-services-config
               key: krb5.conf
+        - name: TARGET_INDEX_CREDENTIAL
+          valueFrom:
+            secretKeyRef:
+              key: targetIndexCredential
+              name: $(params.publishingCredentials)
+              optional: true
       script: |
         #!/usr/bin/env bash
 
@@ -121,8 +130,18 @@ spec:
             indexImageResolved="$(jq -r '.index_image_resolved' <<<  "${build}")"
             newCatalogCreatedDate="$(date --date "$(skopeo inspect --config "docker://${indexImageResolved}" | \
               jq -r .created)" "+%s")"
-            upstreamCatalogCreatedDate="$(date --date "$(skopeo inspect --config "docker://$(params.targetIndex)" | \
-              jq -r .created)" "+%s")"
+
+            # authentication is only required for the targetIndex
+            create_auth_file
+            targetIndexCreated="$(skopeo inspect --config "docker://$(params.targetIndex)" | jq -r .created)"
+
+            if [ -z "${targetIndexCreated}" ]; then
+              # we cannot determine the target index created date, stop here. This causes the task to trigger
+              # a new build.
+              return 0
+            fi
+
+            upstreamCatalogCreatedDate="$(date --date "${targetIndexCreated}" "+%s")"
             # checks if the index_image_resolved in the previous completed build is newer
             # than the upstream catalog index.
             # in case the new catalog index is older than the upstream, a new build is
@@ -132,6 +151,19 @@ spec:
             fi
           fi
           echo "${build}"
+        }
+
+        create_auth_file() {
+          mkdir -p "${HOME}/.config/containers"
+          targetIndex="$(params.targetIndex)"
+          authName="${targetIndex%:*}"
+
+          # disabling debug to not leak the token
+          set +x
+          jq -n --arg authName "${authName}" \
+                --arg token "$(base64 -w 0 < <(printf %s "${TARGET_INDEX_CREDENTIAL}"))" \
+                '.auths[$authName].auth = $token' > "${HOME}/.config/containers/auth.json"
+          set -x
         }
 
         # performs kerberos authentication.

--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -15,6 +15,9 @@ Task to create a internalrequest to add fbc contributions to index images
 | taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                    |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                            | No       | -                    |
 
+## Changes in 4.0.1
+* Adds the `publishingCredentials` parameter to the internal request call
+
 ## Changes in 4.0.0
 * Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 * The pipeline is called via git resolver now instead of cluster resolver

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -97,6 +97,7 @@ spec:
         else
           iib_service_account_secret="iib-service-account-prod"
         fi
+        publishing_credentials=$(jq -r '.fbc.publishingCredentials // "catalog-publishing-secret"' "$DATA_FILE")
 
         timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' "${DATA_FILE}")
         timestamp=$(date "+${timestamp_format}")
@@ -142,6 +143,7 @@ spec:
             -p targetIndex="${target_index}" \
             -p fbcFragment="${fbc_fragment}" \
             -p iibServiceAccountSecret="${iib_service_account_secret}" \
+            -p publishingCredentials="${publishing_credentials}" \
             -p buildTimeoutSeconds="${build_timeout_seconds}" \
             -p buildTags="${build_tags}" \
             -p addArches="${add_arches}" \

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -39,6 +39,7 @@ spec:
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "fbc": {
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "stagedIndex": true,
                   "buildTimeoutSeconds": 420
                 }


### PR DESCRIPTION
this PR adds the publishingCredentials parameter to the update-fbc-catalog pipeline and tasks that is
required to fetch the targetIndex config.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

