### PR TITLE
feat(RELEASE-1252): make run-file-updates task idempotent

### DIFF
--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -16,13 +16,18 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | tempDir                        | temp dir for cloning and updates                                                                                                                                                         | Yes      | /tmp/$(context.taskRun.uid)/file-updates |
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
+## Changes in 1.0.0
+* Add idempotent changes with some fix
+  - It fixed some issue about `glab mr list` to handle anything from 0 to
+    an unlimited number of results
+
 ## Changes in 0.1.1
 * Revert idempotent changes as they are not working
 
 ## Changes in 0.1.0
-* make run-file-updates task idempotent
+* Make run-file-updates task idempotent
 
 ## Changes in 0.0.2
-* add new `internalRequestPipelineRunName` parameter and result
+* Add new `internalRequestPipelineRunName` parameter and result
   - Tekton only supports passing task results as pipeline results,
     so we need to pass the PLR name to the task first and then emit it from the task

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -203,7 +203,7 @@ spec:
               # only a single line was replaced and that the result
               # block has the same number of lines as before
               sed -ne "${startBlock},+${valueSize}p" "${targetFile}" > "${TEMP}/result.txt"
-              diff -u "${TEMP}/{found,result}.txt" > "${TEMP}/diff.txt" || true
+              diff -u "${TEMP}/found.txt" "${TEMP}/result.txt" > "${TEMP}/diff.txt" || true
 
               replacedBlockLines=$(wc -l < "${TEMP}/result.txt")
               if [[ $replacedBlockLines != $(( valueSize +1 )) ]]; then
@@ -251,7 +251,86 @@ spec:
         fi
 
         echo -e "\n*** START LOCAL CHANGES ***\n"
