### PR TITLE
chore(RELEASE-1392): remove push-artifacts task sym link

### DIFF
--- a/internal/resources/push-artifacts-to-cdn-task.yaml
+++ b/internal/resources/push-artifacts-to-cdn-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml


### PR DESCRIPTION
This commit removes the push-artifacts-to-cdn sym link in internal/resources. The pipeline calling it already uses a git resolver, so we do not need the sym link here.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

