### PR TITLE
feat(CLDX-377): add support for generic content type advisories

### DIFF
--- a/pipelines/internal/create-advisory/README.md
+++ b/pipelines/internal/create-advisory/README.md
@@ -11,11 +11,15 @@ advisory URL as well as a result to show the error message if one occurred.
 | advisory_json        | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -                                                         |
 | application          | Application being released                                                                             | No       | -                                                         |
 | origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
+| contentType          | The contentType of the release artifact. One of [image|binary|generic]                                 | Yes      | image                                                     |
 | config_map_name      | The name of the configMap that contains the signing key                                                | No       | -                                                         |
 | advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
 | errata_secret_name   | The name of the secret that contains the errata service account metadata                               | No       | -                                                         |
 | taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |
+
+## Changes in 2.0.0
+* Add support for generic content type advisories
 
 ## Changes in 1.1.1
 * Add new result for the gitlab advisory url

--- a/pipelines/internal/create-advisory/create-advisory.yaml
+++ b/pipelines/internal/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -27,6 +27,10 @@ spec:
     - name: config_map_name
       type: string
       description: The name of the configMap that contains the signing key
+    - name: contentType
+      type: string
+      description: The contentType of the release artifact. One of [image|binary|generic]
+      default: "image"
     - name: advisory_secret_name
       type: string
       description: The name of the secret that contains the advisory creation metadata
@@ -60,6 +64,8 @@ spec:
           value: $(params.origin)
         - name: config_map_name
           value: $(params.config_map_name)
+        - name: contentType
+          value: $(params.contentType)
         - name: advisory_secret_name
           value: $(params.advisory_secret_name)
         - name: errata_secret_name

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -11,10 +11,14 @@ internal request. The success/failure is handled in the task creating the intern
 | advisory_json                  | String containing a JSON representation of the advisory data (e.g. '{"product_id":123,"type":"RHSA"}') | No       | -             |
 | application                    | Application being released                                                                             | No       | -             |
 | origin                         | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -             |
+| contentType                    | The contentType of the release artifact. One of [image|binary|generic]                                 | Yes      | image         |
 | config_map_name                | The name of the configMap that contains the signing key                                                | No       | -             |
 | advisory_secret_name           | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
+
+## Changes in 2.0.0
+* Add support for generic content type advisories
 
 ## Changes in 1.4.0
 * Added compute resource limits

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,6 +40,10 @@ spec:
     - name: internalRequestPipelineRunName
       type: string
       description: Name of the PipelineRun that called this task
+    - name: contentType
+      type: string
+      description: The contentType of the release artifact. One of [image|binary|generic]
+      default: "image"
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -153,8 +157,19 @@ spec:
           # This also cds into the git repo
           git_clone_and_checkout --repository "$GIT_REPO" --revision "$REPO_BRANCH"
 
-          CONTENT_IMAGES=/tmp/content_images.json
-          jq -c '.content.images // []' <<< "$ADVISORY_JSON" > "$CONTENT_IMAGES"
+          if [ "$(params.contentType)" = "image" ]; then
+            echo "Content type is image."
+            spec_content_type=".content.images"
+          elif [ "$(params.contentType)" == "binary" ] || [ "$(params.contentType)" == "generic" ]; then
+            echo "Content type is generic artifact."
+            spec_content_type=".content.artifacts"
+          else
+            echo "Unsupported contentType: $(params.contentType)"| tee -a "$STDERR_FILE"
+            echo "Exiting." | tee -a "$STDERR_FILE"
+            exit 1
+          fi
+          CONTENT_FILE=/tmp/content.json
+          jq -c "${spec_content_type} // []" <<< "$ADVISORY_JSON" > "$CONTENT_FILE"
 
           # Use ISO 8601 format in UTC/Zulu time, e.g. 2024-03-06T17:27:38Z
           SHIP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -182,29 +197,39 @@ spec:
           EXISTING_CONTENT=/tmp/existing_content.json
           for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
               ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
-              yq -o=json '.spec.content.images // []' "${ADVISORY_FILE}" > "$EXISTING_CONTENT"
+              yq -o=json ".spec${spec_content_type} // []" "${ADVISORY_FILE}" > "$EXISTING_CONTENT"
 
               echo "Processing advisory: ${ADVISORY_FILE}"
-              echo "Existing images in advisory: "
+              echo "Existing content in advisory: "
               cat "$EXISTING_CONTENT"
 