-        git diff
+        echo -e "\n*** Result from git diff ***\n"
+        # compare the differences between the working directory and the staging area 
+        git diff | tee "${TEMP}"/tempMRFile.diff
+
+        echo -e "\n*** Result from git diff --cache ***\n"
+        # compare the differences between the staging area and the latest commit
+        git diff --cached | tee "${TEMP}"/tempMRFile-cached.diff
+
+        if [[ -s "${TEMP}"/tempMRFile.diff ]]; then
+            # replacements exist 
+            # It's to deal with the lines like "@@ -N1,N2 +N3,N4 @@", 
+            # but it's possible to meet a line like "@@ -4,7 +4,7 @@ $schema: /app/app-settings.yml".
+            awk '/^@@/ {match($0, /@@ ([^@]+) @@/, arr); print arr[1]}' "${TEMP}"/tempMRFile.diff |\
+               tee "${TEMP}"/lineFile
+        elif [[ ! -s "${TEMP}"/tempMRFile-cached.diff ]]; then
+           # only seed exists and the file with the same content is there already 
+           echo "the seeding file already exists" \
+               | tee -a "$(results.fileUpdatesInfo.path)"
+           echo -n "Success" |tee "$(results.fileUpdatesState.path)"
+           exit 0
+        fi
+
+        # Get all MRs by paginating through results
+        page=1
+        openMRList=""
+        while true; do
+            mrPage=$(glab mr list -R "${UPSTREAM_REPO}" --search "Konflux release" \
+                --per-page 100 --page $page | grep "^!" || true)
+            # add "$mrPagei" == '' check for unit testing
+            if [ -z "$mrPage" ] || [ "$mrPage" == '' ] ; then
+                break
+            fi
+            openMRList="${openMRList}${mrPage}"$'\n'
+            ((page++))
+        done
+
+        # Remove trailing newline
+        openMRList=$(echo "$openMRList" | sed '/^$/d')
+
+        if [ -n "$openMRList" ]; then        
+            while IFS= read -r oneItem; do
+                mrNum=$(echo "$oneItem" | cut -f1 | tr -d '!')
+                foundMR=false
+                glab mr diff "${mrNum}" --repo "${UPSTREAM_REPO}" > "${TEMP}"/oneMR.diff 
+
+                if [[ ! -s "${TEMP}"/lineFile ]]; then
+                    # only seed exists and no replacements  
+                    grep '^[+][^+]' "${TEMP}"/oneMR.diff | sed -E 's/^[+]//' | tee "${TEMP}/mrFile"
+
+                    # compare if the contents and the updated file names are the same 
+                    if  diff -q "${TEMP}"/mrFile "${targetFile}" > /dev/null; then
+                        grep "^diff --git" "${TEMP}"/oneMR.diff | tee "${TEMP}"/tmpFile
+                        while read -r line ; do
+                            changedFileName=$(echo "$line" | awk '{sub(/^b\//, "", $NF); print $NF}')
+                            if [[ "${changedFileName}" != "${targetFile}" ]]; then
+                                continue
+                            fi
+                            foundMR=true
+                            break
+                        done < "${TEMP}"/tmpFile
+                    fi
+                else
+                    # replacements exist
+                    grep '^[-+@]' "${TEMP}"/oneMR.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/mrFile"
+                    grep '^[-+@]' "${TEMP}"/tempMRFile.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/tmpFile"
+                    if diff -q "${TEMP}"/mrFile "${TEMP}"/tmpFile > /dev/null; then
+                        foundMR=true
+                    fi
+                fi
+                # if all the lines are matched, the MR is the same one
+                # it should exit 0 if the same MR exists 
+                if [[ "$foundMR" == true ]]; then
+                    echo "there is an existing MR with the same updates in the repo"
+                    echo "{\"merge_request\":\"${UPSTREAM_REPO}/-/merge_requests/${mrNum}\"}" \
+                        | tee -a "$(results.fileUpdatesInfo.path)" 
+                    echo -n "Success" | tee "$(results.fileUpdatesState.path)"
+                    exit 0
+                fi
+            done <<< "$openMRList"
+        fi
         echo -e "\n*** END LOCAL CHANGES ***\n"
 
         WORKING_BRANCH=$(uuidgen |awk '{print substr($1, 1, 8)}')

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -38,7 +38,11 @@ function glab() {
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     echo "/merge_request/1"
   elif [[ "$*" == *"mr list"* ]]; then
-    echo '!1'
+    if [[ "$*" == *"page 1" ]]; then
+      echo '!1'
+    else
+      echo ''
+    fi
   elif [[ "$*" == *"mr diff"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     if [[ "${gitRepo}" == "replace-idempotent" ]]; then

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-process-file-updates-replacements-idempotent
+spec:
+  description: |
+    Run the process-file-updates task with replacements. No commit
+      is created if there is a mocked MR with the same content.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: pipeline
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: pipeline
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              cd "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+              mkdir replace-idempotent
+              cd replace-idempotent
+              git config --global init.defaultBranch main
+              git init .
+              git config --global user.email "test@test.com"
+              git config --global user.name "tester"
+
+              mkdir addons
+              cat > "addons/my-addon2.yaml" << EOF
+              indexImage:
+              name: test
+              EOF
+              git add addons/my-addon2.yaml
+              git commit -m "prior commit"
+    - name: run-task
+      taskRef:
+        name: process-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://some.gitlab/test/replace-idempotent"
+        - name: repo
+          value: "https://some.gitlab/test/replace-idempotent"
+        - name: ref
+          value: "main"
+        - name: paths
+          value: >-
+            [{"path":"addons/my-addon2.yaml","replacements":[{"key":".indexImage",
+            "replacement":"|indexImage.*|indexImage: Jack|"}]}]
+        - name: application
+          value: "scott"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: tempDir
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+      workspaces:
+        - name: pipeline
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: fileUpdatesInfo
+          value: $(tasks.run-task.results.fileUpdatesInfo)
+        - name: fileUpdatesState
+          value: $(tasks.run-task.results.fileUpdatesState)
+        - name: tempDir
+          value: "$(workspaces.pipeline.path)/$(context.pipelineRun.uid)/file-updates"
+      taskSpec:
+        params:
+          - name: fileUpdatesInfo
+            type: string
+          - name: fileUpdatesState
+            type: string
+          - name: tempDir
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+  
+              cd "$(params.tempDir)/replace-idempotent"
+              commits=$(git log --oneline | wc -l)
+
+              echo "Test no more commit created except the one in setup step"
+              test "${commits}" == "1"
+              rm -rf "$(params.tempDir)"
+
+      workspaces:
+        - name: pipeline
+          workspace: tests-workspace

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -26,6 +26,10 @@ spec:
       type: string
       description: Name of the request
       default: "process-file-updates"
+    - name: requestTimeout
+      type: string
+      default: "900"
+      description: InternalRequest timeout
     - name: synchronously
       type: string
       description: Whether to run synchronously or not
@@ -103,6 +107,7 @@ spec:
                            -p taskGitUrl="$(params.taskGitUrl)" \
                            -p taskGitRevision="$(params.taskGitRevision)" \
                            -s "$(params.synchronously)" \
+                           -t "$(params.requestTimeout)" \
                            -l ${TASK_LABEL}="${TASK_ID}" \
                            -l ${REQUEST_LABEL}="${requestId}" \
                            -l "${PIPELINERUN_LABEL}=$(params.pipelineRunUid)"


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

* The PR is to make the run-file-updates task idempotent by ensuring that
 a new MR isn't created unnecessarily when one already exists with the
same content in the value of `seed` and `replacements` fields in `paths`
 parameter.
* And it added some logic to check all of the `key` in the `replacements`
 parameter. If all of the `key` exist but the content of the file does
 not require any update, return success.
* It fixed some issue about `glab mr list` to handle anything from 0 to
an unlimited number of results in the script.
* Changed `requestTimeout` in run-file-updates task to 900.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

