### PR TITLE
feat(CLDX-268): add advisory tasks to push-artifacts-to-cdn pipeline

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/README.md
+++ b/pipelines/managed/push-artifacts-to-cdn/README.md
@@ -21,6 +21,13 @@ It uses InternalRequests so that it can be run on both public and private cluste
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                               | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                      | No       | -                                                         |
 
+### Changes in 1.0.0
+* Added advisory generation tasks:
+  - `populate-release-notes` - Populates release notes for the advisory
+  - `embargo-check` - Checks for embargoed content
+  - `create-advisory` - Creates the actual advisory
+  - `close-advisory-issues` - Closes any related advisory issues
+
 ## Changes in 0.2.1
 * Required parameter `releasePath` is now passed to the `push-artifacts-to-cdn` task
 

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "1.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -202,7 +202,31 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - check-data-keys
+        - apply-mapping
+    - name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/populate-release-notes/populate-release-notes.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - verify-enterprise-contract
     - name: check-data-keys
       params:
         - name: dataPath
@@ -212,6 +236,7 @@ spec:
         - name: systems
           value:
             - cdn
+            - releaseNotes
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
@@ -229,7 +254,31 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - apply-mapping
+        - populate-release-notes
+    - name: embargo-check
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/embargo-check/embargo-check.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - check-data-keys
     - name: push-artifacts-to-cdn
       timeout: "2h00m0s"
       when:
@@ -267,6 +316,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
+        - embargo-check
     - name: update-cr-status
       params:
         - name: resource
@@ -291,6 +341,60 @@ spec:
           workspace: release-workspace
       runAfter:
         - push-artifacts-to-cdn
+    - name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/create-advisory/create-advisory.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - update-cr-status
+    - name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: advisoryUrl
+          value: "$(tasks.create-advisory.results.advisory_url)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - create-advisory
   finally:
     - name: cleanup
       taskRef:

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -258,6 +258,30 @@
                   }
                 }
               }
+            },
+            "artifacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "component": {
+                    "type": "string",
+                    "description": "The component of the artifact e.g. adv-comp-1"
+                  },
+                  "architecture": {
+                    "type": "string",
+                    "description": "The architecture of the artifact e.g. amd64"
+                  },
+                  "os": {
+                    "type": "string",
+                    "description": "The operating system of the artifact e.g. linux"
+                  },
+                  "purl": {
+                    "type": "string",
+                    "description": "The package URL representing the artifact"
+                  }
+                }
+              }
             }
           }
         },
@@ -689,7 +713,14 @@
             ],
             "properties": {
               "content": {
-                "required": ["images"]
+                "oneOf": [
+                  {
+                    "required": ["images"]
+                  },
+                  {
+                    "required": ["artifacts"]
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
* Added advisory generation tasks:
  - `populate-release-notes` - Populates release notes for the advisory
  - `embargo-check` - Checks for embargoed content
  - `create-advisory` - Creates the actual advisory
  - `close-advisory-issues` - Closes any related advisory issues

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

