### PR TITLE
fix: increase memory in update-fbc-catalog task

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -14,6 +14,9 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
 
+## Changes in 1.2.1
+* Increased memory limit from 128Mi to 512Mi
+
 ## Changes in 1.2.0
 * Added compute resource limits
 

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -68,9 +68,9 @@ spec:
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       computeResources:
         limits:
-          memory: 128Mi
+          memory: 512Mi
         requests:
-          memory: 128Mi
+          memory: 512Mi
           cpu: '1'
       env:
         - name: IIB_SERVICE_URL


### PR DESCRIPTION
this PR increase the memory limit in the task
update-fbc-catalog from 128Mi to 512Mi

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

