### PR TITLE
refactor: process-file-updates idempotent

### DIFF
--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -17,6 +17,10 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
 
+## Changes in 1.1.0
+* Use `git add` to stage modified files and compare the staged content with opened MRs
+  to check if an MR already exists with the same updates in the repo. 
+
 ## Changes in 1.0.1
 * Remove extra characters in the diff result
 

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -220,6 +220,7 @@ spec:
               REPLACEMENTS_PERFORMED=$((REPLACEMENTS_PERFORMED + 1))
             done
           fi
+          git add "${targetFile}"
         done
 
         if [ -n "${replacementsUpdateError}" ]; then
@@ -241,7 +242,7 @@ spec:
                 | tee "$(results.fileUpdatesInfo.path)"
                 echo -n "Failed" |tee "$(results.fileUpdatesState.path)"
             else
-                echo "nothing need change" \
+                echo "nothing needs change" \
                     | tee -a "$(results.fileUpdatesInfo.path)"
                 echo -n "Success" |tee "$(results.fileUpdatesState.path)"
             fi
@@ -251,23 +252,15 @@ spec:
         fi
 
         echo -e "\n*** START LOCAL CHANGES ***\n"
-        echo -e "\n*** Result from git diff ***\n"
-        # compare the differences between the working directory and the staging area 
-        git diff | tee "${TEMP}"/tempMRFile.diff
-
-        echo -e "\n*** Result from git diff --cache ***\n"
+        echo -e "\n*** Result from git diff --cached ***\n"
         # compare the differences between the staging area and the latest commit
         git diff --cached | tee "${TEMP}"/tempMRFile-cached.diff
 
-        if [[ -s "${TEMP}"/tempMRFile.diff ]]; then
-            # replacements exist 
-            # It's to deal with the lines like "@@ -N1,N2 +N3,N4 @@", 
-            # but it's possible to meet a line like "@@ -4,7 +4,7 @@ $schema: /app/app-settings.yml".
-            awk '/^@@/ {match($0, /@@ ([^@]+) @@/, arr); print arr[1]}' "${TEMP}"/tempMRFile.diff |\
-               tee "${TEMP}"/lineFile
-        elif [[ ! -s "${TEMP}"/tempMRFile-cached.diff ]]; then
-           # only seed exists and the file with the same content is there already 
-           echo "the seeding file already exists" \
+        echo -e "\n*** END LOCAL CHANGES ***\n"
+
+        if [[ ! -s "${TEMP}"/tempMRFile-cached.diff ]]; then
+           # nothing needs to change, the MR is merged 
+           echo "nothing needs change" \
                | tee -a "$(results.fileUpdatesInfo.path)"
            echo -n "Success" |tee "$(results.fileUpdatesState.path)"
            exit 0
@@ -279,7 +272,7 @@ spec:
         while true; do
             mrPage=$(glab mr list -R "${UPSTREAM_REPO}" --search "Konflux release" \
                 --per-page 100 --page $page | grep "^!" || true)
-            # add "$mrPagei" == '' check for unit testing
+            # add "$mrPage" == '' check for unit testing
             if [ -z "$mrPage" ] || [ "$mrPage" == '' ] ; then
                 break
             fi
@@ -290,42 +283,16 @@ spec:
         # Remove trailing newline
         openMRList=$(echo "$openMRList" | sed '/^$/d')
 
-        if [ -n "$openMRList" ]; then        
+        if [ -n "$openMRList" ]; then
             while IFS= read -r oneItem; do
                 mrNum=$(echo "$oneItem" | cut -f1 | tr -d '!')
-                foundMR=false
-                glab mr diff "${mrNum}" --repo "${UPSTREAM_REPO}" > "${TEMP}"/oneMR.diff 
+                git fetch origin merge-requests/"${mrNum}"/head:mr_"${mrNum}"
 
-                if [[ ! -s "${TEMP}"/lineFile ]]; then
-                    # only seed exists and no replacements  
-                    grep '^[+][^+]' "${TEMP}"/oneMR.diff | sed -E 's/^[+]//' | tee "${TEMP}/mrFile"
+                # compare if the cached content and the content in MR are the same 
+                git diff --cached mr_"${mrNum}" | tee "${TEMP}"/final.diff 
 
