### PR TITLE
feat(RELEASE-1401): close issues fixed in advisories

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.11.0
+* Add new task `close-advisory-issues` to close all issues listed in the releaseNotes after the advisory is published
+
 ## Changes in 1.10.0
 * Add new task `set-advisory-severity` to run after `populate-release-notes` that will inject a severity
   key into the releaseNotes in the data file based on the releaseNotes.type and CVEs present

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.10.0"
+    app.kubernetes.io/version: "1.11.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -747,6 +747,27 @@ spec:
         - rh-sign-image
         - rh-sign-image-cosign
         - set-advisory-severity
+    - name: close-advisory-issues
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: advisoryUrl
+          value: "$(tasks.create-advisory.results.advisory_url)"
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - create-advisory
     - name: update-cr-status
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:

--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -1,0 +1,14 @@
+# close-advisory-issues
+
+Tekton task to close all issues referenced in the releaseNotes. It is meant to run after the advisory is published.
+A comment will be added to each closed issue with a link to the advisory it was fixed in.
+
+Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication.
+Issues in other servers will be skipped without the task failing.
+
+## Parameters
+
+| Name        | Description                                                                               | Optional | Default value |
+|-------------|-------------------------------------------------------------------------------------------|----------|---------------|
+| dataPath    | Path to data JSON in the data workspace                                                   | No       | -             |
+| advisoryUrl | The url of the advisory the issues were fixed in. This is added in a comment on the issue | No       | -             |

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: close-advisory-issues
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >
+    Tekton task to close all issues referenced in the releaseNotes. It is meant to run after
+    the advisory is published. A comment will be added to each closed issue with a link
+    to the advisory it was fixed in
+  params:
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+    - name: advisoryUrl
+      description: The url of the advisory the issues were fixed in. This is added in a comment on the issue
+      type: string
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  steps:
+    - name: close-issues
+      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      env:
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-advisory-jira-secret
+              key: token
+      script: |
+        #!/usr/bin/env bash
+        # We do not set -x here because it would leak the ACCESS_TOKEN
+        set -eu
+
+        ISSUE_TRACKERS='{
+            "Jira": {
+                "api": "rest/api/2/issue",
+                "servers": [
+                    "issues.redhat.com",
+                    "jira.atlassian.com"
+                ]
+            },
+            "bugzilla": {
+                "api": "rest/bug",
+                "servers": [
+                    "bugzilla.redhat.com"
+                ]
+            }
+        }'
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        RC=0
+
+        NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
+        for ((i = 0; i < NUM_ISSUES; i++)); do
+            issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
+            server=$(jq -r '.source' <<< "$issue")
+            if [ "$server" != "issues.redhat.com" ] ; then
+                echo "This task currently only supports closing issues on issues.redhat.com"
+                echo "Skipping issue $issue as it is on $server"
+                continue
+            fi
+
+            CURL_ARGS=(
+              -H "Authorization: Bearer $ACCESS_TOKEN"
+              --retry 3
+              --fail
+            )
+
+            API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$ISSUE_TRACKERS")
+            API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
+
+            if [ "$(curl "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')" == "Closed" ] ; then
+                echo "Issue $issue is already in Closed state. Skipping it."
+                continue
+            fi
+
+            echo "Closing issue $issue"
+            # Get the Closed transition id. This varies per Jira project
+            if ! CLOSED_ID="$(curl "${CURL_ARGS[@]}" "${API_URL}/transitions" \
+              | jq -r '.transitions[] | select(.name=="Closed") | .id')"; then
+                echo "Error: failed to fetch the closed state id for issue $issue."
+                RC=1
+                continue
+            fi
+
+            # Close the issue
+            CLOSE_COMMENT="Fixed in Konflux Advisory $(params.advisoryUrl)"
+            if ! curl "${CURL_ARGS[@]}" -XPOST --data \
+              '{"transition":{"id":"'"$CLOSED_ID"'"},"update":{"comment":[{"add":{"body":"'"$CLOSE_COMMENT"'"}}]}}' \
+              -H "Content-Type: application/json" "${API_URL}/transitions"; then
+                echo "Error: failed to close issue $issue."
+                RC=1
+            fi
+        done
+
+        exit $RC

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function curl() {
+  echo Mock curl called with: $* >&2
+  echo $* >> $(workspaces.data.path)/mock_curl.txt
+
+  if [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  then
+    :
+  elif [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  then
+    exit 1
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  then
+    echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/transitions" ]]
+  then
+    exit 1
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/CLOSED-987" ]]
+  then
+    echo '{"fields":{"status":{"name":"Closed","id":"99"}}}'
+  else
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy access token secret (and delete it first if it exists)
+kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-close-advisory-issues-closed-issue
+spec:
+  description: |
+    Test for close-advisory-issues where the issue is already closed. Curl should only be
+    called once for the issue
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "CLOSED-987",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: data.json
+        - name: advisoryUrl
+          value: https://domain.com/advisory.yaml
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)"/mock_curl.txt)" != 1 ]; then
+                  echo Error: curl was expected to be called 1 time. Actual calls:
+                  cat "$(workspaces.data.path)"/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"CLOSED-987" ]]
+      runAfter:
+        - run-task

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-close-advisory-issues-fail-closing-issue
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test for close-advisory-issues where the curl command to close the issue fails. This is
+    done with the mocks because of the issue id
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "FAIL-999",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: data.json
+        - name: advisoryUrl
+          value: https://domain.com/advisory.yaml
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-close-advisory-issues-fail-getting-closed-id
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test for close-advisory-issues where the curl command to get the id of the Closed
+    transition state fails. This is done with the mocks because of the issue id
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "NOCLOSE-555",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: data.json
+        - name: advisoryUrl
+          value: https://domain.com/advisory.yaml
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-close-advisory-issues-no-issues
+spec:
+  description: Test for close-advisory-issues where there are no issues listed
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "foo": "bar"
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: data.json
+        - name: advisoryUrl
+          value: https://domain.com/advisory.yaml
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-close-advisory-issues
+spec:
+  description: Test for close-advisory-issues where the curl commands all succeed
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "ISSUE-123",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: data.json
+        - name: advisoryUrl
+          value: https://domain.com/advisory.yaml
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)"/mock_curl.txt)" != 3 ]; then
+                  echo Error: curl was expected to be called 3 times. Actual calls:
+                  cat "$(workspaces.data.path)"/mock_curl.txt
+                  exit 1
+              fi
+
+              [[ $(head -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"ISSUE-123" ]]
+              [[ $(head -n 2 "$(workspaces.data.path)/mock_curl.txt" | tail -n 1) == *"ISSUE-123/transitions" ]]
+              [[ $(tail -n 1 "$(workspaces.data.path)/mock_curl.txt") == *"Content-Type"*"ISSUE-123"* ]]
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit adds a new task, `close-advisory-issues` to the `rh-advisories` pipeline. It should run after the advisory is created. It will close all issues listed in the releaseNotes and add a comment saying what advisory they were fixed in.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

