### PR TITLE
feat(RELEASE-1341): fbc ir should use release sa

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -108,6 +108,10 @@
         "pipelineImage": {
           "type": "string",
           "description": "An image with CLI tools needed for the signing by the internal signing pipelines"
+        },
+        "internalRequestServiceAccount": {
+          "type": "string",
+          "description": "The service account used to run the internal request"
         }
       }
     },

--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -4,16 +4,20 @@ Task to create an internalrequest to add fbc contributions to index images
 
 ## Parameters
 
-| Name            | Description                                                                               | Optional | Default value        |
-|-----------------|-------------------------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath    | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | No       | -                    |
-| dataPath        | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                    |
-| fromIndex       | fromIndex value updated by update-ocp-tag task                                            | No       | -                    |
-| pipelineRunUid  | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                    |
-| targetIndex     | targetIndex value updated by update-ocp-tag task                                          | No       | -                    |
-| resultsDirPath  | Path to results directory in the data workspace                                           | No       | -                    |
-| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -                    |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                            | No       | -                    |
+| Name                              | Description                                                                               | Optional                | Default value |
+|-----------------------------------|-------------------------------------------------------------------------------------------|-------------------------|---------------|
+| snapshotPath                      | Path to the JSON string of the mapped Snapshot spec in the data workspace                 | No                      | -             |
+| dataPath                          | Path to the JSON string of the merged data to use in the data workspace                   | No                      | -             |
+| fromIndex                         | fromIndex value updated by update-ocp-tag task                                            | No                      | -             |
+| pipelineRunUid                    | The uid of the current pipelineRun. Used as a label value when creating internal requests | No                      | -             |
+| targetIndex                       | targetIndex value updated by update-ocp-tag task                                          | No                      | -             |
+| resultsDirPath                    | Path to results directory in the data workspace                                           | No                      | -             |
+| taskGitUrl                        | The url to the git repo where the release-service-catalog tasks to be used are stored     | No                      | -             |
+| taskGitRevision                   | The revision in the taskGitUrl repo to be used                                            | No                      | -             |
+
+## Changes in 4.0.2
+* The task now reads the `internalRequestServiceAccount` key from the ReleasePlanAdmission data field and passes it to
+the `internal-request` script, to set the SA that will be used to run IR's pipelinerun.
 
 ## Changes in 4.0.1
 * Adds the `publishingCredentials` parameter to the internal request call

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "4.0.1"
+    app.kubernetes.io/version: "4.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -91,6 +91,8 @@ spec:
         request_timeout_seconds=$(jq -r --arg request_timeout_seconds ${default_request_timeout_seconds} \
             '.fbc.requestTimeoutSeconds // $request_timeout_seconds' "${DATA_FILE}")
         fbc_fragment=$(jq -cr '.components[0].containerImage' "${SNAPSHOT_PATH}")
+        internal_request_service_account=$(jq -r '.fbc.internalRequestServiceAccount // "release-service-account"' \
+            "${DATA_FILE}")
 
         if [ "${staged_index}" = "true" ]; then
           iib_service_account_secret="iib-service-account-stage"
@@ -151,6 +153,7 @@ spec:
             -p stagedIndex="${staged_index}" \
             -p taskGitUrl="$(params.taskGitUrl)" \
             -p taskGitRevision="$(params.taskGitRevision)" \
+            --service-account "${internal_request_service_account}" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
             -t "${request_timeout_seconds}" |tee "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -88,7 +88,12 @@ spec:
                 tac | tail -1)"
 
               internalRequest=$(echo "${internalRequest}" | xargs)
-              requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+              requestParams="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")"
+              serviceAccount="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.serviceAccount}")"
+
+              if [ "${serviceAccount}" != "release-service-account" ]; then
+                echo "service account does not match"
+              fi
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -91,6 +91,11 @@ spec:
 
               internalRequest=$(echo "${internalRequest}" | xargs)
               requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+              serviceAccount="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.serviceAccount}")"
+
+              if [ "${serviceAccount}" != "release-service-account" ]; then
+                echo "service account does not match"
+              fi
 
               if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
                 echo "fromIndex does not match"

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -100,6 +100,11 @@ spec:
 
               internalRequest=$(echo "${internalRequest}" | xargs)
               requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+              serviceAccount="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.serviceAccount}")"
+
+              if [ "${serviceAccount}" != "release-service-account" ]; then
+                echo "service account does not match"
+              fi
 
               test "$(jq -r '.index_image.target_index' \
                 "$(workspaces.data.path)"/results/add-fbc-contribution-results.json)" == \


### PR DESCRIPTION
this PR add a new parameter to the add-fbc-contribution task to allow setting the parameter service-account in the internal-request script, so the internal-request can run as the release-service-account sa, which has access to the rhoai quay.io pull-secrets.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