-              # Update CONTENT_IMAGES by removing images that already exist in the advisory
-              jq --argfile existing "$EXISTING_CONTENT" '
-                map(select(
-                  .containerImage as $ci |
-                  .tags as $tags |
-                  .repository as $repo |
-                  ($existing | map(select(
-                    .containerImage == $ci and .tags == $tags and .repository == $repo
-                  )) | length == 0)
-                ))' "$CONTENT_IMAGES" > /tmp/content_images_filtered.json
-              mv /tmp/content_images_filtered.json "$CONTENT_IMAGES"
+              # Update CONTENT by removing entries that already exist in the advisory
+              if [ "$(params.contentType)" == "generic" ]; then
+                # Use purl as unique key for generic artifacts
+                jq --argfile existing "$EXISTING_CONTENT" '
+                  map(select(
+                    .purl as $p |
+                    ($existing | map(select(.purl == $p)) | length == 0)
+                  ))' "$CONTENT_FILE" > /tmp/content_filtered.json
+              else
+                jq --argfile existing "$EXISTING_CONTENT" '
+                  map(select(
+                    .containerImage as $ci |
+                    .tags as $tags |
+                    .repository as $repo |
+                    ($existing | map(select(
+                      .containerImage == $ci and .tags == $tags and .repository == $repo
+                    )) | length == 0)
+                  ))' "$CONTENT_FILE" > /tmp/content_filtered.json
+              fi
 
-              echo "Remaining images after filtering:"
-              cat "$CONTENT_IMAGES"
+              mv /tmp/content_filtered.json "$CONTENT_FILE"
 
-              # If after filtering, no images are left, then we can exit early
-              if jq -e 'length == 0' "$CONTENT_IMAGES" >/dev/null; then
+              echo "Remaining entries after filtering:"
+              cat "$CONTENT_FILE"
+
+              # If after filtering, no entries are left, then we can exit early
+              if jq -e 'length == 0' "$CONTENT_FILE" >/dev/null; then
                   echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
                   ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${ADVISORY_FILE}"
                   ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
@@ -216,12 +241,12 @@ spec:
               fi
           done
 
-          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argfile new_images "$CONTENT_IMAGES" \
-            '.content.images = $new_images')
+          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argfile new_content "$CONTENT_FILE" \
+            "${spec_content_type} = \$new_content")
 
           signingKey=$(kubectl get configmap "$(params.config_map_name)" -o jsonpath="{.data.SIG_KEY_NAME}")
           advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \
-            '.content.images[] += {"signingKey": $key}' <<< "$NEW_ADVISORY_JSON")
+            "${spec_content_type}[] += {\"signingKey\": \$key}" <<< "$NEW_ADVISORY_JSON")
 
           LIVE_ID=$(jq -r '.live_id' <<< "$ADVISORY_JSON" )
           if [[ "$LIVE_ID" == null ]]; then

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-generic-content
+spec:
+  description: |
+    Run the create-advisory task with the contentType param set as generic
+    and check that an advisory url is emitted as a task result
+  tasks:
+    - name: run-task
+      taskRef:
+        name: create-advisory-task
+      params:
+        - name: advisory_json
+          value: >-
+            {"product_id":123,"product_name":"Red Hat Product","product_version":"1.2.3","product_stream":"tp1",
+            "cpe":"cpe:/a:example:product:el8","type":"RHSA","synopsis":"test synopsis","topic":"test topic",
+            "description":"test description","solution":"test solution","references":["https://docs.example.com/notes"],
+            "content":{"images":[{"containerImage":"quay.io/example/openstack@sha256:abdeNEW",
+            "repository":"rhosp16-rhel8/openstack","tags":["latest"],"architecture":"amd64",
+            "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+            "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}}]}}
+        - name: application
+          value: "test-app"
+        - name: origin
+          value: "not-existing-origin"
+        - name: config_map_name
+          value: "create-advisory-test-cm"
+        - name: advisory_secret_name
+          value: "create-advisory-secret"
+        - name: errata_secret_name
+          value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: contentType
+          value: "generic"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: advisory_url
+          value: $(tasks.run-task.results.advisory_url)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: advisory_url
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that result is Success
+              test "$(params.result)" == Success
+
+              echo Test that advisory_url was properly set
+              test "$(params.advisory_url)" == \
+                https://access.redhat.com/errata/RHSA-2024:1234

--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -15,6 +15,8 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | dataPath                 | Path to data JSON in the data workspace                                                                                    | No        | -                       |
 | resultsDirPath           | Path to results directory in the data workspace                                                                            | No        | -                       |
 | request                  | Type of request to be created                                                                                              | Yes       | create-advisory         |
