### PR TITLE
feat(RELEASE-455): add-fbc-contribution support for multiple components

### DIFF
--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -20,6 +20,10 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                                      | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                             | No       | -                                                         |
 
+## Changes in 4.5.0
+* Add `prepare-fbc-release` task to the Pipeline, which adds new information required by `add-fbc-contribution` to
+  build multiple components
+
 ## Changes in 4.4.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers
 

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.4.0"
+    app.kubernetes.io/version: "4.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -245,6 +245,26 @@ spec:
       runAfter:
         - collect-data
         - get-ocp-version
+    - name: prepare-fbc-release
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+      runAfter:
+        - update-ocp-tag
     - name: check-fbc-packages
       workspaces:
         - name: data
@@ -304,6 +324,7 @@ spec:
         - verify-enterprise-contract
         - update-ocp-tag
         - collect-data
+        - prepare-fbc-release
     - name: extract-requester-from-release
       taskRef:
         resolver: "git"

--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -15,6 +15,10 @@ Task to create an internalrequest to add fbc contributions to index images
 | taskGitUrl                        | The url to the git repo where the release-service-catalog tasks to be used are stored     | No                      | -             |
 | taskGitRevision                   | The revision in the taskGitUrl repo to be used                                            | No                      | -             |
 
+## Changes in 4.1.0
+* The task now supports snapshots with multi-components on it. In addition, image digests are now saved in a result file
+  instead of the pipeline results, as they might eventually overflow if the image list is too long.
+
 ## Changes in 4.0.2
 * The task now reads the `internalRequestServiceAccount` key from the ReleasePlanAdmission data field and passes it to
 the `internal-request` script, to set the SA that will be used to run IR's pipelinerun.

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "4.0.2"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -49,6 +49,8 @@ spec:
       description: The targetIndex used in this request
     - name: requestResultsFile
       description: Internal Request results file
+    - name: internalRequestResultsFile
+      description: Additional Internal Request results file
     - name: requestMessage
       description: Internal Request message
     - name: requestReason
@@ -66,13 +68,18 @@ spec:
         #
         set -eo pipefail
 
-        SNAPSHOT_PATH=$(workspaces.data.path)/$(params.snapshotPath)
-        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/add-fbc-contribution-results.json"
+        SNAPSHOT_PATH="$(workspaces.data.path)/$(params.snapshotPath)"
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
             exit 1
         fi
+
+        # adding a new result as modifying the current one used breaks e2e for single component.
+        # to be handled in RELEASE-1640.
+        RESULTS_FILE="$(params.resultsDirPath)/internal-requests-results.json"
+        echo -n "$RESULTS_FILE" > "$(results.internalRequestResultsFile.path)"
+        RESULTS_FILE=$(workspaces.data.path)/${RESULTS_FILE}
 
         echo -n "$(workspaces.data.path)/ir-$(context.taskRun.uid)-result.json" > "$(results.requestResultsFile.path)"
 
@@ -90,7 +97,6 @@ spec:
             '.fbc.buildTimeoutSeconds // $build_timeout_seconds' "${DATA_FILE}")
         request_timeout_seconds=$(jq -r --arg request_timeout_seconds ${default_request_timeout_seconds} \
             '.fbc.requestTimeoutSeconds // $request_timeout_seconds' "${DATA_FILE}")
-        fbc_fragment=$(jq -cr '.components[0].containerImage' "${SNAPSHOT_PATH}")
         internal_request_service_account=$(jq -r '.fbc.internalRequestServiceAccount // "release-service-account"' \
             "${DATA_FILE}")
 
@@ -130,72 +136,152 @@ spec:
           target_index="${target_index}-${product_name}-${product_version}-${timestamp}"
         fi
 
+        # to keep compatibility with current single component mode
         echo -n "$timestamp" > "$(results.buildTimestamp.path)"
         echo -n "$target_index" > "$(results.requestTargetIndex.path)"
         jq -n --arg target_index "$target_index" \
