### PR TITLE
feat(ISV-5733): Release service uploads SBOMs to Atlas v2

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.0.7
+* Target for SBOM upload has been changed from Atlas v1 to Atlas v2.
+
 ## Changes in 2.0.6
 * set-advisory-severity should use the artifacts from embargo-check
 

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.6"
+    app.kubernetes.io/version: "2.0.7"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -742,8 +742,8 @@ spec:
           value: "$(tasks.collect-atlas-params.results.secretName)"
         - name: ssoTokenUrl
           value: "$(tasks.collect-atlas-params.results.ssoTokenUrl)"
-        - name: bombasticApiUrl
-          value: "$(tasks.collect-atlas-params.results.bombasticApiUrl)"
+        - name: atlasApiUrl
+          value: "$(tasks.collect-atlas-params.results.atlasApiUrl)"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
@@ -930,8 +930,8 @@ spec:
           value: "$(tasks.collect-atlas-params.results.secretName)"
         - name: ssoTokenUrl
           value: "$(tasks.collect-atlas-params.results.ssoTokenUrl)"
-        - name: bombasticApiUrl
-          value: "$(tasks.collect-atlas-params.results.bombasticApiUrl)"
+        - name: atlasApiUrl
+          value: "$(tasks.collect-atlas-params.results.atlasApiUrl)"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/tasks/managed/collect-atlas-params/README.md
+++ b/tasks/managed/collect-atlas-params/README.md
@@ -19,11 +19,15 @@ strings as results, indicating that the Atlas push should be skipped.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No          | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No          | ""                      |
 
+## Changes in 1.2.1
+* Deprecate the Atlas v1 API in favor of v2.
+* A result `bombasticApiUrl` was renamed to `atlasApiUrl`.
+
 ## Changes in 1.2.0
 * Added compute resource limits
 
 ## Changes in 1.1.0
-* now supports specifying secret names for stage and prod. 
+* now supports specifying secret names for stage and prod.
 
 ## Changes in 1.0.1
 * Also collect SBOM retry S3 bucket data.

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-atlas-params
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -50,10 +50,10 @@ spec:
   workspaces:
     - name: data
   results:
-    - name: bombasticApiUrl
+    - name: atlasApiUrl
       type: string
       description: |
-        URL of the bombastic API.
+        URL of the Atlas API.
     - name: ssoTokenUrl
       type: string
       description: |
@@ -61,7 +61,7 @@ spec:
     - name: secretName
       type: string
       description: |
-        The kubernetes secret to use to authenticate to bombastic.
+        The kubernetes secret to use to authenticate to Atlas.
     - name: retryAWSSecretName
       type: string
       description: |
@@ -137,20 +137,20 @@ spec:
         atlasServer=$(jq -r '.atlas.server' "$DATA_FILE")
         if [ "$atlasServer" = "null" ]; then
             # In this case, SBOM processing will be skipped.
-            bombasticApiUrl=""
+            atlasApiUrl=""
             ssoTokenUrl=""
             secretName=""
             retryAWSSecretName=""
             retryS3Bucket=""
         elif [ "$atlasServer" = "stage" ]; then
-            bombasticApiUrl="https://sbom.atlas.release.stage.devshift.net"
+            atlasApiUrl="https://atlas.release.stage.devshift.net"
             ssoTokenUrl="https://auth.stage.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
             secretName=$(jq -r '.atlas."atlas-sso-secret-name" // "atlas-staging-sso-secret"' "$DATA_FILE")
             retryAWSSecretName=$(jq -r '.atlas."atlas-retry-aws-secret-name" // "atlas-retry-s3-staging-secret"' \
               "$DATA_FILE")
             retryS3Bucket="mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"
         elif [ "$atlasServer" = "production" ]; then
