### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -24,6 +24,9 @@ based on the issues visibility
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.2.0
+* Added compute resource limits
+
 ## Changes in 2.1.2
 * Bump the utils image to allow 201 and other 2xx codes in `curl-with-retry` script
 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: embargo-check
   labels:
-    app.kubernetes.io/version: "2.1.2"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -112,6 +112,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: check-issues
       image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 50m
       env:
         - name: ACCESS_TOKEN
           valueFrom:
@@ -229,6 +235,12 @@ spec:
         exit $RC
     - name: check-cves
       image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 100m
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/managed/publish-index-image/README.md
+++ b/tasks/managed/publish-index-image/README.md
@@ -22,6 +22,9 @@ Publish a built FBC index image using skopeo
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 5.1.0
+* Added compute resource limits
+
 ## Changes in 5.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-index-image
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -123,6 +123,12 @@ spec:
     - name: publish-index-image
       image: >-
         quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 200m
       script: |
         #!/usr/bin/env bash
         set -e

--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -22,6 +22,9 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 7.2.0
+* Added compute resource limits
+
 ## Changes in 7.1.0
 * Increase default number of retries from 0 to 3.
 

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "7.1.0"
+    app.kubernetes.io/version: "7.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -129,6 +129,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
       image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: '2'
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/rh-sign-image-cosign/README.md
+++ b/tasks/managed/rh-sign-image-cosign/README.md
@@ -20,6 +20,9 @@ Tekton task to sign container images in snapshot by cosign.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                             | No        | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                    | No        | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image-cosign
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,6 +116,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: sign-image
       image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
+          cpu: '2'
       env:
         - name: AWS_DEFAULT_REGION
           valueFrom:

--- a/tasks/managed/validate-single-component/README.md
+++ b/tasks/managed/validate-single-component/README.md
@@ -9,6 +9,9 @@ single component. The task will fail otherwise.
 |--------------|--------------------------------------------------------------------|----------|---------------|
 | snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace | No       | -             |
 
+## Changes in 0.6.0
+* Added compute resource limits
+
 ## Changes in 0.5.0
 * Updated the base image used in this task
 

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: validate-single-component
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,12 @@ spec:
   steps:
     - name: validate-single-component
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
       script: |
         #!/usr/bin/env sh
         set -eux


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: embargo-check, publish-index-image, push-snapshot, rh-sign-image-cosign, and validate-single-component. The goal is to reduce the amount of resources tasks use.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

