### PR TITLE
feat(RELEASE-1535): add option to use custom advisory id

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -255,6 +255,14 @@
               }
             }
           }
+        },
+        "live_id": {
+          "type": "integer",
+          "description": "Custom advisory live id e.g. 1234"
+        },
+        "allow_custom_live_id": {
+          "type": "boolean",
+          "description": "Whether to allow custom live id or not e.g. true"
         }
       }
     },

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,10 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.2.0
+* Allow setting of custom advisory live id
+  * If `live_id` is set in the advisory json, use that instead of requesting one from Errata Tool API
+
 ## Changes in 1.1.3
 * Change the `advisory_url` result to use link to customer portal instead of git repo
 

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -208,19 +208,23 @@ spec:
           advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \
             '.content.images[] += {"signingKey": $key}' <<< "$NEW_ADVISORY_JSON")
 
-          # write keytab to file
-          echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
-          # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
-          KRB5CCNAME=$(mktemp)
-          export KRB5CCNAME
-          # see https://stackoverflow.com/a/12308187
-          KRB5_CONFIG=$(mktemp)
-          export KRB5_CONFIG
-          export KRB5_TRACE=/dev/stderr
-          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
-          kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
-          ID=$(curl --retry 3 --negotiate -u : "${ERRATA_API}/advisory/reserve_live_id" -XPOST | jq -r '.live_id')
-          ADVISORY_NUM=$(printf "%04d" "$ID")
+          LIVE_ID=$(jq -r '.live_id' <<< "$ADVISORY_JSON" )
+          if [[ "$LIVE_ID" == null ]]; then
+            # write keytab to file
+            echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
+            # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
+            KRB5CCNAME=$(mktemp)
+            export KRB5CCNAME
+            # see https://stackoverflow.com/a/12308187
+            KRB5_CONFIG=$(mktemp)
+            export KRB5_CONFIG
+            export KRB5_TRACE=/dev/stderr
+            sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
+            kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+            REQUEST_URL="${ERRATA_API}/advisory/reserve_live_id"
+            LIVE_ID=$(curl --retry 3 --negotiate -u : "${REQUEST_URL}" -XPOST | jq -r '.live_id')
+          fi
+          ADVISORY_NUM=$(printf "%04d" "$LIVE_ID")
 
           # group advisories by <origin workspace>/year
           ADVISORY_DIR="data/advisories/$(params.origin)/${YEAR}/${ADVISORY_NUM}"

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-custom-live-id
+spec:
+  description: |
+    Run the create-advisory task and check that an advisory url is emitted as a task result.
+    This test uses a custom advisory live id.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: create-advisory-task
+      params:
+        - name: advisory_json
+          value: >-
+            {"product_id":123,"product_name":"Red Hat Product","product_version":"1.2.3","product_stream":"tp1",
+            "cpe":"cpe:/a:example:product:el8","type":"RHSA","synopsis":"test synopsis","topic":"test topic",
+            "description":"test description","solution":"test solution","references":["https://docs.example.com/notes"],
+            "content":{"images":[{"containerImage":"quay.io/example/openstack@sha256:abdeNEW",
+            "repository":"rhosp16-rhel8/openstack","tags":["latest"],"architecture":"amd64",
+            "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+            "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}}]},
+            "live_id":999}
+        - name: application
+          value: "test-app"
+        - name: origin
+          value: "not-existing-origin"
+        - name: config_map_name
+          value: "create-advisory-test-cm"
+        - name: advisory_secret_name
+          value: "create-advisory-secret"
+        - name: errata_secret_name
+          value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: advisory_url
+          value: $(tasks.run-task.results.advisory_url)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: advisory_url
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that result is Success
+              test "$(params.result)" == Success
+
+              echo Test that advisory_url was properly set
+              test "$(params.advisory_url)" == \
+                https://access.redhat.com/errata/RHSA-2024:0999

--- a/tasks/managed/collect-data/README.md
+++ b/tasks/managed/collect-data/README.md
@@ -29,11 +29,15 @@ should not be present in the Release data section).
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                                                     |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                                                        |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                                                        |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                                                        | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                                                        |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes       | ""                                                        |
 | dataDir                 | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path)                                   |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | Yes       | production                                                |
+
+## Changes in 6.1.0
+* Add the new `releaseNotes.allow_custom_live_id` field to disallowed keys for
+  Release and ReleasePlan
 
 ## Changes in 6.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "6.0.0"
+    app.kubernetes.io/version: "6.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -190,7 +190,7 @@ spec:
         echo -e "\nFetching fbcFragment"
         jq -cr '.components[0].containerImage' < "$(params.dataDir)/$SNAPSHOTSPEC_PATH" | tr -d "\n" \
           | tee "$(results.fbcFragment.path)"
-  
+
         echo -e "\nGenerating collectors data"
         collectors_status=$(get-resource "release" "${RELEASE}" "{.status.collectors}")
         echo "***collectors status"
@@ -209,10 +209,10 @@ spec:
             $val
             end)
             );
