### PR TITLE
fix: ensure severity is present in advisory

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.3
+* Correct missing severity in advisory due to incorrect sourceDataArtifact
+
 ## Changes in 2.0.2
 * Temporarily allow the `close-advisory-issues` task to fail
   * Until https://issues.redhat.com/browse/KONFLUX-7489 is fixed

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -993,7 +993,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.populate-release-notes.results.sourceDataArtifact)"
+          value: "$(tasks.set-advisory-severity.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug


### PR DESCRIPTION
## Describe your changes
- fix incorrect sourceDataArtifact to ensure that severity value is used.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

