### PR TITLE
fix: use correct param name in blob-signing pipeline

### DIFF
--- a/pipelines/internal/blob-signing-pipeline/README.md
+++ b/pipelines/internal/blob-signing-pipeline/README.md
@@ -12,3 +12,7 @@ Tekton pipeline for signing base64 blobs
 | config_map_name | A config map name with configuration                                                  | Yes      | hacbs-signing-pipeline-config                                                         |
 | taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git                             |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                                                     |
+
+## Changes in 0.1.1
+* Update incorrect parameter name to request-signature
+  * `umb_ssl_cert_secret_name` replaced with `umb_ssl_secret_name`

--- a/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
+++ b/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: blob-signing-pipeline
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -71,7 +71,7 @@ spec:
           value: $(tasks.collect-simple-signing-params.results.sig_key_id)
         - name: sig_key_name
           value: $(tasks.collect-simple-signing-params.results.sig_key_name)
-        - name: umb_ssl_cert_secret_name
+        - name: umb_ssl_secret_name
           value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_secret_name)
         - name: umb_ssl_cert_secret_key
           value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_file_name)


### PR DESCRIPTION
The blob signing pipeline was wrongfully migrated with a parameter umb_ssl_cert_secret_name for the request-signature task. It is now corrected to umb_ssl_secret_name.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

