### PR TITLE
test: update check-data-keys test to include issues key

### DIFF
--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -96,7 +96,8 @@ spec:
                     "fixed": [
                       {
                         "id": "RHOSP-12345",
-                        "source": "issues.example.com"
+                        "source": "issues.example.com",
+                        "summary": "some text about the issue"
                       },
                       {
                         "id": "1234567",


### PR DESCRIPTION
    This commit updates one of the unit tests for check-data-keys to include
    the summary key inside a releaseNotes.issue. This is possible in a
    Release CR so we want to make sure the task allows it.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

