### PR TITLE
feat: improve logging for create-advisory task

### DIFF
--- a/pipelines/internal/create-advisory/README.md
+++ b/pipelines/internal/create-advisory/README.md
@@ -17,5 +17,8 @@ advisory URL as well as a result to show the error message if one occurred.
 | taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
 
+## Changes in 1.1.0
+* Add internalRequestPipelineRunName and internalRequestTaskRunName as results to help with debugging
+
 ## Changes in 1.0.0
 * Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/pipelines/internal/create-advisory/create-advisory.yaml
+++ b/pipelines/internal/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -64,8 +64,14 @@ spec:
           value: $(params.advisory_secret_name)
         - name: errata_secret_name
           value: $(params.errata_secret_name)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
   results:
     - name: result
       value: $(tasks.create-advisory-task.results.result)
     - name: advisory_url
       value: $(tasks.create-advisory-task.results.advisory_url)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.create-advisory-task.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.create-advisory-task.results.internalRequestTaskRunName)

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -6,14 +6,22 @@ internal request. The success/failure is handled in the task creating the intern
 
 ## Parameters
 
-| Name                 | Description                                                                                            | Optional | Default value |
-|----------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
-| advisory_json        | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -             |
-| application          | Application being released                                                                             | No       | -             |
-| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -             |
-| config_map_name      | The name of the configMap that contains the signing key                                                | No       | -             |
-| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
-| errata_secret_name   | The name of the secret that contains the errata service account metadata                               | No       | -             |
+| Name                           | Description                                                                                            | Optional | Default value |
+|--------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
+| advisory_json                  | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -             |
+| application                    | Application being released                                                                             | No       | -             |
+| origin                         | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -             |
+| config_map_name                | The name of the configMap that contains the signing key                                                | No       | -             |
+| advisory_secret_name           | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
+| errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
+
+## Changes in 0.12.0
+* Updated logging
+  * Use a STDERR_FILE and tail it into the `result` task result so that the calling task has better
+    visibility into what failed
+  * Add internalRequestPipelineRunName as a parameter to return as a task result and also one for
+    InternalRequestTaskRunName
 
 ## Changes in 0.11.1
 * Update base image

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.11.1"
+    app.kubernetes.io/version: "0.12.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,11 +37,18 @@ spec:
     - name: errata_secret_name
       type: string
       description: The name of the secret that contains the errata service account metadata
+    - name: internalRequestPipelineRunName
+      type: string
+      description: Name of the PipelineRun that called this task
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
     - name: advisory_url
       description: The advisory url if the task succeeds, empty string otherwise
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that called this task
+    - name: internalRequestTaskRunName
+      description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
@@ -95,6 +102,10 @@ spec:
           #!/usr/bin/env bash
           set -eo pipefail
 
+          STDERR_FILE=/tmp/stderr.txt
+          echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+          echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
           exitfunc() {
               local err=$1
               local line=$2
@@ -104,6 +115,9 @@ spec:
               else
                   echo -n \
                     "$0: ERROR '$command' failed at line $line - exited with status $err" > "$(results.result.path)"
+                  if [ -f "$STDERR_FILE" ] ; then
+                      tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"
+                  fi
               fi
               echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
               exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
@@ -166,12 +180,12 @@ spec:
             --template /home/templates/advisory.yaml.jinja
 
           # Ensure the created advisory file passes the advisory schema
-          check-jsonschema --schemafile schema/advisory.json "$ADVISORY_FILEPATH"
+          check-jsonschema --schemafile schema/advisory.json "$ADVISORY_FILEPATH" 2> "$STDERR_FILE"
 
           git add "${ADVISORY_FILEPATH}"
           git commit -m "[Konflux Release] new advisory for $(params.application)"
           echo "Pushing to ${REPO_BRANCH}..."
-          git_push_with_retries --branch $REPO_BRANCH --retries 5 --url origin
+          git_push_with_retries --branch $REPO_BRANCH --retries 5 --url origin 2> "$STDERR_FILE"
           # Construct the advisory url to report back to the user as a result
           # Note: This currently only supports gitlab repos, which is all we expect for now
           ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/${REPO_BRANCH}/${ADVISORY_FILEPATH}"

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -35,6 +35,8 @@ spec:
           value: "create-advisory-secret"
         - name: errata_secret_name
           value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -30,6 +30,8 @@ spec:
           value: "create-advisory-secret"
         - name: errata_secret_name
           value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -20,6 +20,9 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                           |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -                           |
 
+## Changes in 5.1.0
+* Echo the internalRequestPipelineRunName and internalRequestTaskRunName in the log to help with debugging
+
 ## Changes in 5.0.0
 * Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 * The pipeline is called via git resolver now instead of cluster resolver

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -164,6 +164,9 @@ spec:
           errataSecretName="${stagingErrataSecretName}"
         fi
 
+        IR_FILE="$(workspaces.data.path)/$(context.task.name)/ir-result.txt"
+        mkdir -p "$(dirname "$IR_FILE")"
+
         echo "Creating InternalRequest to create advisory..."
         internal-request --pipeline "$(params.request)" \
                          -p application="${application}" \
@@ -176,14 +179,20 @@ spec:
                          -p taskGitRevision="$(params.taskGitRevision)" \
                          -s "$(params.synchronously)" \
                          -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-                         > "$(workspaces.data.path)"/ir-result.txt || \
-                         (grep "^\[" "$(workspaces.data.path)"/ir-result.txt | jq . && exit 1)
+                         > "$IR_FILE" || \
+                         (grep "^\[" "$IR_FILE" | jq . && exit 1)
 
-        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$(workspaces.data.path)"/ir-result.txt)
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
         echo "done (${internalRequest})"
 
         echo -n "" > "$(results.advisory_url.path)"
         results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')
+        internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
+        internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
+
+        echo "** internalRequestPipelineRunName: ${internalRequestPipelineRunName}"
+        echo "** internalRequestTaskRunName: ${internalRequestTaskRunName}"
+
         if [[ "$(echo "${results}" | jq -r '.result')" == "Success" ]]; then
           echo "Advisory created"
         else


### PR DESCRIPTION
This commit modifies the create-advisory task to print out the internalRequest taskrun and pipelinerun name, as well as saving the internal failures to a STDERR file that is tailed into the task result. This should better expose issues to users.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

