### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/check-fbc-packages/README.md
+++ b/tasks/managed/check-fbc-packages/README.md
@@ -9,6 +9,9 @@ Task to check that the packages being shipped in an fbc contribution are in the 
 | snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -             |
 | dataPath       | Path to the JSON string of the merged data to use in the data workspace   | No       | -             |
 
+## Changes in 0.5.0
+* Added compute resource limits
+
 ## Changes in 0.4.1
 * fix linting issues in check-fbc-package task
 

--- a/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-fbc-packages
   labels:
-    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,6 +24,12 @@ spec:
   steps:
     - name: check-contribution
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi  # OOMKilled at 256
+          cpu: 500m
       script: |
         #!/usr/bin/env bash
         #

--- a/tasks/managed/cleanup-workspace/README.md
+++ b/tasks/managed/cleanup-workspace/README.md
@@ -10,6 +10,9 @@ Tekton task to delete a given directory in a passed workspace and cleanup Intern
 | delay          | Time in seconds to delay execution. Needed to allow other finally tasks to access workspace before being deleted | Yes      | 60            |
 | pipelineRunUid | The uid of the current pipelineRun. It is only available at the pipeline level                                   | Yes      | ""            |
 
+## Changes in 0.9.0
+* Added compute resource limits
+
 ## Changes in 0.8.2
 * Fix error if internalrequests are not installed on cluster
 

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: cleanup-workspace
   labels:
-    app.kubernetes.io/version: "0.8.2"
+    app.kubernetes.io/version: "0.9.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,6 +29,12 @@ spec:
   steps:
     - name: cleanup
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 60m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/collect-data/README.md
+++ b/tasks/managed/collect-data/README.md
@@ -34,6 +34,9 @@ should not be present in the Release data section).
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | Yes       | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | Yes       | production                                                |
 
+## Changes in 6.3.0
+* Added compute resource limits
+
 ## Changes in 6.2.0
 * No longer collect and emit the result `fbcFragment`
 * This has been delegated to the task that requires it.

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: collect-data
   labels:
-    app.kubernetes.io/version: "6.2.0"
+    app.kubernetes.io/version: "6.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -134,6 +134,12 @@ spec:
           value: $(params.dataDir)
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 10m
       env:
         - name: "RELEASE"
           value: '$(params.release)'
@@ -285,6 +291,12 @@ spec:
 
     - name: check-data-key-sources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/push-rpm-data-to-pyxis/README.md
+++ b/tasks/managed/push-rpm-data-to-pyxis/README.md
@@ -22,6 +22,9 @@ all repository_id strings found in rpm purl strings in the sboms.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 3.1.0
+* Added compute resource limits
+
 ## Changes in 3.0.0
 * Remove the `sbomPath` result.
 

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -121,6 +121,12 @@ spec:
     - name: download-sbom-files
       image:
         quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 500m
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -178,6 +184,12 @@ spec:
     - name: push-rpm-data-to-pyxis
       image:
         quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: '1'
       env:
         - name: PYXIS_CERT
           valueFrom:

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -31,6 +31,9 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 4.4.0
+* Added compute resource limits
+
 ## Changes in 4.3.0
 * Add support for multicomponent releases
   * The new mandatory task parameter `fbcResultsPath` points to a file with images and manifest digests to sign

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "4.3.0"
+    app.kubernetes.io/version: "4.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -57,6 +57,12 @@ spec:
   steps:
     - name: sign-index-image
       image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -ex


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: check-fbc-packages, cleanup-workspace, collect-data, push-rpm-data-to-pyxis, and sign-index-image. The goal is to reduce the amount of resources task use.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

