### PR TITLE
fix(RELEASE-1252): remove extra characters in the diff result

### DIFF
--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -16,6 +16,10 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | tempDir                        | temp dir for cloning and updates                                                                                                                                                         | Yes      | /tmp/$(context.taskRun.uid)/file-updates |
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
+
+## Changes in 1.0.1
+* Remove extra characters in the diff result
+
 ## Changes in 1.0.0
 * Add idempotent changes with some fix
   - It fixed some issue about `glab mr list` to handle anything from 0 to

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -315,7 +315,9 @@ spec:
                 else
                     # replacements exist
                     grep '^[-+@]' "${TEMP}"/oneMR.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/mrFile"
-                    grep '^[-+@]' "${TEMP}"/tempMRFile.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/tmpFile"
+                    # remove "a/" in  "--- a/dir/file" and "b/" in "+++ b/dir/file" 
+                    grep '^[-+@]' "${TEMP}"/tempMRFile.diff | sed -E 's/^[@]//; s/@@.*//' | \
+                        sed -E 's/^(---|\+\+\+) [ab]\//\1 /' | tee "${TEMP}/tmpFile"
                     if diff -q "${TEMP}"/mrFile "${TEMP}"/tmpFile > /dev/null; then
                         foundMR=true
                     fi

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -46,16 +46,16 @@ function glab() {
   elif [[ "$*" == *"mr diff"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     if [[ "${gitRepo}" == "replace-idempotent" ]]; then
-      echo "diff --git a/addons/my-addon2.yaml b/addons/my-addon2.yaml
---- a/addons/my-addon2.yaml
-+++ b/addons/my-addon2.yaml
+      echo "
+--- addons/my-addon2.yaml
++++ addons/my-addon2.yaml
 @@ -1,2 +1,2 @@
 -indexImage:
 +indexImage: Jack
 "
     else
-      echo "diff --git a/test/one-update.yaml b/test/one-update.yaml
-+++ b/test/one-update.yaml
+      echo "
++++ test/one-update.yaml
 @@ -1,2 +1,2 @@
 +indexImage: Jack
 "

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -131,7 +131,7 @@ spec:
             echo -e "=== Finished ===\n"
             exit 1
           else
-            MR=$(jq -r '.jsonBuildInfo | fromjson | fromjson | .merge_request // "unknown"' <<< "${results}")
+            MR=$(jq -r '.jsonBuildInfo | fromjson | .merge_request // "unknown"' <<< "${results}")
             echo "MR Created: ${MR}"
             echo "${MR}" >> "$(results.mergeRequestUrl.path)"
             RESULTS_JSON=$(jq --arg i "$i" --arg MR "${MR}" '.merge_requests[$i|tonumber] += {"url": $MR}' \

--- a/tasks/managed/run-file-updates/tests/mocks.sh
+++ b/tasks/managed/run-file-updates/tests/mocks.sh
@@ -78,7 +78,7 @@ EOF
       "internalRequestPipelineRunName": "${mockPipelineRunName}",
       "internalRequestTaskRunName": "${mockTaskRunName}",
       "buildState": "$status",
-      "jsonBuildInfo": "\"{\\\\\"merge_request\\\\\":\\\\\"https://g/r/-/merge_requests/18\\\\\"}\"\n"
+      "jsonBuildInfo": "{\"merge_request\":\"https://g/r/-/merge_requests/18\"}\n"
     }
   }
 }


### PR DESCRIPTION
In the output of the `diff` command, `[ab]/` is added to the file path, such
as "+++ a/dir/file". However, the output from `glab mr diff` does not include
 them. Remove it to ensure proper comparison.
Remove one `fromjson` in `jq` command in run-file-update task since it's
applied twice.


## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

