### PR TITLE
feat: bump to 0.2 version and use predefined name for kind kubeconfig secret

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -73,10 +73,12 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+            value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
       params:
         - name: secret-aws-credentials
           value: mapt-kind-secret
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
         - name: id
           value: $(context.pipelineRun.name)
         - name: tags
@@ -89,6 +91,10 @@ spec:
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
+        - name: oci-ref
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: credentials-secret-name
+          value: $(params.konflux-test-infra-secret)
     - name: deploy-konflux
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
@@ -104,10 +110,10 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/konflux-ci/deploy/0.1/deploy-konflux-ci.yaml
+            value: tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
       params:
         - name: cluster-access-secret
-          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
+          value: kfg-$(context.pipelineRun.name)
         - name: component-name
           value: release-service-catalog
         - name: component-pr-owner
@@ -116,6 +122,10 @@ spec:
           value: ""
         - name: component-pr-source-branch
           value: $(tasks.test-metadata.results.source-repo-branch)
+        - name: oci-ref
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: credentials-secret-name
+          value: $(params.konflux-test-infra-secret)
     - name: konflux-e2e-tests
       timeout: 3h
       when:
@@ -149,7 +159,7 @@ spec:
         - name: component-image
           value: "$(tasks.test-metadata.results.container-image)"
         - name: cluster-access-secret-name
-          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
+          value: kfg-$(context.pipelineRun.name)
         - name: test-environment
           value: "upstream"
   finally:
@@ -173,7 +183,7 @@ spec:
         - name: id
           value: $(context.pipelineRun.name)
         - name: cluster-access-secret
-          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
+          value: kfg-$(context.pipelineRun.name)
         - name: oci-container
           value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: oci-credentials


### PR DESCRIPTION
## Describe your changes
Currently, in Tekton, finally tasks that are dependent on the results of a preceding task will not be scheduled if that preceding task is cancelled or fails before generating the expected result. Basically changing the result to a generated param..

Also this Pull Request bump provision to 0.2 to improve artifacts logging gather
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