+| cgwHostname              | The hostname of the content-gateway to publish the metadata to                                                             | Yes       |https://developers.redhat.com/content-gateway/rest/admin |
+| cgwSecret                | The kubernetes secret to use to authenticate to content-gateway. It needs to contain two keys: username and token          | Yes       | publish-to-cgw-secret   |
 | synchronously            | Whether the task should wait for InternalRequests to complete                                                              | Yes       | true                    |
 | pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No        | -                       |
 | ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                   |
@@ -25,6 +27,8 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | dataDir                  | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path) |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
+## Changes in 7.0.0
+* Add support for generic content type advisories
 
 ## Changes in 6.1.3
 * Undo changes in 6.1.2

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "6.1.3"
+    app.kubernetes.io/version: "7.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -64,6 +64,17 @@ spec:
       description: The location where data will be stored
       type: string
       default: $(workspaces.data.path)
+    - name: cgwHostname
+      type: string
+      description: >
+        The hostname of the content-gateway to publish the metadata to
+      default: https://developers.redhat.com/content-gateway/rest/admin
+    - name: cgwSecret
+      type: string
+      description: >
+        The kubernetes secret to use to authenticate to content-gateway.
+        It needs to contain two keys: username and token
+      default: publish-to-cgw-secret
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
@@ -126,6 +137,110 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
+    - name: update-purl
+      image: quay.io/distribution_relengs/publish-to-dev-portal-test-image:purl
+      env:
+        - name: CGW_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cgwSecret)
+              key: username
+        - name: CGW_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cgwSecret)
+              key: token
+        - name: CGW_HOST
+          value: $(params.cgwHostname)
+      script: |
+        #!/bin/bash
+        set -exo pipefail
+
+        # This step fetches the filenames that were previously uploaded to CGW earlier in this pipeline and uses
+        # them to generate the PURL field with downloadURL and checksum.
+        # This step is intended for generic artifacts only and is skipped for images.
+
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+
+        # Try to extract the first contentType if it exists
+        content_type=$(jq -r '.mapping.components[]?.contentGateway?.contentType // empty' "$DATA_FILE" | head -n1)
+
+        # If no contentType is found, then we are not dealing with a generic type and can skip this step
+        if [ -z "$content_type" ]; then
+          echo "content type is not a generic artifact, skipping this"
+          exit 0
+        fi
+
+        COMPONENTS=$(jq -c '.mapping.components[] | select(.contentGateway)' "$DATA_FILE")
+
+        UPDATED_ENTRIES=()
+
+        while IFS= read -r component; do
+            PRODUCT_CODE=$(jq -r '.contentGateway.productCode' <<< "$component")
+            VERSION_NAME=$(jq -r '.contentGateway.productVersionName' <<< "$component")
+            COMPONENT_NAME=$(jq -r '.name' <<< "$component")
+
+            # fetch the downloadURLs inside the loop because the files are organized by component
+            echo "Fetching download URLs for $PRODUCT_CODE $VERSION_NAME..."
+            URLS_JSON=$(python3 /home/utils/get_cgw_download_urls.py --product "$PRODUCT_CODE" \
+              --version "$VERSION_NAME")
+
+            # Create a map of basename -> full download URL
+            declare -A FILE_URL_MAP
+            while IFS= read -r url; do
+                BASENAME=$(basename "$url")
+                FILE_URL_MAP["$BASENAME"]="$url"
+            done <<< "$URLS_JSON"
+
+            # Error if any declared file is missing from the CGW response
+            #   If a file is listed in the RPA to be released to CGW, but isn't returned from our API call
+            #   then we probably should exit as that shouldn't happen.
+            for declared_file in $(jq -r '.staged.files[].source' <<< "$component"); do
+              declared_basename=$(basename "$declared_file")
+              if [[ -z "${FILE_URL_MAP[$declared_basename]}" ]]; then
+                echo "Warning: staged file '$declared_basename' (from $COMPONENT_NAME) was not returned by CGW" >&2
+                exit 1
+              fi
+            done
+
+            # Get all advisory entries that match this component
+            MATCHING_ENTRIES=$(jq -c --arg name "$COMPONENT_NAME" \
+              '.releaseNotes.content.artifacts[] | select(.component == $name)' "$DATA_FILE")
+
+            if [ -z "$MATCHING_ENTRIES" ]; then
+              echo "Warning: no RPA CGW filename matches found for component: $COMPONENT_NAME" >&2
+              continue
+            fi
+
+            while IFS= read -r entry; do
+                ARCH=$(jq -r '.architecture' <<< "$entry")
+                OS=$(jq -r '.os' <<< "$entry")
+
+                FILENAME=$(jq -r --arg arch "$ARCH" --arg os "$OS" \
+                  '.staged.files[] | select(.arch == $arch and .os == $os) | .source' <<< "$component")
+
+                FILENAME_BASENAME=$(basename "$FILENAME")
+                URL="https://access.cdn.redhat.com${FILE_URL_MAP[$FILENAME_BASENAME]}"
+
+                if [ -n "$URL" ]; then
+                  PURL="pkg:generic/$COMPONENT_NAME@$VERSION_NAME?download_url=$URL"
+                else
+                  echo "Warning: No download URL found for $FILENAME"
+                  PURL="MISSING"
+                  # Should we fail here?
+                fi
+
+                UPDATED_ENTRY=$(jq --arg purl "$PURL" '.purl = $purl' <<< "$entry")
+                UPDATED_ENTRIES+=("$UPDATED_ENTRY")
+            done <<< "$MATCHING_ENTRIES"
+
+        done <<< "$COMPONENTS"
+
+        # Merge updated advisory entries back into releaseNotes.content.artifacts in the DATA_FILE
+        ENTRIES_JOINED=$(IFS=,; echo "${UPDATED_ENTRIES[*]}")
+        jq --argjson updated "[$ENTRIES_JOINED]" '
+          .releaseNotes.content.artifacts = $updated
+        ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
       script: |
