### PR TITLE
feat(RELEASE-1395): push disk images int task called via git resolver

### DIFF
--- a/internal/resources/pulp-push-disk-images.yaml
+++ b/internal/resources/pulp-push-disk-images.yaml
@@ -1,1 +1,0 @@
-../../tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml

--- a/pipelines/internal/push-disk-images/README.md
+++ b/pipelines/internal/push-disk-images/README.md
@@ -4,12 +4,17 @@ Tekton Pipeline to push disk images with Pulp
 
 ## Parameters
 
-| Name           | Description                                                       | Optional | Default value                                            |
-|----------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
-| snapshot_json  | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
-| exodusGwSecret | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
-| exodusGwEnv    | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
-| pulpSecret     | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |
-| udcacheSecret  | Env specific secret containing the udcache credentials            | No       | -                                                        |
-| cgwHostname    | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
-| cgwSecret      | Env specific secret containing the content gateway credentials    | No       | -                                                        |
+| Name            | Description                                                                           | Optional | Default value                                             |
+|-----------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json   | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
+| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
+| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
+| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
+| udcacheSecret   | Env specific secret containing the udcache credentials                                | No       | -                                                         |
+| cgwHostname     | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
+| cgwSecret       | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+
+## Changes in 0.3.0
+* Added taskGiturl and taskGitRevision parameters so the task can be called via git resolvers

--- a/pipelines/internal/push-disk-images/push-disk-images.yaml
+++ b/pipelines/internal/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,11 +34,25 @@ spec:
     - name: cgwSecret
       type: string
       description: Env specific secret containing the content gateway credentials
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: pulp-push-disk-images
       timeout: "24h00m0s"
       taskRef:
-        name: pulp-push-disk-images
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
       params:
         - name: snapshot_json
           value: $(params.snapshot_json)


### PR DESCRIPTION
this PR changes push-disk-image to use pulp-push-dis-images using git resolver instead of the cluster resolver.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

