### PR TITLE
feat(RELEASE-1403): rework embargo-check task for issues

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -1,7 +1,9 @@
 # embargo-check
 
 Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json are embargoed. It checks the issues
-by server using curl and checks the CVEs via an InternalRequest. If any issue or CVE is embargoed, the task will fail.
+by server using curl and checks the CVEs via an InternalRequest. If any issue does not exist or any CVE is embargoed,
+the task will fail. The task will also fail if a Jira issue listed is for a component that does not exist in the
+releaseNotes.content.images section or if said component does not list the CVE from the issue.
 
 ## Parameters
 
@@ -12,6 +14,14 @@ by server using curl and checks the CVEs via an InternalRequest. If any issue or
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 1.0.0
+* Authentication is added to checking issues in issues.redhat.com
+* If the issue exists and is not of type `Vulnerability`, the task will pass on that issue
+* If the issue is of type `Vulnerability`
+  * If the `Downstream Component Name` from the issue is not listed in the `releaseNotes.content.images`
+    section, the task will fail
+  * If the `CVE ID` from the issue is not present in its component's fixed cves section, the task will fail
 
 ## Changes in 0.5.0
 * Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -12,7 +12,10 @@ spec:
   description: >
     Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json
     are embargoed. It checks the issues by server using curl and checks the CVEs via an
-    InternalRequest. If any issue or CVE is embargoed, the task will fail.
+    InternalRequest. If any issue does not exist or any CVE is embargoed, the task will
+    fail. The task will also fail if a Jira issue listed is for a component that does
+    not exist in the releaseNotes.content.images section or if said component does not
+    list the CVE from the issue.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
@@ -36,9 +39,14 @@ spec:
   steps:
     - name: check-issues
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      env:
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-advisory-jira-secret
+              key: token
       script: |
         #!/usr/bin/env bash
