### PR TITLE
feat(RELEASE-439): support multiple components in sign-index-image

### DIFF
--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -20,6 +20,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                                      | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                             | No       | -                                                         |
 
+## Changes in 4.6.0
+* Add new `fbcResultsPath` parameter for `sign-index-image`. This is to support multicomponent releases
+
 ## Changes in 4.5.0
 * Add `prepare-fbc-release` task to the Pipeline, which adds new information required by `add-fbc-contribution` to
   build multiple components

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.5.0"
+    app.kubernetes.io/version: "4.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -382,6 +382,8 @@ spec:
           value: $(params.taskGitUrl)
         - name: taskGitRevision
           value: $(params.taskGitRevision)
+        - name: fbcResultsPath
+          value: "$(tasks.add-fbc-contribution-to-index-image.results.internalRequestResultsFile)"
       when:
         - input: "$(tasks.add-fbc-contribution-to-index-image.results.mustSignIndexImage)"
           operator: in

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -4,17 +4,19 @@ Creates an InternalRequest to sign an index image
 
 ## Parameters
 
-| Name                     | Description                                                                               | Optional | Default value  |
-|--------------------------|-------------------------------------------------------------------------------------------|----------|----------------|
-| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                   | No       | -              |
-| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -              |
-| referenceImage           | The image to be signed                                                                    | No       | -              |
-| manifestListDigests      | The manifest digests for each arch in manifest list                                       | No       | -              |
-| requester                | Name of the user that requested the signing, for auditing purposes                        | No       | -              |
-| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 1800           |
-| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -              |
-| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -              |
-| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -              |
+| Name                     | Description                                                                               | Optional | Default value |
+| ------------------------ | ----------------------------------------------------------------------------------------- | -------- | ------------- |
+| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                   | No       | -             |
+| releasePlanAdmissionPath | Path to the JSON string of the releasePlanAdmission in the data workspace                 | No       | -             |
+| referenceImage           | The image to be signed                                                                    | No       | -             |
+| manifestListDigests      | The manifest digests for each arch in manifest list                                       | No       | -             |
+| requester                | Name of the user that requested the signing, for auditing purposes                        | No       | -             |
+| requestTimeout           | InternalRequest timeout                                                                   | Yes      | 1800          |
+| pipelineRunUid           | The uid of the current pipelineRun. Used as a label value when creating internal requests | No       | -             |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
+| fbcResultsPath           | Path to the JSON file in the data workspace containing fbc results                        | No       | -             |
+| concurrentLimit          | The maximum number of concurrent signing requests                                         | Yes      | 16            |
 
 ## Signing data parameters
 
@@ -28,6 +30,11 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 4.3.0
+* Add support for multicomponent releases
+  * The new mandatory task parameter `fbcResultsPath` points to a file with images and manifest digests to sign
+  * Signing is processed in parallel - up to `concurrentLimit` of signing requests at a time
 
 ## Changes in 4.2.1
 * The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.2.1"
+    app.kubernetes.io/version: "4.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -44,6 +44,13 @@ spec:
       description: |
         The revision in the taskGitUrl repo to be used. This is passed to the InternalRequest as it is needed by the
         simple-signing-pipeline
+    - name: fbcResultsPath
+      type: string
+      description: Path to the JSON file in the data workspace containing fbc results
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of concurrent signing requests
+      default: 16
   workspaces:
     - name: data
       description: workspace to read and save files
@@ -52,7 +59,11 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
       script: |
         #!/usr/bin/env bash
-        set -e
+        set -ex
+
+        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        CONCURRENT_LIMIT=$(params.concurrentLimit)
+        REQUEST_COUNT=0
 
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
@@ -61,6 +72,12 @@ spec:
         DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
+            exit 1
+        fi
+
+        RESULTS_FILE="$(workspaces.data.path)/$(params.fbcResultsPath)"
+        if [ ! -f "${RESULTS_FILE}" ] ; then
+            echo "No valid results file was provided."
             exit 1
         fi
 
