### PR TITLE
chore: disable Mintmaker/Renovate PRs in staging

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "baseBranches": ["development"]
+}


### PR DESCRIPTION
## Describe your changes

Because both the development and staging branches
are onboarded in Konflux, we receive update
PRs for both branches. This config should make
sure Renovate will only care about the development branch.

We only want PRs for the development branch, because every week we push all changes from development to staging.

I previously tried to achieve this here: https://github.com/konflux-ci/release-service-catalog/pull/1021

But it turned out that didn't work and we removed it here: https://github.com/konflux-ci/release-service-catalog/pull/1035

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

