### PR TITLE
fix(RELEASE-1450): reduce risk of ir result collision

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -18,6 +18,10 @@ based on the issues visibility
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 1.1.4
+* Use a temp file for `internal-request` result instead of a fixed file in the workspace to reduce risk
+  of interference with other tasks
+
 ## Changes in 1.1.3
 * Enable CVE IDs check
   * Previous change disabled both Downstream Component check as well as the general check the CVE ID in each

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/version: "1.1.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -159,6 +159,8 @@ spec:
 
         echo "Checking the following CVEs: ${CVES}"
 
+        IR_RESULT_FILE=$(mktemp)
+
         internal-request --pipeline "check-embargoed-cves" \
             -p cves="${CVES}" \
             -p taskGitUrl="$(params.taskGitUrl)" \
@@ -166,10 +168,10 @@ spec:
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" \
             -s true \
-            > "$(workspaces.data.path)"/ir-result.txt || \
-            (grep "^\[" "$(workspaces.data.path)"/ir-result.txt | jq . && exit 1)
+            > "$IR_RESULT_FILE" || \
+            (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
 
-        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$(workspaces.data.path)"/ir-result.txt)
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_RESULT_FILE")
         echo "done (${internalRequest})"
 
         results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')

--- a/tasks/managed/push-disk-images/README.md
+++ b/tasks/managed/push-disk-images/README.md
@@ -14,6 +14,10 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 0.4.1
+* Use a temp file for `internal-request` result instead of a fixed file in the workspace to reduce risk
+  of interference with other tasks
+
 ## Changes in 0.4.0
 * Update the release-service-utils image and enable the internalRequests
   to be created using git-ref pipeline instead of cluster pipeline.

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -83,6 +83,8 @@ spec:
           exit 1
         fi
 
+        IR_RESULT_FILE=$(mktemp)
+
         echo "Creating InternalRequest to push disk images..."
         internal-request --pipeline "push-disk-images" \
                          -p snapshot_json="${snapshot}" \
@@ -101,10 +103,10 @@ spec:
                          --pipeline-timeout 24h0m0s \
                          --task-timeout 23h50m0s \
                          --finally-timeout 0h10m0s \
-                         > "$(workspaces.data.path)"/ir-result.txt
+                         > "$IR_RESULT_FILE"
 
         set +x
-        internalRequest=$(awk 'NR==1{ print $2 }' "$(workspaces.data.path)/ir-result.txt" | xargs)
+        internalRequest=$(awk 'NR==1{ print $2 }' "$IR_RESULT_FILE" | xargs)
         echo "done (${internalRequest})"
 
         results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')

--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -25,6 +25,10 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 2.4.2
+* Use a temp file for `internal-request` result instead of a fixed file in the workspace to reduce risk
+  of interference with other tasks
+
 ## Changes in 2.4.1
 * Fix shellcheck/checkton linting issues in the task and tests
 

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.4.1"
+    app.kubernetes.io/version: "2.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -60,6 +60,8 @@ spec:
         echo "- blob=$(params.blob)"
         echo "- requester=$(params.requester)"
 
+        IR_RESULT_FILE=$(mktemp)
+
         internal-request -r "blob-signing-pipeline" \
             -p pipeline_image="${pipeline_image}" \
             -p blob="$(params.blob)" \
@@ -67,12 +69,12 @@ spec:
             -p config_map_name="${config_map_name}" \
             -t "$(params.requestTimeout)" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-            > "$(workspaces.data.path)/ir-result.txt" || \
-            (grep "^\[" "$(workspaces.data.path)/ir-result.txt" | jq . && exit 1)
-          
-        internalRequest=$(awk 'NR==1{ print $2 }' "$(workspaces.data.path)/ir-result.txt" | xargs)
+            > "$IR_RESULT_FILE" || \
+            (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
+
+        internalRequest=$(awk 'NR==1{ print $2 }' "$IR_RESULT_FILE" | xargs)
         echo "done (${internalRequest})"
-        
+
         payload=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results.signed_payload}')
         decoded_payload=$(echo -n "$payload" | base64 -d)
 


### PR DESCRIPTION
## Describe your changes

Some tasks were using hardcoded ir-result.txt file in the shared workspace to store the IR result. Use a temp file instead.

Tasks already safe:
- add-fbc-contribution
- create-advisory
- publish-index-image
- push-artifacts-to-cdn
- rh-sign-image
- run-file-updates
- set-advisory-severity
- sign-index-image

Fixed tasks:
- embargo-check
- push-disk-images
- sign-base64-blob

## Relevant Jira

[RELEASE-1450](https://issues.redhat.com//browse/RELEASE-1450)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

