### PR TITLE
 feat(RELEASE-1343): only part of files can trigger e2e tests

### DIFF
--- a/.tekton/release-service-catalog-pull-request.yaml
+++ b/.tekton/release-service-catalog-pull-request.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "development"
-      && ( !has(body.pull_request) || !body.pull_request.draft)
-      && files.all.exists(x, !x.matches('^(?:.github)/|\\.md$|^(?:.*/)?(?:\\.yamllint|.gitlint|LICENSE)$'))
+      && (!has(body.pull_request) || !body.pull_request.draft)
+      && (".tekton/*.yaml".pathChanged()  
+      || "tasks/internal/*/*.yaml".pathChanged()
+      || "tasks/managed/*/*.yaml".pathChanged()
+      || "pipelines/managed/*/*.yaml".pathChanged()
+      || "schema/dataKeys.json".pathChanged()
+      || "stepactions/*/*.yaml".pathChanged()
+      || "pipelines/internal/*/*.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-service-catalog

--- a/.tekton/release-service-catalog-staging-pull-request.yaml
+++ b/.tekton/release-service-catalog-staging-pull-request.yaml
@@ -11,8 +11,14 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "staging"
-      && ( !has(body.pull_request) || !body.pull_request.draft)
-      && files.all.exists(x, !x.matches('^(?:.github)/|\\.md$|^(?:.*/)?(?:\\.yamllint|.gitlint|LICENSE)$'))
+      && (!has(body.pull_request) || !body.pull_request.draft)
+      && (".tekton/*.yaml".pathChanged()
+      || "tasks/internal/*/*.yaml".pathChanged()
+      || "tasks/managed/*/*.yaml".pathChanged()
+      || "pipelines/managed/*/*.yaml".pathChanged()
+      || "schema/dataKeys.json".pathChanged()
+      || "stepactions/*/*.yaml".pathChanged()
+      || "pipelines/internal/*/*.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-service-catalog-staging


### PR DESCRIPTION
Change on-cell-expression to limit tasks and pipelines .yaml files under managed/internal directories and some specical files to trigger e2e tests. Otherwise, the integration test (including provision cluster) will be always triggered although no e2e-test is needed.  

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

