### PR TITLE
feat(ROK-446): avoid Koji import if contract verification fails

### DIFF
--- a/pipelines/managed/push-rpm-to-koji/README.md
+++ b/pipelines/managed/push-rpm-to-koji/README.md
@@ -20,3 +20,6 @@ Tekton pipeline to push rpms into the koji instance.
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
 | enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 8h0m0s                                                    |
 | enterpriseContractWorkerCount   | Number of parallel workers for policy evaluation                                                                                   | Yes      | 4                                                         |
+
+## Changes in 0.2.0
+* Avoid importing to Koji if enterprise contract verification fails

--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-rpm-to-koji
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: push-koji
@@ -202,7 +202,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - reduce-snapshot
+        - verify-enterprise-contract
     - name: push-rpm-to-koji
       taskRef:
         resolver: "git"


### PR DESCRIPTION
## Describe your changes

We want to ensure the enterprise contract verification passes for the new RPM image before we import the RPMs to Koji.

## Relevant Jira
JIRA: [ROK-446](https://issues.redhat.com//browse/ROK-446)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)