### PR TITLE
feat: store pipeline status in oci artifact

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -242,3 +242,26 @@ spec:
           value: "$(tasks.status)"
         - name: test-event-type
           value: "$(tasks.test-metadata.results.test-event-type)"
+    - name: store-pipeline-status
+      when:
+        - input: "$(tasks.test-metadata.results.pull-request-author)"
+          operator: notin
+          values: ["red-hat-konflux[bot]"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/store-pipeline-status/0.1/store-pipeline-status.yaml
+      params:
+        - name: oci-ref
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: credentials-secret-name
+          value: "$(params.konflux-test-infra-secret)"
+        - name: pipelinerun-name
+          value: $(context.pipelineRun.name)
+        - name: pipeline-aggregate-status
+          value: $(tasks.status)


### PR DESCRIPTION
## Description
Add a Task to the finally section that will wait for all other tasks to complete and then store their status in a json and uploads it to OCI artifact

## JIRA
[KFLUXDP-241](https://issues.redhat.com//browse/KFLUXDP-241)

## Verification
in [this PR](https://github.com/konflux-ci/e2e-tests/pull/1589/files)