### PR TITLE
fix(KONFLUX-7733): advisory_url to point to customer portal

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,9 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.1.3
+* Change the `advisory_url` result to use link to customer portal instead of git repo
+
 ## Changes in 1.1.2
 * Fixes an error introduced in 1.0.0 which affected new advisories.
 

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/version: "1.1.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -127,6 +127,7 @@ spec:
 
           REPO_BRANCH=main
           ADVISORY_URL=""
+          ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
 
           # Switch to /tmp to avoid filesystem permission issues
           cd /tmp
@@ -191,6 +192,9 @@ spec:
               if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
                   echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
                   ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/main/${ADVISORY_FILE}"
+                  ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
+                  ADVISORY_NAME=$(yq -r '.metadata.name' "${ADVISORY_FILE}")
+                  ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
                   echo -n "Success" > "$(results.result.path)"
                   echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
                   exit 0
@@ -240,6 +244,6 @@ spec:
           git commit -m "[Konflux Release] new advisory for $(params.application)"
           echo "Pushing to ${REPO_BRANCH}..."
           git_push_with_retries --branch $REPO_BRANCH --retries 5 --url origin 2> "$STDERR_FILE"
-          # Construct the advisory url to report back to the user as a result
-          # Note: This currently only supports gitlab repos, which is all we expect for now
-          ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/${REPO_BRANCH}/${ADVISORY_FILEPATH}"
+          # Construct the advisory url on customer portal to report back to the user as a result
+          ADVISORY_TYPE=$(jq -r '.type' <<< "$ADVISORY_JSON" )
+          ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -50,26 +50,33 @@ function yq() {
   advisory_year=$(echo "$advisory_path" | awk -F'/' '{print $(NF-2)}')  # Extract Year
   advisory_num=$(echo "$advisory_path" | awk -F'/' '{print $(NF-1)}')   # Extract Advisory Number
 
-  echo "Returning advisory content for ${advisory_year}/${advisory_num}" >&2
+  if [[ "$2" == ".spec.type" ]]; then
+    echo RHSA
+  elif [[ "$2" == ".metadata.name" ]]; then
+    echo "${advisory_year}:${advisory_num}"
+  else
 
-  case "$advisory_num" in
-    1601)
-      echo '[{"architecture":"amd64","component":"release-manager-alpha","containerImage":"quay.io/example/release@sha256:alpha123","repository":"example-stream/release","signingKey":"example-sign-key","tags":["v1.0","latest"]}]'
-      ;;
-    1602)
-      echo '[{"architecture":"amd64","component":"release-manager-beta","containerImage":"quay.io/example/release@sha256:beta123","repository":"example-stream/release","signingKey":"example-sign-key","tags":["v2.0","stable"]}]'
-      ;;
-    1442)
-      echo '[{"architecture":"amd64","component":"foo-foo-manager-1-15","containerImage":"quay.io/example/openstack@sha256:abde","repository":"quay.io/example/openstack","signingKey":"example-sign-key","tags":["v1.0","latest"]}]'
-      ;;
-    1452)
-      echo '[{"architecture":"amd64","component":"foo-foo-manager-1-15","containerImage":"quay.io/example/openstack@sha256:lmnop","repository":"quay.io/example/openstack","signingKey":"example-sign-key","tags":["latest"]}]'
-      ;;
-    *)
-      echo "Error: Unexpected advisory number $advisory_num" >&2
-      exit 1
-      ;;
-  esac
+    echo "Returning advisory content for ${advisory_year}/${advisory_num}" >&2
+
+    case "$advisory_num" in
+      1601)
+        echo '[{"architecture":"amd64","component":"release-manager-alpha","containerImage":"quay.io/example/release@sha256:alpha123","repository":"example-stream/release","signingKey":"example-sign-key","tags":["v1.0","latest"]}]'
+        ;;
+      1602)
+        echo '[{"architecture":"amd64","component":"release-manager-beta","containerImage":"quay.io/example/release@sha256:beta123","repository":"example-stream/release","signingKey":"example-sign-key","tags":["v2.0","stable"]}]'
+        ;;
+      1442)
+        echo '[{"architecture":"amd64","component":"foo-foo-manager-1-15","containerImage":"quay.io/example/openstack@sha256:abde","repository":"quay.io/example/openstack","signingKey":"example-sign-key","tags":["v1.0","latest"]}]'
+        ;;
+      1452)
+        echo '[{"architecture":"amd64","component":"foo-foo-manager-1-15","containerImage":"quay.io/example/openstack@sha256:lmnop","repository":"quay.io/example/openstack","signingKey":"example-sign-key","tags":["latest"]}]'
+        ;;
+      *)
+        echo "Error: Unexpected advisory number $advisory_num" >&2
+        exit 1
+        ;;
+    esac
+  fi
 }
 
 function glab() {

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -64,7 +64,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              EXPECTED_URL="https://gitlab.com/org/repo/-/blob/main/data/advisories/dev-tenant/2024/1234/advisory.yaml"
+              EXPECTED_URL="https://access.redhat.com/errata/RHSA-2024:1234"
 
               if [[ "$(params.result-status)" != "Success" ]]; then
                   echo "Task did not succeed. Status: $(params.result-status)"

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -58,7 +58,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              EXPECTED_URL="https://gitlab.com/org/repo/-/blob/main/data/advisories/dev-tenant/2024/1442/advisory.yaml"
+              EXPECTED_URL="https://access.redhat.com/errata/RHSA-2024:1442"
 
               if [[ "$(params.result-status)" != "Success" ]]; then
                   echo "Task did not succeed. Status: $(params.result-status)"

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -58,4 +58,4 @@ spec:
 
               echo Test that advisory_url was properly set
               test "$(params.advisory_url)" == \
-                https://gitlab.com/org/repo/-/blob/main/data/advisories/not-existing-origin/2024/1234/advisory.yaml
+                https://access.redhat.com/errata/RHSA-2024:1234

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -113,7 +113,7 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: advisoryUrl
-          value: https://domain.com/advisory.yaml
+          value: https://access.redhat.com/errata/RHBA-2025:1111
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
@@ -115,7 +115,7 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: advisoryUrl
-          value: https://domain.com/advisory.yaml
+          value: https://access.redhat.com/errata/RHBA-2025:1111
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
@@ -115,7 +115,7 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: advisoryUrl
-          value: https://domain.com/advisory.yaml
+          value: https://access.redhat.com/errata/RHBA-2025:1111
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -98,7 +98,7 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: advisoryUrl
-          value: https://domain.com/advisory.yaml
+          value: https://access.redhat.com/errata/RHBA-2025:1111
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -111,7 +111,7 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: advisoryUrl
-          value: https://domain.com/advisory.yaml
+          value: https://access.redhat.com/errata/RHBA-2025:1111
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/create-advisory/tests/mocks.sh
+++ b/tasks/managed/create-advisory/tests/mocks.sh
@@ -7,7 +7,7 @@ function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
   then
-    echo '{"result":"Success","advisory_url":"https://github.com/org/repo/advisory"}'
+    echo '{"result":"Success","advisory_url":"https://access.redhat.com/errata/RHBA-2025:1111"}'
   else
     /usr/bin/kubectl $*
   fi

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -59,7 +59,7 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -246,7 +246,7 @@ spec:
 
               # Count the number of InternalRequests
               requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
-              
+
               # Check if the number of InternalRequests is as expected
               if [ "$requestsCount" -ne 1 ]; then
                 echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
@@ -259,7 +259,7 @@ spec:
               if [[ "$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value' )" != \
               "pipelines/internal/create-advisory"* ]]; then
                 echo "InternalRequest doesn't contain 'create-advisory' in 'pipeline' field"
-                exit 1 
+                exit 1
               fi
 
               # Check the application parameter
@@ -300,12 +300,12 @@ spec:
               fi
 
               echo Test that the advisory_url result was properly set
-              test "$(echo $(params.advisory_url))" == "https://github.com/org/repo/advisory"
+              test "$(params.advisory_url)" == "https://access.redhat.com/errata/RHBA-2025:1111"
 
               echo Test that the advisory_url was properly added to the results file
               test "$(jq -r '.advisory.url' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/results/create-advisory-results.json")" == \
-                "https://github.com/org/repo/advisory"
+                "https://access.redhat.com/errata/RHBA-2025:1111"
 
               # Check the advisory_secret_name parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name' )" != \


### PR DESCRIPTION
## Describe your changes

The internal create-advisory-task task produces a result called advisory_url. This is then used for the results file (to be shown in Konflux UI) and it's also added as a comment when closing Jiras in close-advisory-issues.

Until now, we would link to advisory file in the advisories gitlab repo. That's not where we should be pointing users. Instead, we will now link to customer portal, e.g. https://access.redhat.com/errata/RHBA-2025:3373

## Relevant Jira

[KONFLUX-7733](https://issues.redhat.com//browse/KONFLUX-7733)

Paired with this change: https://github.com/konflux-ci/e2e-tests/pull/1574

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

