### PR TITLE
feat(RELEASE-1405): add task to set advisory severity

### DIFF
--- a/pipelines/internal/get-advisory-severity/README.md
+++ b/pipelines/internal/get-advisory-severity/README.md
@@ -1,0 +1,12 @@
+# get-advisory-severity pipeline
+
+Tekton pipeline to execute the get-advisory-severity task. The goal of the task is to fetch the proper severity
+for an advisory.
+
+## Parameters
+
+| Name              | Description                                                                           | Optional | Default value                                             |
+|-------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| releaseNoteImages | Json array of image specific details for the advisory                                 | No       | -                                                         |
+| taskGitUrl        | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision   | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |

--- a/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: get-advisory-severity
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Pipeline to fetch the proper severity for an advisory
+  params:
+    - name: releaseNotesImages
+      type: string
+      description: Json array of image specific details for the advisory
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: get-advisory-severity
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+      params:
+        - name: releaseNotesImages
+          value: $(params.releaseNotesImages)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+  results:
+    - name: result
+      value: $(tasks.get-advisory-severity.results.result)
+    - name: severity
+      value: $(tasks.get-advisory-severity.results.severity)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.get-advisory-severity.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.get-advisory-severity.results.internalRequestTaskRunName)

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.10.0
+* Add new task `set-advisory-severity` to run after `populate-release-notes` that will inject a severity
+  key into the releaseNotes in the data file based on the releaseNotes.type and CVEs present
+
 ## Changes in 1.9.0
 * Task `populate-release-notes-images` renamed to `populate-release-notes`
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.9.0"
+    app.kubernetes.io/version: "1.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -269,6 +269,31 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/embargo-check/embargo-check.yaml
+        resolver: git
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - populate-release-notes
+    - name: set-advisory-severity
+      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/set-advisory-severity/set-advisory-severity.yaml
         resolver: git
       workspaces:
         - name: data
@@ -721,6 +746,7 @@ spec:
         - run-file-updates
         - rh-sign-image
         - rh-sign-image-cosign
+        - set-advisory-severity
     - name: update-cr-status
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:

