### PR TITLE
fix: gitlint regular expression string

### DIFF
--- a/.github/gitlint/contrib_format_conventional_commits.py
+++ b/.github/gitlint/contrib_format_conventional_commits.py
@@ -15,7 +15,7 @@ class ConventionalCommitsFormat(CommitRule):
         """Validate the given commit checking that the title has a
         proper prefix and the description starts with a lowercase."""
 
-        regex_string = "^(chore|docs|feat|fix|refactor|revert|style|test)(\(.*\))?: [a-z].*$"
+        regex_string = r"^(chore|docs|feat|fix|refactor|revert|style|test)(\(.*\))?: [a-z].*$"
         pattern = re.compile(regex_string)
         if not pattern.match(commit.message.title):
             return [


### PR DESCRIPTION
Fixes a gitlint check:

    SyntaxWarning: invalid escape sequence '\('

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

