### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/internal/create-advisory-oci-artifact-task/README.md
+++ b/tasks/internal/create-advisory-oci-artifact-task/README.md
@@ -9,3 +9,6 @@ Creates an oci artifact of an advisory given a Gitlab URL.
 | advisory_url                                    | the url of the advisory                                                                            | No       | -                                                     |
 | internalRequestPipelineRunName                  | Name of the PipelineRun that called this task                                                      | No       | -                                                     |
 | trusted_artifacts_dockerconfig_json_secret_name | The name of the secret that contains to dockerconfig json to use for trusted artifact operations   | Yes      | quay-token-konflux-release-trusted-artifacts-secret   |  
+
+## Changes in 0.1.0
+* Added compute resource limits

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-oci-artifact-task
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,6 +38,12 @@ spec:
   steps:
     - name: create-advisory-oci-artifact
       image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       env:
         - name: TRUSTED_ARTIFACTS_DOCKERCONFIG_JSON
           valueFrom:

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -12,3 +12,6 @@ It returns a list of component names that still need to be released (i.e., not f
 | origin                         | The origin workspace for the release CR (used to locate advisories)                                    | No       | -             |
 | advisory_secret_name           | Name of the secret containing GitLab repo and token information                                        | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
+
+## Changes in 0.2.0
+* Added compute resource limits

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: filter-already-released-advisory-images-task
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -38,6 +38,12 @@ spec:
   steps:
     - name: filter-images
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 500m
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/tasks/internal/pulp-push-disk-images/README.md
+++ b/tasks/internal/pulp-push-disk-images/README.md
@@ -15,6 +15,9 @@ Tekton task to push disk images with Pulp
 | cgwHostname     | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret       | Env specific secret containing the content gateway credentials    | No       | -                                                        |
 
+## Changes in 0.3.0
+* Added compute resource limits
+
 ## Changes in 0.2.3
 * Base image in task is updated
   * The new image contains a fix for a missing helper script used in select-oci-auth

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: pulp-push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.3"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -43,6 +43,12 @@ spec:
   steps:
     - name: pull-and-push-images
       image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 450m
       env:
         - name: EXODUS_CERT
           valueFrom:

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -29,6 +29,9 @@ Tekton task to push artifacts to CDN and optionally Dev Portal with optional sig
 | cgwHostname           | The hostname of the content-gateway to publish the metadata to    | Yes      | https://developers.redhat.com/content-gateway/rest/admin |
 | cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                                        |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * Add new required parameter `signingKeyName`. This is used for checksum signing
 

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-artifacts-to-cdn-task
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -122,6 +122,12 @@ spec:
   steps:
     - name: extract-artifacts
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -228,6 +234,12 @@ spec:
         done
     - name: push-unsigned-using-oras
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -335,6 +347,12 @@ spec:
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -497,6 +515,12 @@ spec:
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
     - name: sign-windows-binaries
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -629,6 +653,12 @@ spec:
         C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
     - name: generate-checksums
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -787,6 +817,12 @@ spec:
 
     - name: compress-artifacts
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -857,6 +893,12 @@ spec:
 
     - name: push-artifacts
       image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared

--- a/tasks/internal/request-advisory-oci-artifact/README.md
+++ b/tasks/internal/request-advisory-oci-artifact/README.md
@@ -11,3 +11,6 @@ Tekton task to request the advisory content from gitlab as an oci artifact.
 | pipelineRunUid   | The uid of the current pipelineRun. Used as a label value when creating internal requests             | No       | -             |  
 | taskGitUrl       | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -             |
 | taskGitRevision  | The revision in the taskGitUrl repo to be used                                                        | No       | -             |  
+
+## Changes in 0.1.0
+* Added compute resource limits

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: request-advisory-oci-artifact
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -45,6 +45,12 @@ spec:
   steps:
     - name: request-advisory-oci-artifact
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       script: |
         #!/usr/bin/env bash
         set -x

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -286,6 +286,12 @@ spec:
     - name: update-fbc-catalog-wait-for-iib-build-step
       image: >-
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 250m
       env:
         - name: IIB_SERVICE_URL
           valueFrom:


### PR DESCRIPTION
This commit adds compute resource limits to the remaining internal tasks. I was unable to get metrics for these, so they are mostly best guess. The tasks affected here are: create-advisory-oci-artifact, filter-already-released-advisory-images-task, pulp-push-disk-images, push-artifacts-to-cdn-task, and request-advisory-oci-artifact.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

