### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -15,6 +15,9 @@ Task to create an internalrequest to add fbc contributions to index images
 | taskGitUrl                        | The url to the git repo where the release-service-catalog tasks to be used are stored     | No                      | -             |
 | taskGitRevision                   | The revision in the taskGitUrl repo to be used                                            | No                      | -             |
 
+## Changes in 4.2.0
+* Added compute resource limits
+
 ## Changes in 4.1.0
 * The task now supports snapshots with multi-components on it. In addition, image digests are now saved in a result file
   instead of the pipeline results, as they might eventually overflow if the image list is too long.

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "4.1.0"
+    app.kubernetes.io/version: "4.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -63,6 +63,12 @@ spec:
   steps:
     - name: add-contribution
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi  # was exiting with code 137 when set to 256Mi
+          cpu: 200m
       script: |
         #!/usr/bin/env bash
         #

--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -39,6 +39,9 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -110,6 +110,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: '1'
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/check-data-keys/README.md
+++ b/tasks/managed/check-data-keys/README.md
@@ -23,6 +23,9 @@ Currently, `releaseNotes`, and `cdn` are the only supported systems.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                                                                                                               |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                                                                                                               |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-data-keys
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -109,6 +109,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: check-data-keys
       image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi  # was exiting with code 137 when set to 32Mi
+          cpu: 10m
       args: ["$(params.systems[*])"]
       env:
         - name: "SCHEMA_FILE"

--- a/tasks/managed/cleanup-internal-requests/README.md
+++ b/tasks/managed/cleanup-internal-requests/README.md
@@ -7,3 +7,6 @@ Tekton task to delete internal requests associated with a pipelinerun
 | Name           | Description                                                                                                      | Optional | Default value |
 |----------------|------------------------------------------------------------------------------------------------------------------|----------|---------------|
 | pipelineRunUid | The uid of the current pipelineRun. It is only available at the pipeline level                                   | No       | -             |
+
+## Changes in 2.1.0
+* Added compute resource limits

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: cleanup-internal-requests
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -18,6 +18,12 @@ spec:
   steps:
     - name: cleanup-internal-requests
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 200m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -21,6 +21,9 @@ Issues in other servers will be skipped without the task failing.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.1
 * Bump the utils image to allow 201 and other 2xx codes in `curl-with-retry` script
 

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: close-advisory-issues
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -105,6 +105,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: close-issues
       image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 50m
       env:
         - name: ACCESS_TOKEN
           valueFrom:


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: add-fbc-contribution, apply-mapping, check-data-keys, cleanup-internal-requests, and close-advisory-issues.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

