### PR TITLE
feat(RELEASE-1263): add idempotency to rh-advisories pipeline

### DIFF
--- a/pipelines/internal/filter-already-released-advisory-images/README.md
+++ b/pipelines/internal/filter-already-released-advisory-images/README.md
@@ -1,0 +1,13 @@
+# filter-already-released-advisory-images pipeline
+
+This pipeline filters out images from a snapshot that have already been published in advisories.  
+
+## Parameters
+
+| Name                 | Description                                                                                            | Optional | Default value                                             |
+|----------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json        | JSON string of the Snapshot spec containing the images to be filtered                                  | No       | -                                                         |
+| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
+| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
+| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |

--- a/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: filter-already-released-advisory-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Pipeline to filter out already-released images from a snapshot
+  params:
+    - name: snapshot_json
+      type: string
+      description: JSON string of the Snapshot spec
+    - name: origin
+      type: string
+      description: |
+          The origin workspace where the release CR comes from.
+          This is used to determine the advisory path
+    - name: advisory_secret_name
+      type: string
+      description: The name of the secret that contains the advisory creation metadata
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: filter-already-released-advisory-images-task
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+      params:
+        - name: snapshot_json
+          value: $(params.snapshot_json)
+        - name: origin
+          value: $(params.origin)
+        - name: advisory_secret_name
+          value: $(params.advisory_secret_name)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+  results:
+    - name: result
+      value: $(tasks.filter-already-released-advisory-images-task.results.result)
+    - name: unreleased_components
+      value: $(tasks.filter-already-released-advisory-images-task.results.unreleased_components)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.filter-already-released-advisory-images-task.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.filter-already-released-advisory-images-task.results.internalRequestTaskRunName)

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,16 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.1.0
+* Add new task `filter-already-released-advisory-images` to filter out images that have already been released in advisories
+  * Task is placed after `apply-mapping` and before `verify-conforma`
+  * Overwrites the original snapshot file in place with the filtered snapshot (subsequent tasks continue to use the same snapshot path)
+  * Makes the pipeline idempotent by preventing validation failures for already released images
+  * When all images in a snapshot are already released in advisories, the pipeline will:
+    - Detect this condition early in the process
+    - Skip all subsequent release tasks (advisory creation, image signing, etc.)
+  * `filter-already-released-advisory-images`: Filters out already released images from the snapshot and sets a `skip_release` result. If all images are already released, this result is used to skip unnecessary pipeline steps (validation, signing, advisory creation, etc.) to avoid redundant work and potential validation failures.
+
 ## Changes in 2.0.8
 * The `update-component-sbom` and `create-product-sbom` tasks are refactored to
   use the new SBOM generation workflow. They no longer depend on

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.8"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -247,8 +247,52 @@ spec:
           workspace: release-workspace
       runAfter:
         - reduce-snapshot
+    - name: filter-already-released-advisory-images
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: subdirectory
+          value: "$(tasks.collect-data.results.subdirectory)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
     - name: verify-conforma
       timeout: "4h00m0s"
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -277,12 +321,16 @@ spec:
         - name: WORKERS
           value: $(params.enterpriseContractWorkerCount)
         - name: SOURCE_DATA_ARTIFACT
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
-        - apply-mapping
+        - filter-already-released-advisory-images
     - name: populate-release-notes
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -291,7 +339,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -310,11 +358,15 @@ spec:
             value: tasks/managed/populate-release-notes/populate-release-notes.yaml
         resolver: git
       runAfter:
-        - apply-mapping
+        - filter-already-released-advisory-images
       workspaces:
         - name: data
           workspace: release-workspace
     - name: embargo-check
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -348,6 +400,10 @@ spec:
         - check-data-keys
         - populate-release-notes
     - name: set-advisory-severity
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -381,6 +437,10 @@ spec:
         - populate-release-notes
         - embargo-check
     - name: collect-cosign-params
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -416,6 +476,9 @@ spec:
         - input: $(tasks.collect-cosign-params.results.cosign-secret-name)
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -457,6 +520,9 @@ spec:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
           values: ["true"]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -476,7 +542,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -491,6 +557,10 @@ spec:
       runAfter:
         - rh-sign-image
     - name: collect-pyxis-params
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -522,6 +592,10 @@ spec:
         - collect-data
     - name: rh-sign-image
       timeout: "6h00m0s"
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       retries: 3
       taskRef:
         resolver: "git"
@@ -574,6 +648,10 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       retries: 5
       taskRef:
         resolver: "git"