@@ -163,13 +278,28 @@ spec:
           advisoryType="$DEFAULT_ADVISORY_TYPE"
         fi
 
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+
+        content_type=$(jq -r '.mapping.components[]?.contentGateway?.contentType // empty' "$DATA_FILE" | head -n1)
+        if [ -z "$content_type" ]; then
+          content_type="image"
+        fi
+
+        if [ "$content_type" = "binary" ] || [ "$content_type" = "generic" ]; then
+          content_path=".content.artifacts"
+        else
+          content_path=".content.images"
+        fi
+
         if ! [[ "$advisoryType" =~ ^(RHSA|RHBA|RHEA)$ ]]; then
             echo "Error: advisory type must be one of RHSA, RHBA or RHEA"
             exit 1
         fi
 
         # Ensure RHSA is only used if CVEs are provided
-        NUM_CVES=$(jq '[.content.images[]?.cves.fixed // [] | length] | add' <<< "$advisoryData")
+
+        NUM_CVES=$(jq "[${content_path}[]?.cves.fixed // [] | length] | add" <<< "$advisoryData")
+
         if [[ "$advisoryType" == "RHSA" ]] && [[ "$NUM_CVES" -eq 0 ]] ; then
             echo "Provided advisory type is RHSA, but no fixed CVEs were listed"
             echo "RHSA should only be used if CVEs are fixed in the advisory. Failing..."
@@ -181,64 +311,87 @@ spec:
         # only 2 gitlab instances are permitted...prod and staging
         # these are their secret names
         #
+
         prodSecretName="create-advisory-prod-secret"
         prodErrataSecretName="errata-prod-service-account"
         stagingSecretName="create-advisory-stage-secret"
         stagingErrataSecretName="errata-stage-service-account"
-        #
-        # detect which one to use based on repositories specified
-        #
-        pending_repositories=$(jq -r '.components[] | select(.repository |
-          contains("quay.io/redhat-pending/")) |
-          .repository' "$(params.dataDir)/$(params.snapshotPath)")
-        prod_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/")) |
-          .repository' "$(params.dataDir)/$(params.snapshotPath)")
-        orphan_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/") |
-          not) | select(.repository | contains("quay.io/redhat-pending/") | not) |
-          .repository' "$(params.dataDir)/$(params.snapshotPath)")
 
-        foundPendingRepositories=false
-        if [ -n "${pending_repositories}" ]; then
-          foundPendingRepositories=true
-        fi
+        if [ "$content_type" = "image" ]; then
 
-        foundProdRepositories=false
-        if [ -n "${prod_repositories}" ]; then
-          foundProdRepositories=true
-        fi
+          #
+          # detect which one to use based on repositories specified
+          #
+          pending_repositories=$(jq -r '.components[] | select(.repository |
+            contains("quay.io/redhat-pending/")) |
+            .repository' "$(params.dataDir)/$(params.snapshotPath)")
+          prod_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/")) |
+            .repository' "$(params.dataDir)/$(params.snapshotPath)")
+          orphan_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/") |
+            not) | select(.repository | contains("quay.io/redhat-pending/") | not) |
+            .repository' "$(params.dataDir)/$(params.snapshotPath)")
 
