### PR TITLE
fix: ensure dockerconfig auth contains single entry

### DIFF
--- a/tasks/managed/rh-sign-image-cosign/README.md
+++ b/tasks/managed/rh-sign-image-cosign/README.md
@@ -12,6 +12,9 @@ Tekton task to sign container images in snapshot by cosign.
 | retries                | Retry cosign N times                                                                                                                                                                                                                              | Yes      | 3             |
 | concurrentLimit       | Number of concurrent cosign operations                                                                                                                                                                                                            | Yes      | 5             |
 
+## Changes in 1.4.0
+* fix to ensure that the auth file used by cosign contains credentials for the registry
+
 ## Changes in 1.3.0
 * Containers are signed only if the signature doesn't exist in the destination image
 * Existing signature validation and signing are done in parallel now controlled by concurrencyLimit paremeter

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image-cosign
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -143,6 +143,13 @@ spec:
           local identity=$1
           local reference=$2
           local digest=$3
+
+          # cosign has very limited support for selecting the right auth entry,
+          # so create a custom auth file with just one entry.
+          DOCKER_CONFIG="$(mktemp -d)"
+          export DOCKER_CONFIG
+          select-oci-auth "${reference}" > "${DOCKER_CONFIG}/config.json"
+
           declare -a COSIGN_REKOR_ARGS=()
           found_signatures=$(check_existing_signatures "$identity" "$reference@$digest" "$digest")
           if [ -z "$found_signatures" ]; then

--- a/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
@@ -137,7 +137,15 @@ function skopeo() {
   fi
 }
 function mktemp() {
-  echo "temp_key_file"
+  if [[ "${1:-}" == "-d" ]]; then
+    /usr/bin/mktemp -d
+  else
+    echo "temp_key_file"
+  fi
+}
+
+function select-oci-auth() {
+    echo "mock select-oci-auth called with: $*"
 }
 
 function cosign () {


### PR DESCRIPTION
## Describe your changes
- many tasks within the catalog use `select-oci-auth.sh` to ensure that
  the docker config that skopeo, oras and cosign use are focused on the
  repos involved.
- we now use `select-oci-auth.sh` to prepare the dockerconfig.json file.

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

