### PR TITLE
fix(KONFLUX-6715): make sure indexImageDigests result is one line only

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -2,7 +2,7 @@
 
 Tekton task to submit a IIB build request to add/update a fbc-fragment to an index image
 
-| Name                    | Description                                                                  | Optional | Default value |    
+| Name                    | Description                                                                  | Optional | Default value |
 | ----------------------- | ---------------------------------------------------------------------------- | -------- | ------------- |
 | fbcFragment             | FBC fragment built by HACBS                                                  | No       | -             |
 | fromIndex               | Index image (catalog of catalogs) the FBC fragment will be added to          | No       | -             |
@@ -13,6 +13,9 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
 
+## Changes in 1.0.2
+* Fix an issue caused by the `indexImageDigests` result being multi line - now the digests are space-separated on one line
+
 ## Changes in 1.0.1
 * fixes the case when an in_progress IIB build is not resumed;
-* adds more unit tests for retry scenarios; 
+* adds more unit tests for retry scenarios;

--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -3,7 +3,7 @@ set -x
 
 # seed for the build status
 yq -o json <<< '
-items: 
+items:
 - id: 1
   distribution_scope: "stage"
   fbc_fragment: "registry.io/image0@sha256:0000"
@@ -117,7 +117,10 @@ function skopeo() {
 
     shift
     if [[ "$*" == "--raw docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib:1" ]]; then
-        echo '{"manifests": [ { "mediaType": "application/vnd.docker.distribution.manifest.v2+json", "digest": "sha256:000" }]}'
+        echo '{"manifests": ['
+        echo '{ "mediaType": "application/vnd.docker.distribution.manifest.v2+json", "digest": "sha256:000" },'
+        echo '{ "mediaType": "application/vnd.docker.distribution.manifest.v2+json", "digest": "sha256:001" }'
+        echo ']}'
     fi
 
     if [[ "$*" == "--config docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib@sha256:0000" ]]; then

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -35,7 +35,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -90,7 +90,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
@@ -31,7 +31,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -86,7 +86,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
@@ -34,7 +34,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -95,7 +95,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
@@ -34,7 +34,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -95,7 +95,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
@@ -35,7 +35,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -97,7 +97,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -34,7 +34,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -90,7 +90,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(params.indexImageDigests)" != "sha256:000" ]; then
+              if [ "$(params.indexImageDigests)" != "sha256:000 sha256:001" ]; then
                 echo "The task did not save a valid digest image in the indexImageDigests result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -297,7 +297,8 @@ spec:
             #
             indexImageDigests=$(echo "${indexImageDigestsRaw}" | \
                jq -r \
-               '.manifests[]? | select(.mediaType=="application/vnd.docker.distribution.manifest.v2+json") | .digest')
+               '.manifests[]? | select(.mediaType=="application/vnd.docker.distribution.manifest.v2+json") | .digest' \
+               | tr '\n' ' ' | sed 's/ $//')  # make sure the result is on one line and remove trailing space
             echo -n "${indexImageDigests}" > "$(results.indexImageDigests.path)"
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"


### PR DESCRIPTION
## Describe your changes

We're still not sure what changed, but recently the task that consumes this result started failing because it expects a one line space-separated list of digests and not a digest per line.

## Relevant Jira

[KONFLUX-6715](https://issues.redhat.com/browse/KONFLUX-6715)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

