### PR TITLE
refactor(RELEASE-1560): update to remove .contentGateway

### DIFF
--- a/tasks/managed/extract-binaries-from-image/README.md
+++ b/tasks/managed/extract-binaries-from-image/README.md
@@ -17,6 +17,10 @@ passed.
 | subdirectory        | Subdirectory inside the workspace to be used for storing the binaries      | Yes      | ""            |
 | dataPath            | Path to the JSON string of the merged data to use in the data workspace    | No       | -             |
 
+## Changes in 2.1.4
+* Updated to use `data.mapping.components[0].contentGateway` and removed support
+  for `data.contentGateway`
+
 ## Changes in 2.1.3
 * Add comprobation to only extract from the layer with the releases directory
 

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-binaries-from-image
   labels:
-    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/version: "2.1.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -55,8 +55,8 @@ spec:
         DESIRED_COMPONENTS_LIST=
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No data JSON was provided."
-        elif [ "$(jq '."contentGateway" | has("components")' "${DATA_FILE}")" = true ]; then
-            DESIRED_COMPONENTS_LIST="$(jq -r '."contentGateway".components[].name' "${DATA_FILE}")"
+        elif [ "$(jq '.mapping.components[0].contentGateway | has("components")' "${DATA_FILE}")" = true ]; then
+            DESIRED_COMPONENTS_LIST="$(jq -r '.mapping.components[0].contentGateway.components[].name' "${DATA_FILE}")"
         fi
 
         NUM_COMPONENTS=$(jq '.components | length' "$SNAPSHOT_SPEC_FILE")

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
@@ -46,10 +46,16 @@ spec:
 
               cat > "$(workspaces.data.path)"/data.json << EOF
               {
-                "contentGateway": {
+                "mapping": {
                   "components": [
-                    {"name": "comp2"},
-                    {"name": "comp3"}
+                    {
+                      "contentGateway": {
+                        "components": [
+                          { "name": "comp2" },
+                          { "name": "comp3" }
+                        ]
+                      }
+                    }
                   ]
                 }
               }

--- a/tasks/managed/publish-to-cgw/README.md
+++ b/tasks/managed/publish-to-cgw/README.md
@@ -14,6 +14,10 @@ Tekton task to publish content to Red Hat's Developer portal using content-gatew
 | cgwHostname | The hostname of the content-gateway to publish the metadata to  | yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret   | The kubernetes secret to use to authenticate to content-gateway | yes      | publish-to-cgw-secret |
 
+## Changes in 1.0.1
+* Updated to use `data.mapping.components[0].contentGateway` and removed support
+  for `data.contentGateway` by bumping the base image used in this task
+  
 ## Changes in 1.0.0
 * Make the task idempotent by checking if files are
   already present in the product name and version.

--- a/tasks/managed/publish-to-cgw/publish-to-cgw.yaml
+++ b/tasks/managed/publish-to-cgw/publish-to-cgw.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-cgw
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,7 @@ spec:
       description: Workspace to save the CR jsons to
   steps:
     - name: run-push-cgw-metadata
-      image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+      image: quay.io/sconroykonflux/release-service-utils:cgw   # Update to new RSU Image
       env:
         - name: CGW_USERNAME
           valueFrom:

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-all.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-all.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/bin/bash
               set -eux
@@ -54,23 +54,27 @@ spec:
 
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
-                "contentGateway": {
-                  "mirrorOpenshiftPush": true,
-                  "productName": "product_name_1",
-                  "productCode": "product_code_1",
-                  "productVersionName": "1.2",
+                "mapping": {
                   "components": [
                     {
-                      "name": "cosign",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
-                    },
-                    {
-                      "name": "gitsign",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
+                      "name": "example-component",
+                      "repository": "quay.io/redhat/example-component",
+                      "contentGateway": {
+                        "mirrorOpenshiftPush": true,
+                        "productName": "product_name_1",
+                        "productCode": "product_code_1",
+                        "productVersionName": "1.2",
+                        "components": [
+                          {
+                            "name": "cosign",
+                            "description": "Red Hat OpenShift Local Sandbox Test"
+                          },
+                          {
+                            "name": "gitsign",
+                            "description": "Red Hat OpenShift Local Sandbox Test"
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -105,7 +109,7 @@ spec:
           - name: resultDataPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/usr/bin/env bash
               python3 <<EOF

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-and-skip.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-create-and-skip.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/bin/bash
               set -eux
@@ -58,23 +58,29 @@ spec:
               
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
-                "contentGateway": {
-                  "mirrorOpenshiftPush": true,
-                  "productName": "product_name_1",
-                  "productCode": "product_code_1",
-                  "productVersionName": "1.2",
+                "mapping": {
                   "components": [
                     {
-                      "name": "skip",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
-                    },
-                    { 
-                      "name": "cosign",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
+                      "name": "example-component",
+                      "repository": "quay.io/redhat/example-component",
+                      "contentGateway": {
+                        "mirrorOpenshiftPush": true,
+                        "productName": "product_name_1",
+                        "productCode": "product_code_1",
+                        "productVersionName": "1.2",
+                        "components": [
+                          {
+                            "name": "skip",
+                            "description": "Red Hat OpenShift Local Sandbox Test",
+                            "hidden": false
+                          },
+                          {
+                            "name": "cosign",
+                            "description": "Red Hat OpenShift Local Sandbox Test",
+                            "hidden": false
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -109,7 +115,7 @@ spec:
           - name: resultDataPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/usr/bin/env bash
               python3 <<EOF

--- a/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-skip-all.yaml
+++ b/tasks/managed/publish-to-cgw/tests/test-publish-to-cgw-skip-all.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:afef3c73a8475f9db6534769e54e601cff1eb40b
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/bin/bash
               set -eux
@@ -44,17 +44,24 @@ spec:
               
               cat > "$(workspaces.data.path)/data.json" << EOF
               {
-                "contentGateway": {
-                  "mirrorOpenshiftPush": true,
-                  "productName": "product_name_1",
-                  "productCode": "product_code_1",
-                  "productVersionName": "1.2",
+                "mapping": {
                   "components": [
                     {
-                      "name": "skip",
-                      "description": "Red Hat OpenShift Local Sandbox Test",
-                      "shortURL": "/cgw/product_code_1/1.1",
-                      "hidden": false
+                      "name": "example-component",
+                      "repository": "quay.io/redhat/example-component",
+                      "contentGateway": {
+                        "mirrorOpenshiftPush": true,
+                        "productName": "product_name_1",
+                        "productCode": "product_code_1",
+                        "productVersionName": "1.2",
+                        "components": [
+                          {
+                            "name": "skip",
+                            "description": "Red Hat OpenShift Local Sandbox Test",
+                            "hidden": false
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -89,7 +96,7 @@ spec:
           - name: resultDataPath
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3826e42200d46e2bd336bc7802332190a9ebd860
+            image: quay.io/sconroykonflux/release-service-utils:cgw
             script: |
               #!/usr/bin/env bash
               python3 <<EOF


### PR DESCRIPTION
## Describe your changes
Updated tasks `publish-to-cgw` and `extract-binaries-from-image` to remove support for `.contentGateway` at the root level and instead use `data.mapping.components[0].contentGateway`. Only the first component is supported for contentGateway for both tasks.
## Depends on 
https://github.com/konflux-ci/release-service-utils/pull/437

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

