### PR TITLE
feat(RELEASE-1366): parallel processing of push snapshot task

### DIFF
--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -9,9 +9,14 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | snapshotPath         | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -             |
 | dataPath             | Path to the JSON string of the merged data to use in the data workspace   | No       | -             |
 | resultsDirPath       | Path to results directory in the data workspace                           | No       | -             |
+| concurrentLimit      | The maximum number of images to be proccessed concurrently                | Yes      | 10            |
 | retries              | Retry copy N times                                                        | Yes      | 0             |
 | caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
 | caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
+
+## Change in 6.6.0
+* Add support for `push_images` to be proccessed in parallel
+  * A new parameter `concurrentLimit` was added to specify the maximum number of `push_images` to be processed at once.
 
 ## Changes in 6.5.0
 * Bump the utils image used in this task

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.5.0"
+    app.kubernetes.io/version: "6.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -21,6 +21,10 @@ spec:
     - name: resultsDirPath
       description: Path to the results directory in the data workspace
       type: string
+    - name: concurrentLimit
+      description: The maximum number of images to be proccessed concurrently
+      type: string
+      default: "10"
     - name: retries
       description: Retry copy N times.
       type: string
@@ -91,8 +95,7 @@ spec:
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
               "$2" "$3"
           fi
-          RESULTS_JSON=$(jq --arg name "$2" --arg url "$4:$5" '.images |= map(select(.name==$name).urls +=
-            [$url])' <<< "$RESULTS_JSON")
+          jq -n --arg name "$2" --arg url "$4:$5" '{name: $name, url: $url}' > "$TMP_RESULTS_DIR/$2-$5.json"
         }
 
         SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
@@ -117,6 +120,21 @@ spec:
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/push-snapshot-results.json"
         RESULTS_JSON="{\"images\":[]}"
         SOURCE_AUTH_FILE=$(mktemp)
+
+        RUNNING_JOBS="\j" # A Bash param for number of jobs running
+        CONCURRENT_LIMIT=$(params.concurrentLimit)
+        REQUEST_COUNT=0
+        SUCCESS=true
+
+        # Wait for a slot to open up in the concurrent limit
+        wait_for_slot () {
+          while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
+            wait -n || SUCCESS=false
+          done
+        }
+
+        # Create a temporary directory to store the results of each push
+        TMP_RESULTS_DIR=$(mktemp -d)
 
         defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' "$DATA_FILE")
 
@@ -183,24 +201,55 @@ spec:
             fi
             # Push the source image with the source tag here. The source image will be
             # pushed with the provided tags below in the loop
+            wait_for_slot
             push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
-              "${repository}" "${source_tag}" ""
+              "${repository}" "${source_tag}" "" > "$TMP_RESULTS_DIR/${name}-${source_tag}.out" 2>&1 &
+            ((++REQUEST_COUNT))
+            echo "Request Count: $REQUEST_COUNT"
           fi
 
           for tag in $(jq -r '.[]' <<< "$imageTags") ; do
+            wait_for_slot
             # Push the container image
             push_image "${origin_digest}" "${name}" "${containerImage}" "${repository}" "${tag}" \
-            "$platform"
+            "$platform" > "$TMP_RESULTS_DIR/${name}-${tag}.out" 2>&1 &
+            ((++REQUEST_COUNT))
+            echo "Request Count: $REQUEST_COUNT"
 
             # This variable will only exist if the above logic determined the source container should
             # be pushed for this component
             if [ -n "${source_container_digest-}" ] ; then
+              wait_for_slot
               push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
-                "${repository}" "${tag}-source" ""
+                "${repository}" "${tag}-source" "" > "$TMP_RESULTS_DIR/${name}-${tag}-source.out" 2>&1 &
+              ((++REQUEST_COUNT))
+              echo "Request Count: $REQUEST_COUNT"
             fi
           done
         done