@@ -85,33 +102,51 @@ spec:
         pipeline_image=$(jq -r --arg default_pipeline_image "${default_pipeline_image}" \
             '.sign.pipelineImage // .fbc.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
         config_map_name=$(jq -r '.sign.configMapName // .fbc.configMapName // "signing-config-map"' "${DATA_FILE}")
-        reference_image="$(params.referenceImage)"
 
-        # Translate direct quay.io reference to public facing registry reference
-        # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
-        reference_image=$(translate-delivery-repo "$reference_image" | jq -r '.[] | select(.repo=="redhat.io") | .url')
+        component_count=$(jq '.components | length' "$RESULTS_FILE")
+        for ((i = 0; i < component_count; i++)); do
+          reference_image=$(jq -r ".components[$i].target_index" "$RESULTS_FILE")
 
-        # get all digests from manifest list
-        for manifest_digest in $(params.manifestListDigests)
-        do
+          # Translate direct quay.io reference to public facing registry reference
+          # quay.io/redhat/product----repo -> registry.redhat.io/product/repo
+          reference_image=$(translate-delivery-repo "$reference_image" \
+            | jq -r '.[] | select(.repo=="redhat.io") | .url')
 
-          echo "Creating ${requestType} to sign image:"
-          echo "- reference=${reference_image}"
-          echo "- manifest_digest=${manifest_digest}"
-          echo "- requester=$(params.requester)"
+          digest_count=$(jq ".components[$i].imageDigests | length" "$RESULTS_FILE")
+          for ((j = 0; j < digest_count; j++)); do
+            while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
+              wait -n
+            done
 
-          ${requestType} --pipeline "${request}" \
-            -p pipeline_image="${pipeline_image}" \
-            -p reference="${reference_image}" \
-            -p manifest_digest="${manifest_digest}" \
-            -p requester="$(params.requester)" \
-            -p config_map_name="${config_map_name}" \
-            -p taskGitUrl="$(params.taskGitUrl)" \
-            -p taskGitRevision="$(params.taskGitRevision)" \
-            -l ${TASK_LABEL}="${TASK_ID}" \
-            -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
-            -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
-            "${EXTRA_ARGS[@]}" -s true
+            manifest_digest=$(jq -r ".components[$i].imageDigests[$j]" "$RESULTS_FILE")
 
-          echo "done"
+            echo "Creating ${requestType} to sign image:"
+            echo "- reference=${reference_image}"
+            echo "- manifest_digest=${manifest_digest}"
+            echo "- requester=$(params.requester)"
+
+            ${requestType} --pipeline "${request}" \
+              -p pipeline_image="${pipeline_image}" \
+              -p reference="${reference_image}" \
+              -p manifest_digest="${manifest_digest}" \
+              -p requester="$(params.requester)" \
+              -p config_map_name="${config_map_name}" \
+              -p taskGitUrl="$(params.taskGitUrl)" \
+              -p taskGitRevision="$(params.taskGitRevision)" \
+              -l ${TASK_LABEL}="${TASK_ID}" \
+              -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+              -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
+              "${EXTRA_ARGS[@]}" -s true &
+
+            ((++REQUEST_COUNT))
+            echo "Request Count: $REQUEST_COUNT"
+
+          done
         done
+
+        echo "Waiting for remaining processes to finish..."
+        while (( ${RUNNING_JOBS@P} > 0 )); do
+          wait -n
+        done
+
+        echo "done"

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-sign-index-image-with-pullspec-rewrite
+  name: test-sign-index-image-multicomponent
 spec:
-  description: Test creating a internal request to sign an image
+  description: |
+    Test creating a internal request to sign an image.
+    In this scenario there will be multiple index images to sign.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -59,9 +61,16 @@ spec:
               {
                   "components": [
                       {
-                          "target_index": "quay.io/redhat/redhat----testimage:tag",
+                          "target_index": "registry.redhat.io/redhat/redhat-operator-index:v4.15",
                           "imageDigests": [
+                              "sha256:6f9a420f660e73a",
                               "sha256:6f9a420f660e73b"
+                          ]
+                      },
+                      {
+                          "target_index": "registry.redhat.io/redhat/redhat-operator-index:v4.16",
+                          "imageDigests": [
+                              "sha256:6f9a420f660e73c"
                           ]
                       }
                   ]
@@ -74,9 +83,9 @@ spec:
         - name: requester
           value: testuser
         - name: referenceImage
-          value: quay.io/redhat/redhat----testimage:tag
+          value: quay.io/testrepo/testimage:tag
         - name: manifestListDigests
-          value: "sha256:6f9a420f660e73b"
+          value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
         - name: taskGitUrl
@@ -106,38 +115,50 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
-                -o custom-columns=":metadata.name")"
-              params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+              testValues='sha256:6f9a420f660e73a sha256:6f9a420f660e73b sha256:6f9a420f660e73c'
+              internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
+              internalRequestsCount=$(echo "$internalRequests" | wc -w)
 
-              if [ "$(jq -r '.reference' <<< "${params}")" != "registry.redhat.io/redhat/testimage:tag" ]; then
-                echo "reference image does not match"
+              if [ "$internalRequestsCount" != "3" ] ; then
+                echo "incorrect number of internalRequests created. Expected 3"
                 exit 1
               fi
 
-              if [ "$(jq -r '.manifest_digest' <<< "${params}")" != "sha256:6f9a420f660e73b" ]; then
-                echo "manifest_digest does not match"
-                exit 1
-              fi
+              for internalRequest in ${internalRequests};
+              do
+                params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
 
-              if [ "$(jq -r '.config_map_name' <<< "${params}")" != "signing-config-map" ]
-              then
-                echo "config_map_name does not match"
-                exit 1
-              fi
+                if [[ "$(jq -r '.reference' <<< "${params}")" \
+                    != "registry.redhat.io/redhat/redhat-operator-index:v4.1"[56] ]]; then
+                  echo "reference image does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.requester' <<< "${params}")" != "testuser" ]
-              then
-                echo "requester does not match"
-                exit 1
-              fi
+                manifest_digest=$(jq -r '.manifest_digest' <<< "${params}")
+                if [[ ! " $testValues " =~ [[:space:]]${manifest_digest}[[:space:]] ]]; then
+                  echo "manifest_digest does not match"
+                  exit 1
+                fi
 
