### PR TITLE
fix: allow 2xx codes in curl-with-retry script

### DIFF
--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -15,11 +15,14 @@ Issues in other servers will be skipped without the task failing.
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 1.0.1
+* Bump the utils image to allow 201 and other 2xx codes in `curl-with-retry` script
 
 ## Changes in 1.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: close-advisory-issues
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -104,7 +104,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: close-issues
-      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
       env:
         - name: ACCESS_TOKEN
           valueFrom:

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-closing-issue.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-fail-getting-closed-id.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -24,6 +24,9 @@ based on the issues visibility
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.2
+* Bump the utils image to allow 201 and other 2xx codes in `curl-with-retry` script
+
 ## Changes in 2.1.1
 * Undo changes introduced in 2.0.3
   * Early failure prevents pasting of internal pipelineRun or taskRun

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "2.1.1"
+    app.kubernetes.io/version: "2.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -111,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
       env:
         - name: ACCESS_TOKEN
           valueFrom:
@@ -228,7 +228,7 @@ spec:
         fi
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Bump the utils image in embargo-check and close-advisory-issues to include a fix to allow 2xx codes as success.

This was brought up by a user who saw the task
fail because Jira returned 201.

Utils PR: https://github.com/konflux-ci/release-service-utils/pull/441

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

