### PR TITLE
feat(RELEASE-1325): update-fbc-catalog internal task uses git resolver

### DIFF
--- a/internal/resources/update-fbc-catalog-task.yaml
+++ b/internal/resources/update-fbc-catalog-task.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml

--- a/pipelines/internal/update-fbc-catalog/README.md
+++ b/pipelines/internal/update-fbc-catalog/README.md
@@ -4,13 +4,18 @@ Tekton pipeline add/update FBC fragments to the FBC catalog by interacting with 
 
 ## Parameters
 
-| Name                    | Description                                                                 | Optional | Default value       |
-|-------------------------|-----------------------------------------------------------------------------|----------|---------------------|
-| iibServiceAccountSecret | Secret containing the credentials for IIB service                           |   yes    | iib-service-account |
-| fbcFragment             | FBC fragment built by HACBS                                                 |   no     | -                   |
-| fromIndex               | Index image (catalog of catalogs) the FBC fragment will be added to         |   no     | -                   |
-| buildTags               | List of additional tags the internal index image copy should be tagged with |   yes    | '[]'                |
-| addArches               | List of arches the index image should be built for                          |   yes    | '[]'                |
-| hotfix                  | Whether this build is a hotfix build                                        |   yes    | false               |
-| stagedIndex             | Whether this build is a staged index build                                  |   yes    | false               |
-| buildTimeoutSeconds     | IIB Build Service timeout seconds                                           |   no     | -                   |
+| Name                    | Description                                                                           | Optional | Default value                                             |
+|-------------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| iibServiceAccountSecret | Secret containing the credentials for IIB service                                     |   yes    | iib-service-account                                       |
+| fbcFragment             | FBC fragment built by HACBS                                                           |   no     | -                                                         |
+| fromIndex               | Index image (catalog of catalogs) the FBC fragment will be added to                   |   no     | -                                                         |
+| buildTags               | List of additional tags the internal index image copy should be tagged with           |   yes    | '[]'                                                      |
+| addArches               | List of arches the index image should be built for                                    |   yes    | '[]'                                                      |
+| hotfix                  | Whether this build is a hotfix build                                                  |   yes    | false                                                     |
+| stagedIndex             | Whether this build is a staged index build                                            |   yes    | false                                                     |
+| buildTimeoutSeconds     | IIB Build Service timeout seconds                                                     |   no     | -                                                         |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored |   yes    | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                        |   no     | -                                                         |
+
+## Changes in 1.0.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/pipelines/internal/update-fbc-catalog/update-fbc-catalog-pipeline.yaml
+++ b/pipelines/internal/update-fbc-catalog/update-fbc-catalog-pipeline.yaml
@@ -48,10 +48,24 @@ spec:
     - name: buildTimeoutSeconds
       type: string
       description: IIB Build Service timeout seconds
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: update-fbc-catalog-task
       taskRef:
-        name: update-fbc-catalog-task
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
       params:
         - name: iibServiceAccountSecret
           value: $(params.iibServiceAccountSecret)

--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -19,6 +19,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | No        | -                                                               |
 
+## Changes in 4.2.2
+* Pass taskGitUrl and taskGitRevision to add-fbc-contribution-to-index-image task
+
 ## Changes in 4.2.1
 * Pass taskGitUrl and taskGitRevision to publish-index-image task
 

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.2.1"
+    app.kubernetes.io/version: "4.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -276,6 +276,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
       runAfter:
         - check-fbc-packages
         - verify-enterprise-contract

--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -4,14 +4,19 @@ Task to create a internalrequest to add fbc contributions to index images
 
 ## Parameters
 
-| Name           | Description                                                                               | Optional | Default value        |
-|----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | No       | -                    |
-| dataPath       | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                    |
-| fromIndex      | fromIndex value updated by update-ocp-tag task                                            | No       | -                    |
-| pipelineRunUid | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
-| targetIndex    | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
-| resultsDirPath | Path to results directory in the data workspace                                           | No       | -                    |
+| Name            | Description                                                                               | Optional | Default value        |
+|-----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | No       | -                    |
+| dataPath        | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                    |
+| fromIndex       | fromIndex value updated by update-ocp-tag task                                            | No       | -                    |
+| pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
+| targetIndex     | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
+| resultsDirPath  | Path to results directory in the data workspace                                           | No       | -                    |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                    |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                            | No       | -                    |
+
+## Changes in 4.0.0
+* Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 
 ## Changes in 3.4.3
 * Change internal request pipeline from `iib` to `update-fbc-catalog`

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "3.4.3"
+    app.kubernetes.io/version: "4.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,6 +30,12 @@ spec:
     - name: resultsDirPath
       type: string
       description: Path to the results directory in the data workspace
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   results:
     - name: buildTimestamp
       description: Build timestamp used in the tag
@@ -141,6 +147,8 @@ spec:
             -p addArches="${add_arches}" \
             -p hotfix="${hotfix}" \
             -p stagedIndex="${staged_index}" \
+            -p taskGitUrl="$(params.taskGitUrl)" \
+            -p taskGitRevision="$(params.taskGitRevision)" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
             -t "${request_timeout_seconds}" |tee "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -62,6 +62,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -106,6 +110,16 @@ spec:
               if [ "$(jq -r '.hotfix' <<< "${requestParams}")" != "true" ]
               then
                 echo "hotfix does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                echo "taskGitUrl image does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                echo "taskGitRevision image does not match"
                 exit 1
               fi
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -65,6 +65,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -67,6 +67,10 @@ spec:
           value: snapshot_spec.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -64,6 +64,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -102,6 +106,16 @@ spec:
               if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image0@sha256:0000" ]
               then
                 echo "fbcFragment does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                echo "taskGitUrl image does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                echo "taskGitRevision image does not match"
                 exit 1
               fi
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -60,6 +60,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -61,6 +61,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -61,6 +61,10 @@ spec:
           value: data.json
         - name: resultsDirPath
           value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -121,6 +125,16 @@ spec:
               if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image0@sha256:0000" ]
               then
                 echo "fbcFragment does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                echo "taskGitUrl image does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                echo "taskGitRevision image does not match"
                 exit 1
               fi
 


### PR DESCRIPTION
This commit updates the update-fbc-catalog internal pipeline to call its one task via git resolver. The pipeline itself still uses a cluster resolver, which will be changed in a separate commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

