### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/populate-release-notes/README.md
+++ b/tasks/managed/populate-release-notes/README.md
@@ -20,6 +20,9 @@ the releaseNotes data can use it.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 5.1.0
+* Added compute resource limits
+
 ## Changes in 5.0.0
 * This task no longer generates data for SBOM purposes.
   * The `sbomDataPath` result is removed.

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: populate-release-notes
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -107,6 +107,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: populate-release-notes-images
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: '1'
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -201,6 +207,12 @@ spec:
         done
     - name: populate-release-notes-binaries
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -277,6 +289,12 @@ spec:
 
     - name: populate-release-notes-type-and-references
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/publish-pyxis-repository/README.md
+++ b/tasks/managed/publish-pyxis-repository/README.md
@@ -43,6 +43,9 @@ shouldn't cause any problems, because RHEC will ignore repos with no published i
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 4.1.0
+* Added compute resource limits
+
 ## Changes in 4.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-pyxis-repository
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -129,6 +129,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: publish-pyxis-repository
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 300m
       env:
         - name: PYXIS_CERT
           valueFrom:

--- a/tasks/managed/reduce-snapshot/README.md
+++ b/tasks/managed/reduce-snapshot/README.md
@@ -20,5 +20,8 @@ Tekton task to reduce a snapshot to a single component based on the component th
 | taskGitUrl                          | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | Yes        | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                     | The revision in the taskGitUrl repo to be used                                                                             | Yes        | production                                                |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: reduce-snapshot
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -124,6 +124,12 @@ spec:
         - name: SNAPSHOT_PATH
           value: $(params.SNAPSHOT_PATH)
       image: quay.io/enterprise-contract/ec-cli@sha256:913c7dac3d41877b01835d2e55bcd970c6cdbf4944f8176e9e3de9548642a2b4
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       command: [reduce-snapshot.sh]
       onError: continue  # progress even if the step fails
     - name: create-trusted-artifact

--- a/tasks/managed/upload-sbom-to-atlas/README.md
+++ b/tasks/managed/upload-sbom-to-atlas/README.md
@@ -33,6 +33,9 @@ lower, they are uploaded as-is.
 | taskGitUrl                | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                                                                            |
 | taskGitRevision           | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                                                                            |
 
+## Changes in 2.2.0
+* Added compute resource limits
+
 ## Changes in 2.1.0
 * Deprecate the Atlas v1 API in favor of v2.
 * A param `bombasticApiUrl` was renamed to `atlasApiUrl`.

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: upload-sbom-to-atlas
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -153,6 +153,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: gather-sboms
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -o errexit -o pipefail -o nounset
@@ -234,6 +240,12 @@ spec:
     # Needs syft, which is in a different image => has to be a separate step
     - name: convert-sboms-if-needed
       image: quay.io/konflux-ci/release-service-utils:80a575e7e12d32f866a6105827804f2f122cea73
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -o errexit -o pipefail -o nounset
@@ -266,6 +278,12 @@ spec:
 
     - name: upload-sboms
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       volumeMounts:
         - name: atlas-secret
           mountPath: /secrets/
@@ -351,6 +369,12 @@ spec:
 
     - name: push-to-s3
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       volumeMounts:
         - name: aws-secret
           mountPath: /secrets

--- a/tasks/managed/verify-access-to-resources/README.md
+++ b/tasks/managed/verify-access-to-resources/README.md
@@ -13,6 +13,9 @@ This Tekton task is used to verify access to various resources in the pipelines.
 | snapshot                | Namespace/name of the Snapshot                          | No       | -             |
 | requireInternalServices | Whether to check if internal requests can be created    | Yes      | false         |
 
+## Changes in 0.4.0
+* Added compute resource limits
+
 ## Changes in 0.3.1
 * Fix shellcheck/checkton linting issues in the task
 

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: verify-access-to-resources
   labels:
-    app.kubernetes.io/version: "0.3.1"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,12 @@ spec:
   steps:
     - name: verify-access-to-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
           #!/usr/bin/env bash
 


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: populate-release-notes, publish-pyxis-repository, reduce-snapshot, upload-sbom-to-atlas, and verify-access-to-resources. The goal is to reduce the amount of resources tasks use.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

