### PR TITLE
fix: support run-test.sh in root

### DIFF
--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -147,7 +147,14 @@ spec:
               export RELEASE_CATALOG_GIT_URL
               export RELEASE_CATALOG_GIT_REVISION
 
-              "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/run-test.sh"
+              # initially, there was a run-test.sh in every test suite directory.
+              # then we moved to have a generic run-test.sh in the root.
+              # support both cases.
+              if [ -f "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/run-test.sh" ]; then
+                "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/run-test.sh"
+              else
+                "/home/e2e/tests/run-test.sh" "$(params.PIPELINE_TEST_SUITE)"
+              fi
 
       runAfter:
         - get-snapshot-data


### PR DESCRIPTION
## Describe your changes
- migrate to using a run-test.sh in the root integration-tests directory.
- but we fail back in case test suites in some PRs have not benn rebased.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