-        set -x
 
         SUPPORTED_ISSUE_TRACKERS='{
             "Jira": {
@@ -62,19 +70,61 @@ spec:
             exit 1
         fi
 
+        # It is expected for the custom field ids to remain stable, but to get them, you can do:
+        # curl -H "Authorization: Bearer $ACCESS_TOKEN" https://issues.redhat.com/rest/api/2/field
+        CVE_FIELD="customfield_12324749"
+        COMPONENT_FIELD="customfield_12324752"
+
         RC=0
 
         NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
         for ((i = 0; i < NUM_ISSUES; i++)); do
+            # We set +x before the curl call and then capture the exit code. That can lead to breaking out of the
+            # current loop iteration or continuing on, so let's set -x at the beginning of each iteration
+            set -x
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$SUPPORTED_ISSUE_TRACKERS")
             API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
-            curl --fail --output /dev/null "${API_URL}"
-            if [ $? -ne 0 ] ; then
-                echo "${issue} is not publicly visible. Assuming it is embargoed and stopping pipelineRun execution."
-                RC=1
+            AUTH_ARGS=()
+            set +x # We don't want to leak the ACCESS_TOKEN
+            if [ "$server" = "issues.redhat.com" ] ; then
+                AUTH_ARGS=(-H "Authorization: Bearer $ACCESS_TOKEN")
             fi
+            OUTPUT=$(curl --retry 3 --fail "${AUTH_ARGS[@]}" "${API_URL}")
+            if [ $? -ne 0 ] ; then
+                echo "Error: ${issue} is not visible. Assuming it is embargoed and stopping pipelineRun execution."
+                RC=1
+                continue
+            fi
+            set -x
+
+            # Perform additional checks only for Vulnerability issues for issues.redhat.com
+            if [ "$server" != "issues.redhat.com" ] ; then
+                continue
+            fi
+            ISSUE_TYPE=$(jq -r '.fields.issuetype.name' <<< "$OUTPUT")
+            if [ "$ISSUE_TYPE" != "Vulnerability" ] ; then
+                continue
+            fi
+            CVE_ID=$(jq -r --arg field "$CVE_FIELD" '.fields[$field]' <<< "$OUTPUT")
+            COMPONENT_NAME=$(jq -r --arg field "$COMPONENT_FIELD" '.fields[$field]' <<< "$OUTPUT")
+            if ! COMPONENT_IN_RELEASE_NOTES="$(jq -ec --arg name "$COMPONENT_NAME" \
+              '.releaseNotes.content.images[] | select(.component==$name)' "$DATA_FILE")"; then
+                echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME but that component does"
+                echo " not appear in releaseNotes.content.images. Failing"
+                RC=1
+                continue
+            fi
+
+            if [ "$(jq --arg CVE "$CVE_ID" '.cves.fixed | has($CVE)' <<< "$COMPONENT_IN_RELEASE_NOTES")" != "true" ]
+            then
+                echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME and 'CVE ID' $CVE_ID"
+                echo " but that CVE is not present in the releaseNotes.content.images section for that component."
+                RC=1
+                continue
+            fi
+            
         done
 
         exit $RC

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -6,15 +6,24 @@ function curl() {
   echo Mock curl called with: $* >&2
   echo $* >> $(workspaces.data.path)/mock_curl.txt
 
-  if [[ "$*" == "--fail --output /dev/null https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
+  if [[ "$*" == "--retry 3 --fail https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
   then
     :
-  elif [[ "$*" == "--fail --output /dev/null https://bugzilla.redhat.com/rest/bug/12345" ]]
+  elif [[ "$*" == "--retry 3 --fail https://bugzilla.redhat.com/rest/bug/12345" ]]
   then
     :
-  elif [[ "$*" == "--fail --output /dev/null https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
+  elif [[ "$*" == "--retry 3 --fail https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
   then
     exit 1
+  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/MISSINGRH-123" ]]
+  then
+    exit 1
+  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
+  then
+    echo '{"fields":{"issuetype":{"name":"Feature"}}}'
+  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/CVE-123" ]] # Vulnerability
+  then
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123","customfield_12324752":"my-component"}}'
   else
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
@@ -5,3 +5,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
 yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Create a dummy access token secret (and delete it first if it exists)
+kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -2,9 +2,9 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-public-issues
+  name: test-embargo-check-non-vuln-rh-issue
 spec:
-  description: Test for embargo-check where all issues are public
+  description: Test for embargo-check with a issues.redhat.com issue that is not of type Vulnerability
   workspaces:
     - name: tests-workspace
   tasks:
@@ -32,8 +32,8 @@ spec:
                         "source": "jira.atlassian.com"
                       },
                       {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "id": "FEATURE-123",
+                        "source": "issues.redhat.com"
                       }
                     ]
                   }
@@ -76,6 +76,6 @@ spec:
               fi
 
               [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123"* ]]
-              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"12345"* ]]
+              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"FEATURE-123"* ]]
       runAfter:
         - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-public-issues
+  name: test-embargo-check-nonexistent-rh-issue
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
-  description: Test for embargo-check where all issues are public
+  description: Test for embargo-check where a issues.redhat.com issue cannot be found
   workspaces:
     - name: tests-workspace
   tasks:
@@ -22,14 +24,14 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.data.path)"/data.json << EOF
+              cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
                   "issues": {
                     "fixed": [
                       {
-                        "id": "ISSUE-123",
-                        "source": "jira.atlassian.com"
+                        "id": "MISSINGRH-123",
+                        "source": "issues.redhat.com"
                       },
                       {
                         "id": "12345",
@@ -57,25 +59,3 @@ spec:
           workspace: tests-workspace
       runAfter:
         - setup
-    - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      taskSpec:
-        steps:
-          - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
-            script: |
-              #!/usr/bin/env bash
-              set -eux
-
-              if [ "$(wc -l < "$(workspaces.data.path)"/mock_curl.txt)" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
-                  cat "$(workspaces.data.path)"/mock_curl.txt
-                  exit 1
-              fi
-
-              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123"* ]]
-              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"12345"* ]]
-      runAfter:
-        - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -2,9 +2,14 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-public-issues
+  name: test-embargo-check-rh-issue-missing-cve
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
-  description: Test for embargo-check where all issues are public
+  description: |
+    Test for embargo-check where a issues.redhat.com issue has a Downstream Component Name value
+    that matches a component in the releaseNotes.content.images section, but said images section
+    does not list CVE-123, which is what the mocks return
   workspaces:
     - name: tests-workspace
   tasks:
@@ -22,18 +27,34 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.data.path)"/data.json << EOF
+              cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
                   "issues": {
                     "fixed": [
                       {
-                        "id": "ISSUE-123",
-                        "source": "jira.atlassian.com"
+                        "id": "CVE-123",
+                        "source": "issues.redhat.com"
                       },
                       {
                         "id": "12345",
                         "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-987": {
+                              "packages": []
+                            }
+                          }
+                        }
                       }
                     ]
                   }
@@ -57,25 +78,3 @@ spec:
           workspace: tests-workspace
       runAfter:
         - setup
-    - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      taskSpec:
-        steps:
-          - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
-            script: |
-              #!/usr/bin/env bash
-              set -eux
-
-              if [ "$(wc -l < "$(workspaces.data.path)"/mock_curl.txt)" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
-                  cat "$(workspaces.data.path)"/mock_curl.txt
-                  exit 1
-              fi
-
-              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123"* ]]
-              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"12345"* ]]
-      runAfter:
-        - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
@@ -2,9 +2,14 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-public-issues
+  name: test-embargo-check-rh-issue-wrong-component
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
-  description: Test for embargo-check where all issues are public
+  description: |
+    Test for embargo-check where a issues.redhat.com issue has a Downstream Component Name value
+    that does not match any component in the releaseNotes.content.images section. The mocks set the
+    Downstream Component Name to my-component
   workspaces:
     - name: tests-workspace
   tasks:
@@ -22,18 +27,27 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.data.path)"/data.json << EOF
+              cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
                   "issues": {
                     "fixed": [
                       {
-                        "id": "ISSUE-123",
-                        "source": "jira.atlassian.com"
+                        "id": "CVE-123",
+                        "source": "issues.redhat.com"
                       },
                       {
                         "id": "12345",
                         "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "not-my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo"
                       }
                     ]
                   }
