### PR TITLE
feat(CLDX-379): use signing key from configMap

### DIFF
--- a/pipelines/internal/push-artifacts-to-cdn/README.md
+++ b/pipelines/internal/push-artifacts-to-cdn/README.md
@@ -8,6 +8,7 @@ Tekton Pipeline to push artifacts to CDN and/or Dev Portal
 |-----------------|----------------------------------------------------------------------------------------|-------------|------------------------------------------------------------|
 | snapshot_json   | String containing a JSON representation of the snapshot spec                           | No          | -                                                          |
 | author          | Author taken from Release to be used for checksum signing                              | No          | -                                                          |
+| signingKeyName  | Signing key name to be used for checksum signing                                       | No          | -                                                          |
 | exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                              | No          | -                                                          |
 | exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                      | No          | -                                                          |
 | pulpSecret      | Env specific secret containing the rhsm-pulp credentials                               | No          | -                                                          |
@@ -17,6 +18,9 @@ Tekton Pipeline to push artifacts to CDN and/or Dev Portal
 | taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored  | Yes         | https://github.com/konflux-ci/release-service-catalog.git  |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                         | No          | -                                                          |
 
+## Changes in 2.0.0
+* Add new required parameter `signingKeyName`. This is used for checksum signing
+  
 ## Changes in 1.0.0
 * Add new required parameter `author`. This was already required by the task inside the pipeline, so the pipeline
   did not work before this

--- a/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,6 +37,9 @@ spec:
     - name: author
       type: string
       description: Author taken from Release to be used for checksum signing
+    - name: signingKeyName
+      type: string
+      description: signing key name to be used for checksum signing
     - name: taskGitUrl
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
       default: https://github.com/konflux-ci/release-service-catalog.git
@@ -73,6 +76,8 @@ spec:
           value: $(params.cgwSecret)
         - name: author
           value: $(params.author)
+        - name: signingKeyName
+          value: $(params.signingKeyName)
   results:
     - name: result
       value: $(tasks.push-artifacts-to-cdn-task.results.result)

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -9,6 +9,7 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 | snapshot_json         | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
 | concurrentLimit       | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
 | author                | Author taken from Release to be used for checksum signing         | No       | -                                                        |
+| signingKeyName        | Signing key name to be used for checksum signing                  | No       | -                                                        |
 | quayUrl               | quay URL of the repo where content will be shared                 | Yes      | quay.io/konflux-artifacts                                |
 | quaySecret            | Secret to interact with Quay                                      | Yes      | quay-credentials                                         |
 | windowsCredentials    | Secret to interact with the Windows signing host                  | Yes      | windows-credentials                                      |
@@ -27,6 +28,9 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 | udcacheSecret         | Env specific secret containing the udcache credentials            | No       | -                                                        |
 | cgwHostname           | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                                        |
+
+## Changes in 2.0.0
+* Add new required parameter `signingKeyName`. This is used for checksum signing
 
 ## Changes in 1.0.1
 * Base64 decode keytab used for interacting with the checksum signing host (ETERA)

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn-task
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -23,6 +23,9 @@ spec:
     - name: author
       type: string
       description: Author taken from Release to be used for checksum signing
+    - name: signingKeyName
+      type: string
+      description: Signing key name to be used for checksum signing
     - name: quayURL
       type: string
       description: quay URL of the repo where content will be shared
@@ -648,6 +651,8 @@ spec:
               key: password
         - name: AUTHOR
           value: $(params.author)
+        - name: SIGNING_KEY_NAME
+          value: $(params.signingKeyName)
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -710,7 +715,7 @@ spec:
             echo "Executing SSH command with sign method: $sign_method"
             # shellcheck disable=SC2029,SC2086
             ssh $SSH_OPTS "$checksum_user@$checksum_host" \
-            "rpm-sign --nat $sign_method --key redhatrelease2 --onbehalfof=$AUTHOR \
+            "rpm-sign --nat $sign_method --key $SIGNING_KEY_NAME --onbehalfof=$AUTHOR \
             --output $output_path $input_file"
         }
 

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
@@ -64,6 +64,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -62,6 +62,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -58,6 +58,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
@@ -62,6 +62,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
@@ -63,6 +63,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
@@ -63,6 +63,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -66,6 +66,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
@@ -63,6 +63,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -96,6 +96,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -60,6 +60,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -65,6 +65,8 @@ spec:
           value: "pulp-task-cgw-secret"
         - name: author
           value: testuser
+        - name: signingKeyName
+          value: testkey
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/managed/push-artifacts-to-cdn/README.md
+++ b/tasks/managed/push-artifacts-to-cdn/README.md
@@ -17,6 +17,9 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | resultsDirPath           | Path to results directory in the data workspace                                           | No       | -             |
 | requestTimeout           | Request timeout                                                                           | Yes      | 86400         |
 