--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -1,0 +1,14 @@
+# get-advisory-severity
+
+This task gets the advisory severity. It does this by querying OSIDB for each CVE present in the
+releaseNotesImages. For each CVE, the overall impact it is looked at. If the OSIDB entry lists an
+impact for the specific affected component, that is used instead of the overall impact. The highest
+impact from all of the CVEs is returned as a task result.
+
+
+## Parameters
+
+| Name                           | Description                                           | Optional | Default value |
+|--------------------------------|-------------------------------------------------------|----------|---------------|
+| releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-advisory-severity
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+      This task gets the advisory severity. It does this by querying OSIDB for each CVE present in the
+      releaseNotesImages. For each CVE, the overall impact it is looked at. If the OSIDB entry lists an
+      impact for the specific affected component, that is used instead of the overall impact. The highest
+      impact from all of the CVEs is returned as a task result.
+  params:
+    - name: releaseNotesImages
+      type: string
+      description: Json array of image specific details for the advisory
+    - name: internalRequestPipelineRunName
+      type: string
+      description: name of the PipelineRun that called this task
+  results:
+    - name: result
+      description: Success if the task succeeds, the error otherwise
+    - name: severity
+      description: The advisory severity level
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that called this task
+    - name: internalRequestTaskRunName
+      description: Name of this Task Run to be made available to caller
+  steps:
+    - name: get-advisory-severity
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      env:
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: name
+        - name: SERVICE_ACCOUNT_KEYTAB
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: base64_keytab
+        - name: OSIDB_URL
+          valueFrom:
+            secretKeyRef:
+              name: osidb-service-account
+              key: osidb_url
+        - name: IMAGES
+          value: $(params.releaseNotesImages)
+      script: |
+          #!/usr/bin/env bash
+          set -eo pipefail
+
+          STDERR_FILE=/tmp/stderr.txt
+          echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+          echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+          # shellcheck disable=SC2317 # shellcheck calls all the commands in exitfunc unreachable because it is called
+          # via trap
+          exitfunc() {
+              local err="$1"
+              local line="$2"
+              local command="$3"
+              if [ "$err" -eq 0 ] ; then
+                  echo -n "Success" > "$(results.result.path)"
+              else
+                  echo -n \
+                    "$0: ERROR '$command' failed at line $line - exited with status $err" > "$(results.result.path)"
+                  if [ -f "$STDERR_FILE" ] ; then
+                      tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"
+                  fi
+              fi
+              exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
+          }
+          # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+          trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+          echo -n "" > "$(results.severity.path)"
+
+          # write keytab to file
+          echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
+          # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
+          KRB5CCNAME=$(mktemp)
+          export KRB5CCNAME
+          KRB5_CONFIG=$(mktemp)
+          export KRB5_CONFIG
+          export KRB5_TRACE=/dev/stderr
+          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
+          kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+
+          INCLUDE_FIELDS="cve_id,impact,affects.ps_component,affects.impact"
+          ADVISORY_SEVERITY=""
+
+          get_higher_severity() { # Return higher sev of the two provided [current highest, new]
+              if [ "$1" == "CRITICAL" ] || [ "$2" == "CRITICAL" ] ; then
+                  echo "CRITICAL"
+              elif [ "$1" == "IMPORTANT" ] || [ "$2" == "IMPORTANT" ] ; then
+                  echo "IMPORTANT"
+              elif [ "$1" == "MODERATE" ] || [ "$2" == "MODERATE" ] ; then
+                  echo "MODERATE"
+              elif [ "$1" == "LOW" ] || [ "$2" == "LOW" ] ; then
+                  echo "LOW"
+              else
+                  # To get here, the one we are comparing against is an invalid value, so just
+                  # return $1, which is the current highest severity
+                  echo "$1"
+              fi
+          }
+
+          NUM_IMAGES=$(jq '.[] | length' <<< "${IMAGES}")
+          for ((i = 0; i < NUM_IMAGES; i++)); do
+              image=$(jq -c --argjson i "$i" '.[$i]' <<< "${IMAGES}")
+              component=$(jq -r '.component' <<< "$image")
+              NUM_CVES=$(jq '.cves.fixed | length' <<< "$image")
+              for ((j = 0; j < NUM_CVES; j++)); do
+                  cve=$(jq -r --argjson j "$j" '.cves.fixed | to_entries[$j].key' <<< "${image}")
+                  echo "Checking CVE ${cve} for component ${component}"
+                  # Get token. They are short lived, so get one for before each request
+                  TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
+                  OUTPUT=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
+                      "${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}" \
+                      | jq '.results[0]')
+                  IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
+                  # If there is a component specific impact, use that instead
+                  if PS_COMP=$(jq -e --arg comp "$component" '.affects[] | select(.ps_component==$comp)' <<< "$OUTPUT")
+                  then
+                      IMPACT=$(jq -r --arg default "$IMPACT" '.impact // $default' <<< "$PS_COMP")
+                  fi
+                  ADVISORY_SEVERITY=$(get_higher_severity "$ADVISORY_SEVERITY" "$IMPACT")
+              done
+          done
+
+          if [ -z "$ADVISORY_SEVERITY" ] ; then
+              echo "Unable to find severity on any cve listed in the releaseNotes" | tee "$STDERR_FILE"
+              exit 1
+          fi
+
+          # Change from all caps to just first letter capitalized
+          ADVISORY_SEVERITY="${ADVISORY_SEVERITY,,}"
+          ADVISORY_SEVERITY="${ADVISORY_SEVERITY^}"
+          echo -n "$ADVISORY_SEVERITY" > "$(results.severity.path)"
+          exit 0

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eux
+
+# mocks to be injected into task step scripts
+
+function kinit() {
+  echo "kinit $*"
+}
+
+function curl() {
+  echo Mock curl called with: $* >&2
+
+  if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
+  then
+    echo '{"access": "dummy-token"}'
+  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-critical"* ]]
+  then
+    echo '{"results": [{"impact":"CRITICAL","affects":[{"ps_component":"component","impact":""}]}]}'
+  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-moderate"* ]]
+  then
+    echo '{"results": [{"impact":"MODERATE","affects":[{"ps_component":"component","impact":"IMPORTANT"},{"ps_component":"foo","impact":"LOW"}]}]}'
+  else
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/tasks/internal/get-advisory-severity/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/get-advisory-severity/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy osidb secret (and delete it first if it exists)
+# The secret name is hardcoded in the task so the mock secret name can't have the task name in it
+kubectl delete secret osidb-service-account --ignore-not-found
+kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=OWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0Cg== --from-literal=osidb_url=myurl

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity-component
+spec:
+  description: |
+    Run the get-advisory-severity task with a CVE that is MODERATE but the component lists an impact.
+    The task result should be IMPORTANT as that is the one from the component
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: '[{"component":"component","cves":{"fixed":{"CVE-moderate":{"components":[]}}}}]'
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: severity
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(params.result)" != Success ]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.severity)" != "Important" ]; then
+                echo Error: severity task result is not correct
+                exit 1
+              fi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity-no-cves
+spec:
+  description: |
+    Run the get-advisory-severity task with no CVEs in the releaseNotesImages.
+    The task result should show a failure
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: '[{"component":"component","cves":{}}]'
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: severity
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [[ "$(params.result)" != *"Unable to find severity"* ]]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.severity)" != "" ]; then
+                echo Error: severity task result is not correct
+                exit 1
+              fi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity
+spec:
+  description: |
+    Run the get-advisory-severity task with a CVE that is critical. The task result
+    should be CRITICAL
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: '[{"component":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: severity
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(params.result)" != Success ]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.severity)" != "Critical" ]; then
+                echo Error: severity task result is not correct
+                exit 1
+              fi

