### PR TITLE
test: cleanup tasks IR CRD update

### DIFF
--- a/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
@@ -29,7 +29,12 @@ spec:
               metadata:
                 name: ir-1
               spec:
-                request: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                    - name: name
+                      value: sample
               ---
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: InternalRequest
@@ -38,7 +43,12 @@ spec:
                 labels:
                   internal-services.appstudio.openshift.io/pipelinerun-uid: "$(params.uid)"
               spec:
-                request: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                    - name: name
+                      value: sample
               EOF
               kubectl apply -f irs
     - name: run-task

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -31,7 +31,12 @@ spec:
               metadata:
                 name: ir-1
               spec:
-                request: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                    - name: name
+                      value: sample
               ---
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: InternalRequest
@@ -40,7 +45,12 @@ spec:
                 labels:
                   internal-services.appstudio.openshift.io/pipelinerun-uid: "$(params.uid)"
               spec:
-                request: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                    - name: name
+                      value: sample
               EOF
               kubectl apply -f irs
     - name: run-task


### PR DESCRIPTION
This commit modifies the example internalRequests in the cleanup-internal-requests and cleanup-workspace tests as spec.request no longer exists.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

