### PR TITLE
feat(CLDX-382): Add populate-release-notes-binaries step

### DIFF
--- a/tasks/managed/populate-release-notes/README.md
+++ b/tasks/managed/populate-release-notes/README.md
@@ -10,15 +10,21 @@ path to a file containing data used in component SBOM generation.
 | Name                    | Description                                                                                                                | Optional | Default value           |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
 | dataPath                | Path to the JSON string of the merged data to update                                                                       | No       | -                       |
+| contentType             | The contentType of the release artifact. One of [image|binary]                                                             | Yes      | image                   |
 | snapshotPath            | Path to the JSON string of the mapped Snapshot in the data workspace                                                       | No       | -                       |
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 4.1.0
+* This task takes a new optional parameter 'contentType'
+  * defaults to 'images' to remain backward compatible
+* Conditionally runs steps based on content type
 
 ## Changes in 4.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -49,6 +49,10 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: contentType
+      type: string
+      description: The contentType of the release artifact. One of [image|binary]
+      default: "image"
   results:
     - name: sbomDataPath
       description: Path to data used in the component SBOM creation in the data workspace
@@ -109,6 +113,10 @@ spec:
         #!/usr/bin/env bash
         set -ex
 
+        if [ "$(params.contentType)" == "binary" ]; then
+            echo "Content type is binary. Skipping image-specific release note generation."
+            exit 0
+        fi
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No data JSON was provided."
@@ -219,6 +227,82 @@ spec:
                     /tmp/sbomData.tmp && mv /tmp/sbomData.tmp "${sbomDataPath}"
             done
         done
+    - name: populate-release-notes-binaries
+      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        if [ "$(params.contentType)" != "binary" ]; then
+            echo "Not binary content. Skipping binary-specific logic."
+            exit 0
+        fi
+
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_FILE}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi
+
+        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
+        for ((i = 0; i < NUM_COMPONENTS; i++))
+        do
+            component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
+            name=$(jq -r '.name' <<< "$component")
+
+            # Construct CVE json
+            CVEsJson='{"cves":{"fixed":{}}}'
+            CVES=$(jq -c '[.releaseNotes.cves[]? | select(.component=="'"$name"'")]' "${DATA_FILE}")
+            NUM_CVES=$(jq 'length' <<< "$CVES")
+            for ((j = 0; j < NUM_CVES; j++)); do
+                cve=$(jq -c --argjson j "$j" '.[$j]' <<< "$CVES")
+                cveJson=$(jq -n \
+                    --arg id "$(jq -r '.key' <<< "$cve")" \
+                    --argjson packages "$(jq -c '.packages // []' <<< "$cve")" \
+                    '{($id): {"packages": $packages}}')
+                CVEsJson=$(jq --argjson cve "$cveJson" '.cves.fixed += $cve' <<< "$CVEsJson")
+            done
+
+            # Get the number of files for this component
+            FILES_LENGTH=$(jq --arg name "$name" \
+              '[.mapping.components[]
+                | select(.name == $name)
+                | .files
+                | length][0]' "$DATA_FILE")
+
+            for ((k = 0; k < FILES_LENGTH; k++)); do
+                file=$(jq -c --arg name "$name" --argjson k "$k" \
+                    '.mapping.components[]
+                      | select(.name == $name)
+                      | .files[$k]' "$DATA_FILE")
+                arch=$(jq -r '.arch' <<< "$file")
+                os=$(jq -r '.os' <<< "$file")
+
+                # This will be filled in with a later task after signing so we have an accurate checksum
+                purl="placeholder"
+
+                jsonString=$(jq -cn \
+                  --arg component "$name" \
+                  --arg arch "$arch" \
+                  --arg os "$os" \
+                  --arg purl "$purl" \
+                  '{"architecture": $arch, "os": $os, "purl": $purl, "component": $component}')
+
+                if [ "$(jq '.cves.fixed | length' <<< "$CVEsJson")" -gt 0 ]; then
+                    jsonString=$(jq --argjson cves "$CVEsJson" '. += $cves' <<< "$jsonString")
+                fi
+
+                jq --argjson content "$jsonString" '.releaseNotes.content.artifacts += [$content]' "${DATA_FILE}" > \
+                    /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+            done
+        done
+
     - name: populate-release-notes-type-and-references
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-cves-artifacts
+spec:
+  description: |
+    Run the populate-release-notes task and ensure CVE information present in the data.json
+    is properly included in the releaseNotes.content.artifacts.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "releng-test-product-binaries",
+                      "files": [
+                        {
+                          "name": "releng-test-product-binaries-windows-amd64.gz",
+                          "arch": "amd64",
+                          "os": "windows"
+                        },
+                        {
+                          "name": "releng-test-product-binaries-linux-amd64.gz",
+                          "arch": "amd64",
+                          "os": "linux"
+                        }
+                      ],
+                      "contentGateway": {
+                        "productName": "Releng Test Product",
+                        "productCode": "RelengTestProduct",
+                        "productVersionName": "1.5.0",
+                        "filePrefix": "releng-test-product-binaries"
+                      }
+                    }
+                  ]
+                },
+                "releaseNotes": {
+                   "cves": [
+                    {
+                      "component": "releng-test-product-binaries",
+                      "packages": [
+                        "pkg1",
+                        "pkg2"
+                      ],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "releng-test-product-binaries",
+                      "packages": [
+                        "pkg3"
+                      ],
+                      "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "product_id": [
+                    123
+                  ],
+                  "product_name": "Releng Test Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHOSP-12345",
+                        "source": "issues.example.com"
+                      },
+                      {
+                        "id": 1234567,
+                        "source": "bugzilla.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "releng-test-product-binaries",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/product----repo",
+                    "rh-registry-repo": "registry.redhat.io/product/repo",
+                    "tags": [
+                      "foo",
+                      "bar"
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: contentType
+          value: "binary"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              # Ensure 'arch' and 'os' are present in the artifact entry
+              test "$(jq -e '.releaseNotes.content.artifacts[0] | has("architecture")' "$DATA_FILE")" == "true"
+              test "$(jq -e '.releaseNotes.content.artifacts[0] | has("os")' "$DATA_FILE")" == "true"
+
+              # The CVEs should be present in the comp artifacts section
+              test "$(jq '.releaseNotes.content.artifacts[0].cves.fixed | length' \
+                "$DATA_FILE")" \
+                == 2
+              test "$(jq -jr '.releaseNotes.content.artifacts[0].cves.fixed | keys[]' \
+                "$DATA_FILE")" == "CVE-123CVE-456"
+              test "$(jq '.releaseNotes.content.artifacts[0].cves.fixed."CVE-123".packages | length' \
+                "$DATA_FILE")" == 2
+      runAfter:
+        - run-task


### PR DESCRIPTION
The populate-release-notes-task was previously designed specifically for image content types. This changes allows us to work with binaries as well based on a contentType parameter.
## Relevant Jira
[CLDX-382](https://issues.redhat.com//browse/CLDX-382)
## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

