### PR TITLE
fix: improve logging in get-advisory-severity

### DIFF
--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -13,6 +13,9 @@ impact from all of the CVEs is returned as a task result.
 | releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |
 
+## Changes in 0.2.1
+* Improve logging by enabling `set -x`
+
 ## Changes in 0.2.0
 * Instead of comparing `ps_component` with the component name to check for component specific severity, use the
   `repository` value from the component in the snapshot and compare that with the `repository_url` from the `purl`

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -53,7 +53,7 @@ spec:
           value: $(params.releaseNotesImages)
       script: |
           #!/usr/bin/env bash
-          set -eo pipefail
+          set -exo pipefail
 
           STDERR_FILE=/tmp/stderr.txt
           echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
@@ -82,7 +82,9 @@ spec:
           echo -n "" > "$(results.severity.path)"
 
           # write keytab to file
+          set +x
           echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
+          set -x
           # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
           KRB5CCNAME=$(mktemp)
           export KRB5CCNAME
@@ -120,10 +122,15 @@ spec:
                   cve=$(jq -r --argjson j "$j" '.cves.fixed | to_entries[$j].key' <<< "${image}")
                   echo "Checking CVE ${cve} for component with repository ${repository}"
                   # Get token. They are short lived, so get one for before each request
+                  set +x
                   TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
+                  CURL_URL="${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}"
+                  echo "Calling OSIDB API: ${CURL_URL}"
                   OUTPUT=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
-                      "${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}" \
+                      "$CURL_URL" \
                       | jq '.results[0]')
+                  set -x
+                  echo "OSIDB API response: ${OUTPUT}"
                   IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
                   # If there is a component specific impact, use that instead
                   # To check if it is the same component, we use the repository value and match it with the

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eux
+set -exo pipefail
 
 # mocks to be injected into task step scripts
 


### PR DESCRIPTION
## Describe your changes

Enable `set -x` to improve logging.

This recently came up in #konflux-users: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743514449792499

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

