### PR TITLE
fix: internal-request timeout in filter task

### DIFF
--- a/tasks/managed/filter-already-released-advisory-images/README.md
+++ b/tasks/managed/filter-already-released-advisory-images/README.md
@@ -1,10 +1,10 @@
 # Filter Already Released Advisory Images
 
-This task filters out images from a snapshot that have already been published in advisories.  
+This task filters out images from a snapshot that have already been published in advisories.
 It is a **managed Tekton task** that triggers an **internal task** using an InternalRequest,
 and overwrites the mapped snapshot file with a filtered version containing only **unpublished images**.
 
-The task also outputs a `skip_release` result, which is set to `true` 
+The task also outputs a `skip_release` result, which is set to `true`
 if all components are already released (and the pipeline can be skipped), or `false` otherwise.
 
 The task overwrites the original mapped snapshot file in place with a filtered version containing only unpublished images. Downstream tasks continue to use the same snapshot path.
@@ -27,6 +27,11 @@ The task overwrites the original mapped snapshot file in place with a filtered v
 | sourceDataArtifact       | Location of trusted artifacts used to populate the data directory                                                          | Yes       | ""                                             |
 | dataDir                  | The location where data will be stored                                                                                     | No        | $(workspaces.data.path)                        |
 | subdirectory             | Subdirectory inside the workspace to be used                                                                               | Yes       | ""                                             |
+
+## Changes in 0.2.1
+* Bump the utils image
+  * The new version aligns the default timeouts for the internal-request script
+    so that the script timeout is 1 hour - same as the pipeline timeout
 
 ## Changes in 0.2.0
 * Added compute resource limits

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: filter-already-released-advisory-images
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+      image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
       computeResources:
         limits:
           memory: 512Mi
@@ -161,7 +161,7 @@ spec:
           test("quay.io/redhat-pending/|quay.io/rh-flatpaks-stage/")) |
           .repository' "$SNAPSHOT_FILE")
         prod_repositories=$(jq -r '.components[] | select(.repository |
-          test("quay.io/redhat-prod/|quay.io/rh-flatpaks-prod/")) |        
+          test("quay.io/redhat-prod/|quay.io/rh-flatpaks-prod/")) |
           .repository' "$SNAPSHOT_FILE")
         orphan_repositories=$(jq -r '.components[] |
           select(.repository |
@@ -240,7 +240,7 @@ spec:
 
         if [[ "$(echo "$results" | jq -r '.result')" == "Success" ]]; then
           echo "Image filtering successful"
-          
+
           # Get the unreleased components list
           UNRELEASED_COMPONENTS=$(echo "$results" | jq -r '.unreleased_components // "[]"')
           if [ -z "$UNRELEASED_COMPONENTS" ]; then

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -52,7 +52,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,14 +202,14 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -ex
 
               # Count the number of InternalRequests
               requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
-              
+
               # Check if the number of InternalRequests is as expected
               if [ "$requestsCount" -ne 1 ]; then
                 echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
@@ -299,7 +299,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -55,7 +55,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -50,7 +50,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-rpa-inputs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-snapshot-inputs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -55,7 +55,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:66e4e23bb327e5f8447b13bec8b13c7ff6a81999
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

The internal-request call in
filter-already-released-advisory-images relies
on defaults, but the script had only 30 minutes as default for the script and 1 hour for the pipeline.

This utils image update aligns them to be both 1 hour.

Note: The timeouts might be wrong in other tasks as well. I created https://issues.redhat.com/browse/RELEASE-1682 for that. Let's just handle the task that was causing issues for the user now.

Related PR: https://github.com/konflux-ci/release-service-utils/pull/449

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

