### PR TITLE
fix: revert image in create-pyxis-image to older version

### DIFF
--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -19,6 +19,14 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                                                                                                                                                                                                                                                                                                                                     | No       |               |
 
+## Changes in 3.7.0
+* Revert image back to the version from 3.5.0
+  * The new image contained two things:
+    * New functionality to update image tags
+    * It stopped creating a second quay.io repository entry in Pyxis
+  * It turns out the second thing breaks clair-wrapper, so revert the change
+    until clair-wrapper is modified
+
 ## Changes in 3.6.0
 * Bumped the utils image used in this task
   * The updated image contains changes in create_container_image python script to enable the use case of updating tags when releasing the same image again

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.6.0"
+    app.kubernetes.io/version: "3.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -51,7 +51,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+      image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -77,7 +77,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:dc0f89c98b102fdff4644fa5dc411a60f2035b29
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

The last image bump contained two things:

* New functionality to update image tags
* It stopped creating a second quay.io repository entry in Pyxis

It turns out the second thing breaks clair-wrapper, so revert the change until clair-wrapper is modified.

This effectively reverts https://github.com/konflux-ci/release-service-catalog/pull/765

## Relevant Jira

[CWFHEALTH-3987](https://issues.redhat.com//browse/CWFHEALTH-3987) - this is where clair-wrapper will be modified to work with our changes

[RELEASE-1433](https://issues.redhat.com/browse/RELEASE-1433) - jira to reapply the changes when ready

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

