### PR TITLE
fix(KONFLUX-7267): missing tag error in create-pyxis-image task

### DIFF
--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -19,6 +19,12 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | snapshotPath | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                                                                                                                                                                                                                                                                                                   | No       | -             |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace                                                                                                                                                                                                                                                                                                                                     | No       |               |
 
+## Changes in 3.8.3
+* Bump the utils image used in this task
+  * Fix an error if there are no tags for a repository in an existing
+    ContainerImage object in Pyxis
+    * The previous fix didn't work
+
 ## Changes in 3.8.2
 * Bump the utils image used in this task
   * Fix an error if there are no tags for a repository in an existing

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "3.8.2"
+    app.kubernetes.io/version: "3.8.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -51,7 +51,7 @@ spec:
       description: The relative path in the workspace to the stored pyxis data json
   steps:
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+      image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -77,7 +77,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -92,7 +92,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -73,7 +73,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-skip-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -76,7 +76,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:646972c31f6e17628a4d7095ba39479af4f567f4
+            image: quay.io/konflux-ci/release-service-utils:6754cca2bad25bbe13377919b3ea805f5d27d195
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Bump the image to include a fix for when an existing ContainerImage object in Pyxis has no tags in a repository field and we would fail on key error.

The previous fix for this did not work.

Related utils PR: https://github.com/konflux-ci/release-service-utils/pull/398

## Relevant Jira

[KONFLUX-7267](https://issues.redhat.com//browse/KONFLUX-7267)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