@@ -613,6 +691,10 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       retries: 5
       taskRef:
         resolver: "git"
@@ -637,7 +719,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -653,6 +735,10 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       retries: 5
       taskRef:
         resolver: "git"
@@ -694,6 +780,9 @@ spec:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         params:
           - name: url
@@ -712,7 +801,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: subdirectory
           value: $(tasks.collect-data.results.subdirectory)
         - name: dataDir
@@ -733,6 +822,9 @@ spec:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: sbomDir
           value: "$(tasks.update-component-sbom.results.sbomPath)"
@@ -775,6 +867,10 @@ spec:
       runAfter:
         - update-component-sbom
     - name: run-file-updates
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -789,7 +885,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -814,6 +910,10 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -852,6 +952,10 @@ spec:
       runAfter:
         - populate-release-notes
     - name: collect-atlas-params
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -886,6 +990,9 @@ spec:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -894,7 +1001,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -925,6 +1032,9 @@ spec:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: sbomDir
           value: "$(tasks.create-product-sbom.results.sbomPath)"
@@ -967,6 +1077,10 @@ spec:
       runAfter:
         - create-product-sbom
     - name: create-advisory
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       retries: 5
       params:
         - name: releasePlanAdmissionPath
@@ -1012,6 +1126,10 @@ spec:
         - rh-sign-image-cosign
         - set-advisory-severity
     - name: close-advisory-issues
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       onError: continue  # until https://issues.redhat.com/browse/KONFLUX-7489 is fixed
       params:
         - name: dataPath
