### PR TITLE
feat(RELEASE-1298): removal of RN.content.images.cves from schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -254,27 +254,6 @@
                   "purl": {
                     "type": "string",
                     "description": "The package URL representing the image e.g. pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
-                  },
-                  "cves": {
-                    "type": "object",
-                    "properties": {
-                      "fixed": {
-                        "type": "object",
-                        "description": "A list of fixed CVEs",
-                        "additionalProperties": {
-                          "type": "object",
-                          "properties": {
-                            "packages": {
-                              "type": "array",
-                              "description": "A list of packages that fixed the CVE e.g. [ 'pkg:golang/golang.org/x/net/http2@1.11.1' ]",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
                   }
                 }
               }


### PR DESCRIPTION
## Describe your changes
This update removes `releaseNotes.content.images.cves`.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

