### PR TITLE
docs(KFLUXSPRT-3346): Update add-fbc-contribution output with helpful note

### DIFF
--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -15,6 +15,9 @@ Task to create an internalrequest to add fbc contributions to index images
 | taskGitUrl                        | The url to the git repo where the release-service-catalog tasks to be used are stored     | No                      | -             |
 | taskGitRevision                   | The revision in the taskGitUrl repo to be used                                            | No                      | -             |
 
+## Changes in 4.0.3
+* The task now adds an extra note to its output message when fbc_opt_in is not set
+
 ## Changes in 4.0.2
 * The task now reads the `internalRequestServiceAccount` key from the ReleasePlanAdmission data field and passes it to
 the `internal-request` script, to set the SA that will be used to run IR's pipelinerun.

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "4.0.2"
+    app.kubernetes.io/version: "4.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -190,7 +190,8 @@ spec:
         if [ "$mustPublishIndexImage" = "true" ]; then
           echo "Index image will be published."
         elif [ "$fbc_opt_in" = "false" ]; then
-          echo "Index image will not be published because fbc_opt_in is set to false in Pyxis."
+          echo "Index image will not be published because fbc_opt_in of at least one referenced bundle"\
+               "image in the fragment is set to false in Pyxis."
           echo "If this is the first time you are releasing, make sure you request fbc_opt_in in Pyxis."
         elif [ "${staged_index}" = "true" ]; then
           echo "Index image will not be published because this is a staging release."


### PR DESCRIPTION
## Describe your changes

It came up that it's not clear, with this message, that multiple different bundle image references could potentially cause a hang-up when trying to add a fragment if only some of the bundle images in the fragment have fbc_opt_in set to true, while some do not.

## Relevant Jira

N/A

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

