### PR TITLE
fix: increase set-advisory-severity IR timeout

### DIFF
--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -5,19 +5,22 @@ OSIDB for each CVE present. If the type is not RHSA, no action will be performed
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional  | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------|
-| dataPath                | Path to data JSON in the data workspace                                                                                    | No        | -                       |
-| requestTimeout          | InternalRequest timeout                                                                                                    | Yes       | 180                     |
-| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No        | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      | 
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes       | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
+| Name                    | Description                                                                                                                | Optional | Default value           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------- |
+| dataPath                | Path to data JSON in the data workspace                                                                                    | No       | -                       |
+| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 2700                    |
+| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                       |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 1.0.1
+* Update the requestTimeout default value to 45 mins
 
 ## Changes in 1.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -19,7 +19,7 @@ spec:
       type: string
     - name: requestTimeout
       type: string
-      default: "1800"
+      default: "2700"
       description: InternalRequest timeout
     - name: pipelineRunUid
       type: string


### PR DESCRIPTION
## Describe your changes

It turns out even 30 minutes is not enough sometimes.

We have [RELEASE-1540](https://issues.redhat.com//browse/RELEASE-1540) to improve the performance of the task, but for now, let's increase the timeout to 45 minutes.

## Relevant Jira

[RELEASE-1540](https://issues.redhat.com//browse/RELEASE-1540)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

