### PR TITLE
fix: remove invalid renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,0 @@
-{
-  "ignoreBranches": ["staging"]
-}


### PR DESCRIPTION
The goal was to disable PRs from Renovate
in the staging branch. But it turns out
this is not a valid config to do that.

So let's remove it until we come up with the correct way to do it.

It was added here: https://github.com/konflux-ci/release-service-catalog/pull/1021

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

