### PR TITLE
chore(RELEASE-1321): remove managed pipeline sym links

### DIFF
--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -1,1 +1,0 @@
-../managed/e2e/e2e.yaml

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -1,1 +1,0 @@
-../managed/fbc-release/fbc-release.yaml

--- a/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
+++ b/pipelines/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml
@@ -1,1 +1,0 @@
-../managed/push-binaries-to-dev-portal/push-binaries-to-dev-portal.yaml

--- a/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -1,1 +1,0 @@
-../managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml

--- a/pipelines/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -1,1 +1,0 @@
-../managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml

--- a/pipelines/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/push-to-addons-registry/push-to-addons-registry.yaml
@@ -1,1 +1,0 @@
-../managed/push-to-addons-registry/push-to-addons-registry.yaml

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -1,1 +1,0 @@
-../managed/push-to-external-registry/push-to-external-registry.yaml

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -1,1 +1,0 @@
-../managed/release-to-github/release-to-github.yaml

--- a/pipelines/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/release-to-mrrc/release-to-mrrc.yaml
@@ -1,1 +1,0 @@
-../managed/release-to-mrrc/release-to-mrrc.yaml

--- a/pipelines/rh-advisories/rh-advisories.yaml
+++ b/pipelines/rh-advisories/rh-advisories.yaml
@@ -1,1 +1,0 @@
-../managed/rh-advisories/rh-advisories.yaml

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -1,1 +1,0 @@
-../managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -1,1 +1,0 @@
-../managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -1,1 +1,0 @@
-../managed/rhtap-service-push/rhtap-service-push.yaml


### PR DESCRIPTION
These sym links were only in place while we migrated users to the new paths in pipelines/managed. All users have been migrated and there is now CI in place preventing new users from using the old pipeline locations, so we can remove the sym links.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

