### PR TITLE
refactor(RELEASE-1568): remove appstudio-pipeline references

### DIFF
--- a/tasks/managed/push-artifacts-to-cdn/README.md
+++ b/tasks/managed/push-artifacts-to-cdn/README.md
@@ -17,10 +17,13 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | resultsDirPath           | Path to results directory in the data workspace                                           | No       | -             |
 | requestTimeout           | Request timeout                                                                           | Yes      | 86400         |
 
+## Changes in 1.0.1
+* The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`
+
 ## Changes in 1.0.0
 * `releasePath` parameter added
   * Author is extracted from the Release.Status and passed to the internalRequest
 
- ## Changes in 0.0.2
- * release-service-utils image is bumped
- * task now creates InternalRequests using the Git Ref of the internal pipeline instead of the cluster pipeline name
+## Changes in 0.0.2
+* release-service-utils image is bumped
+* task now creates InternalRequests using the Git Ref of the internal pipeline instead of the cluster pipeline name

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -70,7 +70,7 @@ spec:
         fi
 
         REQUESTTYPE=$(jq -r '.requestType // "internal-request"' "${DATA_FILE}")
-        service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
+        service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "release-service-account"' "${RPA_FILE}")
         if [ "${REQUESTTYPE}" == "internal-pipelinerun" ] ; then
           requestType=internal-pipelinerun
           requestK8sType=pipelinerun

--- a/tasks/managed/rh-sign-image/README.md
+++ b/tasks/managed/rh-sign-image/README.md
@@ -25,6 +25,9 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                             | No       | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                    | No       | ""                      |
 
+## Changes in 6.0.1
+* The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`
+
 ## Changes in 6.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "6.0.0"
+    app.kubernetes.io/version: "6.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -183,7 +183,7 @@ spec:
         fi
 
         REQUESTTYPE=$(jq -r '.sign.requestType // "internal-request"' "${DATA_FILE}")
-        service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
+        service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "release-service-account"' "${RPA_FILE}")
         if [ "${REQUESTTYPE}" == "internal-pipelinerun" ] ; then
           requestType=internal-pipelinerun
           EXTRA_ARGS=(

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -29,6 +29,9 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 4.2.1
+* The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`
+
 ## Changes in 4.2.0
 * The pipeline is called via git resolver now instead of cluster resolver
   * This was done by changing from `-r` to `--pipeline` in the `internal-request`/`internal-pipelinerun` call

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.2.0"
+    app.kubernetes.io/version: "4.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -71,7 +71,7 @@ spec:
               echo "No valid rpa file was provided."
               exit 1
           fi
-          service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "appstudio-pipeline"' "${RPA_FILE}")
+          service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "release-service-account"' "${RPA_FILE}")
           EXTRA_ARGS=(
           --service-account "${service_account_name}"
           )


### PR DESCRIPTION
The appstudio-pipeline service account is going away, so this commit updates the remaining tasks that used it as a default to instead use the release-service-account service account as the default.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

