### PR TITLE
feat(RELEASE-1562): skip certain steps when pushing binaries

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -4,30 +4,35 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 
 ## Parameters
 
-| Name                  | Description                                                       | Optional | Default value                                            |
-|-----------------------|-------------------------------------------------------------------|----------|----------------------------------------------------------|
-| snapshot_json         | String containing a JSON representation of the snapshot spec      | No       | -                                                        |
-| concurrentLimit       | The maximum number of images to be pulled at once                 | Yes      | 3                                                        |
-| author                | Author taken from Release to be used for checksum signing         | No       | -                                                        |
-| signingKeyName        | Signing key name to be used for checksum signing                  | No       | -                                                        |
-| quayUrl               | quay URL of the repo where content will be shared                 | Yes      | quay.io/konflux-artifacts                                |
-| quaySecret            | Secret to interact with Quay                                      | Yes      | quay-credentials                                         |
-| windowsCredentials    | Secret to interact with the Windows signing host                  | Yes      | windows-credentials                                      |
-| windowsSSHKey         | Secret containing SSH private key for the Windows signing host    | Yes      | windows-ssh-key                                          |
-| macHostCredentials    | Secret to interact with the Mac signing host                      | Yes      | mac-host-credentials                                     |
-| macSigningCredentials | Secret to interact with the Mac signing utils                     | Yes      | mac-signing-credentials                                  |
-| macSSHKey             | Secret containing SSH private key for the Mac signing host        | Yes      | mac-ssh-key                                              |
-| checksumUser          | User to interact with the checksum host                           | Yes      | konflux-release-signing-sa                               |
-| checksumHost          | Hostname of the checksum host                                     | Yes      | etera-worker.hosted.upshift.rdu2.redhat.com              |
-| checksumFingerprint   | Secret containing the fingerprint for the checksum host           | Yes      | checksum-fingerprint                                     |
-| checksumKeytab        | Secret containing the keytab for the checksum host                | Yes      | checksum-keytab                                          |
-| kerberosRealm         | Kerberos realm for the checksum host                              | Yes      | IPA.REDHAT.COM                                           |
-| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs         | No       | -                                                        |
-| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                                        |
-| pulpSecret            | Env specific secret containing the rhsm-pulp credentials          | No       | -                                                        |
-| udcacheSecret         | Env specific secret containing the udcache credentials            | No       | -                                                        |
-| cgwHostname           | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
-| cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                                        |
+| Name                  | Description                                                           | Optional | Default value                                            |
+|-----------------------|-----------------------------------------------------------------------|----------|----------------------------------------------------------|
+| snapshot_json         | String containing a JSON representation of the snapshot spec          | No       | -                                                        |
+| concurrentLimit       | The maximum number of images to be pulled at once                     | Yes      | 3                                                        |
+| author                | Author taken from Release to be used for checksum signing             | No       | -                                                        |
+| signingKeyName        | Signing key name to be used for checksum signing                      | No       | -                                                        |
+| quayUrl               | quay URL of the repo where content will be shared                     | Yes      | quay.io/konflux-artifacts                                |
+| quaySecret            | Secret to interact with Quay                                          | Yes      | quay-credentials                                         |
+| windowsCredentials    | Secret to interact with the Windows signing host                      | Yes      | windows-credentials                                      |
+| windowsSSHKey         | Secret containing SSH private key for the Windows signing host        | Yes      | windows-ssh-key                                          |
+| macHostCredentials    | Secret to interact with the Mac signing host                          | Yes      | mac-host-credentials                                     |
+| macSigningCredentials | Secret to interact with the Mac signing utils                         | Yes      | mac-signing-credentials                                  |
+| macSSHKey             | Secret containing SSH private key for the Mac signing host            | Yes      | mac-ssh-key                                              |
+| checksumUser          | User to interact with the checksum host                               | Yes      | konflux-release-signing-sa                               |
+| checksumHost          | Hostname of the checksum host                                         | Yes      | etera-worker.hosted.upshift.rdu2.redhat.com              |
+| checksumFingerprint   | Secret containing the fingerprint for the checksum host               | Yes      | checksum-fingerprint                                     |
+| checksumKeytab        | Secret containing the keytab for the checksum host                    | Yes      | checksum-keytab                                          |
+| kerberosRealm         | Kerberos realm for the checksum host                                  | Yes      | IPA.REDHAT.COM                                           |
+| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs             | No       | -                                                        |
+| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre]     | No       | -                                                        |
+| pulpSecret            | Env specific secret containing the rhsm-pulp credentials              | No       | -                                                        |
+| udcacheSecret         | Env specific secret containing the udcache credentials                | No       | -                                                        |
+| cgwHostname           | The hostname of the content-gateway to publish the metadata to        | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
+| cgwSecret             | Env specific secret containing the content gateway credentials        | No       | -                                                        |
+
+## Changes in 2.2.0
+* Update Pulp push logic to be controlled by `staged.destination`.
+* When `staged.destination` is present in any component, the task will push to Pulp.
+* When `staged.destination` is not present, the task will skip the Pulp push step.
 
 ## Changes in 2.1.0
 * Added compute resource limits

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn-task
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -179,9 +179,16 @@ spec:
             PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}") \
                   || (echo "Missing containerImage for component." >&2 && exit 1 )
 
