### PR TITLE
revert: change cpe back to string only

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -136,12 +136,8 @@
           "description": "The product stream e.g. RHEL-tp1"
         },
         "cpe": {
-          "type": ["array", "string"],
-          "minItems": 1,
-          "description": "The list of product CPE IDs e.g. [\"cpe:/a:example:openstack:el8\"]",
-          "items": {
-            "type": "string"
-          }
+          "type": "string",
+          "description": "The product CPE ID e.g. cpe:/a:example:openstack:el8"
         },
         "type": {
           "type": "string",


### PR DESCRIPTION
After further discussion, cpe won't be moving to a list. We still need to decide how to do it, but it seems that cpe will eventually move to per item in content.images. Either way, it won't be a list at the top level like we have it now.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