-         '{"index_image": {"target_index": $target_index}}' | tee "$RESULTS_FILE"
+          '{"index_image": {"target_index": $target_index}, "components": []}' \
+          | tee "$RESULTS_FILE"
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
-        # The internal-request script will create the InternalRequest and wait until it finishes to get its status
-        # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
-        echo "Creating InternalRequest to add FBC contribution to index image:"
-        internal-request --pipeline "update-fbc-catalog" \
-            -p fromIndex="$(params.fromIndex)" \
-            -p targetIndex="${target_index}" \
-            -p fbcFragment="${fbc_fragment}" \
-            -p iibServiceAccountSecret="${iib_service_account_secret}" \
-            -p publishingCredentials="${publishing_credentials}" \
-            -p buildTimeoutSeconds="${build_timeout_seconds}" \
-            -p buildTags="${build_tags}" \
-            -p addArches="${add_arches}" \
-            -p hotfix="${hotfix}" \
-            -p stagedIndex="${staged_index}" \
-            -p taskGitUrl="$(params.taskGitUrl)" \
-            -p taskGitRevision="$(params.taskGitRevision)" \
-            --service-account "${internal_request_service_account}" \
-            -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-            -t "${request_timeout_seconds}" |tee "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log
+        LENGTH=$(jq -r '.components | length' "${SNAPSHOT_PATH}")
+        for((i=0; i<LENGTH; i++)); do
+          ocp_version=$(jq -cr --argjson i "$i" '.components[$i].ocpVersion' "${SNAPSHOT_PATH}")
+          fbc_fragment=$(jq -cr --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
 
-        internalRequest=$(awk -F"'" '/created/ { print $2 }' \
-          "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log)
-        echo "done (${internalRequest})"
+          # the target_index is modified when the pipelinerun is a for `hotfix` or a `pre-GA` release
+          target_index=$(jq -cr --argjson i "$i" '.components[$i].updatedTargetIndex' "${SNAPSHOT_PATH}")
+          if [ "${hotfix}" = "true" ]; then
+            issue_id=$(jq -r '.fbc.issueId // empty' "${DATA_FILE}")
+            if [ -z "${issue_id}" ]; then
+              echo "Hotfix releases requires the issue id set in the 'fbc.issueId' key of the ReleasePlanAdmission " \
+                   "spec.data field"
+              exit 1
+            fi
+            target_index="${target_index}-${issue_id}-${timestamp}"
+          elif [ "${pre_ga}" = "true" ]; then
+            if [ -z "${product_name}" ] || [ -z "${product_version}" ]; then
+              echo "Pre-GA releases require 'fbc.productName' and 'fbc.productVersion' set in the " \
+                   "ReleasePlanAdmission spec.data field"
+              exit 1
+            fi
+            target_index="${target_index}-${product_name}-${product_version}-${timestamp}"
+          fi
 
-        # Fetching InternalRequest status and populating results
-        results=$(kubectl get internalrequest "${internalRequest}" -o jsonpath='{.status.results}')
-        echo "${results}" > "$(workspaces.data.path)/ir-$(context.taskRun.uid)-result.json"
+          echo "Processing fragment: ${fbc_fragment}:"
+          # The internal-request script will create the InternalRequest and wait until it finishes to get its status
+          # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
+          echo "Creating InternalRequest to add FBC contribution to index image:"
+          internal-request --pipeline "update-fbc-catalog" \
+              -p fromIndex="$(params.fromIndex)" \
+              -p targetIndex="${target_index}" \
+              -p fbcFragment="${fbc_fragment}" \
+              -p iibServiceAccountSecret="${iib_service_account_secret}" \
+              -p publishingCredentials="${publishing_credentials}" \
+              -p buildTimeoutSeconds="${build_timeout_seconds}" \
+              -p buildTags="${build_tags}" \
+              -p addArches="${add_arches}" \
+              -p hotfix="${hotfix}" \
+              -p stagedIndex="${staged_index}" \
+              -p taskGitUrl="$(params.taskGitUrl)" \
+              -p taskGitRevision="$(params.taskGitRevision)" \
+              --service-account "${internal_request_service_account}" \
+              -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+              -t "${request_timeout_seconds}" |tee "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log
 
-        conditions=$(kubectl get internalrequest "${internalRequest}" \
-          -o jsonpath='{.status.conditions[?(@.type=="Succeeded")]}')
+          internalRequest=$(awk -F"'" '/created/ { print $2 }' \
+            "$(workspaces.data.path)"/ir-"$(context.taskRun.uid)"-output.log)
+          echo "done (${internalRequest})"
 
-        jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.sign_index_image' |tr -d "\n" \
+          # Fetching InternalRequest status and populating results
+          results=$(kubectl get internalrequest "${internalRequest}" -o jsonpath='{.status.results}')
+          echo "${results}" > "$(workspaces.data.path)/ir-$(context.taskRun.uid)-result.json"
+
+          completion_time="$(jq -r '.jsonBuildInfo | fromjson | .updated' <<< "${results}")"
+
+          # construct the results json
+          build_results=$(jq \
+            --arg fragment "$fbc_fragment" \
+            --arg target_index "$target_index" \
+            --arg ocp_version "$ocp_version" \
+            --arg completion_time "$completion_time" \
+          '{ 
+            "fbc_fragment": $fragment,
+            "target_index": $target_index,
+            "ocp_version": $ocp_version,
+            "image_digests": (.indexImageDigests | split(" ") | del(.[] | select(. == ""))),
+            "completion_time": $completion_time,
+            "iibLog": .iibLog
+          }' <<< "${results}")
+
+          # updates the file in place with the new results
+          export build_results
+          yq -i '.components += [ env(build_results) ]' "$RESULTS_FILE"
+
+          mustSignIndexImage=$(jq -r '.genericResult | fromjson' <<< "${results}" \
+            | jq -r '.sign_index_image' |tr -d "\n")
+          mustPublishIndexImage=$(jq -r '.genericResult | fromjson' <<< "${results}" \
+            | jq -r '.publish_index_image' |tr -d "\n")
+          fbc_opt_in=$(jq -r '.genericResult | fromjson' <<< "${results}" | jq -cr '.fbc_opt_in')
+
+          # Store the results in Tekton's results files
+          echo -en "${mustPublishIndexImage}" | tee "$(results.mustPublishIndexImage.path)"
+          echo -en "${mustSignIndexImage}" | tee "$(results.mustSignIndexImage.path)"
+          echo -en "${fbc_opt_in}" | tee "$(results.isFbcOptIn.path)"
+
+          # this results below should be depracated
+          conditions=$(kubectl get internalrequest "${internalRequest}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")]}')
+          jq '.reason // "Unset"'  <<< "${conditions}" | tee "$(results.requestReason.path)"
+          jq '.message // "Unset"' <<< "${conditions}" | tee "$(results.requestMessage.path)"
+          jq -r '.indexImageDigests' <<< "${results}" |  tee "$(results.indexImageDigests.path)"
+
+          # the following ones are used to help debugging in case of failure
+          jq -r '.iibLog' <<< "${results}"
+          RC="$(jq -r '.exitCode' <<< "${results}")"
+
+          # Summarize what happened for the human user. Although the continuation of the pipeline will depend on all
+          # components having the same flag values, we should display them to help the user to understand which of the
+          # component might be misconfigured.
+          if [ "$mustPublishIndexImage" = "true" ]; then
+            echo "Index image will be published."
+          elif [ "$fbc_opt_in" = "false" ]; then
+            echo "Index image will not be published because fbc_opt_in is set to false in Pyxis."
+            echo "If this is the first time you are releasing, make sure you request fbc_opt_in in Pyxis."
+          elif [ "${staged_index}" = "true" ]; then
+            echo "Index image will not be published because this is a staging release."
+          else
+            echo "Index image will not be published for an unspecified reason."
+          fi
+
+          if [ "$RC" -ne 0 ]; then
+            echo "The fragment failed to be processed, check which fragment and its log link above " \
+                 "to understand the reason"
+            exit "$RC"
+          fi
+        done
+
+        # the flags of all components should match. A single unmatching flag should stop signing and publishing.
+        fbcPipelineFlags=$(jq -r '.genericResult | fromjson' <<< "${results}" |jq --slurp  '. | unique')
+        if [ "$(jq -r 'length' <<< "${fbcPipelineFlags}")" == 1 ]; then
+          jq -r '.[].sign_index_image' <<< "${fbcPipelineFlags}" | tr -d "\n" \
             | tee "$(results.mustSignIndexImage.path)"
