### PR TITLE
fix: embargo-check ta used set-advisory-severity

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.6
+* set-advisory-severity should use the artifacts from embargo-check
+
 ## Changes in 2.0.5
 * This pipeline is now using trusted artifacts. Therefore, we can remove the comments and timeouts
   added to workaround PVC contention issues.

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.5"
+    app.kubernetes.io/version: "2.0.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -356,7 +356,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.populate-release-notes.results.sourceDataArtifact)"
+          value: "$(tasks.embargo-check.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -379,6 +379,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - populate-release-notes
+        - embargo-check
     - name: collect-cosign-params
       taskRef:
         resolver: "git"


### PR DESCRIPTION
## Describe your changes
- we must ensure that the embargo-check artifact is used as input to the set-advisory-severity task.
- otherwise, the public flag will not make it into the advisory.
- set-advisory-severity then feeds into create-advisory and must have the alterations that populate-release-notes, embargo-check and set-advisory-severity have made.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)