### PR TITLE
feat(ISV-5887): force retry of S3 PUT request

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.4
+* Don't allow the `upload-product-sbom` task to fail anymore.
+  * The issue should be resolved by curl retrying on all errors.
+
 ## Changes in 2.0.3
 * Correct missing severity in advisory due to incorrect sourceDataArtifact
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -975,7 +975,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - create-product-sbom
-      onError: continue
     - name: create-advisory
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5

--- a/tasks/managed/upload-sbom-to-atlas/README.md
+++ b/tasks/managed/upload-sbom-to-atlas/README.md
@@ -33,6 +33,9 @@ lower, they are uploaded as-is.
 | taskGitUrl                | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                                                                            |
 | taskGitRevision           | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                                                                            |
 
+## Changes in 2.0.1
+* Force curl to retry on all errors in S3 push.
+
 ## Changes in 2.0.0
 * Add a step that pushes SBOMs to S3 if they failed to be pushed to Atlas.
 * Add non-optional parameters to facilitate the S3 push.

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: upload-sbom-to-atlas
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -384,7 +384,8 @@ spec:
 
           echo "Pushing $to_upload to S3."
           if ! curl -X PUT --upload-file "${to_upload}" \
-              --silent --show-error --fail-with-body --retry 5 \
+              --silent --show-error --fail-with-body --retry 10 \
+              --retry-all-errors \
               -H "Host: ${bucket}.s3.${region}.amazonaws.com" \
               -H "Date: ${date_value}" \
               -H "Content-Type: ${content_type}" \


### PR DESCRIPTION
It's possible that the S3 bucket needs more time to scale up. We can utilize curl's exponential backoff to give AWS time. S3 should be able to handle more than 5000 requests per second, which is far above what we use. This PR also fixes the quirk in curl, where the 503 was not retried.

https://issues.redhat.com/browse/ISV-5887