### PR TITLE
fix(KONFLUX-6580): error handling in get-image-architectures

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -18,7 +18,7 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ git_sha }}" -> The git sha that triggered the snapshot being processed
 * "{{ git_short_sha }}" -> The git sha reduced to 7 characters
 * "{{ digest_sha }}" -> The image digest of the respective component
-* "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the   
+* "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
   repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
@@ -30,6 +30,11 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | snapshotPath      | Path to the JSON string of the Snapshot spec in the config workspace to apply the mapping to | No       | -             |
 | dataPath          | Path to the JSON string of the merged data to use in the data workspace                      | No       | -             |
 | failOnEmptyResult | Fail the task if the resulting snapshot contains zero components                             | Yes      | false         |
+
+## Changes in 1.9.1
+* Bump the utils image used in this task
+  * The `get-image-architectures` script now uses `set -e` so that it fails
+    if a `skopeo` or `oras` call fails
 
 ## Changes in 1.9.0
 * support defaults for `contentGateway`

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "1.9.0"
+    app.kubernetes.io/version: "1.9.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -31,7 +31,7 @@ spec:
       description: A true/false value depicting whether or not the snapshot was mapped.
   steps:
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -69,7 +69,7 @@ spec:
 
             # Use `skopeo list-tags` to fetch all tags from the repository
             existing_tags=$(skopeo list-tags docker://"${repo}" | jq -r '.Tags[]')
-            
+
             # Remove `{{ incrementer }}` placeholder to get the version prefix for regex pattern
             # shellcheck disable=SC2001
             version_prefix=$(echo "${tag_template}" | sed 's/{{ incrementer }}//g')
@@ -319,7 +319,7 @@ spec:
             componentCGWSettings=$(jq -c '.contentGateway // {}' <<< "$component")
             updatedComponentCGWSettings=$(merge-json "$defaultCGWSettings" "$componentCGWSettings")
             componentCGWSettingsSize=$(jq '. | length' <<< "${updatedComponentCGWSettings}")
-          
+
             if [ "${componentCGWSettingsSize}" -gt "0" ]; then
               jq --argjson i "$i" --argjson componentCGWSettings "$updatedComponentCGWSettings" \
               '.components[$i].contentGateway = $componentCGWSettings' \

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -20,7 +20,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -146,7 +146,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
                 jq -r '.components[] | select(.name=="comp2") | .contentGateway.filePrefix' \
                 < "$(workspaces.config.path)/test_snapshot_spec.json"
               )" == "myapp-comp1-1"
-  
+
               echo Test that comp3 has the correct contentGateway defaults
               test "$(
                 jq -c '.components[] | select(.name=="comp3") | .contentGateway' \

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -24,7 +24,7 @@ spec:
           - name: snapshot
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -22,7 +22,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -23,7 +23,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-apply-mapping-multi-redhat-components
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json containing multiple components 
+    Run the apply-mapping task with a snapshot.spec json containing multiple components
     and Red Hat specific repository formats. Verify that the resulting json contains the expected transformations.
   workspaces:
     - name: tests-workspace
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-multi-component-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -104,7 +104,7 @@ spec:
           - name: config
         steps:
           - name: check-result-multi-component
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -21,7 +21,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -22,7 +22,7 @@ spec:
           - name: snapshot
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-other-formats-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: config
         steps:
           - name: check-result-other-formats
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -20,7 +20,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -111,7 +111,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -20,7 +20,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -124,7 +124,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -19,7 +19,7 @@ spec:
           - name: config
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -102,7 +102,7 @@ spec:
           - name: config
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -19,6 +19,13 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                                                                                                                                                                                                                                                                                                                                     | No       |               |
 
+## Changes in 3.8.1
+* Bump the utils image used in this task
+  * The `get-image-architectures` script now uses `set -e` so that it fails
+    if a `skopeo` or `oras` call fails
+* Modify the task script to make it fail if `get-image-architectures` fails
+  and add a test for that
+
 ## Changes in 3.8.0
 * Bump the utils image used in this task
   * Clair-wrapper is now ready to work with the changes introduced previously and

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/version: "3.8.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -51,7 +51,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       env:
         - name: pyxisCert
           valueFrom:
@@ -154,6 +154,8 @@ spec:
             fi
 
             select-oci-auth "${REPOSITORY}" > "$AUTH_FILE"
+
+            ARCHITECTURES=$(get-image-architectures "${PULLSPEC}")
 
             index=0
             while IFS= read -r ARCH_DETAIL;
@@ -268,6 +270,6 @@ spec:
                       "os": $os}' <<< "$JSON_OUTPUT")
 
                 index=$((index + 1))
