### PR TITLE
feat(RELEASE-1564): create advisory artifact

### DIFF
--- a/pipelines/internal/create-advisory/README.md
+++ b/pipelines/internal/create-advisory/README.md
@@ -6,16 +6,23 @@ advisory URL as well as a result to show the error message if one occurred.
 
 ## Parameters
 
-| Name                 | Description                                                                                            | Optional | Default value                                             |
-|----------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| advisory_json        | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -                                                         |
-| application          | Application being released                                                                             | No       | -                                                         |
-| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
-| config_map_name      | The name of the configMap that contains the signing key                                                | No       | -                                                         |
-| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
-| errata_secret_name   | The name of the secret that contains the errata service account metadata                               | No       | -                                                         |
-| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
+| Name                    | Description                                                                                            | Optional | Default value                                             |
+|-------------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| advisory_json           | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -                                                         |
+| application             | Application being released                                                                             | No       | -                                                         |
+| origin                  | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
+| config_map_name         | The name of the configMap that contains the signing key                                                | No       | -                                                         |
+| advisory_secret_name    | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
+| errata_secret_name      | The name of the secret that contains the errata service account metadata                               | No       | -                                                         |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                              | Yes      | quay.io/konflux-ci/release-service-trusted-artifacts      |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                        | Yes      | ""                                                        |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                 | Yes      | ""                                                        |
+
+## Changes in 2.0.0
+* Add new mandatory parameter ociStorage that enables the use of trusted artifacts so that the advisory yaml
+  file can be retrieved.
 
 ## Changes in 1.1.0
 * Add internalRequestPipelineRunName and internalRequestTaskRunName as results to help with debugging

--- a/pipelines/internal/create-advisory/create-advisory.yaml
+++ b/pipelines/internal/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -40,6 +40,17 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: ociStorage
+      type: string
+      default: "quay.io/konflux-ci/release-service-trusted-artifacts"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
   tasks:
     - name: create-advisory-task
       taskRef:
@@ -66,11 +77,21 @@ spec:
           value: $(params.errata_secret_name)
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
   results:
     - name: result
       value: $(tasks.create-advisory-task.results.result)
     - name: advisory_url
       value: $(tasks.create-advisory-task.results.advisory_url)
+    - name: advisory_oci_artifact
+      value: $(tasks.create-advisory-task.results.advisory_oci_artifact)
     - name: internalRequestPipelineRunName
       value: $(tasks.create-advisory-task.results.internalRequestPipelineRunName)
     - name: internalRequestTaskRunName

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -6,15 +6,24 @@ internal request. The success/failure is handled in the task creating the intern
 
 ## Parameters
 
-| Name                           | Description                                                                                            | Optional | Default value |
-|--------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
-| advisory_json                  | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -             |
-| application                    | Application being released                                                                             | No       | -             |
-| origin                         | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -             |
-| config_map_name                | The name of the configMap that contains the signing key                                                | No       | -             |
-| advisory_secret_name           | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
-| errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
-| internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
+| Name                           | Description                                                                                                                | Optional | Default value |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| advisory_json                  | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}')                     | No       | -             |
+| application                    | Application being released                                                                                                 | No       | -             |
+| origin                         | The origin workspace where the release CR comes from. This is used to determine the advisory path                          | No       | -             |
+| config_map_name                | The name of the configMap that contains the signing key                                                                    | No       | -             |
+| advisory_secret_name           | The name of the secret that contains the advisory creation metadata                                                        | No       | -             |
+| errata_secret_name             | The name of the secret that contains the errata service account metadata                                                   | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                                              | No       | -             |
+| ociStorage                     | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty         |
+| ociArtifactExpiresAfter        | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d            |
+| trustedArtifactsDebug          | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""            |
+| orasOptions                    | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""            |
+| taskGitUrl                     | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""            |
+| taskGitRevision                | The revision in the taskGitUrl repo to be used                                                                             | No       | ""            |
+
+## Changes in 1.2.0
+* Create an OCI artifact that contains the advisory yaml file and store as result.
 
 ## Changes in 1.2.0
 * Allow setting of custom advisory live id

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -40,15 +40,59 @@ spec:
     - name: internalRequestPipelineRunName
       type: string
       description: Name of the PipelineRun that called this task
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: trusted_artifacts_dockerconfig_json_secret_name
+      type: string
+      description: The name of the secret that contains to dockerconfig json to use for trusted artifact operations
+      default: quay-token-konflux-release-trusted-artifacts-secret
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
     - name: advisory_url
       description: The advisory url if the task succeeds, empty string otherwise
+    - name: advisory_oci_artifact
+      description: The oci artifact pullspec that contains the advisory yaml file
     - name: internalRequestPipelineRunName
       description: Name of the PipelineRun that called this task
     - name: internalRequestTaskRunName
       description: Name of this Task Run to be made available to caller
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: ORAS_OPTIONS
+        value: $(params.orasOptions)
+      - name: DEBUG
+        value: $(params.trustedArtifactsDebug)
   steps:
     - name: create-advisory
       image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
