### PR TITLE
fix: add HOME env to prevent ec track failures

### DIFF
--- a/tasks/managed/update-trusted-tasks/README.md
+++ b/tasks/managed/update-trusted-tasks/README.md
@@ -10,3 +10,4 @@ If it is already in place, it will be used as an input to which the results will
 | Name       | Description                                                             | Optional | Default value |
 |------------|-------------------------------------------------------------------------|----------|---------------|
 | snapshotPath   | Path to the JSON string of the Snapshot spec in the data workspace | No       | -             |
+| homeDir   | Value for the HOME environment variable. | Yes       | -             |

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -19,9 +19,17 @@ spec:
     - name: snapshotPath
       type: string
       description: Path to the JSON string of the Snapshot spec in the data workspace
+    - name: homeDir
+      type: string
+      description: Value for the HOME environment variable.
+      default: /tekton/home
   workspaces:
     - name: data
       description: The workspace where the snapshot json reside
+  stepTemplate:
+    env:
+      - name: HOME
+        value: "$(params.homeDir)"      
   steps:
     - name: update-trusted-tasks
       image: quay.io/konflux-ci/appstudio-utils@sha256:0901e46d9a41d0c564b0efab092f37cd187bd8b4ff2455ec84539ceb8b08f3ea


### PR DESCRIPTION
add HOME env to prevent ec track failures

Even though the `data-acceptable-bundles` artifact is created in a public repository, the `ec track bundle` command fails with:
`Error: POST https://quay.io/v2/konflux-ci/konflux-vanguard/data-acceptable-bundles/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]`

This is a known issue and following this [thread](https://redhat-internal.slack.com/archives/C031J4KBFME/p1738590728823739?thread_ts=1738579323.827419&cid=C031J4KBFME) adding HOME env with a value of `/tekton/home` to the task should resolve the failures
