### PR TITLE
fix: amend additional properties in schema for releaseNotes issues

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -196,12 +196,13 @@
         },
         "issues": {
           "type": "object",
-          "additionalProperties": true,
+          "additionalProperties": false,
           "properties": {
             "fixed": {
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": true,
                 "properties": {
                   "id": {
                     "type": "string",


### PR DESCRIPTION
    This commit updates the schema file for the additionalProperties in
    releaseNotes.issues. Additional properties were changed to be allowed in
    issues in PR 934 to enable the summary key. The setting actually should
    have been switched in the items of the fixed array inside issues
    instead. This remedies that.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

