### PR TITLE
fix: exit early when all advisory images are already matched

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,9 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.1.1
+* Optimized advisory matching with early exit when all images are already released.
+
 ## Changes in 1.1.0
 * Update base image
   * New base image contains a new version of the advisory apply template script that render jinja expressions in

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -182,16 +182,16 @@ spec:
                 ))')
 
               echo "Remaining images after filtering: $CONTENT_IMAGES"
-          done
 
-          # If after filtering, no images are left, then we can exit early
-          if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
-              echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
-              ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/main/${ADVISORY_FILE}"
-              echo -n "Success" > "$(results.result.path)"
-              echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
-              exit 0
-          fi
+              # If after filtering, no images are left, then we can exit early
+              if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
+                  echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
+                  ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/main/${ADVISORY_FILE}"
+                  echo -n "Success" > "$(results.result.path)"
+                  echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
+                  exit 0
+              fi
+          done
 
           NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argjson new_images "$CONTENT_IMAGES" \
             '.content.images = $new_images')


### PR DESCRIPTION
## Describe your changes
Insert a break condition immediately after checking if CONTENT_IMAGES is empty inside the loop
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

