### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/base64-encode-checksum/README.md
+++ b/tasks/managed/base64-encode-checksum/README.md
@@ -10,6 +10,9 @@ It returns as a result the blob to sign, that is the result of the base64 encode
 |----------------------|--------------------------------------------------------------------|-----------|-------------------------------------------------------|
 | binaries_dir         | Path inside the image where the binaries to extract are stored     | Yes       | "binaries"                                            |
 
+## Changes in 1.3.0
+* Added compute resource limits
+
 ## Changes in 1.2.0
 * Updated the base image used in this task
 

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: base64-encode-checksum
   labels:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -27,6 +27,12 @@ spec:
     - name: base64-encode-checksum
       image:
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
       script: |
         #!/usr/bin/env sh
         set -ex

--- a/tasks/managed/create-github-release/README.md
+++ b/tasks/managed/create-github-release/README.md
@@ -15,6 +15,9 @@ a `release` dir.
 | content_directory | The directory inside the workspace to find files for release      | No       | -             |
 | resultsDirPath    | Path to results directory in the data workspace                   | No       | -             |
 
+## Changes in 2.3.0
+* Added compute resource limits
+
 ## Changes in 2.2.1
 * Fix check for existing release
   * The grep was inadequate, because it would also match for substrings. Now we'll

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "2.2.1"
+    app.kubernetes.io/version: "2.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,6 +37,12 @@ spec:
   steps:
     - name: create-release-from-binaries
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/create-product-sbom/README.md
+++ b/tasks/managed/create-product-sbom/README.md
@@ -19,6 +19,9 @@ releaseNotes content.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * Task was refactored to use the new SBOM workflow. SBOMs are now generated from the mapped snapshot spec.
   * Renamed `productSBOMPath` result to `sbomPath` and param `dataJsonPath` to `dataPath`.

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-product-sbom
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -111,6 +111,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: create-sbom
       image: quay.io/konflux-ci/release-service-utils:991c2db1fe04f2fddd940605b5383a17692eb4a5
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -27,6 +27,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                                                                                                                                                                                       | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                                                                                                                                                                              | No       | ""                      |
 
+## Changes in 5.1.0
+* Added compute resource limits
+
 ## Changes in 5.0.0
 * Replace `.pyxis.skipLayers` with `.pyxis.includeLayers`
   * We want to skip the layer details when creating images in Pyxis by default,

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -130,6 +130,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
       image: quay.io/konflux-ci/release-service-utils:6f53e325678d7a8aac51d80fd1ab62927cf44e73
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+          cpu: '1'
       env:
         - name: pyxisCert
           valueFrom:

--- a/tasks/managed/extract-binaries-from-image/README.md
+++ b/tasks/managed/extract-binaries-from-image/README.md
@@ -17,6 +17,9 @@ passed.
 | subdirectory        | Subdirectory inside the workspace to be used for storing the binaries      | Yes      | ""            |
 | dataPath            | Path to the JSON string of the merged data to use in the data workspace    | No       | -             |
 
+## Changes in 2.2.0
+* Added compute resource limits
+
 ## Changes in 2.1.3
 * Add comprobation to only extract from the layer with the releases directory
 

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-binaries-from-image
   labels:
-    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/version: "2.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -37,6 +37,12 @@ spec:
   steps:
     - name: extract-binaries-from-image
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/extract-index-image/README.md
+++ b/tasks/managed/extract-index-image/README.md
@@ -20,6 +20,9 @@ the workspace name for this task *must* be input.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-index-image
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -107,6 +107,12 @@ spec:
     - name: extract-index-image
       image: >-
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/get-ocp-version/README.md
+++ b/tasks/managed/get-ocp-version/README.md
@@ -16,6 +16,9 @@ Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-ocp-version
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -103,6 +103,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: get-ocp-version
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/make-repo-public/README.md
+++ b/tasks/managed/make-repo-public/README.md
@@ -17,5 +17,8 @@ Tekton task that makes repositories public using quay.io API
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: make-repo-public
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -103,6 +103,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: make-repo-public
       image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       env:
         - name: REGISTRY_TOKEN
           valueFrom:

--- a/tasks/managed/marketplacesvm-push-disk-images/README.md
+++ b/tasks/managed/marketplacesvm-push-disk-images/README.md
@@ -13,5 +13,8 @@ It currently supports images in `raw` and `vhd` formats for `AWS` and `Azure` re
 | prePush                 | Whether perform a pre-push (true) or not (false). When true it will not publish PROD.  | Yes      | false           |
 | concurrentLimit         | The maximum number of images to be pulled at once.                                     | Yes      | 3               |
 
+## Changes in 0.3.0
+* Added compute resource limits
+
 ## Changes in 0.2.0
 * Allow `marketplacesvm-push-disk-images` task to run on pre-push mode.

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: marketplacesvm-push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,12 @@ spec:
   steps:
     - name: pull-and-push-images-to-marketplaces
       image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 1Gi
+          cpu: 450m
       env:
         - name: CLOUD_CREDENTIALS
           valueFrom:

--- a/tasks/managed/prepare-fbc-release/README.md
+++ b/tasks/managed/prepare-fbc-release/README.md
@@ -14,6 +14,9 @@ to each component, so other task can use them.
 | snapshotPath | Path to the JSON string of the Snapshot spec in the data workspace      | No       | -                  |
 | dataPath     | Path to the JSON string of the merged data to use in the data workspace | No       | -                  |
 
+## Changes in 1.5.0
+* Added compute resource limits
+
 ## Changes in 1.4.1
 * The task now support multiarchitecture images
 * Changed to use `mktemp` to generate the temporary snapshot json file

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: prepare-fbc-release
   labels:
-    app.kubernetes.io/version: "1.4.1"
+    app.kubernetes.io/version: "1.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -29,6 +29,12 @@ spec:
   steps:
     - name: prepare-fbc-release
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: base64-encode-checksum, create-github-release, create-product-sbom, create-pyxis-image, extract-binaries-from-image, extract-index-image, get-ocp-version, make-repo-public, marketplacesvm-push-disk-images, and prepare-fbc-release. The goal is to reduce the amount of resources tasks use.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

