### PR TITLE
feat(RELEASE-1564): gitlab advisory internal url

### DIFF
--- a/pipelines/internal/create-advisory/README.md
+++ b/pipelines/internal/create-advisory/README.md
@@ -17,6 +17,9 @@ advisory URL as well as a result to show the error message if one occurred.
 | taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
 
+## Changes in 1.1.1
+* Add new result for the gitlab advisory url
+
 ## Changes in 1.1.0
 * Add internalRequestPipelineRunName and internalRequestTaskRunName as results to help with debugging
 

--- a/pipelines/internal/create-advisory/create-advisory.yaml
+++ b/pipelines/internal/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -71,6 +71,8 @@ spec:
       value: $(tasks.create-advisory-task.results.result)
     - name: advisory_url
       value: $(tasks.create-advisory-task.results.advisory_url)
+    - name: advisory_internal_url
+      value: $(tasks.create-advisory-task.results.advisory_internal_url)
     - name: internalRequestPipelineRunName
       value: $(tasks.create-advisory-task.results.internalRequestPipelineRunName)
     - name: internalRequestTaskRunName

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,9 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.3.1
+* Add new result for the gitlab advisory url
+
 ## Changes in 1.3.0
 * Add check for advisory id before creating the advisory
   * This will make sure there isn't an existing advisory with the same year and live id in the repo

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,6 +45,8 @@ spec:
       description: Success if the task succeeds, the error otherwise
     - name: advisory_url
       description: The advisory url if the task succeeds, empty string otherwise
+    - name: advisory_internal_url
+      description: The advisory internal url if the task succeeds, empty string otherwise
     - name: internalRequestPipelineRunName
       description: Name of the PipelineRun that called this task
     - name: internalRequestTaskRunName
@@ -120,6 +122,7 @@ spec:
                   fi
               fi
               echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
+              echo -n "${ADVISORY_INTERNAL_URL}" > "$(results.advisory_internal_url.path)"
               exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
           }
           # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
@@ -127,6 +130,7 @@ spec:
 
           REPO_BRANCH=main
           ADVISORY_URL=""
+          ADVISORY_INTERNAL_URL=""
           ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
 
           # Switch to /tmp to avoid filesystem permission issues
@@ -191,7 +195,7 @@ spec:
               # If after filtering, no images are left, then we can exit early
               if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
                   echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
-                  ADVISORY_URL="${GIT_REPO//\.git/}/-/blob/main/${ADVISORY_FILE}"
+                  ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${ADVISORY_FILE}"
                   ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
                   ADVISORY_NAME=$(yq -r '.metadata.name' "${ADVISORY_FILE}")
                   ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
@@ -260,3 +264,4 @@ spec:
           # Construct the advisory url on customer portal to report back to the user as a result
           ADVISORY_TYPE=$(jq -r '.type' <<< "$ADVISORY_JSON" )
           ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
+          ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/${REPO_BRANCH}/${ADVISORY_FILEPATH}"

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -26,6 +26,9 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 6.1.1
+* Add gitlab advisory internal url to results
+
 ## Changes in 6.1.0
 * Add check for custom advisory id
   * If `.releaseNotes.allow_custom_live_id` is set to `true` in the RPA, then a custom advisory live

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "6.1.0"
+    app.kubernetes.io/version: "6.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -76,6 +76,8 @@ spec:
   results:
     - name: advisory_url
       description: The advisory url if one was created
+    - name: advisory_internal_url
+      description: The advisory internal url if one was created
     - description: Produced trusted data artifact
       name: sourceDataArtifact
       type: string
@@ -278,7 +280,10 @@ spec:
 
         URL=$(echo "${results}" | jq -r '.advisory_url // ""')
         echo -n "$URL" | tee "$(results.advisory_url.path)"
-        jq -n --arg url "$URL" '{"advisory": {"url": $url}}' | tee "$RESULTS_FILE"
+        INTERNAL_URL=$(echo "${results}" | jq -r '.advisory_internal_url // ""')
+        echo -n "$INTERNAL_URL" | tee "$(results.advisory_internal_url.path)"
+        jq -n --arg url "$URL" --arg internal_url "$INTERNAL_URL" \
+          '{"advisory": {"url": $url, "internal_url": $internal_url}}' | tee "$RESULTS_FILE"
     - name: create-trusted-artifact
       ref:
         resolver: "git"


### PR DESCRIPTION
## Describe your changes
- add new result for the gitlab internal advisory url
- useful for checking advisory content once a pipeline has completed.

**Note: a subsequent PR will contain a method to use this URL.**

## Relevant Jira
- [RELEASE-1564](https://issues.redhat.com//browse/RELEASE-1564)

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

