### PR TITLE
feat(RELEASE-567): add compute resource limits to internal tasks

### DIFF
--- a/tasks/internal/check-embargoed-cves-task/README.md
+++ b/tasks/internal/check-embargoed-cves-task/README.md
@@ -9,3 +9,6 @@ internal request. The success/failure is handled in the task creating the intern
 | Name | Description                                                                                | Optional | Default value |
 |------|--------------------------------------------------------------------------------------------|----------|---------------|
 | cves | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |
+
+## Changes in 0.2.0
+* Added compute resource limits

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-embargoed-cves-task
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -28,6 +28,12 @@ spec:
   steps:
     - name: check-embargoed-cves
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       env:
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:

--- a/tasks/internal/collect-simple-signing-params/README.md
+++ b/tasks/internal/collect-simple-signing-params/README.md
@@ -8,6 +8,9 @@ Task to collect parameters for the simple signing pipeline
 |------------------|---------------------------------------------------------------------------------------|----------|--------------------------------------------------------|
 | config_map_name  | Name of a configmap with pipeline configuration                                       | No       | -                                                      |
 
+## Changes in 0.4.0
+* Added compute resource limits
+
 ## Changes in 0.3.0
 * Removed the `ssl_cert_secret_name`, `ssl_cert_file_name`, and `ssl_key_file_name` results
   * The results added in 0.2.0 take their places

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-simple-signing-params
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/tags: release
 spec:
@@ -41,6 +41,12 @@ spec:
   steps:
     - name: collect-simple-signing-params
       image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 25m
       env:
         - name: config_map_name
           value: $(params.config_map_name)

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -16,6 +16,9 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 1.4.0
+* Added compute resource limits
+
 ## Changes in 1.3.4
 * Update base image
   * New base image contains a new version of the advisory template that re-adds the public field for issues.

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -54,6 +54,12 @@ spec:
   steps:
     - name: create-advisory
       image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: '1'  # 1 is the max allowed by at least the staging cluster
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -13,6 +13,9 @@ impact from all of the CVEs is returned as a task result.
 | releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task         | No       | -             |
 
+## Changes in 0.3.0
+* Added compute resource limits
+
 ## Changes in 0.2.2
 * Fix bug where component specific impact exists but is the empty string. The overall impact should be used
   as severity instead in this instance

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-advisory-severity
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -33,6 +33,12 @@ spec:
   steps:
     - name: get-advisory-severity
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: '1'  # 1 is the max allowed by at least the staging cluster
       env:
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:

--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -17,6 +17,9 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
 
+## Changes in 1.2.0
+* Added compute resource limits
+
 ## Changes in 1.1.1
 * Fix formatting of json saved as `fileUpdatesInfo`
   * The result had one too many levels of escaping when being read in run-file-updates

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -55,6 +55,12 @@ spec:
   steps:
     - name: perform-updates
       image: quay.io/konflux-ci/release-service-utils@sha256:504e93b6435a6f10f825bacdbac9ac3da9be4cdfffdae10c0607cb8362928e50
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/tasks/internal/publish-index-image-task/README.md
+++ b/tasks/internal/publish-index-image-task/README.md
@@ -12,5 +12,8 @@ Tekton task to publish a built FBC index image using skopeo
 | publishingCredentials | The credentials used to access the registries | No       | -             |
 | requestUpdateTimeout  | Max seconds waiting for the status update     | Yes      | 360           |
 
+## Changes in 0.3.0
+* Added compute resource limits
+
 ## Changes in 0.2.0
 * Make publish index image task idempotent

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-index-image-task
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,6 +47,12 @@ spec:
               name: $(params.publishingCredentials)
       image: >-
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 400m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/tasks/internal/request-and-upload-signature/README.md
+++ b/tasks/internal/request-and-upload-signature/README.md
@@ -25,7 +25,10 @@ Task to request and upload signatures using RADAS and pyxis
 | pyxis_url                  | Pyxis instance to upload the signature to.                                                            | Yes      | https://pyxis.engineering.redhat.com                  |
 | signature_data_file        | The file where the signing response should be placed                                                  | Yes      | signing_response.json                                 |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.0
-  * Replaced `ssl_cert_secret_name`, `ssl_cert_file_name` and `ssl_key_file_name` parameters with Pyxis and UMB
-    specific ones
-    * This allows us to use the stage version of one system with the prod version of the other
+* Replaced `ssl_cert_secret_name`, `ssl_cert_file_name` and `ssl_key_file_name` parameters with Pyxis and UMB
+  specific ones
+  * This allows us to use the stage version of one system with the prod version of the other

--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: request-and-upload-signature
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -82,6 +82,12 @@ spec:
   steps:
     - name: request-signature
       image: "$(params.pipeline_image)"
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 100m
       workingDir: "$(workspaces.data.path)"
       env:
         - name: UmbCert
@@ -163,6 +169,12 @@ spec:
         echo "signature data file: ${signature_data_file:?}"
     - name: upload-signature
       image: "$(params.pipeline_image)"
+      computeResources:
+        limits:
+          memory: 56Mi
+        requests:
+          memory: 56Mi
+          cpu: 25m
       workingDir: "$(workspaces.data.path)"
       env:
         - name: PyxisCert

--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -14,6 +14,9 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
 
+## Changes in 1.2.0
+* Added compute resource limits
+
 ## Changes in 1.1.1
 * adds equality check of `from_index` and `index_image` in `check_previous_build()`
   to determine if the build was a prod or a staging build

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -66,6 +66,12 @@ spec:
     - name: update-fbc-catalog-prepare-and-call-iib-step
       image: >-
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: '1'
       env:
         - name: IIB_SERVICE_URL
           valueFrom:


### PR DESCRIPTION
The goal is to minimize the amount of resources used by the tasks. The limits were chosen by monitoring taskRuns with `oc adm top pods`. I took the highest value seen for each step and approximately doubled it to pick the limit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

