### PR TITLE
fix: improve logging of embargo-check

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -24,6 +24,12 @@ based on the issues visibility
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.0.5
+* Improve logging of errors
+  * Print all the errors at the end of the script, so it's clear why the task failed
+  * Add an echo explaining that we're checking if the issue is public - the unauthenticated
+    curl call can fail and throw users off.
+
 ## Changes in 2.0.4
 * Update default requestTimeout from 3 mins to 45 mins
 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "2.0.4"
+    app.kubernetes.io/version: "2.0.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -165,7 +165,8 @@ spec:
             CURL_RC=$?
             set -x
             if [ "$CURL_RC" -ne 0 ] ; then
-                echo "Error: ${issue} is not visible. Assuming it is embargoed and stopping pipelineRun execution."
+                echo "Error: ${issue} is not visible. Assuming it is embargoed and stopping pipelineRun execution." \
+                    | tee -a /tmp/errors.txt
                 RC=1
                 continue
             fi
@@ -180,6 +181,7 @@ spec:
             public=false
 
             if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
+                echo "Checking if the issue is public - if not, curl will fail with error 401"
                 if curl-with-retry --retry 3 "${API_URL}" > /dev/null; then
                     public=true
                 fi
@@ -202,13 +204,18 @@ spec:
                 echo "Error: Issue $issue lists 'CVE ID' $CVE_ID" \
                   "but that CVE is not present in the releaseNotes.content.images section for any image." \
                   "This is likely due to CVE $CVE_ID not being provided in the releaseNotes.cves part of" \
-                  "your Release object."
+                  "your Release object." \
+                  | tee -a /tmp/errors.txt
                 RC=1
                 continue
             fi
 
         done
 
+        if [ "$RC" -ne 0 ] ; then
+            echo "Errors were found in the embargo check:"
+            cat /tmp/errors.txt
+        fi
         exit $RC
     - name: check-cves
       image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01


### PR DESCRIPTION
## Describe your changes
- Print all the errors at the end of the script, so it's clear why the task failed
- Add an echo explaining that we're checking if the issue is public
  - the unauthenticated curl call can fail and throw users off.

## Relevant Jira

[KFLUXSPRT-3126](https://issues.redhat.com/browse/KFLUXSPRT-3126)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

