### PR TITLE
fix(RELEASE-1508): update-fbc-catalog safe checks

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -14,6 +14,10 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
 
+## Changes in 1.1.1
+* adds equality check of `from_index` and `index_image` in `check_previous_build()`
+  to determine if the build was a prod or a staging build
+
 ## Changes in 1.1.0
 * adds new parameter `publishingCredentials`
 

--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -6,9 +6,11 @@ yq -o json <<< '
 items:
 - id: 1
   distribution_scope: "stage"
+  from_index: "registry-proxy-stage.engineering.redhat.com/rh-osbs/iib-pub:v4.17"
   fbc_fragment: "registry.io/image0@sha256:0000"
   internal_index_image_copy: "registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib:1"
   index_image_resolved: "registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib@sha256:0000"
+  index_image: "registry-proxy-stage.engineering.redhat.com/rh-osbs/iib-pub:v4.17"
   logs:
     url: "https://fakeiib.host/api/v1/builds/1/logs"
   request_type: "fbc-operations"

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -68,9 +68,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 10 keys on it
+              # the jsonBuild mockes has 12 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 10 ]; then
+              if [ "$keyLength" -ne 12 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -71,9 +71,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 10 keys on it
+              # the jsonBuild mockes has 12 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 10 ]; then
+              if [ "$keyLength" -ne 12 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
@@ -67,9 +67,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 10 keys on it
+              # the jsonBuild mockes has 12 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 10 ]; then
+              if [ "$keyLength" -ne 12 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
@@ -70,9 +70,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 11 keys on it
+              # the jsonBuild mockes has 13 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 11 ]; then
+              if [ "$keyLength" -ne 13 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
@@ -70,9 +70,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 11 keys on it
+              # the jsonBuild mockes has 13 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 11 ]; then
+              if [ "$keyLength" -ne 13 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
@@ -71,9 +71,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 10 keys on it
+              # the jsonBuild mockes has 12 keys on it
               keyLength=$(jq '. | length' <<< "${JSON_BUILDINFO}")
-              if [ "$keyLength" -ne 10 ]; then
+              if [ "$keyLength" -ne 12 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -70,9 +70,9 @@ spec:
               #!/bin/bash
               set -x
 
-              # the jsonBuild mockes has 10 keys on it
+              # the jsonBuild mockes has 12 keys on it
               keyLength=$(jq '. | length' <<< '$(params.jsonBuildInfo)')
-              if [ "$keyLength" -ne 10 ]; then
+              if [ "$keyLength" -ne 12 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -125,6 +125,13 @@ spec:
           build=$(curl -s "${IIB_SERVICE_URL}/builds?user=${user}&from_index=${from_index}" | \
             jq --arg fbc_fragment "${fbc_fragment}" \
               '[.items[] |select(.fbc_fragment==$fbc_fragment and .state!="failed")][0] // empty')
+
+          # if a previous build is found, but from_index and index_image are different, it means that the
+          # previous build was a staging index build, then we should return here causing the task to call
+          # IIB again, but with overwrite_from_index set to true.
+          if [ "$(jq '.from_index != .index_image' <<< "${build}")" == true ]; then
+            return 0
+          fi
 
           if [ "$(jq -r '.state' <<< "${build}")" = "complete" ]; then
             indexImageResolved="$(jq -r '.index_image_resolved' <<<  "${build}")"


### PR DESCRIPTION
this PR adds a equality check of `from_index` and
`index_image` to determine if the previous build
was a production of staging build, so the pipeline will always call IIB when users switch stageIndex
from false to true.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