--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -1,0 +1,14 @@
+# set-advisory-severity
+
+Tekton task to set the severity level in the releaseNotes key of the data.json. It will use an InternalRequest to query
+OSIDB for each CVE present. If the type is not RHSA, no action will be performed.
+
+## Parameters
+
+| Name                     | Description                                                                               | Optional | Default value |
+|--------------------------|-------------------------------------------------------------------------------------------|----------|---------------|
+| dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180           |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: set-advisory-severity
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >
+    Tekton task to set the severity level in the releaseNotes key of the data.json. It will
+    use an InternalRequest to query OSIDB for each CVE present. If the type is not RHSA, no
+    action will be performed.
+  params:
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
+    - name: requestTimeout
+      type: string
+      default: "180"
+      description: InternalRequest timeout
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  steps:
+    - name: set-severity
+      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      script: |
+        #!/usr/bin/env bash
+        set -x
+
+        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        if [[ "$(jq -r '.releaseNotes.type' "${DATA_FILE}")" != "RHSA" ]] ; then
+            echo "Advisory is not of type RHSA. Not setting severity"
+            exit 0
+        fi
+
+        PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+        RELEASENOTESIMAGES=$(jq -c '.releaseNotes.content.images' "${DATA_FILE}")
+
+        IR_FILE="$(workspaces.data.path)/$(context.task.name)/ir-result.txt"
+        mkdir -p "$(dirname "$IR_FILE")"
+
+        internal-request --pipeline "get-advisory-severity" \
+            -p releaseNotesImages="${RELEASENOTESIMAGES}" \
+            -p taskGitUrl="$(params.taskGitUrl)" \
+            -p taskGitRevision="$(params.taskGitRevision)" \
+            -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+            -t "$(params.requestTimeout)" \
+            -s true \
+            > "$IR_FILE" || \
+            (grep "^\[" "$IR_FILE" | jq . && exit 1)
+
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
+        echo "done (${internalRequest})"
+
+        results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')
+        internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
+        internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
+
+        echo "** internalRequestPipelineRunName: ${internalRequestPipelineRunName}"
+        echo "** internalRequestTaskRunName: ${internalRequestTaskRunName}"
+
+        if [[ "$(echo "${results}" | jq -r '.result')" == "Success" ]]; then
+          SEVERITY=$(jq -r '.severity' <<< "$results")
+          echo "Setting severity to $SEVERITY"
+          jq --arg sev "$SEVERITY" '.releaseNotes.severity = $sev' "${DATA_FILE}" > /tmp/data.tmp \
+            && mv /tmp/data.tmp "${DATA_FILE}"
+        else
+          echo "The InternalRequest to find the severity was unsuccessful"
+          jq -r '.result' <<< "$results"
+          exit 1
+        fi

--- a/tasks/managed/set-advisory-severity/tests/mocks.sh
+++ b/tasks/managed/set-advisory-severity/tests/mocks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function internal-request() {
+  if [[ "$*" == *"CVE-999"* ]]; then
+    echo "InternalRequest 'failure-ir' created."
+  else
+    echo "InternalRequest 'success-ir' created."
+  fi
+}
+
+function kubectl() {
+  # The IR won't actually be created, so mock it to return Success as the task wants
+  if [[ "$*" == *"get internalrequest success-ir"* ]]
+  then
+    echo '{"result":"Success","severity":"IMPORTANT"}'
+  elif [[ "$*" == *"get internalrequest failure-ir"* ]]
+  then
+    echo '{"result":"Failure","severity":""}'
+  else
+    /usr/bin/kubectl $*
+  fi
+}

--- a/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-fail-no-data-json.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-fail-no-data-json.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-fail-no-data-json
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: Test for set-advisory-severity where there is no data JSON
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-ir-failure
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test with the InternalRequest failing to ensure task fails. The mocks make the InternalRequest
+    fail if the releaseNotes.content.images contains the string CVE-999
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHSA",
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "containerImage": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-999": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-no-release-notes
+spec:
+  description: Test for set-advisory-severity where the data JSON has no releaseNotes key. The task should succeed
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "foo": "bar"
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-not-rhsa
+spec:
+  description: |
+    Test for set-advisory-severity where the releaseNotes.type is not RHSA. The task should succeed
+    without action
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHBA"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity
+spec:
+  description: |
+    Test that the task sets the releaseNotes.severity to IMPORTANT, which is what the mocks have the
+    InternalRequest return when called with anything but CVE-999
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHSA",
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "containerImage": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-555": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              test "$(jq -r '.releaseNotes.severity' "$(workspaces.data.path)/data.json")" == "IMPORTANT"


### PR DESCRIPTION
This commit adds a managed and internal task. The managed one uses the internal task to get the severity rating for an advisory based on the severity levels of the related CVEs.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

