### PR TITLE
fix: get-advisory-severity properly uses overall impact (#872)

### DIFF
--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -13,6 +13,13 @@ impact from all of the CVEs is returned as a task result.
 | releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |
 
+## Changes in 0.2.2
+* Fix bug where component specific impact exists but is the empty string. The overall impact should be used
+  as severity instead in this instance
+
+## Changes in 0.2.1
+* Improve logging by enabling `set -x`
+
 ## Changes in 0.2.0
 * Instead of comparing `ps_component` with the component name to check for component specific severity, use the
   `repository` value from the component in the snapshot and compare that with the `repository_url` from the `purl`

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -145,7 +145,11 @@ spec:
                         print(PackageURL.from_string('$PURL').to_dict()['qualifiers']['repository_url'])" \
                         2> /dev/null || true)
                       if [ "$AFFECTED_REPOSITORY" == "$repository" ] ; then
-                          IMPACT=$(jq -r --arg default "$IMPACT" '.impact // $default' <<< "$AFFECTED_COMPONENT")
+                          COMPONENT_IMPACT=$(jq -r '.impact // ""' <<< "$AFFECTED_COMPONENT")
+                          # If we found a component specific impact, use that
+                          if [ -n "$COMPONENT_IMPACT" ] ; then
+                              IMPACT="$COMPONENT_IMPACT"
+                          fi
                           break
                       fi
                   done

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity-empty-component-impact
+spec:
+  description: |
+    Run the get-advisory-severity task with a CVE that is critical. The critical CVE will return
+    an entry for the `component` ps_component due to the mocks. This entry has impact, but it is
+    set to "". This test ensures that the overall cve impact is used in this case (Critical) and
+    it is not returned as the empty string, as it did previously.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: '[{"repository":"component","cves":{"fixed":{"CVE-critical":{"components":[]}}}}]'
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: severity
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(params.result)" != Success ]; then
+                echo Error: result task result is not correct
+                exit 1
+              fi
+
+              if [ "$(params.severity)" != "Critical" ]; then
+                echo Error: severity task result is not correct
+                exit 1
+              fi


### PR DESCRIPTION
This commit fixes a bug in the get-advisory-severity internal task. If a component from the releaseNotesImages matches one from the CVE and it has impact "", then the overall CVE impact should be used. Previously, it would only use the overall CVE impact when the component exists in the CVE if the ps_component data was missing the impact key entirely.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

