### PR TITLE
fix(KFLUXSPRT-3442): remove fbcfragment

### DIFF
--- a/pipelines/managed/fbc-release/README.md
+++ b/pipelines/managed/fbc-release/README.md
@@ -20,6 +20,9 @@ Tekton release pipeline to interact with FBC Pipeline
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                                      | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                             | No       | -                                                         |
 
+## Changes in 4.7.0
+* use snapshotPath as input parameter to `get-ocp-version` now
+
 ## Changes in 4.6.0
 * Add new `fbcResultsPath` parameter for `sign-index-image`. This is to support multicomponent releases
 

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: fbc-release
   labels:
-    app.kubernetes.io/version: "4.6.0"
+    app.kubernetes.io/version: "4.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -220,8 +220,11 @@ spec:
           - name: pathInRepo
             value: tasks/managed/get-ocp-version/get-ocp-version.yaml
       params:
-        - name: fbcFragment
-          value: "$(tasks.collect-data.results.fbcFragment)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
     - name: update-ocp-tag

--- a/tasks/managed/collect-data/README.md
+++ b/tasks/managed/collect-data/README.md
@@ -10,8 +10,7 @@ This task also stores the passed resources as json files in a workspace.
 The parameters to this task are lowercase instead of camelCase because they are passed from the operator, and the
 operator passes them as lowercase.
 
-A task result is returned for each resource with the relative path to the stored JSON for it in the workspace. There is
-also a task result for the fbcFragment extracted from the snapshot's first component.
+A task result is returned for each resource with the relative path to the stored JSON for it in the workspace.
 
 Finally, the task checks that the keys from the correct resource (a key that should come from the ReleasePlanAdmission
 should not be present in the Release data section).
@@ -34,6 +33,11 @@ should not be present in the Release data section).
 | dataDir                 | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path)                                   |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | Yes       | production                                                |
+
+## Changes in 6.2.0
+* No longer collect and emit the result `fbcFragment`
+* This has been delegated to the task that requires it.
+* This help reduces the occurence of https://github.com/tektoncd/pipeline/issues/4808
 
 ## Changes in 6.1.0
 * Add the new `releaseNotes.allow_custom_live_id` field to disallowed keys for

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "6.1.0"
+    app.kubernetes.io/version: "6.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -78,9 +78,6 @@ spec:
     - name: snapshotSpec
       type: string
       description: The relative path in the workspace to the stored snapshotSpec json
-    - name: fbcFragment
-      type: string
-      description: The first component's containerImage in the snapshot to use in the fbc pipelines
     - name: data
       type: string
       description: The relative path in the workspace to the stored data json
@@ -186,10 +183,6 @@ spec:
         SNAPSHOTSPEC_PATH="$(params.subdirectory)/snapshot_spec.json"
         echo -n "$SNAPSHOTSPEC_PATH" > "$(results.snapshotSpec.path)"
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" | tee "$(params.dataDir)/$SNAPSHOTSPEC_PATH"
-
-        echo -e "\nFetching fbcFragment"
-        jq -cr '.components[0].containerImage' < "$(params.dataDir)/$SNAPSHOTSPEC_PATH" | tr -d "\n" \
-          | tee "$(results.fbcFragment.path)"
 
         echo -e "\nGenerating collectors data"
         collectors_status=$(get-resource "release" "${RELEASE}" "{.status.collectors}")

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -170,8 +170,6 @@ spec:
           value: $(tasks.run-task.results.releaseServiceConfig)
         - name: snapshotSpec
           value: $(tasks.run-task.results.snapshotSpec)
-        - name: fbcFragment
-          value: $(tasks.run-task.results.fbcFragment)
         - name: singleComponentMode
           value: $(tasks.run-task.results.singleComponentMode)
         - name: snapshotName
@@ -202,8 +200,6 @@ spec:
           - name: releaseServiceConfig
             type: string
           - name: snapshotSpec
-            type: string
-          - name: fbcFragment
             type: string
           - name: singleComponentMode
             type: string
@@ -275,9 +271,6 @@ spec:
 
               echo Test that Snapshot spec was saved to workspace
               test "$(jq -r '.application' < "$(params.dataDir)/$(params.snapshotSpec)")" == foo
-
-              echo Test the fbcFragment result was properly set
-              test "$(params.fbcFragment)" == "newimage"
 
               echo Test that the snapshotName result was properly set
               test "$(params.snapshotName)" == "snapshot-sample"

--- a/tasks/managed/get-ocp-version/README.md
+++ b/tasks/managed/get-ocp-version/README.md
@@ -4,10 +4,12 @@ Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
 
 ## Parameters
 
-| Name        | Description           | Optional | Default value |
-|-------------|-----------------------|----------|---------------|
-| fbcFragment | A FBC container Image | No       | -             |
+| Name          | Description                                                                | Optional | Default value |
+|---------------|----------------------------------------------------------------------------|----------|---------------|
+| snapshotPath  | Path to the JSON string of the mapped Snapshot spec in the data workspace  | No       | -             | 
 
+## Changes in 1.0.0
+* Using new parameter, snapshotPath, obtain the fbcFragment directly.
 
 ## Changes in 0.5.2
 * Bump the utils image used in this task

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-ocp-version
   labels:
-    app.kubernetes.io/version: "0.5.2"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -12,21 +12,31 @@ spec:
   description: >-
     Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`
   params:
-    - name: fbcFragment
-      description: An FBC image to inspect
+    - name: snapshotPath
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
       type: string
   results:
     - name: stored-version
       type: string
       description: Store OCP version number from given Image
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot is stored.
   steps:
     - name: get-ocp-version
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       script: |
         #!/usr/bin/env bash
         set -eux
+        
+        SNAPSHOT_SPEC_FILE="$(workspaces.data.path)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "Error: No valid snapshot file was provided."
+            exit 1
+        fi
 
-        fbc_fragment="$(params.fbcFragment)"
+        echo -e "\nFetching fbcFragment"
+        fbc_fragment="$(jq -r '.components[0].containerImage' < "${SNAPSHOT_SPEC_FILE}" | tr -d "\n")"
 
         # get image metadata
         image_metadata=$(skopeo inspect --raw "docker://${fbc_fragment}")

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -10,12 +10,43 @@ spec:
   workspaces:
     - name: tests-workspace
   tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-snapshot
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "quay.io/fbc/multi-arch@sha256:index"
+                  }
+                ]
+              }
+              EOF
+
     - name: run-task
       taskRef:
         name: get-ocp-version
       params:
-        - name: fbcFragment
-          value: quay.io/fbc/multi-arch@sha256:index
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
     - name: check-result
       params:
         - name: stored-version

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -10,13 +10,43 @@ spec:
   workspaces:
     - name: tests-workspace
   tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-snapshot
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297"
+                  }
+                ]
+              }
+              EOF
+
     - name: run-task
       taskRef:
         name: get-ocp-version
       params:
-        - name: fbcFragment
-          value: >-
-            quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297
+        - name: snapshotPath
+          value: snapshot.json
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
     - name: check-result
       params:
         - name: stored-version


### PR DESCRIPTION
## Describe your changes
- remove fbcFragment from collect-data
- it can potentially add a significantly large result value since it is made up of namespace, application and component names, all of which be quite long.
- Without this, we risk hitting:
  - https://github.com/tektoncd/pipeline/issues/4808

- We ensure now that `get-ocp-version` is able to obtain fbcFragment is the same manner itself.

- Related Tekton bug: https://issues.redhat.com/browse/SRVKP-7717

## Relevant Jira
- [KFLUXSPRT-3442](https://issues.redhat.com//browse/KFLUXSPRT-3442)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

