### PR TITLE
feat(KONFLUX-8347): ensure correct advisory URL for stage releases

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -17,6 +17,10 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 2.0.1
+*  Updated the `ADVISORY_URL_PREFIX` logic to select either `https://access.redhat.com/errata` or 
+  `https://access.stage.redhat.com/errata` based on the Git repository's org.
+
 ## Changes in 2.0.0
 * Add support for generic content type advisories
 

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -141,7 +141,11 @@ spec:
           REPO_BRANCH=main
           ADVISORY_URL=""
           ADVISORY_INTERNAL_URL=""
-          ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
+          if [[ "${GIT_REPO}" == *"/rhtap-release/"* ]]; then
+            ADVISORY_URL_PREFIX="https://access.stage.redhat.com/errata"
+          else
+            ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
+          fi
 
           # Switch to /tmp to avoid filesystem permission issues
           cd /tmp

--- a/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
@@ -9,5 +9,8 @@ yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 kubectl delete secret create-advisory-secret --ignore-not-found
 kubectl create secret generic create-advisory-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/org/repo.git
 
+kubectl delete secret create-stage-advisory-secret --ignore-not-found
+kubectl create secret generic create-stage-advisory-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/rhtap-release/repo.git
+
 kubectl delete secret create-advisory-errata-secret --ignore-not-found
 kubectl create secret generic create-advisory-errata-secret --from-literal=errata_api=https://errata/api/v1 --from-literal=name=errata-tester --from-literal=base64_keytab=Zm9vCg==

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-stage
+spec:
+  description: |
+    Run the create-advisory task and check that the advisory URL is pointing to the staging Errata 
+    when the Git org is 'rhtap-release'. The result should be emitted as a task result.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: create-advisory-task
+      params:
+        - name: advisory_json
+          value: >-
+            {"product_id":123,"product_name":"Red Hat Product","product_version":"1.2.3","product_stream":"tp1",
+            "cpe":"cpe:/a:example:product:el8","type":"RHSA","synopsis":"test synopsis","topic":"test topic",
+            "description":"test description","solution":"test solution","references":["https://docs.example.com/notes"],
+            "content":{"images":[{"containerImage":"quay.io/example/openstack@sha256:abdeNEW",
+            "repository":"rhosp16-rhel8/openstack","tags":["latest"],"architecture":"amd64",
+            "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+            "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}}]}}
+        - name: application
+          value: "test-app"
+        - name: origin
+          value: "not-existing-origin"
+        - name: config_map_name
+          value: "create-advisory-test-cm"
+        - name: advisory_secret_name
+          value: "create-stage-advisory-secret"
+        - name: errata_secret_name
+          value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: advisory_url
+          value: $(tasks.run-task.results.advisory_url)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: advisory_url
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that result is Success
+              test "$(params.result)" == Success
+
+              echo Test that advisory_url was properly set
+              test "$(params.advisory_url)" == \
+                https://access.stage.redhat.com/errata/RHSA-2024:1234


### PR DESCRIPTION
## Describe your changes
Updated the ADVISORY_URL_PREFIX logic to select either https://access.redhat.com/errata or https://access.stage.redhat.com/errata depending on the Git org.

## Relevant Jira
https://issues.redhat.com/browse/KONFLUX-8347

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

