### PR TITLE
feat(CLOUDDST-26262): create pyxis image for operator index images

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -619,6 +619,83 @@ spec:
           values: ["true"]
       runAfter:
         - sign-index-image
+    - name: collect-index-images
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-index-images/collect-index-images.yaml
+      params:
+        - name: buildTimestamp
+          value: $(tasks.add-fbc-contribution-to-index-image.results.buildTimestamp)
+        - name: internalRequestResultsFile
+          value: $(tasks.add-fbc-contribution-to-index-image.results.internalRequestResultsFile)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.add-fbc-contribution-to-index-image.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - add-fbc-contribution-to-index-image
+    - name: create-pyxis-image
+      retries: 5
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+      params:
+        - name: server
+          value: $(tasks.collect-pyxis-params.results.server)
+        - name: pyxisSecret
+          value: $(tasks.collect-pyxis-params.results.secret)
+        - name: rhPush
+          value: "true"
+        - name: snapshotPath
+          value: "$(tasks.collect-index-images.results.indexImageSnapshot)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-index-images.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      when:
+        - input: $(tasks.add-fbc-contribution-to-index-image.results.mustPublishIndexImage)
+          operator: in
+          values: ["true"]
+      runAfter:
+        - collect-pyxis-params
+        - collect-index-images
+        - publish-index-image
     - name: update-cr-status
       params:
         - name: resource

--- a/tasks/managed/collect-index-images/README.md
+++ b/tasks/managed/collect-index-images/README.md
@@ -1,0 +1,18 @@
+# collect-index-images
+
+Tekton task that generates a JSON file to be used to create pyxis image for index images.
+
+## Parameters
+
+| Name                       | Description                                                                                                                | Optional | Default value           |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
+| buildTimestamp             | Build timestamp for the index image                                                                                        | No       | -                       |
+| internalRequestResultsFile | Path to the results file of the InternalRequest build result                                                               | No       | -                       |
+| ociStorage                 | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
+| ociArtifactExpiresAfter    | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
+| trustedArtifactsDebug      | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
+| orasOptions                | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
+| sourceDataArtifact         | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
+| dataDir                    | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
+| taskGitUrl                 | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
+| taskGitRevision            | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -1,0 +1,204 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-index-images
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that generates a JSON file to be used to create pyxis image for index images.
+  params:
+    - name: buildTimestamp
+      type: string
+      description: Build timestamp for the index image
+    - name: internalRequestResultsFile
+      type: string
+      description: Path to the results file of the InternalRequest build result
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  results:
+    - name: indexImageSnapshot
+      type: string
+      description: JSON file to be used to create pyxis image for index images
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+  steps:
+    - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: collect-index-images
+      image:
+        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        RESULTS_FILE=$(params.dataDir)/$(params.internalRequestResultsFile)
+        SNAPSHOT_FILE=$(params.dataDir)/index_image_snapshot.json
+        jq -n '{"components": []}' | tee "$SNAPSHOT_FILE"
+
+        LENGTH="$(jq -r '.components | length' "$RESULTS_FILE")"
+        for((i=0; i<LENGTH; i++)); do
+          TARGETINDEX=$(jq -r --argjson i "$i" '.components[$i].target_index' "$RESULTS_FILE")
+          SOURCEINDEX=$(jq -r  --argjson i "$i" '.components[$i].index_image_resolved' "$RESULTS_FILE")
+          REPOSITORY=${TARGETINDEX%:*}
+
+          TAG=${TARGETINDEX#*:}
+          TAGS=("${TAG}")
+          if [[ ! "${TAG}" =~ .*$(params.buildTimestamp)$ ]]; then
+            TAGS+=("${TAG}-$(params.buildTimestamp)")
+          fi
+          JSON_TAGS=$(jq -n -c '$ARGS.positional' --args -- "${TAGS[@]}")
+
+          COMPONENT=$(jq -n \
+            --arg image "${SOURCEINDEX}" \
+            --arg repository "${REPOSITORY}" \
+            --argjson tags "${JSON_TAGS}" \
+            '{
+              "containerImage": $image,
+              "repository": $repository,
+              "tags": $tags
+            }'
+          )
+          export COMPONENT
+          yq -i '.components += env(COMPONENT) ' "$SNAPSHOT_FILE"
+        done
+        echo -n "index_image_snapshot.json" > "$(results.indexImageSnapshot.path)"
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-index-images-hotfix
+spec:
+  description: |
+    Run the collect-index-images task for hotfix index image and verify the results
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "components": [
+                  {
+                    "target_index": "quay.io/test/fbc-target-index:v4.12-12345-6789",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: collect-index-images
+      params:
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: buildTimestamp
+          value: "6789"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: indexImageSnapshot
+          value: $(tasks.run-task.results.indexImageSnapshot)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: indexImageSnapshot
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(params.indexImageSnapshot)"
+
+              if [ "$(jq -r '.components[0].containerImage' < "${SNAPSHOT_FILE}")" != \
+                "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                echo "containerImage does not match"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+              if [ "$(jq -c '.components[0].tags' < "${SNAPSHOT_FILE}")" != "[\"v4.12-12345-6789\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-index-images-multiple-versions
+spec:
+  description: |
+    Run the collect-index-images task for multiple index image versions and verify the results
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "components": [
+                  {
+                    "target_index": "quay.io/test/fbc-target-index:v4.12",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                  },
+                  {
+                    "target_index": "quay.io/test/fbc-target-index:v4.13",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: collect-index-images
+      params:
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: buildTimestamp
+          value: "1357"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: indexImageSnapshot
+          value: $(tasks.run-task.results.indexImageSnapshot)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: indexImageSnapshot
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(params.indexImageSnapshot)"
+
+              if [ "$(jq -r '.components[0].containerImage' < "${SNAPSHOT_FILE}")" != \
+                "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                echo "containerImage does not match"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+              if [ "$(jq -c '.components[0].tags' < "${SNAPSHOT_FILE}")" != "[\"v4.12\",\"v4.12-1357\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.components[1].containerImage' < "${SNAPSHOT_FILE}")" != \
+                "redhat.com/rh-stage/iib@sha256:lmnopqrstuv" ]; then
+                echo "containerImage does not match"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[1].repository' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+              if [ "$(jq -c '.components[1].tags' < "${SNAPSHOT_FILE}")" != "[\"v4.13\",\"v4.13-1357\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-index-images-single-version
+spec:
+  description: |
+    Run the collect-index-images task for single index image version and verify the results
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "components": [
+                  {
+                    "target_index": "quay.io/test/fbc-target-index:v4.12",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: collect-index-images
+      params:
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: buildTimestamp
+          value: "2468"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: indexImageSnapshot
+          value: $(tasks.run-task.results.indexImageSnapshot)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        params:
+          - name: indexImageSnapshot
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(params.indexImageSnapshot)"
+
+              if [ "$(jq -r '.components[0].containerImage' < "${SNAPSHOT_FILE}")" != \
+                "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                echo "containerImage does not match"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+              if [ "$(jq -c '.components[0].tags' < "${SNAPSHOT_FILE}")" != "[\"v4.12\",\"v4.12-2468\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
To make the catalog page of redhat/redhat-operator-index updated with index images released from Konflux, tasks are added to fbc-release to create pyxis image for index image. collect-index-images is created to generate the snapshotPath required by create-pyxis-image.

## Relevant Jira
- [CLOUDDST-26262](https://issues.redhat.com//browse/CLOUDDST-26262)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

