### PR TITLE
fix(KONFLUX-7710): processing of run-file-updates results

### DIFF
--- a/tasks/managed/run-file-updates/README.md
+++ b/tasks/managed/run-file-updates/README.md
@@ -17,6 +17,10 @@ the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 | taskGitUrl         | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                        |
 | taskGitRevision    | The revision in the taskGitUrl repo to be used                                            | No       | -                        |
 
+## Changes in 3.0.2
+* Fix processing of IR result `jsonBuildInfo`
+  * `fromjson` needs to be applied twice before we get to the actual json
+
 ## Changes in 3.0.0
 * Added taskGiturl and taskGitRevision parameters to be passed to the internalRequest
 * The pipeline is called via git resolver now instead of cluster resolver

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "3.0.1"
+    app.kubernetes.io/version: "3.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -125,13 +125,13 @@ spec:
 
           if [ "$(jq -jr '.buildState' <<< "${results}")" == "Failed" ]; then
             echo -en "  FileUpdates Error: "
-            jq -r '.jsonBuildInfo | fromjson | .error' <<< "${results}"
+            jq -r '.jsonBuildInfo | fromjson | fromjson | .error' <<< "${results}"
             echo -e "  Diff (content might be truncated): "
-            jq -r '.jsonBuildInfo | fromjson | .str | tostring' <<< "${results}" | awk '{ print "\t"$0 }'
+            jq -r '.jsonBuildInfo | fromjson | fromjson | .str | tostring' <<< "${results}" | awk '{ print "\t"$0 }'
             echo -e "=== Finished ===\n"
             exit 1
           else
-            MR=$(jq -r '.jsonBuildInfo | fromjson | .merge_request // "unknown"' <<< "${results}")
+            MR=$(jq -r '.jsonBuildInfo | fromjson | fromjson | .merge_request // "unknown"' <<< "${results}")
             echo "MR Created: ${MR}"
             echo "${MR}" >> "$(results.mergeRequestUrl.path)"
             RESULTS_JSON=$(jq --arg i "$i" --arg MR "${MR}" '.merge_requests[$i|tonumber] += {"url": $MR}' \

--- a/tasks/managed/run-file-updates/tests/mocks.sh
+++ b/tasks/managed/run-file-updates/tests/mocks.sh
@@ -65,7 +65,7 @@ function set_ir_status() {
       "internalRequestPipelineRunName": "${mockPipelineRunName}",
       "internalRequestTaskRunName": "${mockTaskRunName}",
       "buildState": "$status",
-      "jsonBuildInfo": "{\"error\":\"unknown error\",\"str\":\"unknown error\"}\n"
+      "jsonBuildInfo": "\\\\\"{\\\\\"error\\\\\":\\\\\"unknown error\\\\\",\\\\\"str\\\\\":\\\\\"unknown error\\\\\"}\"\n"
     }
   }
 }
@@ -78,7 +78,7 @@ EOF
       "internalRequestPipelineRunName": "${mockPipelineRunName}",
       "internalRequestTaskRunName": "${mockTaskRunName}",
       "buildState": "$status",
-      "jsonBuildInfo": "{\"merge_request\":\"https://g/r/-/merge_requests/18\"}\n"
+      "jsonBuildInfo": "\"{\\\\\"merge_request\\\\\":\\\\\"https://g/r/-/merge_requests/18\\\\\"}\"\n"
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

`fromjson` needs to be applied twice before
we get to the actual json.

## Relevant Jira

[KONFLUX-7710](https://issues.redhat.com//browse/KONFLUX-7710)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

