### PR TITLE
fix(KFLUX-7669): increase set-advisory-severity IR timeout

### DIFF
--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -8,10 +8,13 @@ OSIDB for each CVE present. If the type is not RHSA, no action will be performed
 | Name                     | Description                                                                               | Optional | Default value |
 |--------------------------|-------------------------------------------------------------------------------------------|----------|---------------|
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
-| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 180           |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 1800          |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+
+## Changes in 0.1.3
+* Update the requestTimeout default value to 30 mins
 
 ## Changes in 0.1.2
 * Update the task to fail if the type is RHSA and no CVEs are provided

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -19,7 +19,7 @@ spec:
       type: string
     - name: requestTimeout
       type: string
-      default: "180"
+      default: "1800"
       description: InternalRequest timeout
     - name: pipelineRunUid
       type: string


### PR DESCRIPTION
3 mins is too short. We are seeing some take 8 right now.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

