### PR TITLE
fix: allow close-advisory-issues to fail

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,11 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.2
+* Temporarily allow the `close-advisory-issues` task to fail
+  * Until https://issues.redhat.com/browse/KONFLUX-7489 is fixed
+  * The task fails if the transition scheme is unexpected
+
 ## Changes in 2.0.1
 * Temporarily allow the `upload-product-sbom` task to fail
   * The upload to S3 started giving us 503 errors. It will be investigated in ISV-5887

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -1023,6 +1023,7 @@ spec:
         - rh-sign-image-cosign
         - set-advisory-severity
     - name: close-advisory-issues
+      onError: continue  # until https://issues.redhat.com/browse/KONFLUX-7489 is fixed
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath


### PR DESCRIPTION
This commit updates the close-advisory-issues task to fail in rh-advisories as the task fails when the transition scheme is not expected and it is misleading to users to fail the pipeline on this, as the content is still published via advisory.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