-              if [ "$(jq -r '.pipeline_image' <<< "${params}")" != \
-                 "quay.io/redhat-isv/operator-pipelines-images:released" ]
-              then
-                echo "pipeline_image does not match"
-                exit 1
-              fi
+                if [ "$(jq -r '.config_map_name' <<< "${params}")" != "signing-config-map" ]
+                then
+                  echo "config_map_name does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.requester' <<< "${params}")" != "testuser" ]
+                then
+                  echo "requester does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.pipeline_image' <<< "${params}")" != \
+                   "quay.io/redhat-isv/operator-pipelines-images:released" ]
+                then
+                  echo "pipeline_image does not match"
+                  exit 1
+                fi
+              done
       runAfter:
         - run-task
   finally:

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -57,6 +57,19 @@ spec:
                 }
               }
               EOF
+              cat > "$(workspaces.data.path)/fbcResults.json" << EOF
+              {
+                  "components": [
+                      {
+                          "target_index": "quay.io/redhat/testimage:tag",
+                          "imageDigests": [
+                              "sha256:6f9a420f660e73a",
+                              "sha256:6f9a420f660e73b"
+                          ]
+                      }
+                  ]
+              }
+              EOF
     - name: run-task
       taskRef:
         name: sign-index-image
@@ -77,6 +90,8 @@ spec:
           value: data.json
         - name: releasePlanAdmissionPath
           value: release_plan_admission.json
+        - name: fbcResultsPath
+          value: fbcResults.json
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -55,6 +55,19 @@ spec:
                 }
               }
               EOF
+              cat > "$(workspaces.data.path)/fbcResults.json" << EOF
+              {
+                  "components": [
+                      {
+                          "target_index": "quay.io/testrepo/testimage:tag",
+                          "imageDigests": [
+                              "sha256:6f9a420f660e73a",
+                              "sha256:6f9a420f660e73b"
+                          ]
+                      }
+                  ]
+              }
+              EOF
     - name: run-task
       taskRef:
         name: sign-index-image
@@ -75,6 +88,8 @@ spec:
           value: data.json
         - name: releasePlanAdmissionPath
           value: release_plan_admission.json
+        - name: fbcResultsPath
+          value: fbcResults.json
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -92,9 +107,7 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              counter=0
-              testValues=('sha256:6f9a420f660e73a' \
-                          'sha256:6f9a420f660e73b')
+              testValues='sha256:6f9a420f660e73a sha256:6f9a420f660e73b'
               internalRequests="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers)"
               internalRequestsCount=$(echo "$internalRequests" | wc -w)
 
@@ -112,7 +125,8 @@ spec:
                   exit 1
                 fi
 
-                if [ "$(jq -r '.manifest_digest' <<< "${params}")" != "${testValues[$counter]}" ]; then
+                manifest_digest=$(jq -r '.manifest_digest' <<< "${params}")
+                if [[ ! " $testValues " =~ [[:space:]]${manifest_digest}[[:space:]] ]]; then
                   echo "manifest_digest does not match"
                   exit 1
                 fi
@@ -135,8 +149,6 @@ spec:
                   echo "pipeline_image does not match"
                   exit 1
                 fi
-
-                counter=$((counter+1))
               done
       runAfter:
         - run-task


### PR DESCRIPTION
## Describe your changes

The sign-index-image task now expect a new fbcResultsPath parameter with a json file produced by add-fbc-contribution that contains a list of references and digests to sign.

This way we will support multiple components to be signed.

Depends on https://github.com/konflux-ci/release-service-catalog/pull/930

## Relevant Jira

[RELEASE-439](https://issues.redhat.com//browse/RELEASE-439)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