-        
+
           # Ensure we safely handle missing collectors
           (.? // {}) as $collectors |
-        
+
           # Flatten and combine the managed and tenant sections
           [($collectors.managed? // {} | to_entries | map(.value)) +
            ($collectors.tenant? // {} | to_entries | map(.value))] |
@@ -233,7 +233,7 @@ spec:
 
         # Merge collectors and Release keys. Release has higher priority
         merged_output=$(merge-json "$collectors_result" "$release_result")
-        
+
         # Merge now with ReleasePlan keys. ReleasePlan has higher priority
         merged_output=$(merge-json "$merged_output" "$release_plan_result")
 
@@ -302,14 +302,16 @@ spec:
                 "releaseNotes.product_name",
                 "releaseNotes.product_version",
                 "releaseNotes.product_stream",
-                "releaseNotes.cpe"
+                "releaseNotes.cpe",
+                "releaseNotes.allow_custom_live_id"
             ],
             "ReleasePlan": [
                 "releaseNotes.product_id",
                 "releaseNotes.product_name",
                 "releaseNotes.product_version",
                 "releaseNotes.product_stream",
-                "releaseNotes.cpe"
+                "releaseNotes.cpe",
+                "releaseNotes.allow_custom_live_id"
             ],
             "ReleasePlanAdmission": [
             ]

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -27,7 +27,7 @@ spec:
       description: The location where data will be stored
       type: string
   description: |
-    Run the collect-data task with the disallowed key product_id in the ReleasePlan data.
+    Run the collect-data task with the disallowed key allow_custom_live_id in the ReleasePlan data.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -84,7 +84,7 @@ spec:
                 data:
                   releaseNotes:
                     synopsis: some text field
-                    product_id: 123
+                    allow_custom_live_id: true
               EOF
               kubectl apply -f releaseplan
 

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -20,12 +20,20 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                   |
 | ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                      |
 | trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                      |
-| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      | 
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      |
 | sourceDataArtifact       | Location of trusted artifacts to be used to populate data directory                                                        | Yes       | ""                      |
 | dataDir                  | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path) |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
- 
+
+## Changes in 6.1.0
+* Add check for custom advisory id
+  * If `.releaseNotes.allow_custom_live_id` is set to `true` in the RPA, then a custom advisory live
+    id can be set via `.releaseNotes.live_id` and this will be used instead of requesting one from
+    Errata Tool API.
+  * If `.releaseNotes.allow_custom_live_id` is not set or `false` and `.releaseNotes.live_id` is set,
+    we will exit with an error.
+
 ## Changes in 6.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "6.0.0"
+    app.kubernetes.io/version: "6.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -142,6 +142,14 @@ spec:
         # Extract the advisory key and signing configMap name from the data JSON file
         advisoryData=$(jq -c "$(params.jsonKey)" "$(params.dataDir)/$(params.dataPath)")
         configMapName=$(jq -er '.sign.configMapName' "$(params.dataDir)/$(params.dataPath)")
+
+        # Check custom advisory live id
+        advisoryLiveId=$(jq -r '.live_id' <<< "$advisoryData")
+        advisoryAllowCustomLiveId=$(jq -r '.allow_custom_live_id // false' <<< "$advisoryData")
+        if [ "$advisoryAllowCustomLiveId" != true ] && [ "$advisoryLiveId" != "null" ]; then
+          echo "Error: advisory live id is only allowed if allow_custom_live_id is set to true"
+          exit 1
+        fi
 
         # Validate type
         advisoryType=$(jq -r '.type' <<< "$advisoryData")

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-fail-custom-live-id
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the create-advisory task with releaseNotes.live_id set but without
+    setting releaseNotes.allow_custom_live_id to true.
+    The task should fail.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
+                  },
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "quay.io/redhat-prod/repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHBA",
+                  "live_id": 123
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Run the create-advisory task and verify the internalrequest was created with the proper params
-    and using the production secret due to the presence of redhat-prod repos
+    and using the production secret due to the presence of redhat-prod repos. This test
+    also uses a custom advisory live id.
   workspaces:
     - name: tests-workspace
   params:
@@ -113,7 +114,9 @@ spec:
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "releaseNotes": {
-                  "type": "RHEA"
+                  "type": "RHEA",
+                  "live_id": 1111,
+                  "allow_custom_live_id": true
                 },
                 "sign": {
                   "configMapName": "cm"
@@ -276,7 +279,7 @@ spec:
 
               # Check the advisory_json parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_json' )" != \
-              '{"type":"RHEA"}' ]; then
+              '{"type":"RHEA","live_id":1111,"allow_custom_live_id":true}' ]; then
                 echo "InternalRequest has the wrong advisory_json parameter"
                 exit 1
               fi


### PR DESCRIPTION
Two new data fields are added:
* `.releaseNotes.live_id`
* `.releaseNotes.allow_custom_live_id`

The latter can only be set in RPA and defaults to false. The former can be set in any of R, RP, RPA.

If `live_id` is set, but `allow_custom_live_id` is false, the managed `create_advisory` task fails.

If `live_id` is set and `allow_custom_live_id` is true, the internal `create_advisory_task` task will use this id instead of requesting one from Errata Tool API.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

