### PR TITLE
fix: add empty references for rhea/rhba

### DIFF
--- a/tasks/managed/populate-release-notes/README.md
+++ b/tasks/managed/populate-release-notes/README.md
@@ -12,6 +12,9 @@ path to a file containing data used in component SBOM generation.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 3.0.1
+* If type is RHBA or RHEA, the task will ensure the `references` key exists (although it will be empty)
+
 ## Changes in 3.0.0
 * Task renamed from `populate-release-notes-images` to `populate-release-notes`
 * Task will now inject references if the `releaseNotes.type` is `RHSA`

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -154,7 +154,8 @@ spec:
         fi
 
         if [ "$(jq -r '.releaseNotes.type' "${DATA_FILE}")" != "RHSA" ] ; then
-            echo "Type is not RHSA. Not adding references"
+            echo "Type is not RHSA. Ensuring references key exists, but not adding any"
+            jq '.releaseNotes.references += []' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
             exit 0
         fi
 

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -5,8 +5,7 @@ metadata:
   name: test-populate-release-notes-non-rhsa-references
 spec:
   description: |
-    Run the populate-release-notes task with a type that is RHSA. Ensure that no additional references
-    are added
+    Run the populate-release-notes task with a type that is not RHSA. Ensure that references are []
   workspaces:
     - name: tests-workspace
   tasks:
@@ -96,6 +95,6 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              test "$(jq '.releaseNotes | has("references")' "$(workspaces.data.path)/data.json")" == "false"
+              test "$(jq -c '.releaseNotes.references' "$(workspaces.data.path)/data.json")" == "[]"
       runAfter:
         - run-task


### PR DESCRIPTION
This commit modifies populate-release-notes to ensure that for RHEA or RHBA, the references key exists. It will add it as empty, but the advisory template will break if the key does not at least exist.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

