### PR TITLE
fix: get-advisory-severity jq issue

### DIFF
--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -12,3 +12,6 @@ impact from all of the CVEs is returned as a task result.
 |--------------------------------|-------------------------------------------------------|----------|---------------|
 | releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |
+
+## Changes in 0.1.1
+* Fix bug regarding the jq query that determines the number of images

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -111,7 +111,7 @@ spec:
               fi
           }
 
-          NUM_IMAGES=$(jq '.[] | length' <<< "${IMAGES}")
+          NUM_IMAGES=$(jq 'length' <<< "${IMAGES}")
           for ((i = 0; i < NUM_IMAGES; i++)); do
               image=$(jq -c --argjson i "$i" '.[$i]' <<< "${IMAGES}")
               component=$(jq -r '.component' <<< "$image")

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -13,7 +13,7 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"component":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
+          value: '[{"component":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}},{"component":"bar","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result


### PR DESCRIPTION
Fix an issue in the get-advisory-severity task with the jq query that determined the number of images. Also amend a test to catch this.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

