### PR TITLE
fix: temporarily allow upload-product-sbom to fail

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -26,7 +26,11 @@ the rh-push-to-registry-redhat-io pipeline.
 | ociStorage                      | The OCI repository where the Trusted Artifacts are stored                                                                          | Yes      | quay.io/konflux-ci/release-service-trusted-artifacts      |
 | orasOptions                     | oras options to pass to Trusted Artifacts calls                                                                                    | Yes      | ""                                                        |
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
-| dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      | 
+| dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
+
+## Changes in 2.0.1
+* Temporarily allow the `upload-product-sbom` task to fail
+  * The upload to S3 started giving us 503 errors. It will be investigated in ISV-5887
 
 ## Changes in 2.0.0
 * Activate the use of trusted artifacts

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -975,6 +975,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - create-product-sbom
+      onError: continue
     - name: create-advisory
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5


### PR DESCRIPTION
## Describe your changes

The upload to S3 started giving us 503 errors. It will be investigated in [ISV-5887](https://issues.redhat.com//browse/ISV-5887)

This issue was blocking https://github.com/konflux-ci/e2e-tests/pull/1574 from being merged, so this PR here is paired with that one, so that hopefully e2e passes here, we merge this and this should unblock the e2e PR.

## Relevant Jira

[ISV-5887](https://issues.redhat.com//browse/ISV-5887)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

