### PR TITLE
fix(CLDX-357): base64 decode keytab for checksum signing

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -28,6 +28,9 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 | cgwHostname           | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                                        |
 
+## Changes in 1.0.1
+* Base64 decode keytab used for interacting with the checksum signing host (ETERA)
+
 ## Changes in 1.0.0
 * Add steps for signing: `push-unsigned-using-oras`, `sign-mac-binaries`, `sign-windows-binaries`, `generate-checksums`
   * The code was copied and adapted from the `sign-binaries` managed task

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn-task
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -719,7 +719,8 @@ spec:
         # so we use GSSAPI Delegate (in ssh opts) to transfer the ticket to the checksum host
         KRB5CCNAME=FILE:/tmp/krb5cc_$(id -u)
         export KRB5CCNAME
-        kinit -kt /etc/secrets_keytab/keytab "$(params.checksumUser)@$(params.kerberosRealm)"
+        base64 -d /etc/secrets_keytab/keytab > /tmp/sa.keytab
+        kinit -kt /tmp/sa.keytab "$(params.checksumUser)@$(params.kerberosRealm)"
 
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh
@@ -983,7 +984,7 @@ spec:
                  "in the Developer Portal. Failing" >&2
             exit 1
           fi
-           
+
           productCode="$(jq -r '.productCode' <<< "${contentGatewayConfig}")"
           if [ "${productCode}" == "null" ]; then
             echo "Missing contentGateway.productCode value for component. This should be an existing product" >&2


### PR DESCRIPTION
## Describe your changes
The push-artifacts-to-cdn pipeline interacts with the ETERA host for checksum signing. The old keytab was store in vault in binary format. I recently created a new keytab and it is store in vault base64 encoded to avoid corruption.

## Relevant Jira
[CLDX-357](https://issues.redhat.com//browse/CLDX-357)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

