### PR TITLE
feat(CLDX-378): skip setting advisory severity for generic artifacts

### DIFF
--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -1,7 +1,8 @@
 # set-advisory-severity
 
 Tekton task to set the severity level in the releaseNotes key of the data.json. It will use an InternalRequest to query
-OSIDB for each CVE present. If the type is not RHSA, no action will be performed.
+OSIDB for each CVE present. If the type is not RHSA, no action will be performed. This check is only performed for
+images and not for generic artifact types like binaries or disk images.
 
 ## Parameters
 
@@ -18,6 +19,9 @@ OSIDB for each CVE present. If the type is not RHSA, no action will be performed
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 1.0.3
+* Skip severity setting for generic artifact types
 
 ## Changes in 1.0.2
 * Improve logging of `internal-request`

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -12,7 +12,8 @@ spec:
   description: >
     Tekton task to set the severity level in the releaseNotes key of the data.json. It will
     use an InternalRequest to query OSIDB for each CVE present. If the type is not RHSA, no
-    action will be performed.
+    action will be performed. This check is only performed for images and not for generic
+    artifact types like binaries or disk images.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
@@ -130,7 +131,15 @@ spec:
         fi
 
         # Ensure RHSA is only used if CVEs are provided
-        NUM_CVES=$(jq '[.releaseNotes.content.images[]?.cves.fixed // [] | length] | add' "${DATA_FILE}")
+        NUM_CVES=$(jq '
+        (
+          [.releaseNotes.content.images // [] | .[]?.cves.fixed // {} | length] |
+          add
+        ) + (
+          [.releaseNotes.content.artifacts // [] | .[]?.cves.fixed // {} | length] |
+          add
+        )
+        ' "${DATA_FILE}")
         if [[ "$advisoryType" == "RHSA" ]] && [[ "$NUM_CVES" -eq 0 ]] ; then
             echo "Provided advisory type is RHSA, but no fixed CVEs were listed"
             echo "RHSA should only be used if CVEs are fixed in the advisory. Failing..."
@@ -138,6 +147,12 @@ spec:
         fi
 
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+        # Cleanly exit here if generic artifacts are detected.
+        if jq -e '.releaseNotes.content.artifacts | length > 0' "$DATA_FILE" > /dev/null; then
+            echo "Generic artifact type detected, not setting advisory severity"
+            exit 0
+        fi
 
         RELEASENOTESIMAGES=$(jq -c '.releaseNotes.content.images' "${DATA_FILE}")
 

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-set-advisory-severity-generic-artifact
+spec:
+  description: |
+    Test that the task ensure generic artifacts are skipped
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "type": "RHSA",
+                  "content": {
+                    "artifacts": [
+                      {
+                        "foo": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "components": [
+                                "pkg:rpm/foo"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "foo": "bar",
+                        "cves": {
+                          "fixed": {
+                            "CVE-555": {
+                              "components": [
+                                "pkg:rpm/bar"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: set-advisory-severity
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Should NOT have set severity
+              ! jq -e '.releaseNotes | has("severity")' "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"


### PR DESCRIPTION
Some checks can remain for generic artifacts:
- severity being unset for non-RHSA
- CVEs listed when advisory type is RHSA

Setting advisory severity for generic artifacts is not currently supported. The script will cleanly exit at that point.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

