### PR TITLE
fix: processing of long argument list with jq

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,11 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.3.3
+* Fix handling of long argument list with `jq`
+  * When a large number of objects was in the list, `jq` would fail with `Argument list too long`
+  * The solution is to use `--argfile` instead of `--argjson`
+
 ## Changes in 1.3.2
 * Update base image
   * New base image contains a new version of the advisory template that only renders an issue's id and source as

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.3.2"
+    app.kubernetes.io/version: "1.3.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -147,7 +147,8 @@ spec:
           # This also cds into the git repo
           git_clone_and_checkout --repository "$GIT_REPO" --revision "$REPO_BRANCH"
 
-          CONTENT_IMAGES=$(jq -c '.content.images // []' <<< "$ADVISORY_JSON" )
+          CONTENT_IMAGES=/tmp/content_images.json
+          jq -c '.content.images // []' <<< "$ADVISORY_JSON" > "$CONTENT_IMAGES"
 
           # Use ISO 8601 format in UTC/Zulu time, e.g. 2024-03-06T17:27:38Z
           SHIP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -172,15 +173,17 @@ spec:
               echo "No existing advisories found."
           fi
 
+          EXISTING_CONTENT=/tmp/existing_content.json
           for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
               ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
-              EXISTING_CONTENT=$(yq -o=json '.spec.content.images // []' "${ADVISORY_FILE}")
+              yq -o=json '.spec.content.images // []' "${ADVISORY_FILE}" > "$EXISTING_CONTENT"
 
               echo "Processing advisory: ${ADVISORY_FILE}"
-              echo "Existing images in advisory: $EXISTING_CONTENT"
+              echo "Existing images in advisory: "
+              cat "$EXISTING_CONTENT"
 
               # Update CONTENT_IMAGES by removing images that already exist in the advisory
-              CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --argjson existing "$EXISTING_CONTENT" '
+              jq --argfile existing "$EXISTING_CONTENT" '
                 map(select(
                   .containerImage as $ci |
                   .tags as $tags |
@@ -188,12 +191,14 @@ spec:
                   ($existing | map(select(
                     .containerImage == $ci and .tags == $tags and .repository == $repo
                   )) | length == 0)
-                ))')
+                ))' "$CONTENT_IMAGES" > /tmp/content_images_filtered.json
+              mv /tmp/content_images_filtered.json "$CONTENT_IMAGES"
 
-              echo "Remaining images after filtering: $CONTENT_IMAGES"
+              echo "Remaining images after filtering:"
+              cat "$CONTENT_IMAGES"
 
               # If after filtering, no images are left, then we can exit early
-              if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
+              if jq -e 'length == 0' "$CONTENT_IMAGES" >/dev/null; then
                   echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
                   ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${ADVISORY_FILE}"
                   ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
@@ -205,7 +210,7 @@ spec:
               fi
           done
 
-          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argjson new_images "$CONTENT_IMAGES" \
+          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argfile new_images "$CONTENT_IMAGES" \
             '.content.images = $new_images')
 
           signingKey=$(kubectl get configmap "$(params.config_map_name)" -o jsonpath="{.data.SIG_KEY_NAME}")


### PR DESCRIPTION
## Describe your changes

When using `--argjson` with `jq`, it can fail with: Argument list too long

The fix is to use `--argfile` with a file instead.

This fix was already tested by the user and he confirmed it worked.

## Relevant Jira

[KFLUXSPRT-3088](https://issues.redhat.com/browse/KFLUXSPRT-3088)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