-            bombasticApiUrl="https://sbom.atlas.release.devshift.net"
+            atlasApiUrl="https://atlas.release.devshift.net"
             ssoTokenUrl="https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
             secretName=$(jq -r '.atlas."atlas-sso-secret-name" // "atlas-prod-sso-secret"' "$DATA_FILE")
             retryAWSSecretName=$(jq -r '.atlas."atlas-retry-aws-secret-name" // "atlas-retry-s3-production-secret"' \
@@ -161,7 +161,7 @@ spec:
             exit 1
         fi
 
-        echo -n "$bombasticApiUrl" > "$(results.bombasticApiUrl.path)"
+        echo -n "$atlasApiUrl" > "$(results.atlasApiUrl.path)"
         echo -n "$ssoTokenUrl" > "$(results.ssoTokenUrl.path)"
         echo -n "$secretName" > "$(results.secretName.path)"
         echo -n "$retryAWSSecretName" > "$(results.retryAWSSecretName.path)"

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
@@ -119,13 +119,13 @@ spec:
           value: $(tasks.run-task.results.secretName)
         - name: ssoTokenUrl
           value: $(tasks.run-task.results.ssoTokenUrl)
-        - name: bombasticApiUrl
-          value: $(tasks.run-task.results.bombasticApiUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
       taskSpec:
         params:
           - name: secretName
           - name: ssoTokenUrl
-          - name: bombasticApiUrl
+          - name: atlasApiUrl
         steps:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
@@ -134,12 +134,12 @@ spec:
                 value: '$(params.secretName)'
               - name: "SSO_TOKEN_URL"
                 value: '$(params.ssoTokenUrl)'
-              - name: "BOMBASTIC_API_URL"
-                value: '$(params.bombasticApiUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
             script: |
               #!/usr/bin/env bash
               set -eux
 
               test "$SECRET_NAME" = ""
               test "$SSO_TOKEN_URL" = ""
-              test "$BOMBASTIC_API_URL" = ""
+              test "$ATLAS_API_URL" = ""

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
@@ -125,8 +125,8 @@ spec:
           value: $(tasks.run-task.results.secretName)
         - name: ssoTokenUrl
           value: $(tasks.run-task.results.ssoTokenUrl)
-        - name: bombasticApiUrl
-          value: $(tasks.run-task.results.bombasticApiUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
         - name: retryAWSSecretName
           value: $(tasks.run-task.results.retryAWSSecretName)
         - name: retryS3Bucket
@@ -135,7 +135,7 @@ spec:
         params:
           - name: secretName
           - name: ssoTokenUrl
-          - name: bombasticApiUrl
+          - name: atlasApiUrl
           - name: retryAWSSecretName
           - name: retryS3Bucket
         steps:
@@ -146,8 +146,8 @@ spec:
                 value: '$(params.secretName)'
               - name: "SSO_TOKEN_URL"
                 value: '$(params.ssoTokenUrl)'
-              - name: "BOMBASTIC_API_URL"
-                value: '$(params.bombasticApiUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
               - name: "RETRY_AWS_SECRET_NAME"
                 value: '$(params.retryAWSSecretName)'
               - name: "RETRY_S3_BUCKET"
@@ -158,6 +158,6 @@ spec:
 
               test "$SECRET_NAME" = "atlas-prod-sso-secret"
               test "$SSO_TOKEN_URL" = "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
-              test "$BOMBASTIC_API_URL" = "https://sbom.atlas.release.devshift.net"
+              test "$ATLAS_API_URL" = "https://atlas.release.devshift.net"
               test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-production-secret"
               test "$RETRY_S3_BUCKET" = "mpp-e1-prod-sbom-e02138d3-5c5c-4d90-a38f-6c54f658604d"

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
@@ -125,8 +125,8 @@ spec:
           value: $(tasks.run-task.results.secretName)
         - name: ssoTokenUrl
           value: $(tasks.run-task.results.ssoTokenUrl)
-        - name: bombasticApiUrl
-          value: $(tasks.run-task.results.bombasticApiUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
         - name: retryAWSSecretName
           value: $(tasks.run-task.results.retryAWSSecretName)
         - name: retryS3Bucket
@@ -135,7 +135,7 @@ spec:
         params:
           - name: secretName
           - name: ssoTokenUrl
-          - name: bombasticApiUrl
+          - name: atlasApiUrl
           - name: retryAWSSecretName
           - name: retryS3Bucket
         steps:
@@ -146,8 +146,8 @@ spec:
                 value: '$(params.secretName)'
               - name: "SSO_TOKEN_URL"
                 value: '$(params.ssoTokenUrl)'
-              - name: "BOMBASTIC_API_URL"
-                value: '$(params.bombasticApiUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
               - name: "RETRY_AWS_SECRET_NAME"
                 value: '$(params.retryAWSSecretName)'
               - name: "RETRY_S3_BUCKET"
@@ -159,6 +159,6 @@ spec:
               test "$SECRET_NAME" = "atlas-staging-sso-secret"
               test "$SSO_TOKEN_URL" = "https://auth.stage.redhat.com/auth/realms\
               /EmployeeIDP/protocol/openid-connect/token"
-              test "$BOMBASTIC_API_URL" = "https://sbom.atlas.release.stage.devshift.net"
+              test "$ATLAS_API_URL" = "https://atlas.release.stage.devshift.net"
               test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-staging-secret"
               test "$RETRY_S3_BUCKET" = "mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"

--- a/tasks/managed/upload-sbom-to-atlas/README.md
+++ b/tasks/managed/upload-sbom-to-atlas/README.md
@@ -13,11 +13,11 @@ lower, they are uploaded as-is.
 
 ## Parameters
 | Name                      | Description                                                                                                                | Optional | Default value                                                                 |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------------------------|
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
 | sbomDir                   | Directory containing SBOM files relative to the data workspace.                                                            | No       | None                                                                          |
 | httpRetries               | Max HTTP retry count.                                                                                                      | Yes      | 3                                                                             |
 | atlasSecretName           | Name of the Secret containing SSO auth credentials for Atlas.                                                              | Yes      | atlas-prod-sso-secret                                                         |
-| bombasticApiUrl           | URL of the BOMbastic API host of Atlas.                                                                                    | Yes      | https://sbom.atlas.devshift.net                                               |
+| ATLAS_API_URL             | URL of the Atlas API host.                                                                                                 | Yes      | https://atlas.release.devshift.net                                            |
 | ssoTokenUrl               | URL of the SSO token issuer.                                                                                               | Yes      | https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token |
 | supportedCycloneDxVersion | Maximum supported CycloneDX version.                                                                                       | Yes      | 1.4                                                                           |
 | supportedSpdxVersion      | Maximum supported SPDX version.                                                                                            | Yes      | 2.3                                                                           |
@@ -32,6 +32,11 @@ lower, they are uploaded as-is.
 | dataDir                   | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path)                                                       |
 | taskGitUrl                | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                                                                            |
 | taskGitRevision           | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                                                                            |
+
+## Changes in 2.1.0
+* Deprecate the Atlas v1 API in favor of v2.
+* A param `bombasticApiUrl` was renamed to `atlasApiUrl`.
+* Atlas uploads routes are now pointing to the v2 API.
 
 ## Changes in 2.0.1
 * Force curl to retry on all errors in S3 push.

--- a/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
+++ b/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
@@ -10,7 +10,8 @@ curl() {
 
   # Throw a failure (which should be caught) for Atlas API calls in the curl fail test
   params="$*"
-  if [[ "$params" =~ "https://sbom.atlas.devshift.net/api/v1/sbom?id=spdx_minimal_curl_fail_2_3" ]]; then
+  # A command uploading the "spdx_minimal_curl_fail_2_3" SBOM to Atlas should fail
+  if [[ "$params" =~ "https://atlas.release.devshift.net/api/v2/sbom" && "$params" =~ "spdx_minimal_curl_fail_2_3" ]]; then
     return 1
   fi
 }

--- a/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-cyclonedx.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-cyclonedx.yaml
@@ -264,7 +264,7 @@ spec:
 
                 # Check if all SBOM-s were uploaded
                 # calls are unsorted, so we are checking whole file
-                if ! echo "$curl_calls" | grep -q "https://sbom.atlas.devshift.net/api/v1/sbom?id=$sbom_id"; then
+                if ! echo "$curl_calls" | grep -q "https://atlas.release.devshift.net/api/v2/sbom"; then
                     echo "ERROR: Uploading the SBOM with ID $sbom_id does not match the expected command."
                     exit 1
                 else

--- a/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-spdx.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-spdx.yaml
@@ -256,7 +256,7 @@ spec:
 
                 # Check if all parsed SBOM-s were sent to Atlas
                 # calls are unsorted, so we are checking whole file
-                if ! echo "$curl_calls" | grep -q "https://sbom.atlas.devshift.net/api/v1/sbom?id=$sbom_id"; then
+                if ! echo "$curl_calls" | grep -q "https://atlas.release.devshift.net/api/v2/sbom"; then
                     echo "TEST FAILED: Uploading the SBOM with ID $sbom_id does not match the expected command."
                     exit 1
                 else

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: upload-sbom-to-atlas
   labels:
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -30,9 +30,9 @@ spec:
       default: atlas-prod-sso-secret
       description: Name of the Secret containing SSO auth credentials for Atlas
       type: string
-    - name: bombasticApiUrl
-      default: "https://sbom.atlas.devshift.net"
-      description: URL of the BOMbastic API host of Atlas
+    - name: atlasApiUrl
+      default: "https://atlas.release.devshift.net"
+      description: URL of the Atlas API host
       type: string
     - name: ssoTokenUrl
       default: "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
@@ -166,7 +166,7 @@ spec:
         version_lesser_equal() {
           local first
           first="$(printf "%s\n%s" "$1" "$2" | sort --version-sort | head -n 1)"
-        
+
           if [ "$1" = "$first" ]; then
             echo "SBOM version ($1) is supported (<= $2), will not convert"
           else
@@ -235,7 +235,7 @@ spec:
     - name: convert-sboms-if-needed
       image: quay.io/konflux-ci/release-service-utils:80a575e7e12d32f866a6105827804f2f122cea73
       script: |
-        #!/usr/bin/env bash    
+        #!/usr/bin/env bash
         set -o errexit -o pipefail -o nounset
 
         # creating working directory
@@ -270,7 +270,7 @@ spec:
         - name: atlas-secret
           mountPath: /secrets/
       script: |
-        #!/usr/bin/env bash    
+        #!/usr/bin/env bash
         set -o errexit -o pipefail -o nounset
 
         # creating working directory
@@ -325,21 +325,21 @@ spec:
           sbom_id="$(basename -s .json "$sbom_path")"
           supported_version_of_sbom="${sbom_path}.supported_version"
 
-          bombasticApiUrl=$(params.bombasticApiUrl)
-          echo "Uploading SBOM to $bombasticApiUrl (with id=$sbom_id)"
+          atlasApiUrl=$(params.atlasApiUrl)
+          echo "Uploading SBOM to $atlasApiUrl ($sbom_id)"
 
           handle_atlas_failure () {
             >&2 echo "WARNING: SBOM upload of $1 to Atlas has failed! Upload will be retried later."
             cp "$1" "${failedSbomDir}"
           }
 
-          curl -X PUT "${curl_opts[@]}" \
+          curl -X POST "${curl_opts[@]}" \
             --retry-max-time "$retry_max_time" \
             -H "authorization: Bearer $access_token" \
             -H "transfer-encoding: chunked" \
             -H "content-type: application/json" \
             --data "@$supported_version_of_sbom" \
-            "$bombasticApiUrl/api/v1/sbom?id=$sbom_id" \
+            "$atlasApiUrl/api/v2/sbom" \
             || handle_atlas_failure "$supported_version_of_sbom"
 
           # In the stage environment (and e2e tests), retry the push of all


### PR DESCRIPTION
The Atlas instance used by the release-service has been recently upgraded to a version 2. With a new version the API contract is changing and the upload code needs to be updated.

The new routes have been added to the collect-atlas-params and upload code have been updated in upload-sbom-to-atlas. Changes have been propagate to all relevant pipelines.

With this update Konflux no longer pushes SBOMs to Atlas v1 and switches to v2 instead.

JIRA: [ISV-5733](https://issues.redhat.com//browse/ISV-5733)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