-                    # compare if the contents and the updated file names are the same 
-                    if  diff -q "${TEMP}"/mrFile "${targetFile}" > /dev/null; then
-                        grep "^diff --git" "${TEMP}"/oneMR.diff | tee "${TEMP}"/tmpFile
-                        while read -r line ; do
-                            changedFileName=$(echo "$line" | awk '{sub(/^b\//, "", $NF); print $NF}')
-                            if [[ "${changedFileName}" != "${targetFile}" ]]; then
-                                continue
-                            fi
-                            foundMR=true
-                            break
-                        done < "${TEMP}"/tmpFile
-                    fi
-                else
-                    # replacements exist
-                    grep '^[-+@]' "${TEMP}"/oneMR.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/mrFile"
-                    # remove "a/" in  "--- a/dir/file" and "b/" in "+++ b/dir/file" 
-                    grep '^[-+@]' "${TEMP}"/tempMRFile.diff | sed -E 's/^[@]//; s/@@.*//' | \
-                        sed -E 's/^(---|\+\+\+) [ab]\//\1 /' | tee "${TEMP}/tmpFile"
-                    if diff -q "${TEMP}"/mrFile "${TEMP}"/tmpFile > /dev/null; then
-                        foundMR=true
-                    fi
-                fi
-                # if all the lines are matched, the MR is the same one
-                # it should exit 0 if the same MR exists 
-                if [[ "$foundMR" == true ]]; then
-                    echo "there is an existing MR with the same updates in the repo"
+                if [[ ! -s "${TEMP}"/final.diff ]] ; then
+                    echo "There is an existing MR with the same updates in the repo"
                     echo "{\"merge_request\":\"${UPSTREAM_REPO}/-/merge_requests/${mrNum}\"}" \
                         | tee -a "$(results.fileUpdatesInfo.path)" 
                     echo -n "Success" | tee "$(results.fileUpdatesState.path)"
@@ -333,7 +300,6 @@ spec:
                 fi
             done <<< "$openMRList"
         fi
-        echo -e "\n*** END LOCAL CHANGES ***\n"
 
         WORKING_BRANCH=$(uuidgen |awk '{print substr($1, 1, 8)}')
         git_commit_and_push --branch "$WORKING_BRANCH" --message "fileUpdates changes"

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -3,6 +3,13 @@ set -eux
 
 # mocks to be injected into task step scripts
 function git() {
+  if [[ "$*" == "diff --cached mr_"* ]]; then
+    echo -n '' 
+    exit 0
+  elif [[ "$*" == "diff --cached" ]]; then
+    /usr/bin/git "$@"
+    exit 0
+  fi
   echo "git $*"
   if [[ "$*" == *"clone"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
@@ -28,18 +35,15 @@ function git() {
   if [[ "$*" == "config"* ]]; then
     /usr/bin/git "$@"
   fi
-  if [[ "$*" == "diff"* ]]; then
-    /usr/bin/git "$@"
-  fi
 }
 
 function glab() {
   if [[ "$*" == *"mr create"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
-    echo "/merge_request/1"
+    echo "https://some.gitlab/test/one-update.git/-/merge_request/1"
   elif [[ "$*" == *"mr list"* ]]; then
-    if [[ "$*" == *"page 1" ]]; then
-      echo '!1'
+    if [[ "$*" == *"page 1" ]] && [[ "${gitRepo}" == "replace-idempotent" ]]; then
+      	echo '!1'
     else
       echo ''
     fi

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -93,7 +93,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
@@ -92,9 +92,12 @@ spec:
               #!/usr/bin/env bash
               set -eux
   
+              echo "Test that status is Success"
+              test "$(params.fileUpdatesState)" == "Success"
+
               cd "$(params.tempDir)/replace-idempotent"
               commits=$(git log --oneline | wc -l)
-
+              
               echo "Test no more commit created except the one in setup step"
               test "${commits}" == "1"
               rm -rf "$(params.tempDir)"

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -93,7 +93,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -81,7 +81,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)


### PR DESCRIPTION
Use `git add` to stage modified files and compare the staged content with opened MRs
 to check if an MR already exists with the same updates in the repo.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