-
-        mustPublishIndexImage=$(jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.publish_index_image')
-        fbc_opt_in=$(jq -r '.genericResult | fromjson' <<< "${results}" | jq -r '.fbc_opt_in')
-
-        # Store the results in Tekton's results files
-        echo -n "${mustPublishIndexImage}" | tee "$(results.mustPublishIndexImage.path)"
-        echo -n "${fbc_opt_in}" | tee "$(results.isFbcOptIn.path)"
-
-        jq '.reason // "Unset"'  <<< "${conditions}" | tee "$(results.requestReason.path)"
-        jq '.message // "Unset"' <<< "${conditions}" | tee "$(results.requestMessage.path)"
-
-        jq -r '.indexImageDigests' <<< "${results}" |  tee "$(results.indexImageDigests.path)"
-
-        jq -r '.iibLog' <<< "${results}"
-        RC="$(jq -r '.exitCode' <<< "${results}")"
-
-        # Summarize what happened for the human user.
-        if [ "$mustPublishIndexImage" = "true" ]; then
-          echo "Index image will be published."
-        elif [ "$fbc_opt_in" = "false" ]; then
-          echo "Index image will not be published because fbc_opt_in is set to false in Pyxis."
-          echo "If this is the first time you are releasing, make sure you request fbc_opt_in in Pyxis."
-        elif [ "${staged_index}" = "true" ]; then
-          echo "Index image will not be published because this is a staging release."
+          jq -r '.[].publish_index_image' <<< "${fbcPipelineFlags}" | tr -d "\n" \
+            | tee "$(results.mustPublishIndexImage.path)"
+          jq -r '.[].fbc_opt_in' <<< "${fbcPipelineFlags}" | tr -d "\n" | tee "$(results.isFbcOptIn.path)"
         else
-          echo "Index image will not be published for an unspecified reason."
+          echo -en "false" | tee "$(results.mustSignIndexImage.path)"
+          echo -en "false" | tee "$(results.mustPublishIndexImage.path)"
+          echo -en "false" | tee "$(results.isFbcOptIn.path)"
         fi
 
-        exit "$RC"
+        # if there are multiple components but they are for the same ocp version, only a single index_image needs
+        # to be signed/published.
+        VERSIONS_COUNT="$(jq -r '[ .components[].ocp_version ] | unique | length' "$RESULTS_FILE")"
+        if [[ "$LENGTH" -gt 1 && "$VERSIONS_COUNT" == 1 ]]; then
+          # keep only the most up to date build index_image
+          RESULTS_TEMP_FILE="/tmp/results-temp.json"
+          jq -r  '.components = [ .components | sort_by(.updated) | last ]' "$RESULTS_FILE" > "$RESULTS_TEMP_FILE"
+          mv "$RESULTS_TEMP_FILE" "$RESULTS_FILE"
+        fi

--- a/tasks/managed/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/managed/add-fbc-contribution/tests/mocks.sh
@@ -34,6 +34,8 @@ function set_ir_status() {
 {
   "status": {
     "results": {
+      "jsonBuildInfo": "{\"updated\":\"2023-03-06T16:39:11.314092Z\"}",
+      "indexImageDigests": "quay.io/a quay.io/b",
       "genericResult": "{\"fbc_opt_in\":\"true\",\"publish_index_image\":\"false\",\"sign_index_image\":\"false\"}",
       "iibLog": "Dummy IIB Log",
       "exitCode": "${EXITCODE}"

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -30,7 +30,9 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
-                    "repository": "prod-registry.io/prod-location0"
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
+                    "ocpVersion": "v4.12"
                   }
                 ]
               }
@@ -72,10 +74,24 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: internalRequestResultsFile
+          value: $(tasks.run-task.results.internalRequestResultsFile)
+        - name: indexImageDigests
+          value: $(tasks.run-task.results.indexImageDigests)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pipelineRunUid
+            type: string
+          - name: internalRequestResultsFile
+            type: string
+          - name: indexImageDigests
+            type: string
         steps:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
@@ -84,6 +100,7 @@ spec:
               #
               set -eux
 
+              RESULTS_FILE="$(workspaces.data.path)/$(params.internalRequestResultsFile)"
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
                 tac | tail -1)"
 
@@ -129,9 +146,14 @@ spec:
               fi
 
               TS=1696946200 # ts set in the mocked `date`
-              value=$(jq -r '.targetIndex' <<< "${requestParams}")
-              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:v4.12-bz123456-${TS}" ]; then
+              if [ "$(jq -r '.components[].target_index' "$RESULTS_FILE")" != \
+                "quay.io/scoheb/fbc-target-index-testing:v4.12-bz123456-${TS}" ]; then
                 echo "targetIndex does not match"
+                exit 1
+              fi
+
+              if [ "$(wc -w <<< "$(params.indexImageDigests)")" -ne 2 ]; then
+                echo "indexImageDigest should contain 2 images: $(params.indexImageDigests)"
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -27,14 +27,16 @@ spec:
               set -eux
 
               mkdir $(workspaces.data.path)/results
-              cat > $(workspaces.data.path)/snapshot_spec.json << EOF
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp0",
                     "containerImage": "fail.io/image0@sha256:0000",
-                    "repository": "prod-registry.io/prod-location0"
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
+                    "ocpVersion": "v4.12"
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-add-fbc-contribution
+  name: test-add-fbc-contribution-multiple-components-hotfix
 spec:
-  description: Test creating a internal request for the IIB pipeline
+  description: >
+    Tests running the add-fbc-contribution when the snapshot has multi-components and the FBC data
+    is for a hotfix fbc catalog
   workspaces:
     - name: tests-workspace
   tasks:
@@ -33,6 +35,13 @@ spec:
                     "repository": "prod-registry.io/prod-location0",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
                     "ocpVersion": "v4.12"
+                  },
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
                   }
                 ]
               }
