### PR TITLE
fix(KONFLUX-7847): check for directory beforehand

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,9 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.1.2
+* Fixes an error introduced in 1.0.0 which affected new advisories.
+
 ## Changes in 1.1.1
 * Optimized advisory matching with early exit when all images are already released.
 

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -152,12 +152,16 @@ spec:
           echo "Checking advisories in directory: ${ADVISORY_BASE_DIR}"
 
           # Check existing advisories across ALL years
-          EXISTING_ADVISORIES=$(
-            find "${ADVISORY_BASE_DIR}" -mindepth 2 -type d -printf "%T@ %p\n" |  # year/advisory dir with modified time
-            sort -nr |                                                            # sort by latest modified first
-            cut -d' ' -f2- |                                                      # remove the timestamp, keep only path
-            sed "s|^${ADVISORY_BASE_DIR}/||"                                      # keeping year/advisory format
-          )
+          EXISTING_ADVISORIES=""
+          if [ -d "${ADVISORY_BASE_DIR}" ]; then
+            EXISTING_ADVISORIES=$(
+              # year/advisory dir with modified time
+              find "${ADVISORY_BASE_DIR}" -mindepth 2 -type d -printf "%T@ %p\n" |
+              sort -nr |                       # sort by latest modified first
+              cut -d' ' -f2- |                 # remove the timestamp, keep only path
+              sed "s|^${ADVISORY_BASE_DIR}/||" # keeping year/advisory format
+            )
+          fi
 
           if [[ -z "$EXISTING_ADVISORIES" ]]; then
               echo "No existing advisories found."

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -9,6 +9,7 @@ function git() {
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     mkdir -p "$gitRepo"/schema
     echo '{"$schema": "http://json-schema.org/draft-07/schema#","type": "object", "properties":{}}' > "$gitRepo"/schema/advisory.json
+    mkdir -p "$gitRepo"/data/advisories/dev-tenant
   elif [[ "$*" == *"failing-tenant"* ]]; then
     echo "Mocking failing git command" && false
   else
@@ -19,6 +20,11 @@ function git() {
 
 function find() {
   echo "Mock find called with: $*" >&2
+
+  if echo "$*" | grep -q "not-existing-origin"; then
+    echo "Error: Unexpected call for not existing origin"
+    exit 1
+  fi
 
   if echo "$*" | grep -q "${ADVISORY_BASE_DIR}"; then
     # Simulate directories with timestamps

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -23,7 +23,7 @@ spec:
         - name: application
           value: "test-app"
         - name: origin
-          value: "dev-tenant"
+          value: "not-existing-origin"
         - name: config_map_name
           value: "create-advisory-test-cm"
         - name: advisory_secret_name
@@ -58,4 +58,4 @@ spec:
 
               echo Test that advisory_url was properly set
               test "$(params.advisory_url)" == \
-                https://gitlab.com/org/repo/-/blob/main/data/advisories/dev-tenant/2024/1234/advisory.yaml
+                https://gitlab.com/org/repo/-/blob/main/data/advisories/not-existing-origin/2024/1234/advisory.yaml


### PR DESCRIPTION
## Describe your changes

There was an issue in this tasks where the find command to check for existing advisories failed when there were none. This is common in workflows submitting an advisory for the first time. The fix implemented in this commit is checking for the directory before running the find command.

## Relevant Jira

https://issues.redhat.com/browse/KONFLUX-7847

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

