### PR TITLE
fix(RELEASE-1529): processing of images in embargo-check

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -18,11 +18,15 @@ based on the issues visibility
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 2.0.1
+* Fix processing of releaseNotes.content.images in situations where some images have no CVEs
+  * A `jq` query would previously fail on it
 
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -120,6 +120,7 @@ spec:
               key: token
       script: |
         #!/usr/bin/env bash
+        set -x
 
         SUPPORTED_ISSUE_TRACKERS='{
             "Jira": {
@@ -151,9 +152,6 @@ spec:
 
         NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
         for ((i = 0; i < NUM_ISSUES; i++)); do
-            # We set +x before the curl call and then capture the exit code. That can lead to breaking out of the
-            # current loop iteration or continuing on, so let's set -x at the beginning of each iteration
-            set -x
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$SUPPORTED_ISSUE_TRACKERS")
@@ -164,12 +162,13 @@ spec:
                 AUTH_ARGS=(-H "Authorization: Bearer $ACCESS_TOKEN")
             fi
             OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
-            if [ $? -ne 0 ] ; then
+            CURL_RC=$?
+            set -x
+            if [ "$CURL_RC" -ne 0 ] ; then
                 echo "Error: ${issue} is not visible. Assuming it is embargoed and stopping pipelineRun execution."
                 RC=1
                 continue
             fi
-            set -x
 
             # Perform additional checks only for issues on issues.redhat.com
             if [ "$server" != "issues.redhat.com" ] ; then
@@ -213,6 +212,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       script: |
         #!/usr/bin/env bash
+        set -x
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -222,7 +222,7 @@ spec:
 
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
-        CVES=$(jq -r '.releaseNotes.content.images[].cves.fixed
+        CVES=$(jq -r '.releaseNotes.content.images[] | select(.cves.fixed) | .cves.fixed
             | to_entries[] | .key' "${DATA_FILE}" | sort -u | tr "\n" " ")
 
         if [[ ${CVES} == "" ]] ; then

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -80,6 +80,11 @@ spec:
                   "content": {
                     "images": [
                       {
+                        "component": "my-other-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/other-repo"
+                      },
+                      {
                         "component": "my-component",
                         "architecture": "x86_64",
                         "containerImage": "registry.io/org/repo",


### PR DESCRIPTION
## Describe your changes

In situations where some images have no CVEs, the `jq` query would previously fail with: `null (null) has no keys`

## Relevant Jira

[RELEASE-1529](https://issues.redhat.com//browse/RELEASE-1529)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