@@ -1045,6 +1163,10 @@ spec:
       runAfter:
         - create-advisory
     - name: update-cr-status
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: resource
           value: $(params.release)

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -1,0 +1,14 @@
+# filter-already-released-advisory-images-task
+
+This internal Tekton task filters out images from a snapshot if they have already
+been published in an advisory stored in a GitLab repository.
+It returns a list of component names that still need to be released (i.e., not found in any advisory).
+
+## Parameters
+
+| Name                           | Description                                                                                            | Optional | Default value |
+|--------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
+| snapshot_json                  | String containing the full JSON representation of the snapshot spec                                    | No       | -             |
+| origin                         | The origin workspace for the release CR (used to locate advisories)                                    | No       | -             |
+| advisory_secret_name           | Name of the secret containing GitLab repo and token information                                        | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-images-task
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Filters out images from a snapshot if they are already published in an advisory
+    stored in the GitLab advisory repo. Returns a list of component names
+    that still need to be released (i.e., not found in any advisory). 
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: origin
+      description: The origin workspace for the release CR
+      type: string
+    - name: advisory_secret_name
+      description: Name of the secret containing advisory metadata
+      type: string
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that requested this task
+      type: string
+  results:
+    - name: result
+      description: Success or error message
+    - name: internalRequestPipelineRunName
+      description: The name of the InternalRequest PipelineRun
+    - name: internalRequestTaskRunName
+      description: The name of the InternalRequest TaskRun
+    - name: unreleased_components
+      description: List of components that still need to be released
+  steps:
+    - name: filter-images
+      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      env:
+        - name: GITLAB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_host
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_access_token
+        - name: GIT_REPO
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_repo
+        - name: GIT_AUTHOR_NAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_author_name
+        - name: GIT_AUTHOR_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_author_email
+        - name: SNAPSHOT_JSON
+          value: "$(params.snapshot_json)"
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        STDERR_FILE=/tmp/stderr.txt
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+        echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+        exitfunc() {
+          local err=$1
+          local line=$2
+          local cmd=$3
+          if [ "$err" -eq 0 ]; then
+            echo -n "Success" > "$(results.result.path)"
+          else
+            echo -n "$0: ERROR '$cmd' failed at line $line - exited with status $err" > "$(results.result.path)"
+            if [ -f "$STDERR_FILE" ]; then tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"; fi
+          fi
+          exit 0
+        }
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        ORIGIN="$(params.origin)"
+        ADVISORY_BASE_DIR="data/advisories/${ORIGIN}"
+
+        cd /tmp
+
+        echo "Cloning $GIT_REPO..."
+        git clone "$GIT_REPO" repo
+        cd repo
+
+        echo "Checking existing advisories in ${ADVISORY_BASE_DIR}..."
+        EXISTING_ADVISORIES=""
+        if [ -d "${ADVISORY_BASE_DIR}" ]; then
+          EXISTING_ADVISORIES=$(
+            find "${ADVISORY_BASE_DIR}" -mindepth 2 -type d -printf "%T@ %p\n" |
+            sort -nr | cut -d' ' -f2- | sed "s|^${ADVISORY_BASE_DIR}/||"
+          )
+        fi
+
+        CONTENT_IMAGES=$(jq -c '.components' <<< "$SNAPSHOT_JSON")
+
+        if [[ -z "$EXISTING_ADVISORIES" ]]; then
+          echo "No existing advisories found. No components have been released yet."
+          UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES")
+          echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
+          echo -n "Success" > "$(results.result.path)"
+          exit 0
+        fi
+
+        for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
+          ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
+          EXISTING_CONTENT=$(yq -o=json '.spec.content.images // []' "$ADVISORY_FILE")
+
+          echo "Comparing against: $ADVISORY_FILE"
+
+          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --argjson existing "$EXISTING_CONTENT" '
+            map(select(
+              .containerImage as $ci |
+              .tags as $tags |
+              .repository as $repo |
+              ($existing | map(select(
+                .containerImage == $ci and .tags == $tags and .repository == $repo
+              )) | length == 0)
+            ))')
+
+          # If after filtering, no images are left, then we can exit early
+          if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
+            echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
+            echo -n "[]" > "$(results.unreleased_components.path)"
+            echo -n "Success" > "$(results.result.path)"
+            exit 0
+          fi
+        done
+
+        ORIGINAL_COUNT=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+        NEW_COUNT=$(jq 'length' <<< "$CONTENT_IMAGES")
+        echo "Filtered out $((ORIGINAL_COUNT - NEW_COUNT)) image(s) already in advisories"
+        echo "Remaining unpublished images: $CONTENT_IMAGES"
+
+        # Output the list of component names that still need to be released
+        UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES")
+        echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
+        echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+kubectl delete secret filter-already-released-advisory-images-secret --ignore-not-found
+kubectl create secret generic filter-already-released-advisory-images-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/org/repo.git

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images
+spec:
+  description: |
+    Test the filter-already-released-advisory-images-task by providing a snapshot with
+    both released and new images. Expect only the new image after filtering.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: snapshot_json
+          value: '{"components":[{"name":"released-component","version":"1.0.0","containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"},{"name":"new-component","version":"1.0.0","containerImage":"quay.io/test/new-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: origin
+          value: "test-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+        - name: unreleased_components
+          value: "$(tasks.run-filter-task.results.unreleased_components)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: unreleased_components
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating filter task result..."
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo "Task result was not Success: $(params.result)"
+                exit 1
+              fi
+
+              # Verify unreleased components list
+              UNRELEASED_COUNT=$(jq 'length' <<< '$(params.unreleased_components)')
+              if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
+                echo "Expected 1 unreleased component, but found $UNRELEASED_COUNT"
+                exit 1
+              fi
+
+              UNRELEASED_NAME=$(jq -r '.[0]' <<< '$(params.unreleased_components)')
+              if [[ "$UNRELEASED_NAME" != "new-component" ]]; then
+                echo "Unexpected unreleased component name: $UNRELEASED_NAME"
+                exit 1
+              fi
+
+              echo "Validation successful!"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-no-advisory-directory
+spec:
+  description: |
+    Test the task when the advisory directory for the given origin does not exist.
+    Expected behavior: original snapshot is returned unchanged.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: snapshot_json
+          value: '{"components":[{"name":"test-component","version":"1.0.0","containerImage":"quay.io/test/image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: origin
+          value: "not-existing-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+        - name: unreleased_components
+          value: "$(tasks.run-filter-task.results.unreleased_components)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: unreleased_components
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating task result when advisory directory does not exist..."
+              [[ "$(params.result)" == "Success" ]]
+
+              # Verify all components are marked as unreleased
+              UNRELEASED_COUNT=$(jq 'length' <<< '$(params.unreleased_components)')
+              if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
+                echo "Expected 1 unreleased component, got $UNRELEASED_COUNT"
+                exit 1
+              fi
+
+              UNRELEASED_NAME=$(jq -r '.[0]' <<< '$(params.unreleased_components)')
+              if [[ "$UNRELEASED_NAME" != "test-component" ]]; then
+                echo "Unexpected unreleased component name: $UNRELEASED_NAME"
+                exit 1
+              fi
+
+              echo "Validation successful for advisory directory absence!"

