### PR TITLE
fix(KFLUXSPRT-3481): adjust verify-ec timeouts

### DIFF
--- a/pipelines/managed/push-to-external-registry/README.md
+++ b/pipelines/managed/push-to-external-registry/README.md
@@ -13,12 +13,20 @@ Tekton pipeline to release Snapshots to an external registry.
 | snapshot                        | The namespaced name (namespace/name) of the snapshot                                                                               | No       | -                                                         |
 | enterpriseContractPolicy        | JSON representation of the policy to be applied when validating the enterprise contract                                            | No       | -                                                         |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 40m0s                                                     |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 8h0m0s                                                    |
+| enterpriseContractWorkerCount   | Number of parallel workers to use for policy evaluation.                                                                           | Yes      | 4                                                         |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                                                         | Yes      | true                                                      |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                                          | No       | -                                                         |
 | verify_ec_task_git_revision     | The git revision to be used when consuming the verify-conforma task                                                                | No       | -                                                         |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
+
+## Changes in 5.7.0
+* Set timeout for verify-enterprise-contract task to be 4 hours.
+* Increase enterpriseContractTimeout to a large value, 8 hours.
+    * Users don't have control over this, so set it to a large value so that the pipeline timeout will kick in first,
+      if anything.
+* Add optional parameter enterpriseContractWorkerCount with default of 4
 
 ## Changes in 5.6.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.6.0"
+    app.kubernetes.io/version: "5.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,11 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 40m0s
+      default: 8h0m0s
+    - name: enterpriseContractWorkerCount
+      type: string
+      description: Number of parallel workers for policy evaluation
+      default: 4
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -200,6 +204,7 @@ spec:
       runAfter:
         - reduce-snapshot
     - name: verify-enterprise-contract
+      timeout: "4h"
       taskRef:
         resolver: "bundles"
         params:
@@ -224,6 +229,8 @@ spec:
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT
           value: $(params.enterpriseContractTimeout)
+        - name: WORKERS
+          value: $(params.enterpriseContractWorkerCount)
       workspaces:
         - name: data
           workspace: release-workspace

--- a/pipelines/managed/rh-push-to-external-registry/README.md
+++ b/pipelines/managed/rh-push-to-external-registry/README.md
@@ -13,12 +13,20 @@ Tekton pipeline to release Red Hat Snapshots to an external registry. This pipel
 | snapshot                        | The namespaced name (namespace/name) of the snapshot                                                                               | No       | -                                                         |
 | enterpriseContractPolicy        | JSON representation of the policy to be applied when validating the enterprise contract                                            | No       | -                                                         |
 | enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
-| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 40m0s                                                     |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 8h0m0s                                                    |
+| enterpriseContractWorkerCount   | Number of parallel workers to use for policy evaluation.                                                                           | Yes      | 4                                                         |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                                                         | Yes      | true                                                      |
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                                          | No       | -                                                         |
 | verify_ec_task_git_revision     | The git revision to be used when consuming the verify-conforma task                                                                | No       | -                                                         |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
+
+## Changes in 5.8.0
+* Set timeout for verify-enterprise-contract task to be 4 hours.
+* Increase enterpriseContractTimeout to a large value, 8 hours.
+  * Users don't have control over this, so set it to a large value so that the pipeline timeout will kick in first,
+    if anything.
+* Add optional parameter enterpriseContractWorkerCount with default of 4
 
 ## Changes in 5.7.0
 * Update all tasks that now support trusted artifacts to specify the taskGit* parameters for the step action resolvers

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-push-to-external-registry
   labels:
-    app.kubernetes.io/version: "5.7.0"
+    app.kubernetes.io/version: "5.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -40,7 +40,11 @@ spec:
     - name: enterpriseContractTimeout
       type: string
       description: Timeout setting for `ec validate`
-      default: 40m0s
+      default: 8h0m0s
+    - name: enterpriseContractWorkerCount
+      type: string
+      description: Number of parallel workers for policy evaluation
+      default: 4
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline
@@ -201,6 +205,7 @@ spec:
       runAfter:
         - reduce-snapshot
     - name: verify-enterprise-contract
+      timeout: "4h"
       taskRef:
         resolver: "bundles"
         params:
@@ -225,6 +230,8 @@ spec:
           value: $(params.enterpriseContractExtraRuleData)
         - name: TIMEOUT
           value: $(params.enterpriseContractTimeout)
+        - name: WORKERS
+          value: $(params.enterpriseContractWorkerCount)
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
## Describe your changes
- Set timeout for verify-enterprise-contract task to be 4 hours.
- Increase enterpriseContractTimeout to a large value, 8 hours.
  - Users don't have control over this, so set it to a large value so that the pipeline timeout will kick in first, if anything.
- Add optional parameter enterpriseContractWorkerCount with default of 4

## Relevant Jira
- [KFLUXSPRT-3481](https://issues.redhat.com//browse/KFLUXSPRT-3481)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

