### PR TITLE
chore: cleanup timeouts for ta pipelines

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,10 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.5
+* This pipeline is now using trusted artifacts. Therefore, we can remove the comments and timeouts
+  added to workaround PVC contention issues.
+
 ## Changes in 2.0.4
 * Don't allow the `upload-product-sbom` task to fail anymore.
   * The issue should be resolved by curl retrying on all errors.

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.4"
+    app.kubernetes.io/version: "2.0.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -283,7 +283,6 @@ spec:
       runAfter:
         - apply-mapping
     - name: populate-release-notes
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -316,7 +315,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: embargo-check
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -575,7 +573,6 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -615,7 +612,6 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -656,7 +652,6 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -694,7 +689,6 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: update-component-sbom
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -736,7 +730,6 @@ spec:
         - push-rpm-data-to-pyxis
         - populate-release-notes
     - name: upload-component-sbom
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -783,7 +776,6 @@ spec:
       runAfter:
         - update-component-sbom
     - name: run-file-updates
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -823,7 +815,6 @@ spec:
         - name: data
           workspace: release-workspace
     - name: check-data-keys
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -862,7 +853,6 @@ spec:
       runAfter:
         - populate-release-notes
     - name: collect-atlas-params
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       taskRef:
         resolver: "git"
         params:
@@ -893,7 +883,6 @@ spec:
       runAfter:
         - collect-data
     - name: create-product-sbom
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -929,7 +918,6 @@ spec:
         - collect-atlas-params
         - populate-release-notes
     - name: upload-product-sbom
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -976,7 +964,6 @@ spec:
       runAfter:
         - create-product-sbom
     - name: create-advisory
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       params:
         - name: releasePlanAdmissionPath
@@ -1023,7 +1010,6 @@ spec:
         - set-advisory-severity
     - name: close-advisory-issues
       onError: continue  # until https://issues.redhat.com/browse/KONFLUX-7489 is fixed
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -25,6 +25,10 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      | 
 
+## Changes in 5.0.1
+* This pipeline is now using trusted artifacts. Therefore, we can remove the comments and timeouts
+  added to workaround PVC contention issues.
+
 ## Changes in 5.0.0
 * Activate the use of trusted artifacts
 * Use the verify-conforma task to verify the enterprise contract policy

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-registry-redhat-io
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -144,7 +144,6 @@ spec:
       runAfter:
         - verify-access-to-resources
     - name: check-data-keys
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
@@ -509,7 +508,6 @@ spec:
         - publish-pyxis-repository
         - extract-requester-from-release
     - name: create-pyxis-image
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -549,7 +547,6 @@ spec:
       runAfter:
         - push-snapshot
     - name: publish-pyxis-repository
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -590,7 +587,6 @@ spec:
         - collect-pyxis-params
         - apply-mapping
     - name: push-rpm-data-to-pyxis
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       retries: 5
       taskRef:
         resolver: "git"
@@ -628,7 +624,6 @@ spec:
       runAfter:
         - create-pyxis-image
     - name: run-file-updates
-      timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)


### PR DESCRIPTION
## Describe your changes
- both rh-push-to-registry-redhat-io and rh-advisories are now using trusted artifacts. Therefore, we can remove the comments and timeouts added to workaround PVC contention issues.

## Relevant Jira
- [KONFLUX-5598](https://issues.redhat.com//browse/KONFLUX-5598)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