-        foundOrphanRepositories=false
-        if [ -n "${orphan_repositories}" ]; then
-          foundOrphanRepositories=true
-        fi
+          foundPendingRepositories=false
+          if [ -n "${pending_repositories}" ]; then
+            foundPendingRepositories=true
+          fi
 
-        echo "foundPendingRepositories: ${foundPendingRepositories}"
-        echo "foundProdRepositories: ${foundProdRepositories}"
-        echo "foundOrphanRepositories: ${foundOrphanRepositories}"
+          foundProdRepositories=false
+          if [ -n "${prod_repositories}" ]; then
+            foundProdRepositories=true
+          fi
 
-        if [ "${foundPendingRepositories}" == "true" ] && [ "${foundProdRepositories}" == "true" ]; then
-          echo "Error: cannot publish to both redhat-pending and redhat-prod repositories"
-          exit 1
-        fi
+          foundOrphanRepositories=false
+          if [ -n "${orphan_repositories}" ]; then
+            foundOrphanRepositories=true
+          fi
 
-        if [ "${foundPendingRepositories}" == "false" ] && [ "${foundProdRepositories}" == "false" ]; then
-          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
-          exit 1
-        fi
+          echo "foundPendingRepositories: ${foundPendingRepositories}"
+          echo "foundProdRepositories: ${foundProdRepositories}"
+          echo "foundOrphanRepositories: ${foundOrphanRepositories}"
 
-        if [ "${foundOrphanRepositories}" == "true" ]; then
-          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
-          exit 1
-        fi
+          if [ "${foundPendingRepositories}" == "true" ] && [ "${foundProdRepositories}" == "true" ]; then
+            echo "Error: cannot publish to both redhat-pending and redhat-prod repositories"
+            exit 1
+          fi
 
-        # at this point, one of foundPendingRepositories or foundProdRepositories
-        # is true.
-        #
-        advisorySecretName="${prodSecretName}"
-        errataSecretName="${prodErrataSecretName}"
-        if [ "${foundPendingRepositories}" == "true" ]; then
-          advisorySecretName="${stagingSecretName}"
-          errataSecretName="${stagingErrataSecretName}"
+          if [ "${foundPendingRepositories}" == "false" ] && [ "${foundProdRepositories}" == "false" ]; then
+            echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+            exit 1
+          fi
+
+          if [ "${foundOrphanRepositories}" == "true" ]; then
+            echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+            exit 1
+          fi
+
+          # at this point, one of foundPendingRepositories or foundProdRepositories
+          # is true.
+
+          advisorySecretName="${prodSecretName}"
+          errataSecretName="${prodErrataSecretName}"
+          if [ "${foundPendingRepositories}" == "true" ]; then
+            advisorySecretName="${stagingSecretName}"
+            errataSecretName="${stagingErrataSecretName}"
+          fi
+        else
+          # Continue using the POC and staging credentials until CLDX-225
+          # is complete and stakeholders are ready to ingest these advisories
+          prodSecretName="create-advisory-poc-secret"
+          prodErrataSecretName="errata-stage-service-account"
+          stagingSecretName="create-advisory-poc-secret"
+          stagingErrataSecretName="errata-stage-service-account"
+
+          DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+          INTENTION=$(jq -r '.intention' "$DATA_FILE")
+
+          if [[ "$INTENTION" == "production" ]]; then
+            advisorySecretName="$prodSecretName"
+            errataSecretName="$prodErrataSecretName"
+          elif [[ "$INTENTION" == "staging" ]]; then
+            advisorySecretName="$stagingSecretName"
+            errataSecretName="$stagingErrataSecretName"
+          fi
         fi
 
         IR_FILE="$(params.dataDir)/$(context.task.name)/ir-result.txt"
@@ -250,6 +403,7 @@ spec:
                          -p origin="${origin}" \
                          -p advisory_json="${advisoryData}" \
                          -p config_map_name="${configMapName}" \
+                         -p contentType="${content_type}" \
                          -p advisory_secret_name="${advisorySecretName}" \
                          -p errata_secret_name="${errataSecretName}" \
                          -p taskGitUrl="$(params.taskGitUrl)" \