@@ -57,25 +71,3 @@ spec:
           workspace: tests-workspace
       runAfter:
         - setup
-    - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
-      taskSpec:
-        steps:
-          - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
-            script: |
-              #!/usr/bin/env bash
-              set -eux
-
-              if [ "$(wc -l < "$(workspaces.data.path)"/mock_curl.txt)" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
-                  cat "$(workspaces.data.path)"/mock_curl.txt
-                  exit 1
-              fi
-
-              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123"* ]]
-              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"12345"* ]]
-      runAfter:
-        - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -2,9 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-public-issues
+  name: test-embargo-check-rh-issue
 spec:
-  description: Test for embargo-check where all issues are public
+  description: |
+    Test for embargo-check where a issues.redhat.com issue has a Downstream Component Name value
+    that matches a component in the releaseNotes.content.images section and said images section
+    lists CVE-123, which is what the mocks return. The task should succeed
   workspaces:
     - name: tests-workspace
   tasks:
@@ -22,18 +25,34 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.data.path)"/data.json << EOF
+              cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "releaseNotes": {
                   "issues": {
                     "fixed": [
                       {
-                        "id": "ISSUE-123",
-                        "source": "jira.atlassian.com"
+                        "id": "CVE-123",
+                        "source": "issues.redhat.com"
                       },
                       {
                         "id": "12345",
                         "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "packages": []
+                            }
+                          }
+                        }
                       }
                     ]
                   }
@@ -75,7 +94,7 @@ spec:
                   exit 1
               fi
 
-              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123"* ]]
+              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"CVE-123"* ]]
               [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"12345"* ]]
       runAfter:
         - run-task


### PR DESCRIPTION
This commit reworks the managed embargo-check task for how it handles issues in issues.redhat.com. First, it adds authentication for searching for these issues. If the issue is found and is not of type Vulnerability, it will pass.

If the issue is of type Vulnerability, the task will now ensure that the component from the issue matches a component in the releaseNotes.content.images section and that the CVE from the issue is present in said component section.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