+## Changes in 2.0.0
+* task now extracts the signing key name from the config map and passes it to the internalRequest
+
 ## Changes in 1.0.1
 * The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`
 

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -84,7 +84,8 @@ spec:
         env=$(jq -r '.cdn.env' "$(workspaces.data.path)/$(params.dataPath)")
         AUTHOR=$(jq -r '.status.attribution.author' "$(workspaces.data.path)/$(params.releasePath)")
         if [[ "${AUTHOR}" == "null" ]] ; then echo "No author found in Release.Status. Failing..." ; exit 1 ; fi
-
+        configMapName=$(jq -er '.sign.configMapName' "${DATA_FILE}")
+        signingKeyName=$(kubectl get configmap "$configMapName" -o jsonpath="{.data.SIG_KEY_NAME}")
         RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/push-artifacts-results.json"
         FILES=$(jq -c '{"artifacts": [.components[].staged?.files[]?.filename]}' <<< "$snapshot")
         echo "$FILES" > "$RESULTS_FILE"
@@ -127,6 +128,7 @@ spec:
         ${requestType} --pipeline "${REQUEST}" \
           -p snapshot_json="${snapshot}" \
           -p author="${AUTHOR}" \
+          -p signingKeyName="${signingKeyName}" \
           -p exodusGwSecret="${exodusGwSecret}" \
           -p exodusGwEnv="${exodusGwEnv}" \
           -p pulpSecret="${pulpSecret}" \
@@ -173,7 +175,7 @@ spec:
           results=$(jq -c '.results' <<< "${overallStatus}")
           # despite the assumption of never having a failed pipeline,
           # let's try to at least still a log message about the abnormal
-          # failure 
+          # failure
           if [ "${status}" == "True" ]; then
             resultValue=$(jq -r '.[]  | select(.name == "result").value' <<< "${results}")
             if [ "${resultValue}" == "Success" ]; then

--- a/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
@@ -43,5 +43,20 @@ cat > "/tmp/push-artifacts-to-cdn.json" << EOF
 EOF
 kubectl create -f /tmp/push-artifacts-to-cdn.json
 
+cat > "/tmp/configmap.json" << EOF
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "test-config-map",
+    "namespace": "default"
+  },
+  "data": {
+    "SIG_KEY_ID": "testKey"
+  }
+}
+EOF
+kubectl apply -f /tmp/configmap.json
+
 # Add mocks to the beginning of task step script
 yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
@@ -55,7 +55,9 @@ spec:
                   ]
                 },
                 "cdn": {
-                  "env": "production"
+                  "env": "production",
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
@@ -25,6 +25,9 @@ spec:
               {
                 "cdn": {
                   "env": "production"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
@@ -55,6 +55,9 @@ spec:
                 },
                 "cdn": {
                   "env": "production"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
@@ -37,6 +37,9 @@ spec:
                 },
                 "cdn": {
                   "env": "production"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-artifacts-to-cdn task with the InternalPipelineRun failing and ensure the task fails. The 
+    Run the push-artifacts-to-cdn task with the InternalPipelineRun failing and ensure the task fails. The
     InternalPipelineRun itself will never fail, but the status.results field of it will reflect the failure.
   workspaces:
     - name: tests-workspace
@@ -57,7 +57,10 @@ spec:
                 "cdn": {
                   "env": "production"
                 },
-                "requestType": "internal-pipelinerun"
+                "requestType": "internal-pipelinerun",
+                "sign": {
+                  "configMapName": "test-config-map"
+                }
               }
               EOF
               cat > "$(workspaces.data.path)/release_plan_admission.json" << EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
@@ -53,6 +53,9 @@ spec:
                 },
                 "cdn": {
                   "env": "production"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
@@ -53,6 +53,9 @@ spec:
                 },
                 "cdn": {
                   "env": "qa"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
@@ -72,7 +72,10 @@ spec:
                 "cdn": {
                   "env": "stage"
                 },
-                "requestType": "internal-pipelinerun"
+                "requestType": "internal-pipelinerun",
+                "sign": {
+                  "configMapName": "test-config-map"
+                }
               }
               EOF
 

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
@@ -70,6 +70,9 @@ spec:
                 },
                 "cdn": {
                   "env": "stage"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
@@ -53,6 +53,9 @@ spec:
                 },
                 "cdn": {
                   "env": "stage"
+                },
+                "sign": {
+                  "configMapName": "test-config-map"
                 }
               }
               EOF


### PR DESCRIPTION
The signing key name was previously hard-coded. This propagates the value from the configMap specified in the RPA

## Relevant Jira
[CLDX-379](https://issues.redhat.com//browse/CLDX-379)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