-            DESTINATION="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "${COMPONENT}")/FILES" \
-              || (echo "Missing staged.destination value for component. This should be an existing pulp repo. \
-                  Failing" >&2 && exit 1)
+            STAGED_DESTINATION=$(jq -r '.staged.destination // empty' <<< "${COMPONENT}")
+
+            if [ -z "$STAGED_DESTINATION" ]; then
+              # Use a default destination if not provided
+              DESTINATION="${DISK_IMAGE_DIR}/default/FILES"
+              echo "No staged.destination specified for component; using default destination: $DESTINATION"
+            else
+              DESTINATION="${DISK_IMAGE_DIR}/${STAGED_DESTINATION}/FILES"
+            fi
+
             mkdir -p "${DESTINATION}"
             DOWNLOAD_DIR=$(mktemp -d)
             cd "$DOWNLOAD_DIR"
@@ -1086,9 +1093,16 @@ spec:
 
         echo "$STAGED_JSON" | yq -P -I 4 > staged.yaml
 
-        pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
-          --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
-          2> "$STDERR_FILE"
+        # Check if staged.destination exists in any component
+        HAS_STAGED_DESTINATION=$(jq 'any(.components[]?.staged?.destination; . != null)' <<< "$SNAPSHOT_JSON")
+        if [ "$HAS_STAGED_DESTINATION" = "true" ]; then
+          echo "Pushing to customer portal (Pulp) with destination: $HAS_STAGED_DESTINATION"
+          pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
+            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
+            2> "$STDERR_FILE"
+        else
+          echo "Skipping Pulp push: no staged.destination found in any component."
+        fi
 
         relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
         component_destinations=()

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-pulp-for-binary.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-pulp-for-binary.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-artifacts-to-cdn-fail-no-stageddestination
+  name: test-push-artifacts-to-cdn-skip-pulp-for-binary
 spec:
   description: |
-    Run the push-artifacts task with the component having no staged.destination. This should
-    fail the task
+    Run the task with a binary component that does NOT have
+    staged.destination and ensure Pulp push is skipped and the task succeeds.
   tasks:
     - name: run-task
       taskRef:
@@ -23,24 +23,31 @@ spec:
                   "containerImage": "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
                   "contentGateway": {
                     "filePrefix": "testproduct-",
-                    "productCode": "DISK",
-                    "productName": "Disk Image for Linux",
+                    "productCode": "Code",
+                    "productName": "MyName",
                     "productVersionName": "1.3-staging"
                   },
+                  "name": "testproduct",
                   "staged": {
                     "files": [
                       {
-                        "filename": "testproduct-amd-1.3-x86_64-kvm.qcow2",
-                        "source": "testproduct-disk.qcow2"
+                        "filename": "testproduct-binary-windows-amd64.zip",
+                        "source": "testproduct-binary-windows-amd64.zip",
+                        "binary": "testproduct-binary-windows-amd64.exe"
                       },
                       {
-                        "filename": "testproduct-amd-1.3-x86_64-kvm.raw",
-                        "source": "testproduct-disk.raw"
+                        "filename": "testproduct-binary-darwin-amd64.tar.gz",
+                        "source": "testproduct-binary-darwin-amd64.tar.gz",
+                        "binary": "testproduct-binary-darwin-amd64"
+                      },
+                      {
+                        "filename": "testproduct-binary-linux-amd64.tar.gz",
+                        "source": "testproduct-binary-linux-amd64.tar.gz",
+                        "binary": "testproduct-binary-linux-amd64"
                       }
                     ],
                     "version": "1.3"
-                  },
-                  "name": "testproduct"
+                  }
                 }
               ]
             }
@@ -73,14 +80,11 @@ spec:
         steps:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
-            env:
-              - name: "RESULT"
-                value: '$(params.result)'
             script: |
               #!/usr/bin/env bash
               set -ex
 
-              if [[ ${RESULT/*staged.destination*/} ]] ; then
-                echo "Error: result task result should show failure from staged.destination but doesn't"
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
                 exit 1
               fi


### PR DESCRIPTION
- Skip Pulp (customer portal) logic in push-artifacts-to-cdn-task for any component that does not have a staged.destination field (e.g., binaries or dev portal-only artifacts).
- Make staged.destination optional: the task no longer fails if it is missing; instead, it skips Pulp logic for that component and continues.
- Update and add tests to verify that Pulp push is skipped and the task succeeds when staged.destination is not present.
- Remove or update obsolete tests that expected failure when staged.destination was missing.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

