### PR TITLE
chore(RELEASE-567): up check-fbc-packages memory limit

### DIFF
--- a/tasks/managed/check-fbc-packages/README.md
+++ b/tasks/managed/check-fbc-packages/README.md
@@ -9,6 +9,10 @@ Task to check that the packages being shipped in an fbc contribution are in the 
 | snapshotPath   | Path to the JSON string of the mapped Snapshot spec in the data workspace | No       | -             |
 | dataPath       | Path to the JSON string of the merged data to use in the data workspace   | No       | -             |
 
+## Changes in 0.5.1
+* Up memory resource limit from 512Mi to 1Gi
+  * Saw task OOMKilled in E2E with 512Mi
+
 ## Changes in 0.5.0
 * Added compute resource limits
 

--- a/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-fbc-packages
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -26,9 +26,9 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 1Gi
         requests:
-          memory: 512Mi  # OOMKilled at 256
+          memory: 1Gi  # OOMKilled at 512Mi
           cpu: 500m
       script: |
         #!/usr/bin/env bash


### PR DESCRIPTION
Up the memory limit in the check-fbc-packages managed task as I saw it OOMKilled in E2E with current values.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