@@ -98,9 +142,24 @@ spec:
               key: base64_keytab
         - name: "ADVISORY_JSON"
           value: "$(params.advisory_json)"
+        - name: TRUSTED_ARTIFACTS_DOCKERCONFIG_JSON
+          valueFrom:
+            secretKeyRef:
+              name: $(params.trusted_artifacts_dockerconfig_json_secret_name)
+              key: .dockerconfigjson
+              optional: true
       script: |
           #!/usr/bin/env bash
           set -eo pipefail
+
+          ## AppSRE clusters do not enable credentials-init in Tekton
+          ## therefore, we need to do it ourselves.
+          ## This will be used later in create-trusted-artifact
+          if [ -n "${TRUSTED_ARTIFACTS_DOCKERCONFIG_JSON}" ]; then
+            mkdir -p ~/.docker/
+            echo -n "${TRUSTED_ARTIFACTS_DOCKERCONFIG_JSON}" > ~/.docker/config.json
+          fi
+          ##
 
           STDERR_FILE=/tmp/stderr.txt
           echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
@@ -191,7 +250,6 @@ spec:
               # If after filtering, no images are left, then we can exit early
               if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
                   echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
-                  ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/main/${ADVISORY_FILE}"
                   ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
                   ADVISORY_NAME=$(yq -r '.metadata.name' "${ADVISORY_FILE}")
                   ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
@@ -251,3 +309,53 @@ spec:
           # Construct the advisory url on customer portal to report back to the user as a result
           ADVISORY_TYPE=$(jq -r '.type' <<< "$ADVISORY_JSON" )
           ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
+
+          # copy new advisory yaml so it can be saved as OCI artifact
+          cp -v "$ADVISORY_FILEPATH" /var/workdir
+    - name: skip-trusted-artifact-operations
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: /var/workdir
+    - name: create-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: /var/workdir
+        - name: sourceDataArtifact
+          value: $(results.advisory_oci_artifact.path)
+    - name: patch-source-data-artifact-result
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.advisory_oci_artifact.path)

--- a/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
@@ -11,3 +11,14 @@ kubectl create secret generic create-advisory-secret --from-literal=git_author_e
 
 kubectl delete secret create-advisory-errata-secret --ignore-not-found
 kubectl create secret generic create-advisory-errata-secret --from-literal=errata_api=https://errata/api/v1 --from-literal=name=errata-tester --from-literal=base64_keytab=Zm9vCg==
+
+kubectl delete secret quay-token-konflux-release-trusted-artifacts-secret --ignore-not-found
+
+if [ -z "${DOCKER_CONFIG_JSON}" ]; then
+  DOCKER_CONFIG_JSON=$(mktemp)
+  echo -n '{"auths": {}}' > "${DOCKER_CONFIG_JSON}"
+fi
+echo "Using docker config stored in ${DOCKER_CONFIG_JSON}"
+kubectl create secret generic quay-token-konflux-release-trusted-artifacts-secret \
+  --from-file=.dockerconfigjson="${DOCKER_CONFIG_JSON}" \
+  --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -f -

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -7,6 +7,23 @@ spec:
   description: |
     Run the create-advisory task and check that an advisory url is emitted as a task result.
     This test uses a custom advisory live id.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: "true"
   tasks:
     - name: run-task
       taskRef:
@@ -34,6 +51,16 @@ spec:
           value: "create-advisory-errata-secret"
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -11,6 +11,10 @@ spec:
     unit test.
 
     The failure here is due to the `origin` param being `failing-tenant`, which is accounted for in mocks.sh
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: run-task
       taskRef:
@@ -37,6 +41,10 @@ spec:
           value: "create-advisory-errata-secret"
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -11,6 +11,10 @@ spec:
     The task is expected to recognize these and only create a new advisory for the remaining image (gamma123).
     The test passes if only the unmatched image is included in the resulting advisory and the advisory URL matches the
     expected value.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: run-task
       taskRef:
@@ -43,6 +47,10 @@ spec:
           value: "create-advisory-errata-secret"
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
     - name: check-result
       params:
         - name: advisory-url

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -11,6 +11,10 @@ spec:
     The test passes if the resulting advisory URL matches the one for the existing advisory.
     Note: This test does not validate the actual contents of the advisory file. It assumes that if the task
     succeeded and the advisory was created at the expected URL, then the logic to skip already released images worked.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
   tasks:
     - name: run-task
       taskRef:
@@ -37,6 +41,10 @@ spec:
           value: "create-advisory-errata-secret"
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
     - name: check-result
       params:
         - name: advisory-url

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -6,6 +6,23 @@ metadata:
 spec:
   description: |
     Run the create-advisory task and check that an advisory url is emitted as a task result
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: "true"
   tasks:
     - name: run-task
       taskRef:
@@ -32,6 +49,16 @@ spec:
           value: "create-advisory-errata-secret"
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
     - name: check-result
       runAfter:
         - run-task
@@ -40,13 +67,49 @@ spec:
           value: $(tasks.run-task.results.result)
         - name: advisory_url
           value: $(tasks.run-task.results.advisory_url)