@@ -43,7 +52,9 @@ spec:
                 "fbc": {
                   "fbcPublishingCredentials": "test-fbc-publishing-credentials",
                   "buildTimeoutSeconds": 420,
-                  "requestTimeoutSeconds": 120
+                  "hotfix": true,
+                  "issueId": "bz123456",
+                  "buildTimeoutSeconds": 420
                 }
               }
               EOF
@@ -110,64 +121,70 @@ spec:
               set -eux
 
               RESULTS_FILE="$(workspaces.data.path)/$(params.internalRequestResultsFile)"
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tac | tail -1)"
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+                | xargs)"
 
-              internalRequest=$(echo "${internalRequest}" | xargs)
-              requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-              serviceAccount="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.serviceAccount}")"
+              i=0
+              for internalRequest in $internalRequests; do
+                requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
 
-              if [ "${serviceAccount}" != "release-service-account" ]; then
-                echo "service account does not match"
-              fi
+                TS=1696946200 # ts set in the mocked `date`
+                if [ "$(jq -r '.components[0].target_index' "$RESULTS_FILE")" != \
+                  "quay.io/scoheb/fbc-target-index-testing:v4.12-bz123456-${TS}" ]; then
+                  echo "targetIndex #1 does not match"
+                  exit 1
+                fi
+                if [ "$(jq -r '.components[1].target_index' "$RESULTS_FILE")" != \
+                  "quay.io/scoheb/fbc-target-index-testing:v4.13-bz123456-${TS}" ]; then
+                  echo "targetIndex #2 does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.index_image.target_index' "$RESULTS_FILE")" != \
-                "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
-                echo "targetIndex does not match"
-                exit 1
-              fi
+                fromIndex="quay.io/scoheb/fbc-index-testing:latest"
+                if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "${fromIndex}" ]; then
+                  echo "fromIndex does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
-                echo "fromIndex does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.buildTimeoutSeconds' <<< "${requestParams}")" != "420" ]
+                then
+                  echo "buildTimeoutSeconds does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.buildTimeoutSeconds' <<< "${requestParams}")" != "420" ]
-              then
-                echo "buildTimeoutSeconds does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image${i}@sha256:0000" ]
+                then
+                  echo "fbcFragment does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image0@sha256:0000" ]
-              then
-                echo "fbcFragment does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                  echo "taskGitUrl image does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
-                echo "taskGitUrl image does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                  echo "taskGitRevision image does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
-                echo "taskGitRevision image does not match"
-                exit 1
-              fi
+                if [ "$(params.mustPublishIndexImage)" != "false" ]; then
+                  echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
+                  exit 1
+                fi
 
