### PR TITLE
feat(RELEASE-1536): check for advisory id before creating it

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,10 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.3.0
+* Add check for advisory id before creating the advisory
+  * This will make sure there isn't an existing advisory with the same year and live id in the repo
+
 ## Changes in 1.2.0
 * Allow setting of custom advisory live id
   * If `live_id` is set in the advisory json, use that instead of requesting one from Errata Tool API

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -225,6 +225,15 @@ spec:
             LIVE_ID=$(curl --retry 3 --negotiate -u : "${REQUEST_URL}" -XPOST | jq -r '.live_id')
           fi
           ADVISORY_NUM=$(printf "%04d" "$LIVE_ID")
+
+          # Check if the advisory number is already used
+          FIND_RESULT=$(find data/advisories -type d -path "*/${YEAR}/${ADVISORY_NUM}")
+          if [[ -n "${FIND_RESULT}" ]]; then
+            echo "An advisory with number ${ADVISORY_NUM} already exists:" | tee -a "$STDERR_FILE"
+            echo "${FIND_RESULT}" | tee -a "$STDERR_FILE"
+            echo "Exiting." | tee -a "$STDERR_FILE"
+            exit 1
+          fi
 
           # group advisories by <origin workspace>/year
           ADVISORY_DIR="data/advisories/$(params.origin)/${YEAR}/${ADVISORY_NUM}"

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -9,32 +9,22 @@ function git() {
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     mkdir -p "$gitRepo"/schema
     echo '{"$schema": "http://json-schema.org/draft-07/schema#","type": "object", "properties":{}}' > "$gitRepo"/schema/advisory.json
-    mkdir -p "$gitRepo"/data/advisories/dev-tenant
+
+    mkdir -p "$gitRepo"/data/advisories/dev-tenant/2025/1602
+    mkdir -p "$gitRepo"/data/advisories/dev-tenant/2025/1601
+    mkdir -p "$gitRepo"/data/advisories/dev-tenant/2024/1452
+    mkdir -p "$gitRepo"/data/advisories/dev-tenant/2024/1442
+
+    touch -d "@1712012345" "$gitRepo"/data/advisories/dev-tenant/2025/1602
+    touch -d "@1712012344" "$gitRepo"/data/advisories/dev-tenant/2024/1452
+    touch -d "@1708012343" "$gitRepo"/data/advisories/dev-tenant/2025/1602
+    touch -d "@1704012342" "$gitRepo"/data/advisories/dev-tenant/2024/1442
+
   elif [[ "$*" == *"failing-tenant"* ]]; then
     echo "Mocking failing git command" && false
   else
     # Mock the other git functions to pass
     : # no-op - do nothing
-  fi
-}
-
-function find() {
-  echo "Mock find called with: $*" >&2
-
-  if echo "$*" | grep -q "not-existing-origin"; then
-    echo "Error: Unexpected call for not existing origin"
-    exit 1
-  fi
-
-  if echo "$*" | grep -q "${ADVISORY_BASE_DIR}"; then
-    # Simulate directories with timestamps
-    echo "1712012345.0 ${ADVISORY_BASE_DIR}/2025/1602"  # Contains image-beta
-    echo "1712012344.0 ${ADVISORY_BASE_DIR}/2025/1601"  # Contains image-alpha
-    echo "1708012343.0 ${ADVISORY_BASE_DIR}/2024/1452"
-    echo "1704012342.0 ${ADVISORY_BASE_DIR}/2024/1442"
-  else
-    echo "Error: Unexpected find command: $*" >&2
-    exit 1
   fi
 }
 

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-fail-existing-id
+spec:
+  description: |
+    Run the create-advisory task and have it fail. In this scenario it fails because an advisory with year 2024
+    and the live id 1352 already exists (created in the git clone mock)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: create-advisory-task
+      params:
+        - name: advisory_json
+          value: >-
+            {"product_id":123,"product_name":"Red Hat Product","product_version":"1.2.3","product_stream":"tp1",
+            "cpe":"cpe:/a:example:product:el8","type":"RHSA","synopsis":"test synopsis","topic":"test topic",
+            "description":"test description","solution":"test solution","references":["https://docs.example.com/notes"],
+            "content":{"images":[{"containerImage":"quay.io/example/openstack@sha256:abdefail",
+            "repository":"rhosp16-rhel8/openstack","tags":["latest"],"architecture":"amd64",
+            "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+            "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}}]},
+            "live_id":1452}
+        - name: application
+          value: "test-app"
+        - name: origin
+          value: "failing-tenant"
+        - name: config_map_name
+          value: "create-advisory-test-cm"
+        - name: advisory_secret_name
+          value: "create-advisory-secret"
+        - name: errata_secret_name
+          value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: advisory_url
+          value: $(tasks.run-task.results.advisory_url)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: advisory_url
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that result is contains the failed command
+              grep "already exists" <<< "$(params.result)"
+
+              echo Test that advisory_url was not set
+              test -z "$(params.advisory_url)"


### PR DESCRIPTION
## Describe your changes

Before creating a new advisory in the Gitlab repo, make sure that there isn't an existing advisory with the same year and live id. If we find one, exit with a failure result.

This check will happen regardless of whether we get the live id from Errata Tool API, or it's set in the data file.

## Relevant Jira

[RELEASE-1536](https://issues.redhat.com//browse/RELEASE-1536)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