--- a/tasks/managed/filter-already-released-advisory-images/README.md
+++ b/tasks/managed/filter-already-released-advisory-images/README.md
@@ -1,0 +1,29 @@
+# Filter Already Released Advisory Images
+
+This task filters out images from a snapshot that have already been published in advisories.  
+It is a **managed Tekton task** that triggers an **internal task** using an InternalRequest,
+and overwrites the mapped snapshot file with a filtered version containing only **unpublished images**.
+
+The task also outputs a `skip_release` result, which is set to `true` 
+if all components are already released (and the pipeline can be skipped), or `false` otherwise.
+
+The task overwrites the original mapped snapshot file in place with a filtered version containing only unpublished images. Downstream tasks continue to use the same snapshot path.
+
+## Parameters
+
+| Name                     | Description                                                                                                                | Optional  | Default value                                  |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------|------------------------------------------------|
+| snapshotPath             | Path to the JSON file of the Snapshot spec in the workspace                                                                | No        | -                                              |
+| releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the workspace                                                         | No        | -                                              |
+| resultsDirPath           | Path to the results directory within the workspace                                                                         | No        | -                                              |
+| synchronously            | Whether the task should wait for the InternalRequest to complete                                                           | Yes       | true                                           |
+| pipelineRunUid           | UID of the current pipelineRun, used as a label on the InternalRequest                                                     | No        | -                                              |
+| taskGitUrl               | Git URL of the release-service-catalog containing internal task logic                                                      | No        | -                                              |
+| taskGitRevision          | Git revision or branch name used to run the internal task                                                                  | No        | -                                              |
+| ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                  | No        | -                                              |
+| ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                                             |
+| trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                                             |
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                                             |
+| sourceDataArtifact       | Location of trusted artifacts used to populate the data directory                                                          | Yes       | ""                                             |
+| dataDir                  | The location where data will be stored                                                                                     | No        | $(workspaces.data.path)                        |
+| subdirectory             | Subdirectory inside the workspace to be used                                                                               | Yes       | ""                                             |

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -1,0 +1,309 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Managed Tekton task that filters out already-released images from a snapshot
+    via an InternalRequest.
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+    - name: releasePlanAdmissionPath
+      type: string
+      description: Path to the JSON string of the ReleasePlanAdmission in the data workspace
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: Git revision to use for internal task
+    - name: pipelineRunUid
+      type: string
+      description: UID of the current pipelineRun
+    - name: synchronously
+      type: string
+      description: Whether to wait for the InternalRequest completion
+      default: "true"
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
+  workspaces:
+    - name: data
+      description: Workspace to mount internal request outputs
+  results:
+    - name: result
+      description: Success or failure result
+    - name: skip_release
+      description: Whether to skip release tasks (true if all components are already released)
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+  steps:
+    - name: skip-trusted-artifact-operations
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: run-script
+      image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+      script: |
+        #!/bin/bash
+        set -x
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        if [ ! -f "$SNAPSHOT_FILE" ]; then
+            echo "No valid snapshot file was provided at $SNAPSHOT_FILE"
+            exit 1
+        fi
+        snapshot=$(jq -c '.' "$SNAPSHOT_FILE")
+        if [ -z "$snapshot" ]; then
+            echo "Failed to read snapshot file"
+            exit 1
+        fi
+
+        RPA_FILE="$(params.dataDir)/$(params.releasePlanAdmissionPath)"
+        if [ ! -f "$RPA_FILE" ]; then
+            echo "No valid ReleasePlanAdmission file was provided at $RPA_FILE"
+            exit 1
+        fi
+        origin=$(jq -r '.spec.origin' "$RPA_FILE")
+        if [ -z "$origin" ]; then
+            echo "Failed to read origin from ReleasePlanAdmission"
+            exit 1
+        fi
+
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+        # Determine advisory_secret_name based on repositories in snapshot
+        pending_repositories=$(jq -r '.components[] | select(.repository |
+          test("quay.io/redhat-pending/|quay.io/rh-flatpaks-stage/")) |
+          .repository' "$SNAPSHOT_FILE")
+        prod_repositories=$(jq -r '.components[] | select(.repository |
+          test("quay.io/redhat-prod/|quay.io/rh-flatpaks-prod/")) |        
+          .repository' "$SNAPSHOT_FILE")
+        orphan_repositories=$(jq -r '.components[] |
+          select(.repository |
+            test("quay.io/redhat-prod/|quay.io/rh-flatpaks-prod/") | not) |
+          select(.repository |
+            test("quay.io/redhat-pending/|quay.io/rh-flatpaks-stage/") | not) |
+          .repository' "$SNAPSHOT_FILE")
+        foundPendingRepositories=false
+        [ -n "${pending_repositories}" ] && foundPendingRepositories=true
+        foundProdRepositories=false
+        [ -n "${prod_repositories}" ] && foundProdRepositories=true
+        foundOrphanRepositories=false
+        [ -n "${orphan_repositories}" ] && foundOrphanRepositories=true
+
+        echo "Repository status:"
+        echo "- Pending repositories: ${foundPendingRepositories}"
+        echo "- Production repositories: ${foundProdRepositories}"
+        echo "- Orphan repositories: ${foundOrphanRepositories}"
+
+        if [ "${foundPendingRepositories}" == "true" ] && [ "${foundProdRepositories}" == "true" ]; then
+          echo "Error: cannot publish to both redhat-pending and redhat-prod repositories"
+          exit 1
+        fi
+
+        if [ "${foundPendingRepositories}" == "false" ] && [ "${foundProdRepositories}" == "false" ]; then
+          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+          exit 1
+        fi
+
+        if [ "${foundOrphanRepositories}" == "true" ]; then
+          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+          exit 1
+        fi
+
+        # Select the correct secret name
+        advisorySecretName="create-advisory-prod-secret"
+        if [ "${foundPendingRepositories}" == "true" ]; then
+          advisorySecretName="create-advisory-stage-secret"
+        fi
+
+        RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/filter-already-released-advisory-images-results.json"
+        IR_FILE="$(params.dataDir)/$(context.task.name)/ir-result.txt"
+        mkdir -p "$(dirname "$IR_FILE")"
+
+        echo "Creating internal request for filtering already-released advisory images..."
+        # Because of the tee, this will always succeed
+        internal-request --pipeline "filter-already-released-advisory-images" \
+                         -p snapshot_json="$snapshot" \
+                         -p origin="$origin" \
+                         -p advisory_secret_name="$advisorySecretName" \
+                         -p internalRequestPipelineRunName="$(params.pipelineRunUid)" \
+                         -p taskGitUrl="$(params.taskGitUrl)" \
+                         -p taskGitRevision="$(params.taskGitRevision)" \
+                         -s "$(params.synchronously)" \
+                         -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+                         | tee "$IR_FILE"
+
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
+        echo "Internal request created: ${internalRequest}"
+
+        echo "Internal request status:"
+        kubectl get internalrequest "${internalRequest}" -o json | jq .
+
+        results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')
+        if [ -z "$results" ]; then
+          echo "No results found in internal request. Status:"
+          kubectl get internalrequest "${internalRequest}" -o yaml
+          exit 1
+        fi
+
+        internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
+        internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
+        echo "Internal request details:"
+        echo "- Pipeline run: ${internalRequestPipelineRunName}"
+        echo "- Task run: ${internalRequestTaskRunName}"
+
+        if [[ "$(echo "$results" | jq -r '.result')" == "Success" ]]; then
+          echo "Image filtering successful"
+          
+          # Get the unreleased components list
+          UNRELEASED_COMPONENTS=$(echo "$results" | jq -r '.unreleased_components // "[]"')
+          if [ -z "$UNRELEASED_COMPONENTS" ]; then
+            echo "No unreleased components list found in results. Results:"
+            echo "$results"
+            exit 1
+          fi
+
+          # Filter the original snapshot using the unreleased components list
+          FILTERED_SNAPSHOT=$(jq --argjson unreleased "$UNRELEASED_COMPONENTS" '
+            .components = (
+              .components | map(
+                select(
+                  .name as $name | ($unreleased | contains([$name]))
+                )
+              )
+            )
+          ' <<< "$snapshot")
+
+          # Check if the filtered snapshot has any components
+          if jq -e '.components | length == 0' <<< "$FILTERED_SNAPSHOT"; then
+            echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
+            SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
+            echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_PATH"
+            echo -n "Success" > "$(results.result.path)"
+            echo -n "true" > "$(results.skip_release.path)"
+            jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+            exit 0
+          fi
+
+          SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
+          echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_PATH"
+          echo -n "Success" > "$(results.result.path)"
+          echo -n "false" > "$(results.skip_release.path)"
+          jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+        else
+          echo "Filtering failed. Results:"
+          echo "$results"
+          exit 1
+        fi
+    - name: create-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  then
+    echo '{
+      "result": "Success",
+      "unreleased_components": ["new-component"],
+      "internalRequestPipelineRunName": "test-pipeline-run",
+      "internalRequestTaskRunName": "test-task-run"
+    }'
+  else
+    /usr/bin/kubectl "$@"
+  fi
+}

