### PR TITLE
chore: disable Mintmaker/Renovate on staging branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "ignoreBranches": ["staging"]
+}


### PR DESCRIPTION
## Describe your changes

When we needed to set up periodic e2e runs for the catalog staging branch, the staging branch was onboarded to Konflux as a new component. Because of that, we now also get Mintmaker PRs for that branch. But those are duplicate PRs, because we already get those for the development branch and every Wednesday all the changes from development are pushed to staging as part of our branch promotion process.

So let's add a renovate config to ignore the staging branch.

Note: This will likely only make a difference once this change gets promoted to staging.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

