### PR TITLE
feat(RELEASE-1298):  adds a test for disallowing of cves in `RN.content`

### DIFF
--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-cves-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-cves-key.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-fail-invalid-releasenotes-cves-key
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the check-data-keys task with with cves being placed in releaseNotes.content.images.cves 
+    instead of releaseNotes.cves and verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "product_name": "Red Hat Openstack Product",
+                  "product_id": [123],
+                  "product_version": "1.2.3",
+                  "product_stream": "rhtas-tp1",
+                  "cpe": [
+                    "cpe:/a:example:openstack:el8"
+                  ],
+                  "type": "RHSA",
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "this should be an array"
+                  ],
+                  "content": {
+                    "images": [
+                      {
+                        "containerImage": "quay.io/example/openstack@sha256:abcde",
+                        "repository": "rhosp16-rhel8/openstack",
+                        "tags": [
+                          "latest"
+                        ],
+                        "architecture": "amd64",
+                        "signingKey": "abcde",
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
+                      }
+                    ],
+                    "cves": {
+                      "fixed": {
+                        "CVE-2022-1234": {
+                          "components": [
+                            "pkg:golang/golang.org/x/net/http2@1.11.1"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: "data.json"
+        - name: systems
+          value:
+            - releaseNotes
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup


### PR DESCRIPTION
## Describe your changes
Add a test in check-data-keys to verify that a "cves" property is not allowed under releaseNotes.content.images.cves. The test ensures that any CVE content provided within releaseNotes.content.cves trigger a validation failure.

This update complements:
https://github.com/konflux-ci/release-service-catalog/pull/853.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

