### PR TITLE
chore(KFLUXVNGD-171): add task to update and push trusted tasks

### DIFF
--- a/tasks/managed/update-trusted-tasks/README.md
+++ b/tasks/managed/update-trusted-tasks/README.md
@@ -1,0 +1,12 @@
+# update-trusted-tasks
+Tekton task to update trusted-tasks list OCI artifact.
+Once a task is released as a bundle, the list of trusted-tasks should be 
+updated with the new task.
+The OCI artifact containing the trusted-tasks list is named `acceptable-data-bundles` and should reside in the same org in the registry.
+If it is already in place, it will be used as an input to which the results will be appended, else a new artifact will be created.
+
+## Parameters
+
+| Name       | Description                                                             | Optional | Default value |
+|------------|-------------------------------------------------------------------------|----------|---------------|
+| snapshotPath   | Path to the JSON string of the Snapshot spec in the data workspace | No       | -             |

--- a/tasks/managed/update-trusted-tasks/tests/mocks.sh
+++ b/tasks/managed/update-trusted-tasks/tests/mocks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function skopeo() {
+  echo Mock skopeo called with: $* >&2
+  echo $* >> $(workspaces.data.path)/mock_skopeo.txt
+
+  if [[ "$*" =~ list-tags\ docker://quay.io/exists ]]; then
+      echo '{"Tags": ["v2.0.0-3", "latest", "v2.0.0-2"]}'
+      return
+  elif [[ "$*" =~ list-tags\ docker://quay.io ]]; then
+      echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
+      return
+  fi
+
+  echo Error: Unexpected call
+  exit 1
+}
+
+function ec() {
+  echo Mock ec called with: $* >&2
+  echo $* >> $(workspaces.data.path)/mock_ec.txt
+
+  if [[ "$*" =~ "track bundle".*fail-image.* ]]; then
+      exit 1
+  
+  elif [[ "$*" =~ "track bundle".* ]]; then
+      return
+  fi
+  
+  echo Error: Unexpected call
+  exit 1
+}
+

--- a/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TASK_PATH=$1
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $TASK_PATH

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-fail-ec
+  annotations:
+    test/assert-task-failure: "run-task"  
+spec:
+  description: |
+    Run the update-trusted-tasks task and fail the ec command
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat >"$(workspaces.data.path)/snapshot.json" << EOF
+              {
+                "application": "tasks",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/example/echo-v01@sha256:abcde",
+                    "name": "echo-v01",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.1",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/fail-image/task-echo",
+                    "tags": [
+                      "0.1"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |  
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_ec.txt")" != 1 ]; then
+                echo Error: ec was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-fail-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-trusted-tasks task wthout snapshot spec.
+    The task should fail
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+  
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+  finally:
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              # Expect skopeo and ec not to be called
+              if [ -f "$(workspaces.data.path)/mock_skopeo.txt" ] ; then
+                echo Error: skopeo was expected not to be called. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ -f "$(workspaces.data.path)/mock_ec.txt" ] ; then
+                echo Error: skopeo was expected not to be called. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-success-latest
+spec:
+  description: |
+    Run the update-trusted-tasks task, the ACCEPTABLE_BUNDLES has
+    `latest` tag
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot.json" << EOF
+              {
+                "application": "tasks",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/example/echo-v01@sha256:abcde",
+                    "name": "echo-v01",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.1",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/exists/task-echo",
+                    "tags": [
+                      "0.1"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_ec.txt")" != 1 ]; then
+                echo Error: ec was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi
+
+              if ! grep -q -- '--input' "$(workspaces.data.path)/mock_ec.txt"; then
+                echo "Error: The ec command should contain --input option"
+                exit 1
+              fi
+
+      runAfter:
+        - run-task

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-success-several-components
+spec:
+  description: |
+    Run the update-trusted-tasks task with several components
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot.json" << EOF
+              {
+                "application": "tasks",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/example/echo-v01@sha256:abcde",
+                    "name": "echo-v01",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.1",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/notexist/task-echo-v01",
+                    "tags": [
+                      "0.1"
+                    ]
+                  },
+                  {
+                    "containerImage": "quay.io/example/echo-v02@sha256:abcde",
+                    "name": "echo-v02",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.2",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/exists/task-echo-v02",
+                    "tags": [
+                      "0.2"
+                    ]
+                  },
+                  {
+                    "containerImage": "quay.io/example/echo-v03@sha256:abcde",
+                    "name": "echo-v03",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.3",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/exists/task-echo",
+                    "tags": [
+                      "0.3"
+                    ]
+                  }                                    
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 3 ]; then
+                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_ec.txt")" != 3 ]; then
+                echo Error: ec was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi
+
+      runAfter:
+        - run-task

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-success-multiple-tags
+spec:
+  description: |
+    Run the update-trusted-tasks task with multiple tags
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot.json" << EOF
+              {
+                "application": "tasks",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/example/echo-v01@sha256:abcde",
+                    "name": "echo-v01",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.1",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/notexist/task-echo",
+                    "tags": [
+                      "0.1",
+                      "test",
+                      "stage"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 3 ]; then
+                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_ec.txt")" != 3 ]; then
+                echo Error: ec was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi
+
+      runAfter:
+        - run-task

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-trusted-tasks-success-no-latest
+spec:
+  description: |
+    Run the update-trusted-tasks task, the ACCEPTABLE_BUNDLES has
+    no `latest` tag
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot.json" << EOF
+              {
+                "application": "tasks",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/example/echo-v01@sha256:abcde",
+                    "name": "echo-v01",
+                    "source": {
+                      "git": {
+                        "context": "task/echo/0.1",
+                        "revision": "abcde",
+                        "url": "https://example.com"
+                      }
+                    },
+                    "repository": "quay.io/notexist/task-echo",
+                    "tags": [
+                      "0.1"
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+    - name: run-task
+      taskRef:
+        name: update-trusted-tasks
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                cat "$(workspaces.data.path)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(workspaces.data.path)/mock_ec.txt")" != 1 ]; then
+                echo Error: ec was expected to be called 1 time. Actual calls:
+                cat "$(workspaces.data.path)/mock_ec.txt"
+                exit 1
+              fi
+
+              if grep -q -- '--input' "$(workspaces.data.path)/mock_ec.txt"; then
+                echo "Error: The ec command should not contain --input option"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-trusted-tasks
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to update trusted-tasks list bundles.
+    Once a task is released as a bundle, the list of trusted-tasks should be 
+    updated with the new task.
+    If an OCI artifact named data-acceptable-bundles is already in place we will use
+    it as an input and append it, else we will create a new artifact
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot json reside
+  steps:
+    - name: update-trusted-tasks
+      image: quay.io/konflux-ci/appstudio-utils@sha256:0901e46d9a41d0c564b0efab092f37cd187bd8b4ff2455ec84539ceb8b08f3ea
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+        
+        SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        TAG="latest"
+
+        # check if snapshot exsits
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "No valid snapshot file was found."
+            exit 1
+        fi
+
+        # Extract the application from the snapshot
+        application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
+
+        # Get the number of components
+        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
+
+        printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
+        for ((i = 0; i < NUM_COMPONENTS; i++))
+        do
+            # extract the component from the snapshot 
+            component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
+
+            # Extract the repository from the snapshot
+            repository=$(jq -r '.repository' <<< "$component")
+
+            # The data-acceptable-bundles repo should reside in the same org in the registry.
+            # Fetch the repository and replace the repo with data-acceptable-bundles
+            # for example: quay.io/myorg/myrepo -> quay.io/myorg/data-acceptable-bundles
+            ACCEPTABLE_BUNDLES=$(echo "${repository}" | awk -F'/' '{$NF="data-acceptable-bundles"; print $0}' OFS='/')
+
+            # Extract the image sha
+            sha=$(jq -r '.containerImage' <<< "$component" | awk -F'@' '{print "@" $2}')
+            
+            # Get the number of tags from the component
+            NUM_TAGS=$(jq '.tags | length' <<< "$component")
+
+            # update the tasks list OCI artifact for each tag in the component
+            for ((j = 0; j < NUM_TAGS; j++))
+            do
+                imageTag=$(jq -c -r --argjson j "$j" '.tags[$j]' <<< "$component")
+                
+                set +e
+                # Check if ACCEPTABLE_BUNDLES OCI artifact has a latest tag
+                skopeo list-tags docker://"${ACCEPTABLE_BUNDLES}" | jq -r '.Tags[]' | grep "^${TAG}$" &> /dev/null
+                RESULT=$?
+                set -e
+
+                # If it has a latest tag, use it as an --input for the ec track bundle command
+                if [ $RESULT -eq 0 ]; then
+                    echo "${ACCEPTABLE_BUNDLES}:${TAG} exists - using it as an input"
+                    ec track bundle --bundle "${repository}:${imageTag}${sha}" \
+                    --input oci:"${ACCEPTABLE_BUNDLES}:${TAG}" --output oci:"${ACCEPTABLE_BUNDLES}:${TAG}"
+
+                # Else - Do not use it as an --input
+                else
+                    echo "${ACCEPTABLE_BUNDLES}:${TAG} does not exist"
+                    ec track bundle --bundle "${repository}:${imageTag}@${sha}" \
+                    --output oci:"${ACCEPTABLE_BUNDLES}:${TAG}"
+                fi        
+            done
+        done


### PR DESCRIPTION
Add a step to update and push the list of trusted tasks This task will be a part of a new release pipeline called `push-bundles-to-external-registry` that will release tekton tasks as bundles and will update the list of trusted-tasks


