### PR TITLE
fix(RELEASE-1455): avoid failing on purls in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/README.md
+++ b/tasks/managed/push-rpm-data-to-pyxis/README.md
@@ -13,6 +13,10 @@ all repository_id strings found in rpm purl strings in the sboms.
 | server          | The server type to use. Options are 'production','production-internal,'stage-internal' and 'stage'. | Yes      | production    |
 | concurrentLimit | The maximum number of images to be processed at once                                                | Yes      | 4             |
 
+## Changes in 1.3.4
+* Updated the base image used in this task
+  * The new image avoids failing on purls that miss qualifiers. Instead, such entries are skipped
+
 ## Changes in 1.3.3
 * Fix shellcheck/checkton linting issues in the task and tests
 

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "1.3.3"
+    app.kubernetes.io/version: "1.3.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+        quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -100,7 +100,7 @@ spec:
 
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+        quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
       env:
         - name: PYXIS_CERT
           valueFrom:

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -83,7 +83,7 @@ spec:
           - name: sbomPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

A user was facing an issue where the upload_rpm_data script was failing when a purl was missing qualifiers. Now we skip such entries.

This change bumps the utils image to contain this fix.

Related utils change: https://github.com/konflux-ci/release-service-utils/pull/384

## Relevant Jira

[RELEASE-1455](https://issues.redhat.com//browse/RELEASE-1455)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

