### PR TITLE
feat: collect secrets for collectors

### DIFF
--- a/.github/resources/crd_rbac.yaml
+++ b/.github/resources/crd_rbac.yaml
@@ -46,6 +46,14 @@ rules:
       - list
       - watch
       - patch
+  - apiGroups:
+      -
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pipelines/run-collectors/run-collectors.yaml
+++ b/pipelines/run-collectors/run-collectors.yaml
@@ -73,6 +73,28 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+    - name: collect-collectors-secret
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collectors/collect-collectors-secrets/collect-collectors-secrets.yaml
+      params:
+        - name: collectorsPath
+          value: $(tasks.collect-collectors-resources.results.collectorsResource)
+        - name: collectorsResourceType
+          value: $(params.collectorsResourceType)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-collectors-resources
     - name: run-collectors
       taskRef:
         resolver: "git"
@@ -102,7 +124,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - collect-collectors-resources
+        - collect-collectors-secret
     - name: save-collectors-results
       taskRef:
         resolver: "git"

--- a/tasks/collectors/collect-collectors-secrets/collect-collectors-secrets.yaml
+++ b/tasks/collectors/collect-collectors-secrets/collect-collectors-secrets.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-collectors-secrets
+  labels:
+    app.kubernetes.io/version: "0.0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: Tekton task to collect the secrets needed for collectors
+  params:
+    - name: collectorsPath
+      type: string
+      description: Path to the JSON string of the resource containing the collectors in the data workspace
+    - name: collectorsResourceType
+      description: The type of resource that contains the collectors
+      type: string
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
+    - name: secretRootDir
+      description: root directory where linked, labelled secrets are copied to
+      type: string
+      default: "secrets"
+  workspaces:
+    - name: data
+      description: Workspace to save the CR jsons to
+  steps:
+    - name: collect-collectors-secrets
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      env:
+        - name: "COLLECTORS_PATH"
+          value: '$(params.collectorsPath)'
+        - name: "COLLECTORS_RESOURCE_TYPE"
+          value: '$(params.collectorsResourceType)'
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        SECRETS_DIR_NAME="$(params.secretRootDir)"
+        if [ -n "$(params.subdirectory)" ]; then
+          mkdir -p "$(workspaces.data.path)/$(params.subdirectory)"
+          SECRETS_DIR_PATH="$(params.subdirectory)/${SECRETS_DIR_NAME}"
+        fi
+        mkdir -p "$(workspaces.data.path)/${SECRETS_DIR_PATH}"
+
+        COLLECTORS_FILE="$(workspaces.data.path)/$(params.collectorsPath)"
+
+        serviceAccountName=$(jq -r '.spec.collectors.serviceAccountName // "appstudio-pipeline"' "${COLLECTORS_FILE}")
+        serviceAccountJson=$(kubectl get "sa/${serviceAccountName}" -ojson)
+        linkedSecretCount=$(jq -c '.secrets? // {} | length' <<< "${serviceAccountJson}")
+        if [ "${linkedSecretCount}" -eq 0 ]; then
+          echo "WARNING: no linked secrets exist for Service Account ${serviceAccountName}"
+          exit
+        fi
+
+        COLLECTORS="$(jq -cr '.spec.collectors.items[]?.name' "${COLLECTORS_FILE}")"
+        collectorLinkedSecrets=()
+        for collector in $COLLECTORS;
+        do
+          # find secrets labelled for the collector
+          secretListJson=$(kubectl get secret -l konflux-ci.dev/collector="${collector}" -ojson)
+
+          # any labelled AND linked secrets?
+          approvedSecrets=$(jq --argjson sa "$serviceAccountJson" '
+            (.items // [])
+            | map(select(.metadata.name as $name | ($sa.secrets // []) | any(.name == $name)))
+            ' <<< "$secretListJson")
+
+          NUM_SECRETS="$(jq -r 'length' <<< "${approvedSecrets}")"
+          for ((i = 0; i < NUM_SECRETS; i++)) ; do
+            secretName="$(jq -r --argjson i "$i" '.[$i].metadata.name' <<< "${approvedSecrets}")"
+            collectorLinkedSecrets+=("$secretName")
+          done
+        done
+        
+        for secret in "${collectorLinkedSecrets[@]}";
+        do
+          echo "found linked, labelled secret: $secret"
+          secretJson=$(kubectl get secret "$secret" -ojson)
+          secretData=$(jq -r '.data' <<< "${secretJson}")
+          secretFields=$(jq -r 'to_entries[] | "\(.key),\(.value)"' <<< "${secretData}" )
+          for field in ${secretFields};
+          do
+            fieldName=$(echo "${field}" | cut -f1 -d,)
+            fieldValue=$(echo "${field}" | cut -f2 -d, | base64 -d)
+
+            mkdir -p "$(workspaces.data.path)/${SECRETS_DIR_PATH}/${secret}"
+            echo -n "${fieldValue}" > "$(workspaces.data.path)/${SECRETS_DIR_PATH}/${secret}/${fieldName}"
+          done
+        done
+
+        ls -lR "$(workspaces.data.path)/${SECRETS_DIR_PATH}"

--- a/tasks/collectors/collect-collectors-secrets/tests/pre-apply-task-hook.sh
+++ b/tasks/collectors/collect-collectors-secrets/tests/pre-apply-task-hook.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# Create a dummy secret for jira collector (and delete it first if it exists)
+kubectl delete secret my-jira-token --ignore-not-found
+kubectl create secret generic my-jira-token --from-literal=apitoken=ABCDEF
+kubectl label secret my-jira-token konflux-ci.dev/collector=test-collector
+
+# Create a dummy secret for jira collector (and delete it first if it exists)
+kubectl delete secret my-jira-token-not-labelled --ignore-not-found
+kubectl create secret generic my-jira-token-not-labelled --from-literal=apitoken=ABCDEF
+
+# Create a dummy secret for bugzilla collector (and delete it first if it exists)
+kubectl delete secret my-bugzilla-token --ignore-not-found
+kubectl create secret generic my-bugzilla-token --from-literal=apitoken=STUVWXYZ
+kubectl label secret my-bugzilla-token konflux-ci.dev/collector=test-collector
+
+# Create a dummy sa for collectors (and delete it first if it exists)
+kubectl delete sa tenant-collector-sa --ignore-not-found
+cat > serviceAccount << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-collector-sa
+secrets:
+  - name: my-jira-token
+  - name: my-bugzilla-token
+EOF
+kubectl apply -f serviceAccount
+
+# Create a dummy sa for collectors (and delete it first if it exists)
+kubectl delete sa tenant-collector-sa-2 --ignore-not-found
+cat > serviceAccount << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-collector-sa-2
+EOF
+kubectl apply -f serviceAccount
+
+# Create the default Tekton SA for collectors (and delete it first if it exists)
+kubectl delete sa appstudio-pipeline --ignore-not-found
+cat > serviceAccount << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+secrets:
+  - name: my-jira-token
+  - name: my-bugzilla-token
+EOF
+kubectl apply -f serviceAccount
+
+kubectl delete sa tenant-collector-sa-3 --ignore-not-found
+cat > serviceAccount << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-collector-sa-3
+secrets:
+  - name: my-jira-token-not-labelled
+EOF
+kubectl apply -f serviceAccount

--- a/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-default-sa.yaml
+++ b/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-default-sa.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-collectors-secrets-default-sa
+spec:
+  description: |
+    Run the collect-collectors-secrets task and verify that secrets linked to the default 
+    tekton SA are made available
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/test_release_plan.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlan",
+                "metadata": {
+                  "name": "test-rp",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "application": "app",
+                  "collectors": {
+                    "serviceAccountName": "tenant-collector-sa",
+                    "items": [
+                      {
+                        "name": "test-collector",
+                        "type": "dummy-collector",
+                        "timeout": 600,
+                        "params": [
+                          {
+                            "name": "test-arg",
+                            "value": "test-value"
+                          }
+                        ]
+                      }
+                    ],
+                    "target": "managed"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: collect-collectors-secrets
+      params:
+        - name: collectorsPath
+          value: test_release_plan.json
+        - name: collectorsResourceType
+          value: releaseplan
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d | wc -l)" -ne 3 ] ; then
+                  echo "Two secret directories should exist, but that is not the case. Secret directories:"
+                  find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d
+                  exit 1
+              fi
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux

--- a/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-labelled-not-linked.yaml
+++ b/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-labelled-not-linked.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-collectors-secrets-labelled-not-linked
+spec:
+  description: |
+    Run the collect-collectors-secrets task with a labelled secret that is not linked to the ServiceAccount
+    and verify that the secret is not accepted to be copied.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/test_release_plan.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlan",
+                "metadata": {
+                  "name": "test-rp",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "application": "app",
+                  "collectors": {
+                    "serviceAccountName": "tenant-collector-sa-2",
+                    "items": [
+                      {
+                        "name": "test-collector",
+                        "type": "dummy-collector",
+                        "timeout": 600,
+                        "params": [
+                          {
+                            "name": "test-arg",
+                            "value": "test-value"
+                          }
+                        ]
+                      }
+                    ],
+                    "target": "managed"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: collect-collectors-secrets
+      params:
+        - name: collectorsPath
+          value: test_release_plan.json
+        - name: collectorsResourceType
+          value: releaseplan
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d | wc -l)" -ne 1 ] ; then
+                  echo "No secret directories should exist, but that is not the case. Secret directories:"
+                  find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d
+                  exit 1
+              fi
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux

--- a/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-linked-not-labelled.yaml
+++ b/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets-linked-not-labelled.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-collectors-secrets-linked-not-labelled
+spec:
+  description: |
+    Run the collect-collectors-secrets task with a non-labelled secret that is linked to the ServiceAccount
+    and verify that the secret is not accepted to be copied.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/test_release_plan.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlan",
+                "metadata": {
+                  "name": "test-rp",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "application": "app",
+                  "collectors": {
+                    "serviceAccountName": "tenant-collector-sa-3",
+                    "items": [
+                      {
+                        "name": "test-collector",
+                        "type": "dummy-collector",
+                        "timeout": 600,
+                        "params": [
+                          {
+                            "name": "test-arg",
+                            "value": "test-value"
+                          }
+                        ]
+                      }
+                    ],
+                    "target": "managed"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: collect-collectors-secrets
+      params:
+        - name: collectorsPath
+          value: test_release_plan.json
+        - name: collectorsResourceType
+          value: releaseplan
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d | wc -l)" -ne 1 ] ; then
+                  echo "No secret directories should exist, but that is not the case. Secret directories:"
+                  find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d
+                  exit 1
+              fi
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux

--- a/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets.yaml
+++ b/tasks/collectors/collect-collectors-secrets/tests/test-collect-collectors-secrets.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-collectors-secrets
+spec:
+  description: |
+    Run the collect-collectors-secrets task and verify that secrets linked to SA are made available
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(workspaces.data.path)/test_release_plan.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlan",
+                "metadata": {
+                  "name": "test-rp",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "application": "app",
+                  "collectors": {
+                    "serviceAccountName": "tenant-collector-sa",
+                    "items": [
+                      {
+                        "name": "test-collector",
+                        "type": "dummy-collector",
+                        "timeout": 600,
+                        "params": [
+                          {
+                            "name": "test-arg",
+                            "value": "test-value"
+                          }
+                        ]
+                      }
+                    ],
+                    "target": "managed"
+                  }
+                }
+              }
+              EOF
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: collect-collectors-secrets
+      params:
+        - name: collectorsPath
+          value: test_release_plan.json
+        - name: collectorsResourceType
+          value: releaseplan
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d | wc -l)" -ne 3 ] ; then
+                  echo "Two secret directories should exist, but that is not the case. Secret directories:"
+                  find "$(workspaces.data.path)/$(params.subdirectory)/secrets/" -type d
+                  exit 1
+              fi
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux


### PR DESCRIPTION
## Describe your changes
- using SA linked secrets and secrets that are labelled by collector, copy the secret data to the workspace so collectors can access.

ServiceAccount
```
apiVersion: v1
kind: ServiceAccount
metadata:
  name: tenant-collector-sa
secrets:
  - name: my-jira-token
```

Labelled Secret
```
kubectl label secret my-jira-token konflux-ci.dev/collector=test-collector
```

This would create:

```
<workspace>/<pipeline id>/secrets/my-jira-token/<field name>
```

with its unencrypted content.

NOTE: this requires [RELEASE-1464](https://issues.redhat.com//browse/RELEASE-1464)

## Relevant Jira

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

