### PR TITLE
chore(RELEASE-1334): remove push to stable branch

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -101,7 +101,6 @@ if [ "${PROMOTION_TYPE}" == development-to-staging ]; then
 elif [ "${PROMOTION_TYPE}" == staging-to-production ]; then
     SOURCE_BRANCH=staging
     TARGET_BRANCH=production
-    SRE_DUPLICATE_BRANCH=stable
 else
     echo "Invalid promotion type. Only 'development-to-staging' and 'staging-to-production' are allowed"
     print_help
@@ -155,9 +154,6 @@ fi
 
 git checkout $SOURCE_BRANCH
 git push origin $SOURCE_BRANCH:$TARGET_BRANCH
-if [ -v SRE_DUPLICATE_BRANCH ] ; then
-    git push origin $SOURCE_BRANCH:$SRE_DUPLICATE_BRANCH
-fi
 
 cd -
 rm -rf ${tmpDir}


### PR DESCRIPTION
This commit updates the promote_branch.sh script called in the promote branch github workflow. The script will no longer push the production content to the stable branch. Since we now use git resolvers for all internal tasks, we no longer need this stable branch.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