-              if [ "$(params.mustPublishIndexImage)" != "false" ]; then
-                echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
-                exit 1
-              fi
+                if [ "$(params.isFbcOptIn)" != "true" ]; then
+                  echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
+                  exit 1
+                fi
 
-              if [ "$(params.isFbcOptIn)" != "true" ]; then
-                echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
-                exit 1
-              fi
-
-              if [ "$(wc -w <<< "$(params.indexImageDigests)")" -ne 2 ]; then
-                echo "indexImageDigest should contain 2 images: $(params.indexImageDigests)"
-                exit 1
-              fi
+                num_images="$(wc -w <<< "$(jq -r '.components[].image_digests[]' "$RESULTS_FILE")")"
+                if [ "$num_images" -ne 4 ]; then
+                  echo "Unexpected value for number of image digests: $num_images"
+                  exit 1
+                fi
+                i=$(( i+1 ))
+              done
       runAfter:
         - run-task
   finally:

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-multiple-components-same-ver
+spec:
+  description: >
+    Tests running the add-fbc-contribution when the snapshot has multi-components being all components
+    for the same Openshift version
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)/snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "registry.io/image0@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
+                  },
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
+                  }
+
+                ]
+              }
+              EOF
+
+              cat > "$(workspaces.data.path)/data.json" << EOF
+              {
+                "fbc": {
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "buildTimeoutSeconds": 420,
+                  "buildTimeoutSeconds": 420
+                }
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: fromIndex
+          value: "quay.io/scoheb/fbc-index-testing:latest"
+        - name: targetIndex
+          value: "quay.io/scoheb/fbc-target-index-testing:v4.12"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+        - name: resultsDirPath
+          value: results
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: isFbcOptIn
+          value: $(tasks.run-task.results.isFbcOptIn)
+        - name: mustPublishIndexImage
+          value: $(tasks.run-task.results.mustPublishIndexImage)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: internalRequestResultsFile
+          value: $(tasks.run-task.results.internalRequestResultsFile)
+        - name: indexImageDigests
+          value: $(tasks.run-task.results.indexImageDigests)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: isFbcOptIn
+            type: string
+          - name: mustPublishIndexImage
+            type: string  
+          - name: pipelineRunUid
+            type: string
+          - name: internalRequestResultsFile
+            type: string
+          - name: indexImageDigests
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              #
+              set -eux
+
+              RESULTS_FILE="$(workspaces.data.path)/$(params.internalRequestResultsFile)"
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+                | xargs)"
+
+              i=0
+              for internalRequest in $internalRequests; do
+                requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+
+                if [ "$(jq -r '.components[0].target_index' "$RESULTS_FILE")" != \
+                  "quay.io/scoheb/fbc-target-index-testing:v4.13" ]; then
+                  echo "targetIndex #1 does not match"
+                  exit 1
+                fi
+
+                fromIndex="quay.io/scoheb/fbc-index-testing:latest"
+                if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "${fromIndex}" ]; then
+                  echo "fromIndex does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.buildTimeoutSeconds' <<< "${requestParams}")" != "420" ]
+                then
+                  echo "buildTimeoutSeconds does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image${i}@sha256:0000" ]
+                then
+                  echo "fbcFragment does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                  echo "taskGitUrl image does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                  echo "taskGitRevision image does not match"
+                  exit 1
+                fi
+
+                if [ "$(params.mustPublishIndexImage)" != "false" ]; then
+                  echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
+                  exit 1
+                fi
+
+                if [ "$(params.isFbcOptIn)" != "true" ]; then
+                  echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
+                  exit 1
+                fi
+
+                num_components=$"$(jq -r '.components | length' "$RESULTS_FILE")"
+                if [ "$num_components" -ne 1 ]; then
+                  echo "Unexpected value for number of components: $num_components"
+                  exit 1
+                fi
+
+                num_images=$(wc -w <<< "$(jq -r '.components[].image_digests[]' "$RESULTS_FILE")")
+                if [ "$num_images" -ne 2 ]; then
+                  echo "Unexpected value for number of image digests: $num_images"
+                  exit 1
+                fi
+                i=$(( i+1 ))
+              done
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
@@ -2,9 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-add-fbc-contribution
+  name: test-add-fbc-contribution-multiple-components
 spec:
-  description: Test creating a internal request for the IIB pipeline
+  description: >
+    Tests running the add-fbc-contribution when the snapshot has multi-components on it
   workspaces:
     - name: tests-workspace
   tasks:
@@ -33,6 +34,13 @@ spec:
                     "repository": "prod-registry.io/prod-location0",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
                     "ocpVersion": "v4.12"
+                  },
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1@sha256:0000",
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
                   }
                 ]
               }
@@ -110,64 +118,64 @@ spec:
               set -eux
 
               RESULTS_FILE="$(workspaces.data.path)/$(params.internalRequestResultsFile)"
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                tac | tail -1)"
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+                | xargs)"
 
-              internalRequest=$(echo "${internalRequest}" | xargs)
-              requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-              serviceAccount="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.serviceAccount}")"
+              i=0
+              for internalRequest in $internalRequests; do
+                requestParams=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
 
-              if [ "${serviceAccount}" != "release-service-account" ]; then
-                echo "service account does not match"
-              fi
+                if [ "$(jq -r '.components[0].target_index' "$RESULTS_FILE")" != \
+                  "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
+                  echo "targetIndex #1 does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.index_image.target_index' "$RESULTS_FILE")" != \
-                "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
-                echo "targetIndex does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.components[1].target_index' "$RESULTS_FILE")" != \
+                  "quay.io/scoheb/fbc-target-index-testing:v4.13" ]; then
+                  echo "targetIndex #2 does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "quay.io/scoheb/fbc-index-testing:latest" ]; then
-                echo "fromIndex does not match"
-                exit 1
-              fi
+                fromIndex="quay.io/scoheb/fbc-index-testing:latest"
+                if [ "$(jq -r '.fromIndex' <<< "${requestParams}")" != "${fromIndex}" ]; then
+                  echo "fromIndex does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.buildTimeoutSeconds' <<< "${requestParams}")" != "420" ]
-              then
-                echo "buildTimeoutSeconds does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.buildTimeoutSeconds' <<< "${requestParams}")" != "420" ]
+                then
+                  echo "buildTimeoutSeconds does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image0@sha256:0000" ]
-              then
-                echo "fbcFragment does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.fbcFragment' <<< "${requestParams}")" != "registry.io/image${i}@sha256:0000" ]
+                then
+                  echo "fbcFragment does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
-                echo "taskGitUrl image does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.taskGitUrl' <<< "${requestParams}")" != "http://localhost" ]; then
+                  echo "taskGitUrl image does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
-                echo "taskGitRevision image does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.taskGitRevision' <<< "${requestParams}")" != "main" ]; then
+                  echo "taskGitRevision image does not match"
+                  exit 1
+                fi
 