--- a/tasks/managed/create-advisory/tests/mock_generic_type_advisories.sh
+++ b/tasks/managed/create-advisory/tests/mock_generic_type_advisories.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  then
+    echo '{"result":"Success","advisory_url":"https://access.redhat.com/errata/RHBA-2025:1111"}'
+  else
+    /usr/bin/kubectl $*
+  fi
+}
+
+function python3() {
+  if [[ "$1" == "/home/utils/get_cgw_download_urls.py" ]]; then
+    if [[ "$3" == "helm" ]]; then
+      cat <<EOF
+/content/origin/files/sha256/64/645cf4d7eeedac3983a3d6b0c30970fe6c6e1d5161a2af741d98352da6ec3435/sha256sum.txt
+/content/origin/files/sha256/48/48c417949ed3324cd9e07f70665034b034e181be76c0d98c66be1701ba8dcefc/sha256sum.txt.gpg
+/content/origin/files/sha256/4f/4f6b0af28e8193bfa8b48f93096abe6a11cbc97589d81b339ca7cc37b7f92d3c/sha256sum.txt.sig
+/content/origin/files/sha256/c6/c6ff9aa942d710e73c877d765b7682bc22fcdbc59e43d708511ba21d249696c7/helm-linux-amd64
+/content/origin/files/sha256/d3/d305ee5018571f2aca631da5faf4c87eb5ceced40ec59d134b7d2dd166b82bc6/helm-linux-amd64.tar.gz
+/content/origin/files/sha256/68/682d2b002129ce26b33cce58c04a332d676f0b73913e4e9b07b430770b0fbfb3/helm-linux-arm64
+/content/origin/files/sha256/79/79214155dddc843e33740e980a903bf960d69af30003a94869c312ae21b82c4e/helm-linux-arm64.tar.gz
+/content/origin/files/sha256/bb/bbae88959ce1c212a98295e3444d74a048e6adcc69ef4d37673a8bf0cf383627/helm-linux-ppc64le
+/content/origin/files/sha256/5a/5ae75a1fee696087a43f6704fb26bec0e3b4fdbdd5a3733526c976f997975cac/helm-linux-ppc64le.tar.gz
+/content/origin/files/sha256/d4/d471c7386ae66d4624b2247d70a030adcedab47847dcf3b4fcf309511fd6a798/helm-linux-s390x
+/content/origin/files/sha256/15/15d181a99a0d8a79727add99cf883a30b8deaf2526c4fb57f9d567d07e5c7b39/helm-linux-s390x.tar.gz
+/content/origin/files/sha256/b2/b2bb962464ce206ad4b2afa9b5decd63b6a517cbe32fbb83c1b21ccb89c7b6df/helm-darwin-arm64
+/content/origin/files/sha256/37/374ceeafa7c71a098f5985a2af4e33491fe0d532c8133e3e7a5e50ede35bf359/helm-darwin-arm64.tar.gz
+/content/origin/files/sha256/6f/6f84bde5012e08b6ea46c39f3602793829d6dd62bc0639e76ce8c2c93c9c2345/helm-darwin-amd64
+/content/origin/files/sha256/d6/d6d8ccfa84be20f8e3018c441e97f5459179d16e77a3c2996bf2c08559ad5832/helm-darwin-amd64.tar.gz
+/content/origin/files/sha256/05/058c1052d82901c93d089f6ce261c0527067d5c3e2dd36776d2e67df68b10b7e/helm-windows-amd64.exe
+/content/origin/files/sha256/38/38fb333e0c359824a451631e127247d0db44f1ac1de5b9b4d31bd5bb6ec9/helm-windows-amd64.exe.zip
+EOF
+    elif [[ "$3" == "odo" ]]; then
+      cat <<EOF
+/content/origin/files/sha256/31/31ac6ba34c1d807e7b282c305341ab03f9a4bd6559192b81334c393a1aee9d79/sha256sum.txt
+/content/origin/files/sha256/ac/acc4ccfaed1deb346145c47c947da05dd656a89b43ef53fc12402d64dbdb5e85/sha256sum.txt.gpg
+/content/origin/files/sha256/84/84108ebb0a74b46401511e00bf0a2e74a6bed6874000a44e4785d13c1cf2d048/sha256sum.txt.sig
+/content/origin/files/sha256/5b/5ba537ab031969c7ab934f511400c1ab0bc5d3bd4714ddc5a1c84d03f1da62b1/odo-darwin-amd64
+/content/origin/files/sha256/84/843a4845176f5b8f8d693a6138afaa893dd195ead6a1122cae437a71ec78b4cb/odo-darwin-amd64.tar.gz
+/content/origin/files/sha256/25/258c981ca05894a4d3a4b9812939c3d78a4115ae9fcbefaeabeb6445005040c0/odo-darwin-arm64
+/content/origin/files/sha256/68/68bc64b88474ca42d553f50f50ab28d7e0ddabca305ab9ee56c450558798f4b7/odo-darwin-arm64.tar.gz
+/content/origin/files/sha256/c2/c271940c4b9d88f753423aae78984b7ef7a99ac9133154714b679f8b8b3bec8e/odo-linux-amd64
+/content/origin/files/sha256/e5/e539bb37a2084d381562ed8808f3dca3dc918e1c4917d94e5357f2e97185b415/odo-linux-amd64.tar.gz
+/content/origin/files/sha256/52/52236760344ec54724c65567832e1473d28afef65276826531435947457ac375/odo-linux-arm64
+/content/origin/files/sha256/0f/0fa32171f48a3856c38bec4ffd923b2dd9be18f07e1380c303615ac8a830d363/odo-linux-arm64.tar.gz
+/content/origin/files/sha256/1d/1dccd03466e2fabc981585fb5efb6f84d18ecf53f0350ec4e1d5c67ff88e5aa1/odo-linux-ppc64le
+/content/origin/files/sha256/be/bee804564395d0830034ac33b327c7a2f8a7b5b9bccf9fb3b399890b728d7a3e/odo-linux-ppc64le.tar.gz
+/content/origin/files/sha256/1d/1d70e9777cd10ba280d4c04d7fe69bf1a86e1901c135c7592ee189291716e8c8/odo-linux-s390x
+/content/origin/files/sha256/e9/e9e44c7a2c086662dc0907207faee0589b6c84c79a270700f488577d180379c8/odo-linux-s390x.tar.gz
+/content/origin/files/sha256/e1/e147d6d9c9940389790084fcbff749600dbeafd5f4495320ba1a09ea0ddcef3c/odo-windows-amd64.exe
+/content/origin/files/sha256/04/04b0a14eb0ef13c0d8ac862cd2abeea9de74e26624c6d38fc6bc8a5759a8f9e8/odo-windows-amd64.exe.zip
+EOF
+    else
+      echo "Unknown product: $3" >&2
+      return 1
+    fi
+  else
+    /usr/bin/python3 "$@"
+  fi
+}

