### PR TITLE
feat(KONFLUX-5590): replace skipLayers with includeLayers

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -327,9 +327,9 @@
           "type": "boolean",
           "description": "Skip setting the pyxis repo to published"
         },
-        "skipLayers": {
+        "includeLayers": {
           "type": "boolean",
-          "description": "When creating ContainerImage in Pyxis, omit details about layers"
+          "description": "When creating ContainerImage in Pyxis, include details about layers"
         }
       }
     },

--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -27,6 +27,12 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                                                                                                                                                                                       | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                                                                                                                                                                              | No       | ""                      |
 
+## Changes in 5.0.0
+* Replace `.pyxis.skipLayers` with `.pyxis.includeLayers`
+  * We want to skip the layer details when creating images in Pyxis by default,
+    so to include it in the future, the data will need to set
+    `.pyxis.includeLayers=true` explicitly
+
 ## Changes in 4.1.0
 * Remove logic to determine dockerfile name
   * This logic was added as a temporary fix until it's fixed on build side. And now it is

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "5.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -189,7 +189,7 @@ spec:
         AUTH_FILE=$(mktemp)
 
         # Default to false
-        skipLayers="$(jq -r ".pyxis.skipLayers // false" "${DATA_FILE}")"
+        includeLayers="$(jq -r ".pyxis.includeLayers // false" "${DATA_FILE}")"
 
         COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         JSON_OUTPUT='{}'
@@ -252,8 +252,8 @@ spec:
                 # This causes upload to pyxis to fail which cannot tolerate duplicate "top_layer_id" values.
                 # This flag allows to overcome this limitation by just deleting the layers so that no layer
                 # information is uploaded.
-                if [ "$skipLayers" = true ]; then
-                  echo ".pyxis.skipLayers is true in data file, so delete the layers"
+                if [ "$includeLayers" != true ]; then
+                  echo ".pyxis.includeLayers is not true in data file, so delete the layers"
                   jq '.layers = []' "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
                   mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
                 fi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-skip-layers
+  name: test-create-pyxis-image-include-layers-false
 spec:
   description: |
-    Run the create-pyxis-image task with an image that has layers, but
-    .pyxis.skipLayers=true, so the layers will be deleted and not processed
+    Run the create-pyxis-image task with an image that has layers and
+    .pyxis.includeLayers=false, so the layers will be deleted and not processed.
   workspaces:
     - name: tests-workspace
   params:

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -6,7 +6,9 @@ metadata:
 spec:
   description: |
     Run the create-pyxis-image task with an image that has gzipped layers, to
-    see that we reported the uncompressed digests correctly
+    see that we reported the uncompressed digests correctly. The data file
+    also has .pyxis.includeLayers set to true, otherwise the layers would be
+    deleted and not processed.
   workspaces:
     - name: tests-workspace
   params:
@@ -80,6 +82,9 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
+                "pyxis": {
+                  "includeLayers": true
+                }
               }
               EOF
           - name: skip-trusted-artifact-operations


### PR DESCRIPTION
## Describe your changes

It is only important for certain base images like ubi to save the layer details in Pyxis, but the operation is expensive (download all layers, decompress them, measure their sizes, upload those sizes).

So let's make layer processing disabled by default to save time. This requires downstream users to set includeLayers explicitly to true where needed.

Related: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/5650

Note: This is an updated version of https://github.com/konflux-ci/release-service-catalog/pull/911 

## Relevant Jira

[KONFLUX-5590](https://issues.redhat.com//browse/KONFLUX-5590)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