+        - name: advisory_oci_artifact
+          value: $(tasks.run-task.results.advisory_oci_artifact)
+        - name: ociStorage
+          value: $(params.ociStorage)
       taskSpec:
         params:
           - name: result
             type: string
           - name: advisory_url
             type: string
+          - name: advisory_oci_artifact
+            type: string
+          - name: ociStorage
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: /var/workdir
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: /var/workdir
+              - name: sourceDataArtifact
+                value: $(params.advisory_oci_artifact)
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
             script: |
@@ -59,3 +122,13 @@ spec:
               echo Test that advisory_url was properly set
               test "$(params.advisory_url)" == \
                 https://access.redhat.com/errata/RHSA-2024:1234
+
+              if [ "$(params.ociStorage)" != "empty" ]; then
+                echo Test that advisory.yaml was saved as an oci artifact
+                test -f "/var/workdir/advisory.yaml"
+                product_id=$(yq .spec.product_id "/var/workdir/advisory.yaml")
+                echo Test that product_id is correct in advisory.yaml
+                test "${product_id}" == "123"
+              else
+                echo "skipping advisory.yaml check since params.ociStorage == $(params.ociStorage)"
+              fi

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -26,6 +26,10 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 6.1.1
+* This task now exposes advisory_oci_artifact representing the location of an oci artifact that contains
+  the advisory yaml file.
+
 ## Changes in 6.1.0
 * Add check for custom advisory id
   * If `.releaseNotes.allow_custom_live_id` is set to `true` in the RPA, then a custom advisory live

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "6.1.0"
+    app.kubernetes.io/version: "6.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -76,6 +76,8 @@ spec:
   results:
     - name: advisory_url
       description: The advisory url if one was created
+    - name: advisory_oci_artifact
+      description: The advisory internal url if one was created
     - description: Produced trusted data artifact
       name: sourceDataArtifact
       type: string
@@ -277,8 +279,11 @@ spec:
         fi
 
         URL=$(echo "${results}" | jq -r '.advisory_url // ""')
+        OCI_ARTIFACT=$(echo "${results}" | jq -r '.advisory_oci_artifact // ""')
         echo -n "$URL" | tee "$(results.advisory_url.path)"
-        jq -n --arg url "$URL" '{"advisory": {"url": $url}}' | tee "$RESULTS_FILE"
+        echo -n "$OCI_ARTIFACT" | tee "$(results.advisory_oci_artifact.path)"
+        jq -n --arg url "$URL" --arg oci_artifact "$OCI_ARTIFACT" \
+          '{"advisory": {"url": $url, "oci_artifact": $oci_artifact}}' | tee "$RESULTS_FILE"
     - name: create-trusted-artifact
       ref:
         resolver: "git"

--- a/tasks/managed/create-advisory/tests/mocks.sh
+++ b/tasks/managed/create-advisory/tests/mocks.sh
@@ -7,7 +7,7 @@ function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
   then
-    echo '{"result":"Success","advisory_url":"https://access.redhat.com/errata/RHBA-2025:1111"}'
+    echo '{"result":"Success","advisory_url":"https://access.redhat.com/errata/RHBA-2025:1111","advisory_oci_artifact":"quay.io/scoheb/trusted-artifacts@sha256:mydigest"}'
   else
     /usr/bin/kubectl $*
   fi

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -194,6 +194,8 @@ spec:
       params:
         - name: advisory_url
           value: $(tasks.run-task.results.advisory_url)
+        - name: advisory_oci_artifact
+          value: $(tasks.run-task.results.advisory_oci_artifact)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
@@ -205,6 +207,8 @@ spec:
           - name: data
         params:
           - name: advisory_url
+            type: string
+          - name: advisory_oci_artifact
             type: string
           - name: sourceDataArtifact
             type: string
@@ -304,11 +308,17 @@ spec:
 
               echo Test that the advisory_url result was properly set
               test "$(params.advisory_url)" == "https://access.redhat.com/errata/RHBA-2025:1111"
+              echo Test that the advisory_oci_artifact result was properly set
+              test "$(params.advisory_oci_artifact)" == "quay.io/scoheb/trusted-artifacts@sha256:mydigest"
 
               echo Test that the advisory_url was properly added to the results file
               test "$(jq -r '.advisory.url' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/results/create-advisory-results.json")" == \
                 "https://access.redhat.com/errata/RHBA-2025:1111"
+              echo Test that the advisory_oci_artifact was properly added to the results file
+              test "$(jq -r '.advisory.oci_artifact' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/create-advisory-results.json")" == \
+                "quay.io/scoheb/trusted-artifacts@sha256:mydigest"
 
               # Check the advisory_secret_name parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name' )" != \


### PR DESCRIPTION
## Describe your changes
- the internal create advisory pipeline now creates an oci artifact that contains the advisory yaml file.
- it is make available as a result which makes its way to 'release.status'

Requires:
- https://github.com/hacbs-release/app-interface-deployments/pull/307
- app-interface#141226

## Relevant Jira
* [RELEASE-1564](https://issues.redhat.com//browse/RELEASE-1564)

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

