### PR TITLE
fix(RELEASE-1512): disable checking of component name in embargo-check

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -18,6 +18,10 @@ based on the issues visibility
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 1.1.2
+* Disable checking of Downstream Component Name Jira field for CVEs while we figure out
+  the right way of doing this
+
 ## Changes in 1.1.1
 * Deal with Jira API rate limiting using a new `curl-with-retry` script from utils image
   * Bump the utils image to a version containing the new script

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -72,8 +72,10 @@ spec:
 
         # It is expected for the custom field ids to remain stable, but to get them, you can do:
         # curl -H "Authorization: Bearer $ACCESS_TOKEN" https://issues.redhat.com/rest/api/2/field
-        CVE_FIELD="customfield_12324749"
-        COMPONENT_FIELD="customfield_12324752"
+        # Disable the Jira CVE checks temporarily while we figure out what's the proper way of doing this
+        # See https://issues.redhat.com/browse/RELEASE-1512
+        # CVE_FIELD="customfield_12324749"
+        # COMPONENT_FIELD="customfield_12324752"
 
         RC=0
 
@@ -124,23 +126,26 @@ spec:
                 continue
             fi
 
-            CVE_ID=$(jq -r --arg field "$CVE_FIELD" '.fields[$field]' <<< "$OUTPUT")
-            COMPONENT_NAME=$(jq -r --arg field "$COMPONENT_FIELD" '.fields[$field]' <<< "$OUTPUT")
-            if ! COMPONENT_IN_RELEASE_NOTES="$(jq -ec --arg name "$COMPONENT_NAME" \
-              '.releaseNotes.content.images[] | select(.component==$name)' "$DATA_FILE")"; then
-                echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME but that component does"
-                echo " not appear in releaseNotes.content.images. Failing"
-                RC=1
-                continue
-            fi
+            # Disable the two checks below temporarily while we figure out what's the proper way of doing this
+            # See https://issues.redhat.com/browse/RELEASE-1512
 
-            if [ "$(jq --arg CVE "$CVE_ID" '.cves.fixed | has($CVE)' <<< "$COMPONENT_IN_RELEASE_NOTES")" != "true" ]
-            then
-                echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME and 'CVE ID' $CVE_ID"
-                echo " but that CVE is not present in the releaseNotes.content.images section for that component."
-                RC=1
-                continue
-            fi
+            # CVE_ID=$(jq -r --arg field "$CVE_FIELD" '.fields[$field]' <<< "$OUTPUT")
+            # COMPONENT_NAME=$(jq -r --arg field "$COMPONENT_FIELD" '.fields[$field]' <<< "$OUTPUT")
+            # if ! COMPONENT_IN_RELEASE_NOTES="$(jq -ec --arg name "$COMPONENT_NAME" \
+            #   '.releaseNotes.content.images[] | select(.component==$name)' "$DATA_FILE")"; then
+            #     echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME but that"
+            #     echo " component does not appear in releaseNotes.content.images. Failing"
+            #     RC=1
+            #     continue
+            # fi
+
+            # if [ "$(jq --arg CVE "$CVE_ID" '.cves.fixed | has($CVE)' <<< "$COMPONENT_IN_RELEASE_NOTES")" != "true" ]
+            # then
+            #     echo -n "Error: Issue $issue lists 'Downstream Component Name' $COMPONENT_NAME and 'CVE ID' $CVE_ID"
+            #     echo " but that CVE is not present in the releaseNotes.content.images section for that component."
+            #     RC=1
+            #     continue
+            # fi
 
         done
 

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -3,8 +3,10 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: test-embargo-check-rh-issue-missing-cve
-  annotations:
-    test/assert-task-failure: "run-task"
+  # The check that would make this fail is temporarily disabled.
+  # See https://issues.redhat.com/browse/RELEASE-1512
+  # annotations:
+  #   test/assert-task-failure: "run-task"
 spec:
   description: |
     Test for embargo-check where a issues.redhat.com issue has a Downstream Component Name value

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-wrong-component.yaml
@@ -3,8 +3,10 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: test-embargo-check-rh-issue-wrong-component
-  annotations:
-    test/assert-task-failure: "run-task"
+  # The check that would make this fail is temporarily disabled.
+  # See https://issues.redhat.com/browse/RELEASE-1512
+  # annotations:
+  #   test/assert-task-failure: "run-task"
 spec:
   description: |
     Test for embargo-check where a issues.redhat.com issue has a Downstream Component Name value


### PR DESCRIPTION
## Describe your changes

Disable checking of Downstream Component Name Jira field for CVEs while we figure out the right way of doing this.

## Relevant Jira

[RELEASE-1512](https://issues.redhat.com/browse/RELEASE-1512)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

