### PR TITLE
fix(KONFLUX-7489): do not fail if we cannot close an issue

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,11 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.1.1
+* Remove snippet to allow `close-advisory-issues` to fail
+  * This was added temporarily in 2.0.1
+  * We no longer need it since the task no longer fails if it cannot close an issue
+
 ## Changes in 2.1.0
 * Add new task `filter-already-released-advisory-images` to filter out images that have already been released in advisories
   * Task is placed after `apply-mapping` and before `verify-conforma`

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -1130,7 +1130,6 @@ spec:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
           operator: in
           values: ["false"]
-      onError: continue  # until https://issues.redhat.com/browse/KONFLUX-7489 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"

--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -21,6 +21,11 @@ Issues in other servers will be skipped without the task failing.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 1.2.0
+* Change the logic to pass the task even if we cannot close an issue
+  * In some cases we do not have the permissions to close a Jira
+  * If we cannot close it, we at least try to add a comment
+
 ## Changes in 1.1.0
 * Added compute resource limits
 

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: close-advisory-issues
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -144,8 +144,6 @@ spec:
             exit 1
         fi
 
-        RC=0
-
         NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
         for ((i = 0; i < NUM_ISSUES; i++)); do
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
@@ -170,25 +168,31 @@ spec:
             fi
 
             echo "Closing issue $issue"
+            CLOSE_COMMENT="Fixed in Konflux Advisory $(params.advisoryUrl)"
+            CLOSING_RC=0
             # Get the Closed transition id. This varies per Jira project
             if ! CLOSED_ID="$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}/transitions" \
-              | jq -r '.transitions[] | select(.name=="Closed") | .id')"; then
-                echo "Error: failed to fetch the closed state id for issue $issue."
-                RC=1
-                continue
-            fi
-
+              | jq -er '.transitions[] | select(.name=="Closed") | .id')"; then
+                echo "Warning: failed to fetch the closed state id for issue $issue. We most likely do not have" \
+                  "permission to close it. Will try to add a comment instead."
+                CLOSING_RC=1
             # Close the issue
-            CLOSE_COMMENT="Fixed in Konflux Advisory $(params.advisoryUrl)"
-            if ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
+            elif ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
               '{"transition":{"id":"'"$CLOSED_ID"'"},"update":{"comment":[{"add":{"body":"'"$CLOSE_COMMENT"'"}}]}}' \
               -H "Content-Type: application/json" "${API_URL}/transitions"; then
-                echo "Error: failed to close issue $issue."
-                RC=1
+                echo "Warning: failed to close issue $issue. Will try to add a comment instead."
+                CLOSING_RC=1
+            fi
+
+            if [ "$CLOSING_RC" -ne 0 ] ; then
+                # Try to add the comment even if closing failed
+                if ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
+                  '{"body":"'"$CLOSE_COMMENT"'"}' \
+                  -H "Content-Type: application/json" "${API_URL}/comment"; then
+                    echo "Warning: failed to add comment to issue $issue."
+                fi
             fi
         done
-
-        exit $RC
     - name: create-trusted-artifact
       ref:
         resolver: "git"

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -11,16 +11,25 @@ function curl-with-retry() {
     :
   elif [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
   then
-    exit 1
+    return 1
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  then
+    echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
   elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
   then
     echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
   elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/transitions" ]]
   then
-    exit 1
+    echo '{"expand":"transitions","transitions":[]}'
   elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/CLOSED-987" ]]
   then
     echo '{"fields":{"status":{"name":"Closed","id":"99"}}}'
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/comment" ]]
+  then
+    echo '{}'
+  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/comment" ]]
+  then
+    echo '{}'
   else
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -2,13 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-fail-getting-closed-id
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-close-advisory-issues-cannot-close-issue
 spec:
   description: |
-    Test for close-advisory-issues where the curl command to get the id of the Closed
-    transition state fails. This is done with the mocks because of the issue id
+    Test for close-advisory-issues where the curl command to close the issue fails. This is
+    done with the mocks because of the issue id. The task will add a comment to the Jira and
+    succeed.
   workspaces:
     - name: tests-workspace
   params:
@@ -70,7 +69,7 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "NOCLOSE-555",
+                        "id": "FAIL-999",
                         "source": "issues.redhat.com"
                       },
                       {

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -2,13 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-fail-closing-issue
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-close-advisory-issues-cannot-get-transitions
 spec:
   description: |
-    Test for close-advisory-issues where the curl command to close the issue fails. This is
-    done with the mocks because of the issue id
+    Test for close-advisory-issues where the curl command to get the id of the Closed
+    transition state returns an empty transitions array. This is done with the mocks because of the issue id.
+    This can happen if we don't have the permissions to close the issue.
+    The task will add a comment to the Jira and succeed.
   workspaces:
     - name: tests-workspace
   params:
@@ -70,7 +70,7 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "FAIL-999",
+                        "id": "NOCLOSE-555",
                         "source": "issues.redhat.com"
                       },
                       {


### PR DESCRIPTION
## Describe your changes

* change the rh-advisories pipeline to not allow close-advisory-issues to fail
* change close-advisory-issues so that it does not fail if it cannot get the transition id to close an issue or if closing the issue fails. If one of these fails, we will at least try to add a comment. But even if we cannot add the comment, we will not fail.

## Relevant Jira

[KONFLUX-7489](https://issues.redhat.com//browse/KONFLUX-7489)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

