### PR TITLE
fix: specify a number of retries for push-snapshot

### DIFF
--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -9,7 +9,7 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                       |
 | dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |
 | resultsDirPath          | Path to results directory in the data workspace                                                                            | No       | -                       |
-| retries                 | Retry copy N times                                                                                                         | Yes      | 0                       |
+| retries                 | Retry copy N times                                                                                                         | Yes      | 3                       |
 | concurrentLimit         | The maximum number of images to be proccessed concurrently                                                                 | Yes      | 10                      |
 | caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca              |
 | caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt           |
@@ -21,6 +21,9 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 7.1.0
+* Increase default number of retries from 0 to 3.
 
 ## Changes in 7.0.1
 * Fix a bug in parallel processing of pushes

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "7.0.1"
+    app.kubernetes.io/version: "7.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,7 +28,7 @@ spec:
     - name: retries
       description: Retry copy N times.
       type: string
-      default: "0"
+      default: "3"
     - name: caTrustConfigMapName
       type: string
       description: The name of the ConfigMap to read CA bundle data from.


### PR DESCRIPTION
## Describe your changes
specify a number of retries for push-snapshot

This is a nice feature, but users have no way to specify a value other than 0 today.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

