### PR TITLE
fix: bug in parallel processing of pushes

### DIFF
--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -16,11 +16,18 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 7.0.1
+* Fix a bug in parallel processing of pushes
+  * We used just one temp file for the source image docker config and as a result, while a push for
+    one component was running in the background, another component was already changing the contents
+    of that docker config temp file.
+  * The fix is to use a new temp file for each component. That way they won't interfere.
 
 ## Changes in 7.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "7.0.0"
+    app.kubernetes.io/version: "7.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -205,7 +205,6 @@ spec:
 
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/push-snapshot-results.json"
         RESULTS_JSON="{\"images\":[]}"
-        SOURCE_AUTH_FILE=$(mktemp)
 
         RUNNING_JOBS="\j" # A Bash param for number of jobs running
         CONCURRENT_LIMIT=$(params.concurrentLimit)
@@ -239,6 +238,7 @@ spec:
           registry=$(echo "${containerImage}" | cut -d '/' -f 1)
           # Apply-mapping ensures that the containerImage contains a sha256 digest
           source_repo=${containerImage%%@sha256:*}
+          SOURCE_AUTH_FILE=$(mktemp)
           select-oci-auth "${containerImage}" | jq -c \
             '.auths."'"$source_repo"'" = .auths."'"$registry"'" | del(.auths."'"$registry"'")' > "$SOURCE_AUTH_FILE"
 
@@ -316,7 +316,7 @@ spec:
 
         echo "Waiting for all jobs to complete...."
         while (( ${RUNNING_JOBS@P} > 0 )); do
-          wait -n || SUCCESS=false 
+          wait -n || SUCCESS=false
         done
 
         echo "Printing outputs for each push image"
@@ -335,7 +335,7 @@ spec:
         jq --argjson PUSHES "$PUSHES" '
           reduce $PUSHES[] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
         ' <<< "$RESULTS_JSON" | tee "$RESULTS_FILE"
-        
+
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
       volumeMounts:
         - name: trusted-ca


### PR DESCRIPTION
## Describe your changes

We used just one temp file for the source image docker config and as a result, while a push for one component was running in the background, another component was already changing the contents of that docker config temp file.

The fix is to use a new temp file for each component. That way they won't interfere.

Related Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742456258615699

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

