### PR TITLE
feat(RELEASE-1461): handle jira rate limiting via curl-with-retry

### DIFF
--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -12,3 +12,7 @@ Issues in other servers will be skipped without the task failing.
 |-------------|-------------------------------------------------------------------------------------------|----------|---------------|
 | dataPath    | Path to data JSON in the data workspace                                                   | No       | -             |
 | advisoryUrl | The url of the advisory the issues were fixed in. This is added in a comment on the issue | No       | -             |
+
+## Changes in 0.1.1
+* Deal with Jira API rate limiting using a new `curl-with-retry` script from utils image
+  * Bump the utils image to a version containing the new script

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: close-advisory-issues
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,7 +25,7 @@ spec:
       description: The workspace where the snapshot spec json file resides
   steps:
     - name: close-issues
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       env:
         - name: ACCESS_TOKEN
           valueFrom:
@@ -74,20 +74,19 @@ spec:
             CURL_ARGS=(
               -H "Authorization: Bearer $ACCESS_TOKEN"
               --retry 3
-              --fail
             )
 
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$ISSUE_TRACKERS")
             API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
 
-            if [ "$(curl "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')" == "Closed" ] ; then
+            if [ "$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')" == "Closed" ] ; then
                 echo "Issue $issue is already in Closed state. Skipping it."
                 continue
             fi
 
             echo "Closing issue $issue"
             # Get the Closed transition id. This varies per Jira project
-            if ! CLOSED_ID="$(curl "${CURL_ARGS[@]}" "${API_URL}/transitions" \
+            if ! CLOSED_ID="$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}/transitions" \
               | jq -r '.transitions[] | select(.name=="Closed") | .id')"; then
                 echo "Error: failed to fetch the closed state id for issue $issue."
                 RC=1
@@ -96,7 +95,7 @@ spec:
 
             # Close the issue
             CLOSE_COMMENT="Fixed in Konflux Advisory $(params.advisoryUrl)"
-            if ! curl "${CURL_ARGS[@]}" -XPOST --data \
+            if ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
               '{"transition":{"id":"'"$CLOSED_ID"'"},"update":{"comment":[{"add":{"body":"'"$CLOSE_COMMENT"'"}}]}}' \
               -H "Content-Type: application/json" "${API_URL}/transitions"; then
                 echo "Error: failed to close issue $issue."

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # mocks to be injected into task step scripts
-function curl() {
+function curl-with-retry() {
   echo Mock curl called with: $* >&2
   echo $* >> $(workspaces.data.path)/mock_curl.txt
 

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -60,7 +60,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -18,6 +18,10 @@ based on the issues visibility
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 1.1.1
+* Deal with Jira API rate limiting using a new `curl-with-retry` script from utils image
+  * Bump the utils image to a version containing the new script
+
 ## Changes in 1.1.0
 * The task injects the `public` key to each issue for the `issues.redhat.com` server based on if the issue is
   publicly visible
@@ -38,7 +42,7 @@ based on the issues visibility
 * Updated logic to determine InternalRequest name more reliably
 
 ## Changes in 0.4.1
-* fix linting issues in embargo-check task 
+* fix linting issues in embargo-check task
 
 ## Changes in 0.4.0
 * updated the base image used in this task

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the snapshot spec json file resides
   steps:
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       env:
         - name: ACCESS_TOKEN
           valueFrom:
@@ -91,7 +91,7 @@ spec:
             if [ "$server" = "issues.redhat.com" ] ; then
                 AUTH_ARGS=(-H "Authorization: Bearer $ACCESS_TOKEN")
             fi
-            OUTPUT=$(curl --retry 3 --fail "${AUTH_ARGS[@]}" "${API_URL}")
+            OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
             if [ $? -ne 0 ] ; then
                 echo "Error: ${issue} is not visible. Assuming it is embargoed and stopping pipelineRun execution."
                 RC=1
@@ -109,7 +109,7 @@ spec:
             public=false
 
             if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
-                if curl -o /dev/null --retry 3 --fail "${API_URL}" ; then
+                if curl-with-retry --retry 3 "${API_URL}" > /dev/null; then
                     public=true
                 fi
             fi
@@ -141,12 +141,12 @@ spec:
                 RC=1
                 continue
             fi
-            
+
         done
 
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       script: |
         #!/usr/bin/env bash
 

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -2,17 +2,17 @@
 set -x
 
 # mocks to be injected into task step scripts
-function curl() {
+function curl-with-retry() {
   echo Mock curl called with: $* >&2
   echo $* >> $(workspaces.data.path)/mock_curl.txt
 
-  if [[ "$*" == "--retry 3 --fail https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
+  if [[ "$*" == "--retry 3 https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
   then
     :
-  elif [[ "$*" == "--retry 3 --fail https://bugzilla.redhat.com/rest/bug/12345" ]]
+  elif [[ "$*" == "--retry 3 https://bugzilla.redhat.com/rest/bug/12345" ]]
   then
     :
-  elif [[ "$*" == "--retry 3 --fail https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
+  elif [[ "$*" == "--retry 3 https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
   then
     exit 1
   elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/MISSINGRH-123" ]]

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -64,7 +64,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -64,7 +64,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -93,7 +93,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
@@ -22,7 +22,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Update close-advisory-issues and embargo-check tasks to use a new curl-with-retry script in place of curl
to retry in case of Jira api rate limiting.

Depends on https://github.com/konflux-ci/release-service-utils/pull/407

## Relevant Jira

[RELEASE-1461](https://issues.redhat.com//browse/RELEASE-1461)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

