### PR TITLE
fix(KONFLUX-7710): formatting of process-file-updates-task result

### DIFF
--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -17,9 +17,13 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
 
+## Changes in 1.1.1
+* Fix formatting of json saved as `fileUpdatesInfo`
+  * The result had one too many levels of escaping when being read in run-file-updates
+
 ## Changes in 1.1.0
 * Use `git add` to stage modified files and compare the staged content with opened MRs
-  to check if an MR already exists with the same updates in the repo. 
+  to check if an MR already exists with the same updates in the repo.
 
 ## Changes in 1.0.1
 * Remove extra characters in the diff result

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -259,7 +259,7 @@ spec:
         echo -e "\n*** END LOCAL CHANGES ***\n"
 
         if [[ ! -s "${TEMP}"/tempMRFile-cached.diff ]]; then
-           # nothing needs to change, the MR is merged 
+           # nothing needs to change, the MR is merged
            echo "nothing needs change" \
                | tee -a "$(results.fileUpdatesInfo.path)"
            echo -n "Success" |tee "$(results.fileUpdatesState.path)"
@@ -288,13 +288,13 @@ spec:
                 mrNum=$(echo "$oneItem" | cut -f1 | tr -d '!')
                 git fetch origin merge-requests/"${mrNum}"/head:mr_"${mrNum}"
 
-                # compare if the cached content and the content in MR are the same 
-                git diff --cached mr_"${mrNum}" | tee "${TEMP}"/final.diff 
+                # compare if the cached content and the content in MR are the same
+                git diff --cached mr_"${mrNum}" | tee "${TEMP}"/final.diff
 
                 if [[ ! -s "${TEMP}"/final.diff ]] ; then
                     echo "There is an existing MR with the same updates in the repo"
                     echo "{\"merge_request\":\"${UPSTREAM_REPO}/-/merge_requests/${mrNum}\"}" \
-                        | tee -a "$(results.fileUpdatesInfo.path)" 
+                        | tee -a "$(results.fileUpdatesInfo.path)"
                     echo -n "Success" | tee "$(results.fileUpdatesState.path)"
                     exit 0
                 fi
@@ -307,7 +307,7 @@ spec:
         echo "Creating Pull Request..."
         GITLAB_MR_MSG="[Konflux release] $(params.application): fileUpdates changes ${WORKING_BRANCH}"
         gitlab_create_mr --head "$WORKING_BRANCH" --target-branch "$REVISION" --title "${GITLAB_MR_MSG}" \
-            --description "${GITLAB_MR_MSG}" --upstream-repo "${UPSTREAM_REPO}" | jq '. | tostring' \
+            --description "${GITLAB_MR_MSG}" --upstream-repo "${UPSTREAM_REPO}" | jq . \
             | tee -a "$(results.fileUpdatesInfo.path)"
 
         echo -n "Success" |tee "$(results.fileUpdatesState.path)"

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -93,7 +93,7 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+              test "$(jq -r .merge_request <<< '$(params.fileUpdatesInfo)')" == \
                   "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -93,7 +93,7 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+              test "$(jq -r .merge_request <<< '$(params.fileUpdatesInfo)')" == \
                   "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -81,7 +81,7 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+              test "$(jq -r .merge_request <<< '$(params.fileUpdatesInfo)')" == \
                   "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"


### PR DESCRIPTION
## Describe your changes

The `fileUpdatesInfo` result had one too many levels of escaping when being read in `run-file-updates`.

For the other case where the MR already exists and we construct the json manually it worked without issues.

## Relevant Jira

[KONFLUX-7710](https://issues.redhat.com//browse/KONFLUX-7710)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

