### PR TITLE
refactor(RELEASE-1361): accept arrays for cpe and product_id

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -115,8 +115,12 @@
       "type": "object",
       "properties": {
         "product_id": {
-          "type": "integer",
-          "description": "The product ID e.g 321"
+          "type": ["array", "integer"],
+          "minItems": 1,
+          "description": "The list of product IDs e.g [321]",
+          "items": {
+            "type": "integer"
+          }
         },
         "product_name": {
           "type": "string",
@@ -132,8 +136,12 @@
           "description": "The product stream e.g. RHEL-tp1"
         },
         "cpe": {
-          "type": "string",
-          "description": "The product CPE ID e.g. cpe:/a:example:openstack:el8"
+          "type": ["array", "string"],
+          "minItems": 1,
+          "description": "The list of product CPE IDs e.g. [\"cpe:/a:example:openstack:el8\"]",
+          "items": {
+            "type": "string"
+          }
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
This commit modifies the schemafile to allow arrays for releaseNotes.product_id and releaseNotes.cpe. This is a temporary measure to ensure backwards compatibility; a future commit will remove the singleton types so that only an array is allowed for each.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