--- a/tasks/managed/create-advisory/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/create-advisory/tests/pre-apply-task-hook.sh
@@ -13,4 +13,9 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
+
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mock_generic_type_advisories.sh") + .spec.steps[2].script' "$TASK_PATH"
+# Create a dummy publish-to-cgw secret (and delete it first if it exists)
+kubectl delete secret publish-to-cgw-secret --ignore-not-found
+kubectl create secret generic publish-to-cgw-secret --from-literal=username=myusername --from-literal=token=mytoken

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
@@ -1,0 +1,405 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-update-purl
+spec:
+  description: |
+    Assert that the update purl step can process the downloadURLs from CGW and generate
+    the purl field for the releaseNotes
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": [
+                    "app"
+                  ],
+                  "policy": "policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "github.com"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipeline.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "sa"
+                  },
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "OpenShift",
+                "components": [
+                  {
+                    "name": "helm",
+                    "repository": "quay.io/redhat-prod/repo"
+                  },
+                  {
+                    "name": "odo",
+                    "repository": "quay.io/redhat-prod/repo"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+                {
+                  "mapping": {
+                    "components": [
+                      {
+                        "name": "helm",
+                        "staged": {
+                          "destination": "placeholder-destination",
+                          "version": "1.5.0",
+                          "files": [
+                            {
+                              "filename": "helm-windows",
+                              "source": "/releases/helm-windows-amd64.exe.zip",
+                              "arch": "amd64",
+                              "os": "windows"
+                            },
+                            {
+                              "filename": "helm-linux",
+                              "source": "helm-linux-amd64.tar.gz",
+                              "arch": "amd64",
+                              "os": "linux"
+                            }
+                          ]
+                        },
+                        "contentGateway": {
+                          "contentType": "binary",
+                          "productName": "helm",
+                          "productCode": "helm",
+                          "productVersionName": "1.5.0",
+                          "filePrefix": "helm"
+                        }
+                      },
+                      {
+                        "name": "odo",
+                        "staged": {
+                          "destination": "placeholder-destination",
+                          "version": "v3.16.1",
+                          "files": [
+                            {
+                              "filename": "odo-linux",
+                              "source": "odo-linux-amd64.tar.gz",
+                              "arch": "amd64",
+                              "os": "linux"
+                            }
+                          ]
+                        },
+                        "contentGateway": {
+                          "contentType": "binary",
+                          "productName": "odo",
+                          "productCode": "odo",
+                          "productVersionName": "v3.16.1",
+                          "filePrefix": "odo"
+                        }
+                      }
+                    ]
+                  },
+                "releaseNotes": {
+                  "content": {
+                    "artifacts": [
+                      { "architecture": "amd64",
+                        "component": "helm",
+                        "os": "windows",
+                        "containerImage": "foo",
+                        "purl": "placeholder"
+                      },
+                      { "architecture": "amd64",
+                        "component": "helm",
+                        "os": "linux",
+                        "containerImage": "foo",
+                        "purl": "placeholder"
+                      },
+                      { "architecture": "amd64",
+                        "component": "odo",
+                        "os": "linux",
+                        "containerImage": "foo",
+                        "purl": "placeholder"
+                      }
+                    ]
+                  }
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: "contentType"
+          value: "binary"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check if the 'pipelineRef' field contains the 'create-advisory' pipeline
+              if [[ "$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value' )" != \
+              "pipelines/internal/create-advisory"* ]]; then
+                echo "InternalRequest doesn't contain 'create-advisory' in 'pipeline' field"
+                exit 1
+              fi
+
+              advisoryJson=$(echo "$internalRequest" | jq -r '.spec.params.advisory_json')
+
+              # Parse advisory_json content
+              artifacts=$(echo "$advisoryJson" | jq -c '.content.artifacts')
+
+              # Ensure there are exactly two artifacts
+              artifactCount=$(echo "$artifacts" | jq 'length')
+              if [ "$artifactCount" -ne 3 ]; then
+                echo "Expected exactly 2 artifacts in advisory_json, but found $artifactCount"
+                echo "$artifacts" | jq
+                exit 1
+              fi
+
+              # Assert the three expected PURLs are exactly what's present
+              baseUrl="https://access.cdn.redhat.com/content/origin/files"
+
+              printf -v helmWindowsPath "%s%s" \
+                "sha256/38/38fb333e0c359824a451631e127247d0db44f1ac1de5b9b4d31bd5bb6ec9/" \
+                "helm-windows-amd64.exe.zip"
+
+              printf -v helmLinuxPath "%s%s" \
+                "sha256/d3/d305ee5018571f2aca631da5faf4c87eb5ceced40ec59d134b7d2dd166b82bc6/" \
+                "helm-linux-amd64.tar.gz"
+
+              printf -v odoLinuxPath "%s%s" \
+                "sha256/e5/e539bb37a2084d381562ed8808f3dca3dc918e1c4917d94e5357f2e97185b415/" \
+                "odo-linux-amd64.tar.gz"
+
+              expectedHelmWindowsPurl="pkg:generic/helm@1.5.0?download_url=${baseUrl}/${helmWindowsPath}"
+              expectedHelmLinuxPurl="pkg:generic/helm@1.5.0?download_url=${baseUrl}/${helmLinuxPath}"
+              expectedOdoLinuxPurl="pkg:generic/odo@v3.16.1?download_url=${baseUrl}/${odoLinuxPath}"
+
+              helmWindowsPurl=$(
+                echo "$artifacts" | jq -r '.[] | select(.component == "helm" and .os == "windows") | .purl')
+              helmLinuxPurl=$(
+                echo "$artifacts" | jq -r '.[] | select(.component == "helm" and .os == "linux") | .purl')
+              odoLinuxPurl=$(
+                echo "$artifacts" | jq -r '.[] | select(.component == "odo" and .os == "linux") | .purl')
+
+              if [ "$helmWindowsPurl" != "$expectedHelmWindowsPurl" ]; then
+                echo "Unexpected PURL for Helm Windows artifact"
+                exit 1
+              fi
+
+              if [ "$helmLinuxPurl" != "$expectedHelmLinuxPurl" ]; then
+                echo "Unexpected PURL for Helm Linux artifact"
+                exit 1
+              fi
+
+              if [ "$odoLinuxPurl" != "$expectedOdoLinuxPurl" ]; then
+                echo "Unexpected PURL for Odo Linux artifact"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
## Add support for generic content type advisories. This currently focuses on binary content types but can later be expanded to include any content type under 'generic' that doesn't fit under 'images'

## [CLDX-377](https://issues.redhat.com//browse/CLDX-377)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

