### PR TITLE
fix(RELEASE-1543): add author to push-artifacts-to-cdn

### DIFF
--- a/pipelines/internal/push-artifacts-to-cdn/README.md
+++ b/pipelines/internal/push-artifacts-to-cdn/README.md
@@ -7,6 +7,7 @@ Tekton Pipeline to push artifacts to CDN and/or Dev Portal
 | Name            | Description                                                                            | Optional    | Default value                                              |
 |-----------------|----------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|
 | snapshot_json   | String containing a JSON representation of the snapshot spec                           | No          | -                                                          |
+| author          | Author taken from Release to be used for checksum signing                              | No          | -                                                          |
 | exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                              | No          | -                                                          |
 | exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                      | No          | -                                                          |
 | pulpSecret      | Env specific secret containing the rhsm-pulp credentials                               | No          | -                                                          |
@@ -15,3 +16,7 @@ Tekton Pipeline to push artifacts to CDN and/or Dev Portal
 | cgwSecret       | Env specific secret containing the content gateway credentials                         | No          | -                                                          |
 | taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored  | Yes         | https://github.com/konflux-ci/release-service-catalog.git  |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                         | No          | -                                                          |
+
+## Changes in 1.0.0
+* Add new required parameter `author`. This was already required by the task inside the pipeline, so the pipeline
+  did not work before this

--- a/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,9 @@ spec:
     - name: cgwSecret
       type: string
       description: Env specific secret containing the content gateway credentials
+    - name: author
+      type: string
+      description: Author taken from Release to be used for checksum signing
     - name: taskGitUrl
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
       default: https://github.com/konflux-ci/release-service-catalog.git
@@ -68,6 +71,8 @@ spec:
           value: $(params.cgwHostname)
         - name: cgwSecret
           value: $(params.cgwSecret)
+        - name: author
+          value: $(params.author)
   results:
     - name: result
       value: $(tasks.push-artifacts-to-cdn-task.results.result)

--- a/pipelines/managed/push-artifacts-to-cdn/README.md
+++ b/pipelines/managed/push-artifacts-to-cdn/README.md
@@ -21,6 +21,9 @@ It uses InternalRequests so that it can be run on both public and private cluste
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                               | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                      | No       | -                                                         |
 
+## Changes in 0.2.1
+* Required parameter `releasePath` is now passed to the `push-artifacts-to-cdn` task
+
 ## Changes in 0.2.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers
 * Align workspace name with changes in the apply-mapping task

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -246,6 +246,8 @@ spec:
           - name: pathInRepo
             value: tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
       params:
+        - name: releasePath
+          value: "$(tasks.collect-data.results.release)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: snapshotPath

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -4,16 +4,29 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 
 ## Parameters
 
-| Name            | Description                                                       | Optional | Default value                                            |
-|-----------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
-| snapshot_json   | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
-| concurrentLimit | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
-| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
-| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
-| pulpSecret      | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |
-| udcacheSecret   | Env specific secret containing the udcache credentials            | No       | -                                                        |
-| cgwHostname     | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
-| cgwSecret       | Env specific secret containing the content gateway credentials    | No       | -                                                        |
+| Name                  | Description                                                       | Optional | Default value                                            |
+|-----------------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
+| snapshot_json         | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
+| concurrentLimit       | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
+| author                | Author taken from Release to be used for checksum signing         | No       | -                                                        |
+| quayUrl               | quay URL of the repo where content will be shared                 | Yes      | quay.io/konflux-artifacts                                |
+| quaySecret            | Secret to interact with Quay                                      | Yes      | quay-credentials                                         |
+| windowsCredentials    | Secret to interact with the Windows signing host                  | Yes      | windows-credentials                                      |
+| windowsSSHKey         | Secret containing SSH private key for the Windows signing host    | Yes      | windows-ssh-key                                          |
+| macHostCredentials    | Secret to interact with the Mac signing host                      | Yes      | mac-host-credentials                                     |
+| macSigningCredentials | Secret to interact with the Mac signing utils                     | Yes      | mac-signing-credentials                                  |
+| macSSHKey             | Secret containing SSH private key for the Mac signing host        | Yes      | mac-ssh-key                                              |
+| checksumUser          | User to interact with the checksum host                           | Yes      | konflux-release-signing-sa                               |
+| checksumHost          | Hostname of the checksum host                                     | Yes      | etera-worker.hosted.upshift.rdu2.redhat.com              |
+| checksumFingerprint   | Secret containing the fingerprint for the checksum host           | Yes      | checksum-fingerprint                                     |
+| checksumKeytab        | Secret containing the keytab for the checksum host                | Yes      | checksum-keytab                                          |
+| kerberosRealm         | Kerberos realm for the checksum host                              | Yes      | IPA.REDHAT.COM                                           |
+| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
+| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
+| pulpSecret            | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |
+| udcacheSecret         | Env specific secret containing the udcache credentials            | No       | -                                                        |
+| cgwHostname           | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
+| cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                                        |
 
 ## Changes in 1.0.0
 * Add steps for signing: `push-unsigned-using-oras`, `sign-mac-binaries`, `sign-windows-binaries`, `generate-checksums`

--- a/tasks/managed/push-artifacts-to-cdn/README.md
+++ b/tasks/managed/push-artifacts-to-cdn/README.md
@@ -7,10 +7,19 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 
 | Name                     | Description                                                                               | Optional | Default value |
 |--------------------------|-------------------------------------------------------------------------------------------|----------|---------------|