-              if [ "$(params.mustPublishIndexImage)" != "false" ]; then
-                echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
-                exit 1
-              fi
+                if [ "$(params.mustPublishIndexImage)" != "false" ]; then
+                  echo "Unexpected value for mustPublishIndexImage: $(params.mustPublishIndexImage)"
+                  exit 1
+                fi
 
-              if [ "$(params.isFbcOptIn)" != "true" ]; then
-                echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
-                exit 1
-              fi
-
-              if [ "$(wc -w <<< "$(params.indexImageDigests)")" -ne 2 ]; then
-                echo "indexImageDigest should contain 2 images: $(params.indexImageDigests)"
-                exit 1
-              fi
+                if [ "$(params.isFbcOptIn)" != "true" ]; then
+                  echo "Unexpected value for fbc_opt_in: $(params.isFbcOptIn)"
+                  exit 1
+                fi
+                i=$(( i+1 ))
+              done
       runAfter:
         - run-task
   finally:

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -31,7 +31,9 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
-                    "repository": "prod-registry.io/prod-location0"
+                    "repository": "prod-registry.io/prod-location0",
+                    "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocpVersion": "v4.13"
                   }
                 ]
               }
@@ -74,10 +76,24 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: internalRequestResultsFile
+          value: $(tasks.run-task.results.internalRequestResultsFile)
+        - name: indexImageDigests
+          value: $(tasks.run-task.results.indexImageDigests)
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        params:
+          - name: pipelineRunUid
+            type: string
+          - name: internalRequestResultsFile
+            type: string
+          - name: indexImageDigests
+            type: string
         steps:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
@@ -86,6 +102,7 @@ spec:
               #
               set -eux
 
+              RESULTS_FILE="$(workspaces.data.path)/$(params.internalRequestResultsFile)"
               internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
                 tac | tail -1)"
 
@@ -125,9 +142,15 @@ spec:
               fi
 
               TS=1696946200 # ts set in the mocked `date`
-              value=$(jq -r '.targetIndex' <<< "${requestParams}")
-              if [  "${value}" != "quay.io/scoheb/fbc-target-index-testing:v4.12-pre-ga-product-v2-${TS}" ]; then
+              if [ "$(jq -r '.components[].target_index' "$RESULTS_FILE")" != \
+                "quay.io/scoheb/fbc-target-index-testing:v4.13-pre-ga-product-v2-${TS}" ]; then
                 echo "targetIndex does not match"