--- a/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -1,0 +1,307 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images
+spec:
+  description: |
+    Run the filter-already-released-advisory-images managed task and validate it creates an InternalRequest correctly.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "old-component",
+                    "repository": "quay.io/redhat-pending/repo",
+                    "containerImage": "quay.io/redhat-pending/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "new-component",
+                    "repository": "quay.io/redhat-pending/repo2",
+                    "containerImage": "quay.io/redhat-pending/repo2@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: result
+            type: string
+          - name: skip_release
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check if the 'pipelineRef' field contains the correct pipeline path
+              expected_pipeline="pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml"
+              pipeline_ref=$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value')
+              if [[ "$pipeline_ref" != "$expected_pipeline" ]]; then
+                echo "InternalRequest doesn't contain the correct pipeline path"
+                exit 1
+              fi
+
+              # Check the snapshot_json parameter
+              snapshotJson=$(echo "$internalRequest" | jq -r '.spec.params.snapshot_json')
+              if [ "$(jq -r '.application' <<< "$snapshotJson")" != "myapp" ]; then
+                echo "InternalRequest has the wrong application in snapshot_json"
+                exit 1
+              fi
+
+              # Check the origin parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.origin' )" != "dev" ]; then
+                echo "InternalRequest has the wrong origin parameter"
+                exit 1
+              fi
+
+              # Check the advisory_secret_name parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name' )" != \
+                "create-advisory-stage-secret" ]; then
+                echo "InternalRequest has the wrong advisory_secret_name parameter"
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
+                exit 1
+              fi
+
+              # Check that the filtered snapshot contains only the new component
+              base_dir="$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              results_file="$base_dir/filter-already-released-advisory-images-results.json"
+              filteredSnapshot=$(jq -r '.filtered_snapshot' "$results_file")
+              if [ "$(jq -r '.components | length' <<< "$filteredSnapshot")" != "1" ]; then
+                echo "Filtered snapshot should contain only one component"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].name' <<< "$filteredSnapshot")" != "new-component" ]; then
+                echo "Filtered snapshot should contain only the new component"
+                exit 1
+              fi
+
+              # Check that skip_release is set to false
+              if [ "$(params.skip_release)" != "false" ]; then
+                echo "skip_release should be false when some components are not released"
+                exit 1
+              fi
+
+              # Check that the result was properly set
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-prod-or-pending
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with a snapshot containing only non-prod and non-pending
+    repositories and verify the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "dev-component",
+                    "repository": "quay.io/redhat-dev/repo",
+                    "containerImage": "quay.io/redhat-dev/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "other-component",
+                    "repository": "quay.io/other/repo",
+                    "containerImage": "quay.io/other/repo@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-rpa
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with no ReleasePlanAdmission and verify it fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored.
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+      description: The location where data will be stored.
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-missing-rpa-inputs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "quay.io/redhat-prod/repo",
+                    "tags": ["v1.0"],
+                    "containerImage": "quay.io/redhat-prod/repo@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+              # Note: No RPA file created
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/missing_rpa.json"  # this file doesn't exist
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with no Snapshot and verify it fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored.
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+      description: The location where data will be stored.
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-missing-snapshot-inputs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "spec": {
+                  "origin": "dev"
+                }
+              }
+              EOF
+              # Note: No snapshot file created
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/missing_snapshot.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-orphan
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with a snapshot containing both prod and non-prod
+    repositories (orphan scenario) and verify the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "prod-component",
+                    "repository": "quay.io/redhat-prod/repo",
+                    "containerImage": "quay.io/redhat-prod/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "dev-component",
+                    "repository": "quay.io/redhat-dev/repo",
+                    "containerImage": "quay.io/redhat-dev/repo@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace


### PR DESCRIPTION
## Describe your changes
Add filter-already-released-advisory-images task
to make rh-advisories pipeline idempotent

- Creates a new task (filter-already-released-advisory-images) to
  filter out images already published in advisories,
  ensuring idempotency.
- Places the filtering task after apply-mapping and before
  conforma/EC validation in the pipeline.
- Overwrites the original snapshot file in place with the filtered snapshot;
  subsequent tasks continue to use the same snapshot path.
- Introduces a skip_release result, which is used in when expressions
  in the pipeline to conditionally skip downstream tasks
  if all images are already released.
- Includes tests and documentation for the new task and pipeline logic.
## Relevant Jira
[RELEASE-1263](https://issues.redhat.com//browse/RELEASE-1263)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