+| releasePath              | Path to the release data JSON file                                                        | No       | -             |
 | snapshotPath             | Path to the JSON file of the Snapshot spec in the data workspace                          | No       | -             |
 | dataPath                 | Path to data JSON in the data workspace                                                   | No       | -             |
+| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -             |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 | resultsDirPath           | Path to results directory in the data workspace                                           | No       | -             |
+| requestTimeout           | Request timeout                                                                           | Yes      | 86400         |
+
+## Changes in 1.0.0
+* `releasePath` parameter added
+  * Author is extracted from the Release.Status and passed to the internalRequest
 
  ## Changes in 0.0.2
  * release-service-utils image is bumped

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "0.0.2"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -13,6 +13,9 @@ spec:
     Tekton task to push artifacts via an InternalRequest to Exodus CDN in addition to Developer Portal.
     The environment to use is pulled from the `cdn.env` key in the data file.
   params:
+    - name: releasePath
+      description: Path to the JSON string of the release in the data workspace
+      type: string
     - name: snapshotPath
       type: string
       description: Path to the JSON string of the Snapshot spec in the data workspace
@@ -79,6 +82,8 @@ spec:
         snapshot=$(jq -c '.' "$(workspaces.data.path)/$(params.snapshotPath)")
         # .cdn.env is likely to change in the future. This is just for POC
         env=$(jq -r '.cdn.env' "$(workspaces.data.path)/$(params.dataPath)")
+        AUTHOR=$(jq -r '.status.attribution.author' "$(workspaces.data.path)/$(params.releasePath)")
+        if [[ "${AUTHOR}" == "null" ]] ; then echo "No author found in Release.Status. Failing..." ; exit 1 ; fi
 
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/push-artifacts-results.json"
         FILES=$(jq -c '{"artifacts": [.components[].staged?.files[]?.filename]}' <<< "$snapshot")
@@ -121,6 +126,7 @@ spec:
 
         ${requestType} --pipeline "${REQUEST}" \
           -p snapshot_json="${snapshot}" \
+          -p author="${AUTHOR}" \
           -p exodusGwSecret="${exodusGwSecret}" \
           -p exodusGwEnv="${exodusGwEnv}" \
           -p pulpSecret="${pulpSecret}" \

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
@@ -85,6 +85,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -92,6 +102,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
@@ -54,6 +54,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -61,6 +71,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
@@ -64,6 +64,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -71,6 +81,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "test_snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-artifacts-to-cdn-fail-no-snapshot
+  name: test-push-artifacts-to-cdn-fail-no-release-author
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-artifacts task with no snapshot JSON and verify the task fails as expected
+    Run the push-artifacts task with no author in the release JSON and verify the task fails as expected
   workspaces:
     - name: tests-workspace
   tasks:
@@ -21,6 +21,24 @@ spec:
               set -eux
 
               mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/test_snapshot_spec.json" << EOF
+              {
+                "application": "artifacts",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  },
+                  {
+                    "name": "amd-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/amd@sha256:abcdefg",
+                    "repository": "repo2"
+                  }
+                ]
+              }
+              EOF
+
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
                 "contentGateway": {
@@ -69,10 +87,8 @@ spec:
 
               cat > "$(workspaces.data.path)/release.json" << EOF
               {
-                "status": {
-                  "attribution": {
-                    "author": "JohnDoe"
-                  }
+                "spec": {
+                  "releasePlan": "foo"
                 }
               }
               EOF
@@ -86,7 +102,7 @@ spec:
         - name: releasePath
           value: release.json
         - name: snapshotPath
-          value: "snapshot_spec.json"
+          value: "test_snapshot_spec.json"
         - name: dataPath
           value: "data.json"
         - name: releasePlanAdmissionPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
@@ -86,6 +86,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -93,6 +103,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
@@ -82,6 +82,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -89,6 +99,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath
@@ -171,6 +183,12 @@ spec:
               # Check the udcacheSecret parameter
               if [ "$(jq -r '.spec.params.udcacheSecret' <<< "$internalRequest")" != "udcache-prod-secret" ]; then
                 echo "InternalRequest has the wrong udcacheSecret parameter"
+                exit 1
+              fi
+
+              # Check the author parameter
+              if [ "$(jq -r '.spec.params.author' <<< "$internalRequest")" != "JohnDoe" ]; then
+                echo "InternalRequest has the wrong author parameter"
                 exit 1
               fi
   finally:

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
@@ -82,6 +82,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -89,6 +99,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
@@ -102,6 +102,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -109,6 +119,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
@@ -100,6 +100,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -107,6 +117,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
@@ -82,6 +82,16 @@ spec:
                 }
               }
               EOF
+
+              cat > "$(workspaces.data.path)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -89,6 +99,8 @@ spec:
       taskRef:
         name: push-artifacts-to-cdn
       params:
+        - name: releasePath
+          value: release.json
         - name: snapshotPath
           value: "snapshot_spec.json"
         - name: dataPath


### PR DESCRIPTION
The push-artifacts-to-cdn-task internal task has a required parameter `author` but the internal pipeline that calls it did not pass it. So, the task always failed. This commit updates the pipeline to accept the `author` parameter and pass it to the task. It also updates the managed task that calls the internal pipeline to retrieve the author from the release json file and pass it to the internalRequest.

Finally, it adds some missing parameters to related READMEs as they were listed in the yaml files but not READMEs.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