-        echo -n "${RESULTS_JSON}" | tee "$RESULTS_FILE"
+
+        echo "Waiting for all jobs to complete...."
+        while (( ${RUNNING_JOBS@P} > 0 )); do
+          wait -n || SUCCESS=false 
+        done
+
+        echo "Printing outputs for each push image"
+        for file in "$TMP_RESULTS_DIR"/*.out; do
+          echo "=== $(basename "${file}" .out) ==="
+          cat "$file"
+          echo
+        done
+
+        if [ "$SUCCESS" != true ]; then
+            echo "One or more jobs failed. Please check the logs above for details."
+            exit 1
+        fi
+
+        PUSHES=$(jq -s . "$TMP_RESULTS_DIR"/*.json)
+        jq --argjson PUSHES "$PUSHES" '
+          reduce $PUSHES[] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
+        ' <<< "$RESULTS_JSON" | tee "$RESULTS_FILE"
+        
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
       volumeMounts:
         - name: trusted-ca

--- a/tasks/managed/push-snapshot/tests/mocks.sh
+++ b/tasks/managed/push-snapshot/tests/mocks.sh
@@ -7,6 +7,25 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> "$(workspaces.data.path)"/mock_cosign.txt
 
+  if [[ "$*" == "copy -f registry.io/parallel-image:tag"*" "*":"* ]]
+  then 
+    LOCk_FILE="$(workspaces.data.path)/${RANDOM}.lock"
+    touch $LOCk_FILE
+    sleep 1
+    LOCK_FILE_COUNT=$(ls $(workspaces.data.path)/*.lock | wc -l)
+    # Create a .count file to log the number of parallel cosign calls currently running.
+    echo $LOCK_FILE_COUNT > $(workspaces.data.path)/${RANDOM}.count
+    sleep 1
+    rm $LOCk_FILE
+  fi
+
+  # mock cosign failing for the no-permission test 
+  if [[ "$*" == "copy -f registry.io/no-permmission:tag "*":"* ]]
+  then
+    echo Invalid credentials for registry.io/no-permmission:tag
+    return 1
+  fi
+
   # mock cosign failing the first 3x for the retry test
   if [[ "$*" == "copy -f registry.io/retry-image:tag "*":"* ]]
   then

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-fail-no-credentials
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot task and check that it fails when trying to access a container
+    image without credentials while continuing to push the remaining images.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repository": "prod-registry.io/prod-location1",
+                    "tags": [
+                      "tag1-12345",
+                      "tag2-zyxw"
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/no-permmission:tag",
+                    "repository": "prod-registry.io/prod-location2",
+                    "tags": [
+                      "latest"
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repository": "prod-registry.io/prod-location3",
+                    "tags": [
+                      "some-cool-tag"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: concurrentLimit
+          value: "1"
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: results
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-parallel
+spec:
+  description: |
+    Run the push-snapshot task with various components and tags with multiple images proccessed in parallel.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/parallel-image:tag1",
+                    "repository": "prod-registry.io/prod-location1",
+                    "tags": [
+                      "tag1-12345",
+                      "tag2-zyxw"
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/parallel-image:tag2",
+                    "repository": "prod-registry.io/prod-location2",
+                    "tags": [
+                      "some-cool-tag"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: concurrentLimit
+          value: "5"
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: results
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter: 
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Validate mock call counts first
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_cosign.txt")" != 5 ]; then
+                echo Error: cosign was expected to be called 5 times.
+                cat "$(workspaces.data.path)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times.
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_oras.txt")" != 8 ]; then
+                echo Error: oras was expected to be called 8 times.
+                cat "$(workspaces.data.path)/mock_oras.txt"
+                exit 1
+              fi
+
+              if ! grep -q '5' "$(workspaces.data.path)"/*.count; then
+                echo "Error: Expected to see 5 parallel runs of push_image at some point."
+                echo "Actual counts:"
+                cat "$(workspaces.data.path)"/*.count
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -94,13 +94,19 @@ spec:
                prod-registry.io/prod-location:testtag-source
               EOF
 
-              if [ "$(md5sum < "$(workspaces.data.path)"/cosign_expected_calls.txt)" \
-                != "$(md5sum < "$(workspaces.data.path)/mock_cosign.txt")" ]; then
+              # Sort to ignore the cosign call orders as it differs from parallel execution.
+              sort "$(workspaces.data.path)"/cosign_expected_calls.txt > \
+              "$(workspaces.data.path)"/cosign_expected_calls_sorted.txt
+              sort "$(workspaces.data.path)/mock_cosign.txt" > \
+              "$(workspaces.data.path)"/mock_cosign_sorted.txt
+
+              if [ "$(md5sum < "$(workspaces.data.path)"/cosign_expected_calls_sorted.txt)" \
+                != "$(md5sum < "$(workspaces.data.path)/mock_cosign_sorted.txt")" ]; then
                 echo "Error: Expected cosign calls do not match actual calls"
                 echo Actual calls:
-                cat "$(workspaces.data.path)/mock_cosign.txt"
+                cat "$(workspaces.data.path)/mock_cosign_sorted.txt"
                 echo Expected calls:
-                cat "$(workspaces.data.path)"/cosign_expected_calls.txt
+                cat "$(workspaces.data.path)"/cosign_expected_calls_sorted.txt
                 exit 1
               fi
 

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -96,13 +96,19 @@ spec:
                prod-registry.io/prod-location:testtag-source
               EOF
 
-              if [ "$(md5sum < "$(workspaces.data.path)"/cosign_expected_calls.txt)" \
-                != "$(md5sum < "$(workspaces.data.path)/mock_cosign.txt")" ]; then
+              # Sort to ignore the cosign call orders as it differs from parallel execution.
+              sort "$(workspaces.data.path)"/cosign_expected_calls.txt > \
+              "$(workspaces.data.path)"/cosign_expected_calls_sorted.txt
+              sort "$(workspaces.data.path)"/mock_cosign.txt > \
+              "$(workspaces.data.path)"/mock_cosign_sorted.txt
+
+              if [ "$(md5sum < "$(workspaces.data.path)"/cosign_expected_calls_sorted.txt)" \
+                != "$(md5sum < "$(workspaces.data.path)/mock_cosign_sorted.txt")" ]; then
                 echo "Error: Expected cosign calls do not match actual calls"
                 echo Actual calls:
-                cat "$(workspaces.data.path)/mock_cosign.txt"
+                cat "$(workspaces.data.path)/mock_cosign_sort.txt"
                 echo Expected calls:
-                cat "$(workspaces.data.path)"/cosign_expected_calls.txt
+                cat "$(workspaces.data.path)"/cosign_expected_calls_sort.txt
                 exit 1
               fi
 


### PR DESCRIPTION
## Describe your changes
This improves pushSnapshot performance by running the push_images task in parallel. Each push_image now writes its
result to a temporary JSON file. Once all Cosign copies are finished, those files are merged into a single JSON file.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

