### PR TITLE
Default .pyxis.skipLayers to true instead of false

### DIFF
--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -27,6 +27,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                                                                                                                                                                                       | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                                                                                                                                                                              | No       | ""                      |
 
+## Changes in 5.0.0
+* The default value of `.pyxis.skipLayers` now defaults to true instead of false
+
 ## Changes in 4.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -188,8 +188,9 @@ spec:
 
         AUTH_FILE=$(mktemp)
 
-        # Default to false
-        skipLayers="$(jq -r ".pyxis.skipLayers // false" "${DATA_FILE}")"
+        # Default to true
+        EXPRESSION='.pyxis | (if has("skipLayers") and .skipLayers == false then .skipLayers else true end)'
+        skipLayers="$(jq -r "${EXPRESSION}" "${DATA_FILE}")"
 
         COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         JSON_OUTPUT='{}'

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -80,6 +80,9 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
+                "pyxis": {
+                  "skipLayers": false
+                }
               }
               EOF
           - name: skip-trusted-artifact-operations


### PR DESCRIPTION
It is only important for certain base images like ubi, but the operation is expensive (download all layers, decompress them, measure their sizes, upload those sizes).

Default it to true here to save time. Requires downstream users to set this explicitly to true where needed.

Unfortunately, the expression to default to true is more complicated now because `false // true` evaluates to `true`.

https://issues.redhat.com/browse/KONFLUX-5590