### PR TITLE
feat(RELEASE-1439): add public key to issues in embargo-check task

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -23,6 +23,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 1.11.1
+* Task `embargo-check` is set to run after `check-data-keys` as it will inject the `public` key to each issue,
+  which isn't in the schema
+
 ## Changes in 1.11.0
 * Add new task `close-advisory-issues` to close all issues listed in the releaseNotes after the advisory is published
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/version: "1.11.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -274,6 +274,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
+        - check-data-keys
         - populate-release-notes
     - name: set-advisory-severity
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -5,6 +5,9 @@ by server using curl and checks the CVEs via an InternalRequest. If any issue do
 the task will fail. The task will also fail if a Jira issue listed is for a component that does not exist in the
 releaseNotes.content.images section or if said component does not list the CVE from the issue.
 
+Finally, the task will inject the `public` key to each issue listed for `issues.redhat.com`. This is a boolean value that is set
+based on the issues visibility
+
 ## Parameters
 
 | Name                     | Description                                                                               | Optional | Default value |
@@ -14,6 +17,10 @@ releaseNotes.content.images section or if said component does not list the CVE f
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 1.1.0
+* The task injects the `public` key to each issue for the `issues.redhat.com` server based on if the issue is
+  publicly visible
 
 ## Changes in 1.0.0
 * Authentication is added to checking issues in issues.redhat.com

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -99,14 +99,31 @@ spec:
             fi
             set -x
 
-            # Perform additional checks only for Vulnerability issues for issues.redhat.com
+            # Perform additional checks only for issues on issues.redhat.com
             if [ "$server" != "issues.redhat.com" ] ; then
                 continue
             fi
+
+            # Public should be true if and only if the security field doesn't exist and the issue is accessible
+            # without authentication
+            public=false
+
+            if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
+                if curl -o /dev/null --retry 3 --fail "${API_URL}" ; then
+                    public=true
+                fi
+            fi
+
+            # Inject public key
+            jq --argjson i "$i" --argjson public $public '.releaseNotes.issues.fixed[$i].public = $public' \
+                "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+
+            # Perform cve specific checks only if the type is Vulnerability
             ISSUE_TYPE=$(jq -r '.fields.issuetype.name' <<< "$OUTPUT")
             if [ "$ISSUE_TYPE" != "Vulnerability" ] ; then
                 continue
             fi
+
             CVE_ID=$(jq -r --arg field "$CVE_FIELD" '.fields[$field]' <<< "$OUTPUT")
             COMPONENT_NAME=$(jq -r --arg field "$COMPONENT_FIELD" '.fields[$field]' <<< "$OUTPUT")
             if ! COMPONENT_IN_RELEASE_NOTES="$(jq -ec --arg name "$COMPONENT_NAME" \

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -x
 
 # mocks to be injected into task step scripts
 function curl() {
@@ -20,10 +20,23 @@ function curl() {
     exit 1
   elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
   then
-    echo '{"fields":{"issuetype":{"name":"Feature"}}}'
+    echo '{"fields":{"issuetype":{"name":"Feature"},"security":"a"}}'
   elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/CVE-123" ]] # Vulnerability
   then
-    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123","customfield_12324752":"my-component"}}'
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123","customfield_12324752":"my-component","security":"a"}}'
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
+  then
+    echo '{"fields":{"foo":"bar"}}'
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
+  then
+    if [[ "$*" == *"Authorization: Bearer"* ]] ; then
+      :
+    else
+      return 1
+    fi
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-2" ]] # Private: has security field
+  then
+    echo '{"fields":{"security":"bar"}}'
   else
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-embargo-check-rh-issue-public-key-added
+spec:
+  description: |
+    Test for embargo-check with 4 issues. One is not from issues.redhat.com so should have no
+    public key added. Two are private and should have the key added with false (one because
+    it has a security field, one because it can only be seen with authenticated curl). The final
+    one is public because it can be seen without authentication. Ensure the public keys are all
+    properly added.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "PUBLIC-1",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "PRIVATE-1",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "PRIVATE-2",
+                        "source": "issues.redhat.com"
+                      },
+                      {
+                        "id": "12345",
+                        "source": "bugzilla.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "packages": []
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: embargo-check
+      params:
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-1") | .public' \
+                "$(workspaces.data.path)/data.json")" == true
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-1") | .public' \
+                "$(workspaces.data.path)/data.json")" == false
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-2") | .public' \
+                "$(workspaces.data.path)/data.json")" == false
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="12345") | has("public")' \
+                "$(workspaces.data.path)/data.json")" == false
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit modifies the embargo-check task to inject a public key for each releaseNotes.issues.fixed to specify whether the issue is publicly visible.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

