### PR TITLE
revert(RELEASE-1409): remove baseImage key from mapping

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -395,10 +395,6 @@
                 "type": "string",
                 "description": "URL where you want to push the artifact e.g. quay.io/redhat/example-component"
               },
-              "baseImage": {
-                "type": "boolean",
-                "description": "Indicates if the component serves as a base image for another component's containerImage"
-              },
               "tags": {
                 "type": "array",
                 "description": "The tags to push the artifact e.g. [ {{ git_sha }}, {{ digest_sha }}, 1.0 ]",


### PR DESCRIPTION
The feature is dropped, so we no longer plan to support specifying images as baseImage in the mapping section of the data file.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