+                exit 1
+              fi
+
+              num_images=$(wc -w <<< "$(jq -r '.components[].image_digests[]' "$RESULTS_FILE")")
+              if [ "$num_images" -ne 2 ]; then
+                echo "Unexpected value for number of image digests: $num_images"
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/prepare-fbc-release/README.md
+++ b/tasks/managed/prepare-fbc-release/README.md
@@ -14,6 +14,10 @@ to each component, so other task can use them.
 | snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace      | No       | -                  |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace | No       | -                  |
 
+## Changes in 1.4.1
+* The task now support multiarchitecture images
+* Changed to use `mktemp` to generate the temporary snapshot json file
+
 ## Changes in 1.4.0
 * Removed the `binaryImage` parameter so IIB can auto resolve it
 

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: prepare-fbc-release
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -89,8 +89,27 @@ spec:
             # which includes the OCP version, formatted as "registry:version".
             # Example: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
             # The script then isolates the version part (e.g., "v4.12") from this string.
-            ocpVersion=$(skopeo inspect --raw docker://"$containerImage" \
-                | jq -r '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2)
+            image_metadata=$(skopeo inspect --raw "docker://${containerImage}")
+            media_type=$(jq -r .mediaType <<< "${image_metadata}")
+
+            # multiplatform images will not contain the base name with the OCP version, so it should fetch
+            # the manifest image
+            if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
+                ocpVersion=$(jq -r '.annotations."org.opencontainers.image.base.name"' <<< "${image_metadata}" \
+                  | cut -d: -f2 | sed 's/"//g')
+            else
+              # image is an index of multiplatform components
+              arch_json=$(get-image-architectures "${containerImage}")
+
+              # it is not required to loop all images as they are all built for the same OCP version
+              manifest_image_sha="$(jq -rs 'map(.digest)[0]'  <<< "$arch_json")"
+
+              # replace the image sha with the manifests's one
+              fbc_fragment="${containerImage%@*}@${manifest_image_sha}"
+
+              ocpVersion=$(skopeo inspect --raw docker://"${fbc_fragment}" \
+                  | jq '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed 's/"//g')
+            fi
 
             # Check if the version matches the pattern
             if ! [[ "$ocpVersion" =~ $pattern ]]; then
@@ -102,11 +121,12 @@ spec:
             updatedFromIndex=$(replace_tag "$fromIndex" "$ocpVersion")
             updatedTargetIndex=$(replace_tag "$targetIndex" "$ocpVersion")
 
-            # if {{OCP_VERSION}} is not set, the original targetIndex will be kept but its ocp version should
+            # if {{OCP_VERSION}} is not set, the original Index will be kept but its ocp version should
             # match base image version.
-            for index in "${updatedFromIndex}" "${updatedTargetIndex}"; do
-              validateOCPVersion "${index}" "${ocpVersion}"
-            done
+            validateOCPVersion "${updatedFromIndex}" "${ocpVersion}"
+            if [ -n "${updatedTargetIndex}" ]; then
+              validateOCPVersion "${updatedTargetIndex}" "${ocpVersion}"
+            fi
 
             # Print updated values
             echo "Component: $componentName"
@@ -115,11 +135,13 @@ spec:
             echo "Updated targetIndex for $componentName: $updatedTargetIndex"
             echo
 
+            TEMP="/tmp/temp.json"
             # Apply each update directly
             jq ".components[$i].ocpVersion |= \"$ocpVersion\"" \
-              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+              "$SNAPSHOT_PATH" > "$TEMP" && mv "$TEMP" "$SNAPSHOT_PATH"
             jq ".components[$i].updatedFromIndex |= \"$updatedFromIndex\"" \
-              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+              "$SNAPSHOT_PATH" > "$TEMP" && mv "$TEMP" "$SNAPSHOT_PATH"
             jq ".components[$i].updatedTargetIndex |= \"$updatedTargetIndex\"" \
-              "$SNAPSHOT_PATH" > temp.json && mv temp.json "$SNAPSHOT_PATH"
+              "$SNAPSHOT_PATH" > "$TEMP" && mv "$TEMP" "$SNAPSHOT_PATH"
+
         done


### PR DESCRIPTION
this PR changes the task to support fbc fragments
containing multiple components.

changes made in the task:

- loops through the components and create internal- requests (IR) for each of these components;
- save the results for each IR in the RESULTS_FILE file;
- update tests

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

