### PR TITLE
revert(RELEASE-1636): undo changes from PR 951

### DIFF
--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -26,6 +26,10 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 6.1.3
+* Undo changes in 6.1.2
+  * Early failure prevents pasting of internal pipelineRun or taskRun
+
 ## Changes in 6.1.2
 * Improve logging of `internal-request`
   * Previously we would just swallow the output and if it failed for any reason, the log wouldn't have anything useful

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "6.1.2"
+    app.kubernetes.io/version: "6.1.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -130,7 +130,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
       script: |
         #!/bin/bash
-        set -exo pipefail
+        set -ex
 
         DEFAULT_ADVISORY_TYPE="RHBA"
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/create-advisory-results.json"
@@ -256,7 +256,8 @@ spec:
                          -p taskGitRevision="$(params.taskGitRevision)" \
                          -s "$(params.synchronously)" \
                          -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-                         | tee "$IR_FILE" || exit 1
+                         | tee "$IR_FILE" || \
+                         (grep "^\[" "$IR_FILE" | jq . && exit 1)
 
         internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
         echo "done (${internalRequest})"

--- a/tasks/managed/create-advisory/tests/mocks.sh
+++ b/tasks/managed/create-advisory/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exo pipefail
+set -ex
 
 # mocks to be injected into task step scripts
 

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -23,6 +23,11 @@ based on the issues visibility
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 2.1.1
+* Undo changes introduced in 2.0.3
+  * Early failure prevents pasting of internal pipelineRun or taskRun
+
 ## Changes in 2.1.0
 * Handle content types of artifacts with releaseNotes.content.artifacts
 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -231,7 +231,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       script: |
         #!/usr/bin/env bash
-        set -xo pipefail
+        set -x
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -268,7 +268,8 @@ spec:
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" \
             -s true \
-            | tee "$IR_RESULT_FILE" || exit 1
+            | tee "$IR_RESULT_FILE" || \
+            (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
 
         internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_RESULT_FILE")
         echo "done (${internalRequest})"

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xo pipefail
+set -x
 
 # mocks to be injected into task step scripts
 function curl-with-retry() {

--- a/tasks/managed/push-disk-images/README.md
+++ b/tasks/managed/push-disk-images/README.md
@@ -14,6 +14,10 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 0.4.3
+* Undo changes introduced in 0.4.2
+  * Early failure prevents pasting of internal pipelineRun or taskRun
+
 ## Changes in 0.4.2
 * Improve logging of `internal-request`
   * Previously we would just swallow the output and if it failed for any reason, the log wouldn't have anything useful

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.4.2"
+    app.kubernetes.io/version: "0.4.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -39,7 +39,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
       script: |
         #!/usr/bin/env bash
-        set -exo pipefail
+        set -ex
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
         snapshot=$(jq -c '.' "$(workspaces.data.path)/$(params.snapshotPath)")

--- a/tasks/managed/push-disk-images/tests/mocks.sh
+++ b/tasks/managed/push-disk-images/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exo pipefail
+set -ex
 
 # mocks to be injected into task step scripts
 

--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -20,6 +20,10 @@ images and not for generic artifact types like binaries or disk images.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 1.0.4
+* Undo changes introduced in 1.0.2
+  * Early failure prevents pasting of internal pipelineRun or taskRun
+
 ## Changes in 1.0.3
 * Skip severity setting for generic artifact types
 

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "1.0.3"
+    app.kubernetes.io/version: "1.0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -112,7 +112,7 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
       script: |
         #!/usr/bin/env bash
-        set -xo pipefail
+        set -x
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -166,7 +166,8 @@ spec:
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" \
             -s true \
-            | tee "$IR_FILE" || exit 1
+            | tee "$IR_FILE" || \
+            (grep "^\[" "$IR_FILE" | jq . && exit 1)
 
         internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
         echo "done (${internalRequest})"

--- a/tasks/managed/set-advisory-severity/tests/mocks.sh
+++ b/tasks/managed/set-advisory-severity/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xo pipefail
+set -eux
 
 # mocks to be injected into task step scripts
 function internal-request() {

--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -27,6 +27,10 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 2.5.2
+* Undo changes introduced in 2.5.1
+  * Early failure prevents pasting of internal pipelineRun or taskRun
+
 ## Changes in 2.5.1
 * Improve logging of `internal-request`
   * Previously we would just swallow the output and if it failed for any reason, the log wouldn't have anything useful

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.5.1"
+    app.kubernetes.io/version: "2.5.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -48,7 +48,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -ex
-        set -o pipefail
 
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -77,7 +76,8 @@ spec:
             -p taskGitRevision="$(params.taskGitRevision)" \
             -t "$(params.requestTimeout)" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-            | tee "$IR_RESULT_FILE" || exit 1
+            | tee "$IR_RESULT_FILE" || \
+            (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
 
         internalRequest=$(awk 'NR==1{ print $2 }' "$IR_RESULT_FILE" | xargs)
         echo "done (${internalRequest})"


### PR DESCRIPTION
The changes in PR 951 made it so that the managed tasks failed if the internal-request script call failed. This makes it significantly harder to debug failures, as the internal pipelineRun and taskRun are no longer printed. This commit undos the changes for this reason.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

