### PR TITLE
fix: run update-trusted-tasks after make-repo-public

### DIFF
--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/README.md
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/README.md
@@ -20,6 +20,9 @@ Tekton pipeline to release tekton tasks bundles to an external registry and upda
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 0.4.0
+Update the `update-trusted-tasks` task to run after the `make-repo-public` task
+
 ## Changes in 0.3.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers
 * Align workspace name with changes in the apply-mapping task

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-tekton-task-bundles-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -260,28 +260,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
-    - name: update-trusted-tasks
-      when:
-        - input: "$(tasks.apply-mapping.results.mapped)"
-          operator: in
-          values: ["true"]
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
-      params:
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-      workspaces:
-        - name: data
-          workspace: release-workspace
-      runAfter:
-        - push-snapshot
     - name: collect-registry-token-secret
       taskRef:
         resolver: "git"
@@ -326,6 +304,28 @@ spec:
       runAfter:
         - collect-registry-token-secret
         - push-snapshot
+    - name: update-trusted-tasks
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - make-repo-public        
     - name: update-cr-status
       params:
         - name: resource


### PR DESCRIPTION
- run the update-trusted-tasks after making the repository public
- Version bumped to 0.4.0
- Changes in 0.4.0 section was added to the README file

The flow in the `push-tekton-task-bundles-to-external-registry` pipeline should be updated.
After pushing the snapshot to a repository we run another task to update the trusted-tasks list.
This task uses the `ec track bundle` command with a reference to the pushed snaphot.
If the snapshot was pushed to non public repository, the `update-trusted-tasks` task will fail because it is not authorized to get the pushed snapshot.
By moving this task to run after the repository is public, the task should succeed.