-            done <<< "$(get-image-architectures "${PULLSPEC}" | jq -c)"
+            done <<< "$ARCHITECTURES"
         done
         echo "$JSON_OUTPUT" | tee "$(workspaces.data.path)/${PYXIS_DATA_PATH}"

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -50,6 +50,9 @@ function get-image-architectures() {
   if [[ "$*" =~ registry.io/multi-arch-image.?@sha256:mydigest.? ]]; then
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
     echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
+  elif [[ "$1" = registry.io/fail-get-image-architectures@sha256:mydigest ]]; then
+    echo "Simulating get-image-architectures failure" >&2
+    return 1
   else
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
   fi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -77,7 +77,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -2,13 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-fail-no-data-file
+  name: test-create-pyxis-image-fail-get-image-architectures
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-snapshot task with the no data file present in the default filepath of
-    data.json. The task should fail.
+    Run the create-pyxis-image task with a single containerImage in the snapshot.
+    The get-image-architectures script will fail, thus failing the whole task.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -23,35 +23,41 @@ spec:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
-              mkdir "$(workspaces.data.path)/results"
-              cat > "$(workspaces.data.path)/mapped_snapshot.json" << EOF
+              cat > "$(workspaces.data.path)"/mapped_snapshot.json << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp",
-                    "containerImage": "registry.io/image:tag",
-                    "repository": "prod-registry.io/prod-location",
+                    "containerImage": "source@sha256:mydigest",
+                    "repository": "registry.io/fail-get-image-architectures",
                     "tags": [
-                      "tag"
+                      "testtag"
                     ]
                   }
                 ]
               }
               EOF
+
+              cat > "$(workspaces.data.path)/mydata.json" << EOF
+              {
+              }
+              EOF
     - name: run-task
       taskRef:
-        name: push-snapshot
+        name: create-pyxis-image
       params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
         - name: snapshotPath
           value: mapped_snapshot.json
         - name: dataPath
-          value: data.json
-        - name: resultsDirPath
-          value: results
+          value: mydata.json
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/get-ocp-version/README.md
+++ b/tasks/managed/get-ocp-version/README.md
@@ -9,6 +9,11 @@ Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
 | fbcFragment | A FBC container Image | No       | -             |
 
 
+## Changes in 0.5.2
+* Bump the utils image used in this task
+  * The `get-image-architectures` script now uses `set -e` so that it fails
+    if a `skopeo` or `oras` call fails
+
 ## Changes in 0.5.1
 * Task updated to handle multi-arch fbc fragments
 
@@ -22,4 +27,4 @@ Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
 * Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead
 
 ## Changes in 0.1
-* update Tekton API to v1 
+* update Tekton API to v1

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-ocp-version
   labels:
-    app.kubernetes.io/version: "0.5.1"
+    app.kubernetes.io/version: "0.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -21,7 +21,7 @@ spec:
       description: Store OCP version number from given Image
   steps:
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -27,7 +27,7 @@ spec:
           - name: stored-version
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -28,7 +28,7 @@ spec:
           - name: stored-version
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/populate-release-notes/README.md
+++ b/tasks/managed/populate-release-notes/README.md
@@ -12,6 +12,11 @@ path to a file containing data used in component SBOM generation.
 | dataPath     | Path to the JSON string of the merged data to update                 | No       | -             |
 | snapshotPath | Path to the JSON string of the mapped Snapshot in the data workspace | No       | -             |
 
+## Changes in 3.0.2
+* Bump the utils image used in this task
+  * The `get-image-architectures` script now uses `set -e` so that it fails
+    if a `skopeo` or `oras` call fails
+
 ## Changes in 3.0.1
 * If type is RHBA or RHEA, the task will ensure the `references` key exists (although it will be empty)
 
@@ -35,10 +40,10 @@ path to a file containing data used in component SBOM generation.
 * Add unique tag info to purl
 
 ## Changes in 2.2.0
-* Updated to use the `rh-registry-repo` key from the snapshot JSON for constructing 
-  the image repository path, instead of relying on the data field. This change 
+* Updated to use the `rh-registry-repo` key from the snapshot JSON for constructing
+  the image repository path, instead of relying on the data field. This change
   ensures that the task correctly references the internal Red Hat registry format.
-* Removed the use of the `translate-delivery-repo` script as the task now directly 
+* Removed the use of the `translate-delivery-repo` script as the task now directly
   accesses the `rh-registry-repo` value from the snapshot JSON.
 
 ## Changes in 2.1.0

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes
   labels:
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,7 +26,7 @@ spec:
       description: The workspace where the data JSON file resides
   steps:
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -142,7 +142,7 @@ spec:
             done
         done
     - name: populate-release-notes-references
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -124,7 +124,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -111,7 +111,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -101,7 +101,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -90,7 +90,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -125,7 +125,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -99,7 +99,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -13,6 +13,11 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
 | caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
 
+## Changes in 6.4.4
+* Bump the utils image used in this task
+  * The `get-image-architectures` script now uses `set -e` so that it fails
+    if a `skopeo` or `oras` call fails
+
 ## Changes in 6.4.3
 * Fix source container image handling by removing platform-specific parameters
 

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.4.3"
+    app.kubernetes.io/version: "6.4.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the snapshot spec and data json files reside
   steps:
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -66,7 +66,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -67,7 +67,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
## Describe your changes

All tasks that use get-image-architecture were updated to get a new version that has `set -e` so that it fails if skopeo or oras fails.

It's better to fail rather than to get a bogus empty value as a result of the script.

Also, modify create-pyxis-image to actually be able to fail if `get-image-architecture` fails and add a test. (It turns out failing something when doing `<<< $(command)` never fails the script, even with `set -e`. The other places that call `get-image-architecture` look ok.)

## Relevant Jira

[KONFLUX-6580](https://issues.redhat.com//browse/KONFLUX-6580)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

