### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/create-advisory/README.md
+++ b/tasks/managed/create-advisory/README.md
@@ -28,6 +28,9 @@ Only all `redhat-pending` or all `redhat-prod` repositories may be specified in 
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 7.1.0
+* Added compute resource limits
+
 ## Changes in 7.0.1
 * Update data source for update-purl step
   * reads from files instead of staged.files

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "7.0.1"
+    app.kubernetes.io/version: "7.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -139,6 +139,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: update-purl
       image: quay.io/distribution_relengs/publish-to-dev-portal-test-image:purl
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       env:
         - name: CGW_USERNAME
           valueFrom:
@@ -243,6 +249,12 @@ spec:
         ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
       script: |
         #!/bin/bash
         set -ex

--- a/tasks/managed/filter-already-released-advisory-images/README.md
+++ b/tasks/managed/filter-already-released-advisory-images/README.md
@@ -27,3 +27,6 @@ The task overwrites the original mapped snapshot file in place with a filtered v
 | sourceDataArtifact       | Location of trusted artifacts used to populate the data directory                                                          | Yes       | ""                                             |
 | dataDir                  | The location where data will be stored                                                                                     | No        | $(workspaces.data.path)                        |
 | subdirectory             | Subdirectory inside the workspace to be used                                                                               | Yes       | ""                                             |
+
+## Changes in 0.2.0
+* Added compute resource limits

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: filter-already-released-advisory-images
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -122,6 +122,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
       script: |
         #!/bin/bash
         set -x

--- a/tasks/managed/push-artifacts-to-cdn/README.md
+++ b/tasks/managed/push-artifacts-to-cdn/README.md
@@ -17,6 +17,9 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | resultsDirPath           | Path to results directory in the data workspace                                           | No       | -             |
 | requestTimeout           | Request timeout                                                                           | Yes      | 86400         |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * task now extracts the signing key name from the config map and passes it to the internalRequest
 

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -47,6 +47,12 @@ spec:
   steps:
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/push-disk-images/README.md
+++ b/tasks/managed/push-disk-images/README.md
@@ -14,6 +14,9 @@ The environment to use is pulled from the `cdn.env` key in the data file.
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks to be used are stored     | No       | -             |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                            | No       | -             |
 
+## Changes in 0.5.0
+* Added compute resource limits
+
 ## Changes in 0.4.3
 * Undo changes introduced in 0.4.2
   * Early failure prevents pasting of internal pipelineRun or taskRun

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.4.3"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,6 +37,12 @@ spec:
   steps:
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/run-file-updates/README.md
+++ b/tasks/managed/run-file-updates/README.md
@@ -23,6 +23,9 @@ the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                       |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                       |
 
+## Changes in 4.1.0
+* Added compute resource limits
+
 ## Changes in 4.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: run-file-updates
   labels:
-    app.kubernetes.io/version: "4.0.0"
+    app.kubernetes.io/version: "4.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -126,6 +126,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 100m
       script: |
         #!/bin/bash
         #

--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -20,6 +20,9 @@ images and not for generic artifact types like binaries or disk images.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.4
 * Undo changes introduced in 1.0.2
   * Early failure prevents pasting of internal pipelineRun or taskRun

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: set-advisory-severity
   labels:
-    app.kubernetes.io/version: "1.0.4"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -110,6 +110,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: set-severity
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -27,6 +27,9 @@ data:
         configMapName: <configmap name>
 ```
 
+## Changes in 2.6.0
+* Added compute resource limits
+
 ## Changes in 2.5.2
 * Undo changes introduced in 2.5.1
   * Early failure prevents pasting of internal pipelineRun or taskRun

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.5.2"
+    app.kubernetes.io/version: "2.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,6 +45,12 @@ spec:
     - name: sign-base64-blob
       image:
         quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       script: |
         #!/usr/bin/env bash
         set -ex


### PR DESCRIPTION
This commit adds compute resource limits to the remaining managed tasks that call the internal-request script. I was unable to get metrics for ~3 weeks for these, so they are mostly best guess. The tasks affected here are: create-advisory, filter-already-released-advisory-images, push-artifacts-to-cdn, push-disk-images, run-file-updates, set-advisory-severity, and sign-base64-blob.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

