### PR TITLE
feat(RELEASE-1326): publish-index-image internal task uses git resolver

### DIFF
--- a/internal/pipelines/publish-index-image-pipeline/README.md
+++ b/internal/pipelines/publish-index-image-pipeline/README.md
@@ -4,10 +4,15 @@ Tekton pipeline to publish a built FBC index image using skopeo
 
 ## Parameters
 
-| Name                  | Description                                   | Optional | Default value |
-|-----------------------|-----------------------------------------------|----------|---------------|
-| sourceIndex           | sourceIndex signing image                     | No       | -             |
-| targetIndex           | targetIndex signing image                     | No       | -             |
-| retries               | Number of skopeo retries                      | Yes      | 0             |
-| publishingCredentials | The credentials used to access the registries | No       | -             |
-| requestUpdateTimeout  | Max seconds waiting for the status update     | Yes      | 360           |
+| Name                  | Description                                                                           | Optional | Default value                                             |
+|-----------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| sourceIndex           | sourceIndex signing image                                                             | No       | -                                                         |
+| targetIndex           | targetIndex signing image                                                             | No       | -                                                         |
+| retries               | Number of skopeo retries                                                              | Yes      | 0                                                         |
+| publishingCredentials | The credentials used to access the registries                                         | No       | -                                                         |
+| requestUpdateTimeout  | Max seconds waiting for the status update                                             | Yes      | 360                                                       |
+| taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision       | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+
+## Changes in 1.0.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/internal/pipelines/publish-index-image-pipeline/publish-index-image-pipeline.yaml
+++ b/internal/pipelines/publish-index-image-pipeline/publish-index-image-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: publish-index-image-pipeline
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,10 +29,24 @@ spec:
       type: string
       default: "360"
       description: Max seconds waiting for the status update
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: publish-index-image-task
       taskRef:
-        name: publish-index-image-task
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/publish-index-image-task/publish-index-image-task.yaml
       params:
         - name: sourceIndex
           value: $(params.sourceIndex)

--- a/internal/resources/publish-index-image-task.yaml
+++ b/internal/resources/publish-index-image-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/publish-index-image-task/publish-index-image-task.yaml

--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.2.1
+* Pass taskGitUrl and taskGitRevision to publish-index-image task
+
 ## Changes in 4.2.0
 * Update all task pathInRepo values as they are now in `tasks/managed`
 

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.2.0"
+    app.kubernetes.io/version: "4.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -389,6 +389,10 @@ spec:
           value: "3"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       when:
         - input: $(tasks.add-fbc-contribution-to-index-image.results.mustPublishIndexImage)
           operator: in

--- a/tasks/managed/publish-index-image/README.md
+++ b/tasks/managed/publish-index-image/README.md
@@ -4,15 +4,20 @@ Publish a built FBC index image using skopeo
 
 ## Parameters
 
-| Name           | Description                                                                               | Optional | Default value |
-|----------------|-------------------------------------------------------------------------------------------|----------|---------------|
-| dataPath       | Path to the JSON string of the merged data to use in the data workspace                   | No       | -             |
-| sourceIndex    | Pullspec to pull the image from                                                           | No       | -             |
-| targetIndex    | Pullspec to push the image to                                                             | No       | -             |
-| retries        | Number of skopeo retries                                                                  | Yes      | 0             |
-| requestTimeout | Max seconds waiting for the status update                                                 | Yes      | 360           |
-| buildTimestamp | Build timestamp for the publishing image                                                  | No       | -             |
-| pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| Name            | Description                                                                               | Optional | Default value |
+|-----------------|-------------------------------------------------------------------------------------------|----------|---------------|
+| dataPath        | Path to the JSON string of the merged data to use in the data workspace                   | No       | -             |
+| sourceIndex     | Pullspec to pull the image from                                                           | No       | -             |
+| targetIndex     | Pullspec to push the image to                                                             | No       | -             |
+| retries         | Number of skopeo retries                                                                  | Yes      | 0             |
+| requestTimeout  | Max seconds waiting for the status update                                                 | Yes      | 360           |
+| buildTimestamp  | Build timestamp for the publishing image                                                  | No       | -             |
+| pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 4.0.0
+* Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 
 ## Changes in 3.3.0
 * updated the base image used in this task

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -35,6 +35,12 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: data
       description: Workspace to store the params and responses for the internalRequest
@@ -76,6 +82,8 @@ spec:
                 -p targetIndex="${publishingImages[$i]}" \
                 -p publishingCredentials="${credentials}" \
                 -p retries="$(params.retries)" \
+                -p taskGitUrl="$(params.taskGitUrl)" \
+                -p taskGitRevision="$(params.taskGitRevision)" \
                 -t "$(params.requestTimeout)" \
                 -l ${pipelinerun_label}="$(params.pipelineRunUid)"
             echo "=== done"

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -45,6 +45,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: dataPath
           value: data.json
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -85,6 +89,16 @@ spec:
               targetIndex=$(jq -r '.targetIndex' <<< "${params}")
               if [ "$targetIndex" != "quay.io/test/targetIndex:tag-abc-11111111111" ]; then
                 echo "targetIndex image does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
+                echo "taskGitUrl image does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitRevision' <<< "${params}")" != "main" ]; then
+                echo "taskGitRevision image does not match"
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -45,6 +45,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: dataPath
           value: data.json
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -101,6 +105,16 @@ spec:
                         echo "targetIndex image does not match"
                         exit 1
                       fi
+                  fi
+
+                  if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
+                    echo "taskGitUrl image does not match"
+                    exit 1 
+                  fi
+
+                  if [ "$(jq -r '.taskGitRevision' <<< "${params}")" != "main" ]; then
+                    echo "taskGitRevision image does not match"
+                    exit 1 
                   fi
               done
       runAfter:


### PR DESCRIPTION
This commit updates the publish-index-image internal pipeline to call its one task via git resolver. The pipeline itself still uses a cluster resolver, which will be changed in a separate commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

