### PR TITLE
refactor(RELEASE-1459): use purl to check severity

### DIFF
--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -13,5 +13,10 @@ impact from all of the CVEs is returned as a task result.
 | releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |
 
+## Changes in 0.2.0
+* Instead of comparing `ps_component` with the component name to check for component specific severity, use the
+  `repository` value from the component in the snapshot and compare that with the `repository_url` from the `purl`
+  in OSIDB
+
 ## Changes in 0.1.1
 * Fix bug regarding the jq query that determines the number of images

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -92,7 +92,7 @@ spec:
           sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
           kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
 
-          INCLUDE_FIELDS="cve_id,impact,affects.ps_component,affects.impact"
+          INCLUDE_FIELDS="cve_id,impact,affects.purl,affects.impact"
           ADVISORY_SEVERITY=""
 
           get_higher_severity() { # Return higher sev of the two provided [current highest, new]
@@ -114,11 +114,11 @@ spec:
           NUM_IMAGES=$(jq 'length' <<< "${IMAGES}")
           for ((i = 0; i < NUM_IMAGES; i++)); do
               image=$(jq -c --argjson i "$i" '.[$i]' <<< "${IMAGES}")
-              component=$(jq -r '.component' <<< "$image")
+              repository=$(jq -r '.repository' <<< "$image")
               NUM_CVES=$(jq '.cves.fixed | length' <<< "$image")
               for ((j = 0; j < NUM_CVES; j++)); do
                   cve=$(jq -r --argjson j "$j" '.cves.fixed | to_entries[$j].key' <<< "${image}")
-                  echo "Checking CVE ${cve} for component ${component}"
+                  echo "Checking CVE ${cve} for component with repository ${repository}"
                   # Get token. They are short lived, so get one for before each request
                   TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
                   OUTPUT=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
@@ -126,10 +126,22 @@ spec:
                       | jq '.results[0]')
                   IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
                   # If there is a component specific impact, use that instead
-                  if PS_COMP=$(jq -e --arg comp "$component" '.affects[] | select(.ps_component==$comp)' <<< "$OUTPUT")
-                  then
-                      IMPACT=$(jq -r --arg default "$IMPACT" '.impact // $default' <<< "$PS_COMP")
-                  fi
+                  # To check if it is the same component, we use the repository value and match it with the
+                  # repository_url field in the purl from OSIDB. Thus, we have to check each entry as
+                  # repository_url is not its own field
+                  NUM_AFFECTED_COMPONENTS=$(jq '.affects | length' <<< "$OUTPUT")
+                  for ((k = 0; k < NUM_AFFECTED_COMPONENTS; k++)); do
+                      AFFECTED_COMPONENT=$(jq --argjson k "$k" '.affects[$k]' <<< "$OUTPUT")
+                      PURL=$(jq -r '.purl // ""' <<< "$AFFECTED_COMPONENT")
+                      # .purl can be empty, so we direct stderr and just have it return empty string if purl was empty
+                      AFFECTED_REPOSITORY=$(python3 -c "from packageurl import PackageURL; \
+                        print(PackageURL.from_string('$PURL').to_dict()['qualifiers']['repository_url'])" \
+                        2> /dev/null || true)
+                      if [ "$AFFECTED_REPOSITORY" == "$repository" ] ; then
+                          IMPACT=$(jq -r --arg default "$IMPACT" '.impact // $default' <<< "$AFFECTED_COMPONENT")
+                          break
+                      fi
+                  done
                   ADVISORY_SEVERITY=$(get_higher_severity "$ADVISORY_SEVERITY" "$IMPACT")
               done
           done

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -15,10 +15,10 @@ function curl() {
     echo '{"access": "dummy-token"}'
   elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-critical"* ]]
   then
-    echo '{"results": [{"impact":"CRITICAL","affects":[{"ps_component":"component","impact":""}]}]}'
+    echo '{"results": [{"impact":"CRITICAL","affects":[{"purl":"pkg:oci/kubernetes?repository_url=component&a=b","impact":""}]}]}'
   elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-moderate"* ]]
   then
-    echo '{"results": [{"impact":"MODERATE","affects":[{"ps_component":"component","impact":"IMPORTANT"},{"ps_component":"foo","impact":"LOW"}]}]}'
+    echo '{"results": [{"impact":"MODERATE","affects":[{"purl":"pkg:oci/kubernetes?repository_url=foo&a=b","impact":"LOW"},{"purl":"pkg:oci/kubernetes?repository_url=component&a=b","impact":"IMPORTANT"},{"purl":"","impact":"LOW"}]}]}'
   else
     echo Error: Unexpected call
     exit 1

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -13,7 +13,7 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"component":"component","cves":{"fixed":{"CVE-moderate":{"components":[]}}}}]'
+          value: '[{"repository":"component","cves":{"fixed":{"CVE-moderate":{"components":[]}}}}]'
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -13,7 +13,7 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"component":"component","cves":{}}]'
+          value: '[{"repository":"component","cves":{}}]'
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -13,7 +13,7 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"component":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}},{"component":"bar","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
+          value: '[{"repository":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}},{"repository":"bar","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result


### PR DESCRIPTION
This commit updates the get-advisory-severity internal task to compare the repository values from the purl to check for component specific impacts instead of using component names, as those can be arbitrary.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

