### PR TITLE
fix(RELEASE-1405): remove advisory severity for non RHSA

### DIFF
--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -12,3 +12,6 @@ OSIDB for each CVE present. If the type is not RHSA, no action will be performed
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 0.1.1
+* If a non RHSA type is provided, remove the severity key in case the user provided it

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,6 +48,10 @@ spec:
 
         if [[ "$(jq -r '.releaseNotes.type' "${DATA_FILE}")" != "RHSA" ]] ; then
             echo "Advisory is not of type RHSA. Not setting severity"
+            if [ "$(jq '.releaseNotes | has("severity")' "${DATA_FILE}")" == "true" ] ; then
+              echo "User provided severity key for non RHSA advisory. Removing it"
+              jq 'del(.releaseNotes.severity)' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+            fi
             exit 0
         fi
 

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-not-rhsa-user-severity
+spec:
+  description: |
+    Test for set-advisory-severity where the releaseNotes.type is not RHSA, but the user provided a severity.
+    The task should remove the severity key from the data file
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHBA",
+                  "severity": "Moderate"
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              test "$(jq '.releaseNotes | has("severity")' "$(workspaces.data.path)/data.json")" == "false"


### PR DESCRIPTION
This commit modifies the set-advisory-severity task to ensure that severity does not exist if the type is not RHSA. In other words, if the user provided a severity, it will remove it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

