### PR TITLE
docs: tell user if they use rhsa with no cves sooner

### DIFF
--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -13,5 +13,8 @@ OSIDB for each CVE present. If the type is not RHSA, no action will be performed
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 0.1.2
+* Update the task to fail if the type is RHSA and no CVEs are provided
+
 ## Changes in 0.1.1
 * If a non RHSA type is provided, remove the severity key in case the user provided it

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -46,13 +46,22 @@ spec:
             exit 1
         fi
 
-        if [[ "$(jq -r '.releaseNotes.type' "${DATA_FILE}")" != "RHSA" ]] ; then
+        advisoryType=$(jq -r '.releaseNotes.type' "${DATA_FILE}")
+        if [[ "$advisoryType" != "RHSA" ]] ; then
             echo "Advisory is not of type RHSA. Not setting severity"
             if [ "$(jq '.releaseNotes | has("severity")' "${DATA_FILE}")" == "true" ] ; then
               echo "User provided severity key for non RHSA advisory. Removing it"
               jq 'del(.releaseNotes.severity)' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
             fi
             exit 0
+        fi
+
+        # Ensure RHSA is only used if CVEs are provided
+        NUM_CVES=$(jq '[.releaseNotes.content.images[]?.cves.fixed // [] | length] | add' "${DATA_FILE}")
+        if [[ "$advisoryType" == "RHSA" ]] && [[ "$NUM_CVES" -eq 0 ]] ; then
+            echo "Provided advisory type is RHSA, but no fixed CVEs were listed"
+            echo "RHSA should only be used if CVEs are fixed in the advisory. Failing..."
+            exit 1
         fi
 
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-rhsa-no-cves
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test for set-advisory-severity where the releaseNotes.type is RHSA but no cves are listed.
+    The task should fail
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHSA",
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "foo"
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup


### PR DESCRIPTION
We already tell the user they can't use an RHSA with no cves in the create-advisory task. However, the new set-severity-task runs before the create-advisory task and will also fail if the user specifies RHSA with no cves (it will say it couldn't find a severity for any cve). This commit adds the same error message from create-advisory to set-advisory-severity so it is more clear to the user.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

