### PR TITLE
feat(RELEASE-1340): simple-signing-pipeline called via git resolver

### DIFF
--- a/internal/resources/collect-simple-signing-params.yaml
+++ b/internal/resources/collect-simple-signing-params.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml

--- a/internal/resources/simple-signing-pipeline.yaml
+++ b/internal/resources/simple-signing-pipeline.yaml
@@ -1,1 +1,0 @@
-../../pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml

--- a/pipelines/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -1,1 +1,0 @@
-../internal/simple-signing-pipeline/simple-signing-pipeline.yaml

--- a/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -1,1 +1,0 @@
-../internal/collect-simple-signing-params/collect-simple-signing-params.yaml

--- a/tasks/managed/rh-sign-image/README.md
+++ b/tasks/managed/rh-sign-image/README.md
@@ -20,6 +20,11 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | signRegistryAccessPath   | The relative path in the workspace to a text file that contains a list of repositories that needs registry.access.redhat.com image references to be signed (i.e. requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9". | No       | -             |
 
 
+## Changes in 5.1.0
+* The pipeline is called via git resolver now instead of cluster resolver
+  * This was done by changing from `-r` to `--pipeline` in the `internal-request`/`internal-pipelinerun` call
+  * The base image was updated to include this new functionality
+
 ## Changes in 5.0.3
 * Increase `requestTimeout` value to 30 minutes
   * The internal-request/internal-pipeline is set to a timeout of 30 minutes, but the internal-request/internal-pipeline script

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "5.0.3"
+    app.kubernetes.io/version: "5.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -60,7 +60,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
       computeResources:
         limits:
           memory: 4Gi
@@ -115,8 +115,6 @@ spec:
         if [ "${REQUESTTYPE}" == "internal-pipelinerun" ] ; then
           requestType=internal-pipelinerun
           EXTRA_ARGS=(
-          --task-git-url "$(params.taskGitUrl)"
-          --task-git-revision "$(params.taskGitRevision)"
           --service-account "${service_account_name}"
           )
         else
@@ -228,7 +226,7 @@ spec:
                     echo "- manifest_digest=${manifest_digest}"
                     echo "- requester=$(params.requester)"
 
-                    ${requestType} -r "${request}" \
+                    ${requestType} --pipeline "${request}" \
                       -p pipeline_image="${pipeline_image}" \
                       -p reference="${registry_reference}:${tag}" \
                       -p manifest_digest="${manifest_digest}" \
@@ -275,7 +273,7 @@ spec:
                       echo "- manifest_digest=${sourceContainerDigest}"
                       echo "- requester=$(params.requester)"
 
-                      ${requestType} -r "${request}" \
+                      ${requestType} --pipeline "${request}" \
                         -p pipeline_image="${pipeline_image}" \
                         -p reference="${registry_reference}:${sourceTag}" \
                         -p manifest_digest="${sourceContainerDigest}" \

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -110,7 +110,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -207,7 +207,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -215,7 +215,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -112,7 +112,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,7 +123,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -144,7 +144,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,7 +123,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -190,7 +190,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -122,7 +122,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -23,7 +23,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -118,7 +118,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -29,6 +29,11 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 4.2.0
+* The pipeline is called via git resolver now instead of cluster resolver
+  * This was done by changing from `-r` to `--pipeline` in the `internal-request`/`internal-pipelinerun` call
+  * The base image was updated to include this new functionality
+
 ## Changes in 4.1.1
 * Increase `requestTimeout` value to 30 minutes
   * The internal-request/internal-pipeline is set to a timeout of 30 minutes, but the internal-request/internal-pipeline script

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.1.1"
+    app.kubernetes.io/version: "4.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -49,7 +49,7 @@ spec:
       description: workspace to read and save files
   steps:
     - name: sign-index-image
-      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
       script: |
         #!/usr/bin/env bash
         set -e
@@ -73,8 +73,6 @@ spec:
           fi
           service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
           EXTRA_ARGS=(
-          --task-git-url "$(params.taskGitUrl)"
-          --task-git-revision "$(params.taskGitRevision)"
           --service-account "${service_account_name}"
           )
         else
@@ -102,7 +100,7 @@ spec:
           echo "- manifest_digest=${manifest_digest}"
           echo "- requester=$(params.requester)"
 
-          ${requestType} -r "${request}" \
+          ${requestType} --pipeline "${request}" \
             -p pipeline_image="${pipeline_image}" \
             -p reference="${reference_image}" \
             -p manifest_digest="${manifest_digest}" \

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -89,7 +89,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,7 +87,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -131,7 +131,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,7 +87,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/request-and-upload-signature/request-and-upload-signature.yaml
@@ -1,1 +1,0 @@
-../internal/request-and-upload-signature/request-and-upload-signature.yaml


### PR DESCRIPTION
This commit updates the managed tasks that call the simple-signing-pipeline internal pipeline to call the pipeline via git resolver instead of cluster resolver.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

