### PR TITLE
feat(RELEASE-567): add compute resource limits to stepactions

### DIFF
--- a/stepactions/create-trusted-artifact-array/create-trusted-artifact-array.yaml
+++ b/stepactions/create-trusted-artifact-array/create-trusted-artifact-array.yaml
@@ -8,6 +8,12 @@ spec:
     This stepaction creates trusted artifacts. It does nothing if a .skip-trusted-artifacts file exists
     in root folder.
   image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+  computeResources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 128Mi
+      cpu: 250m
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME

--- a/stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+++ b/stepactions/create-trusted-artifact/create-trusted-artifact.yaml
@@ -8,6 +8,12 @@ spec:
     This stepaction creates a trusted artifact. It does nothing if a .skip-trusted-artifacts file exists
     in root folder.
   image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+  computeResources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 128Mi
+      cpu: 250m
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME

--- a/stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+++ b/stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
@@ -9,6 +9,12 @@ spec:
     "empty". Creating the Tekton result is something that Trusted Artifacts
     would perform when not disabled.
   image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+  computeResources:
+    limits:
+      memory: 32Mi
+    requests:
+      memory: 32Mi
+      cpu: 20m
   params:
     - name: ociStorage
       type: string

--- a/stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+++ b/stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
@@ -8,6 +8,12 @@ spec:
     This stepaction creates the file .skip-trusted-artifacts if the param ociStorage is
     "empty".
   image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+  computeResources:
+    limits:
+      memory: 32Mi
+    requests:
+      memory: 32Mi
+      cpu: 20m
   params:
     - name: ociStorage
       type: string

--- a/stepactions/use-trusted-artifact-array/use-trusted-artifact-array.yaml
+++ b/stepactions/use-trusted-artifact-array/use-trusted-artifact-array.yaml
@@ -7,6 +7,12 @@ spec:
   description: >-
     This stepaction extracts an array of Trusted Artifacts into a folder.
   image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+  computeResources:
+    limits:
+      memory: 32Mi
+    requests:
+      memory: 32Mi
+      cpu: 20m
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME

--- a/stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+++ b/stepactions/use-trusted-artifact/use-trusted-artifact.yaml
@@ -7,6 +7,12 @@ spec:
   description: >-
     This stepaction extracts a Trusted Artifact into a folder.
   image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+  computeResources:
+    limits:
+      memory: 32Mi
+    requests:
+      memory: 32Mi
+      cpu: 20m
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME


### PR DESCRIPTION
This commit adds compute resource limits to the stepactions defined in this repo. The goal of this is to reduce the resources required to start the pods used in them.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

