### PR TITLE
fix(KONFLUX-8071): migrate blob-signing-pipeline

### DIFF
--- a/pipelines/internal/blob-signing-pipeline/README.md
+++ b/pipelines/internal/blob-signing-pipeline/README.md
@@ -1,0 +1,14 @@
+# blob-signing pipeline
+
+Tekton pipeline for signing base64 blobs
+
+## Parameters
+
+| Name            | Description                                                                           | Optional | Default value                                                                         |
+|-----------------|---------------------------------------------------------------------------------------|----------|---------------------------------------------------------------------------------------|
+| pipeline_image  | An image with CLI tools needed for the signing.                                       | Yes      | quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3 |
+| blob            | Blob that needs to be signed.                                                         | No       | -                                                                                     |
+| requester       | Name of the user that requested the signing, for auditing purposes                    | No       | -                                                                                     |
+| config_map_name | A config map name with configuration                                                  | Yes      | hacbs-signing-pipeline-config                                                         |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git                             |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                                                     |

--- a/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
+++ b/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: blob-signing-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline for simple signing
+  params:
+    - name: pipeline_image
+      description: An image with CLI tools needed for the signing.
+      default: quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3
+    - name: blob
+      description: Blob that needs to be signed.
+    - name: requester
+      description: Name of the user that requested the signing, for auditing purposes
+      type: string
+    - name: config_map_name
+      description: A config map name with configuration
+      default: hacbs-signing-pipeline-config
+      type: string
+    - name: taskGitUrl
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+      type: string
+    - name: taskGitRevision
+      description: The revision in the taskGitUrl repo to be used
+      type: string
+  workspaces:
+    - name: pipeline
+  results:
+    - name: signed_payload
+      value: "$(tasks.request-signature.results.signed_payload)"
+  tasks:
+    - name: collect-simple-signing-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+      params:
+        - name: config_map_name
+          value: $(params.config_map_name)
+    - name: request-signature
+      taskRef:
+        resolver: "bundles"
+        params:
+          - name: bundle
+            value: quay.io/redhat-isv/tkn-signing-bundle:7059415075
+          - name: name
+            value: request-signature-blob
+          - name: kind
+            value: task
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: blob
+          value: "$(params.blob)"
+        - name: requester
+          value: $(params.requester)
+        - name: sig_key_id
+          value: $(tasks.collect-simple-signing-params.results.sig_key_id)
+        - name: sig_key_name
+          value: $(tasks.collect-simple-signing-params.results.sig_key_name)
+        - name: umb_ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_secret_name)
+        - name: umb_ssl_cert_secret_key
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_file_name)
+        - name: umb_ssl_key_secret_key
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_key_file_name)
+        - name: umb_client_name
+          value: $(tasks.collect-simple-signing-params.results.umb_client_name)
+        - name: umb_listen_topic
+          value: $(tasks.collect-simple-signing-params.results.umb_listen_topic)
+        - name: umb_publish_topic
+          value: $(tasks.collect-simple-signing-params.results.umb_publish_topic)
+        - name: umb_url
+          value: $(tasks.collect-simple-signing-params.results.umb_url)
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: signing
+      runAfter:
+        - collect-simple-signing-params

--- a/pipelines/managed/release-to-github/README.md
+++ b/pipelines/managed/release-to-github/README.md
@@ -20,6 +20,10 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.5.0
+* The `sign-base64-blob` task is now passed the `taskGitUrl` and `taskGitRevision` parameters
+  * They are required by the task now
+
 ## Changes in 4.4.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers
 

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "4.4.0"
+    app.kubernetes.io/version: "4.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -283,6 +283,10 @@ spec:
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
       runAfter:
         - base64-encode-checksum
         - extract-requester-from-release

--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -4,15 +4,17 @@ Creates an InternalRequest to sign a base64 encoded blob
 
 ## Parameters
 
-| Name                 | Description                                                                               | Optional | Default value         |
-|----------------------|-------------------------------------------------------------------------------------------|----------|-----------------------|
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace                   | No       | -                     |
-| referenceImage       | The image to be signed                                                                    | No       | -                     |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                             | Yes      | ""                    |
-| requester            | Name of the user that requested the signing, for auditing purposes                        | No       | -                     |
-| requestTimeout       | InternalRequest timeout                                                                   | Yes      | 180                   |
-| binariesPath         | The directory inside the workspace where the binaries are stored                          | Yes      | binaries              |
-| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -                     |
+| Name                 | Description                                                                                           | Optional | Default value         |
+|----------------------|-------------------------------------------------------------------------------------------------------|----------|-----------------------|
+| dataPath             | Path to the JSON string of the merged data to use in the data workspace                               | No       | -                     |
+| referenceImage       | The image to be signed                                                                                | No       | -                     |
+| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                                         | Yes      | ""                    |
+| requester            | Name of the user that requested the signing, for auditing purposes                                    | No       | -                     |
+| requestTimeout       | InternalRequest timeout                                                                               | Yes      | 180                   |
+| binariesPath         | The directory inside the workspace where the binaries are stored                                      | Yes      | binaries              |
+| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests             | No       | -                     |
+| taskGitUrl           | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -                     |
+| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                        | No       | -                     |  
 
 ## Signing data parameters
 
@@ -24,6 +26,12 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 2.5.0
+* The pipeline is called via git resolver now instead of cluster resolver
+  * This was done by changing from `-r` to `--pipeline` in the `internal-request` call
+  * The base image was updated to include this new functionality
+  * New parameters `taskGitUrl` and `taskGitRevision` added to enable the git resolver
 
 ## Changes in 2.4.2
 * Use a temp file for `internal-request` result instead of a fixed file in the workspace to reduce risk

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.4.2"
+    app.kubernetes.io/version: "2.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,13 +32,19 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string 
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: data
       description: workspace to read and save files
   steps:
     - name: sign-base64-blob
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -62,11 +68,13 @@ spec:
 
         IR_RESULT_FILE=$(mktemp)
 
-        internal-request -r "blob-signing-pipeline" \
+        internal-request --pipeline "blob-signing-pipeline" \
             -p pipeline_image="${pipeline_image}" \
             -p blob="$(params.blob)" \
             -p requester="$(params.requester)" \
             -p config_map_name="${config_map_name}" \
+            -p taskGitUrl="$(params.taskGitUrl)" \
+            -p taskGitRevision="$(params.taskGitRevision)" \
             -t "$(params.requestTimeout)" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
             > "$IR_RESULT_FILE" || \

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -17,7 +17,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -46,6 +46,10 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: dataPath
           value: data.json
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -58,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -112,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
This commit migrates the blob-signing-pipeline from gitlab to this repo. This allows us to use a git resolver to call it, instead of relying on a cluster ref. The managed task is updated accordingly.

This is the last thing using a cluster reference, so switching this allows us to turn off support for those in the internal-services operator manager.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

