### PR TITLE
feat(RELEASE-567): add compute resource limits to tasks

### DIFF
--- a/tasks/managed/prepare-validation/README.md
+++ b/tasks/managed/prepare-validation/README.md
@@ -25,6 +25,9 @@ tasks:
         value: '{"components":[{"name":"component1","containerImage":"quay.io/repo/component1:digest"}}]}'
 ```
 
+## Changes in 0.8.0
+* Added compute resource limits
+
 ## Changes in 0.7.1
 * Fix shellcheck/checkton linting issues in the task
 

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: prepare-validation
   labels:
-    app.kubernetes.io/version: "0.7.1"
+    app.kubernetes.io/version: "0.8.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -24,6 +24,12 @@ spec:
     - name: prepare-validation
       image:
         quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/publish-to-mrrc/README.md
+++ b/tasks/managed/publish-to-mrrc/README.md
@@ -10,7 +10,9 @@ This task will work with [collect-mrrc-task](../collect-mrrc-params/README.md) t
 | mrrcParamFilePath | Path of the mrrc.env file which contains the MRRC parameters as environment viariables | No       | -             |
 | charonAWSSecret   | The secret which contains the aws credential settings for the charon usage             | No       | -             |
 
-## Changes in 0.2.0
+## Changes in 0.3.0
+* Added compute resource limits
 
+## Changes in 0.2.0
 * Used the single charon-config file instead of a configmap
 * Consumed the OCI registries which are collected through Snapshot from collect-mrrc-params task

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-to-mrrc
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -22,6 +22,12 @@ spec:
   steps:
     - name: prepare-repo
       image: quay.io/konflux-ci/release-service-utils:4576e1e2a30439129cb69c8a4f39f7ced2d44376
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -46,6 +52,12 @@ spec:
           mountPath: "/workdir"
     - name: upload-maven-repo
       image: quay.io/konflux-ci/charon@sha256:95b22f4f0fc1d6bb984a2f63334c3f66a539e433d79cde4eafa7731d8924377f
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 250m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/push-rpm-to-koji/README.md
+++ b/tasks/managed/push-rpm-to-koji/README.md
@@ -12,6 +12,9 @@ Tekton task to push konflux build rpms to koji instance.
 | subdirectory         | Path to results directory in the data workspace                                | No       | -             |
 | pipelineImage        | The image url with koji (1.34 or higher), jq and kinit installed for running the push-rpm-to-koji task | No       | -             |
 
+## Changes in 0.4.0
+* Added compute resource limits
+
 ## Changes in 0.3.0
 * Tags builds using `koji.build-target` annotation on the RPM image.
 

--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-to-koji
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: push-koji
@@ -36,6 +36,12 @@ spec:
     - name: push-rpm-to-koji
       # The pipelineImage will be fetching from get-secrets task with koji installed there
       image: "$(params.pipelineImage)"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 250m
       env:
         - name: SNAPSHOT_SPEC_FILE
           value: $(workspaces.data.path)/$(params.snapshotPath)

--- a/tasks/managed/send-slack-notification/README.md
+++ b/tasks/managed/send-slack-notification/README.md
@@ -10,6 +10,9 @@ Sends message to Slack using postMessage API
 | secretName      | Name of secret which contains authentication token for app | No       | -                         |
 | secretKeyName   | Name of key within secret which contains webhook URL       | No       | -                         |
 
+## Changes in 1.4.0
+* Added compute resource limits
+
 ## Changes in 1.3.1
 * Fix shellcheck/checkton linting issues in the task and tests
 

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
@@ -30,6 +30,12 @@ spec:
   steps:
     - name: send-message
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       volumeMounts:
         - name: slack-token
           mountPath: "/etc/secrets"

--- a/tasks/managed/update-component-sbom/README.md
+++ b/tasks/managed/update-component-sbom/README.md
@@ -18,6 +18,9 @@ Tekton task to update component-level SBOMs with purls containing release-time i
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.2
 * Limited concurrency to 8 SBOM updates
 

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-component-sbom
   labels:
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -118,6 +118,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: update-sboms
       image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
       script: |
         #!/usr/bin/env bash
         set -eux

--- a/tasks/managed/update-cr-status/README.md
+++ b/tasks/managed/update-cr-status/README.md
@@ -19,6 +19,9 @@ A tekton task that updates the passed CR status with the contents stored in the 
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 1.1.0
+* Added compute resource limits
+
 ## Changes in 1.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-cr-status
   labels:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -120,6 +120,12 @@ spec:
           value: $(params.resultArtifacts)
     - name: update-cr-status
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/update-infra-deployments/README.md
+++ b/tasks/managed/update-infra-deployments/README.md
@@ -18,6 +18,9 @@
 | defaultGithubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
 | defaultGithubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
 
+## Changes in 1.4.0
+* Added compute resource limits
+
 ## Changes in 1.3.0
 * Updated the base image used in this task
   * Deprecated the `gitImage` and `scriptImage` parameters

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
@@ -42,6 +42,12 @@ spec:
   steps:
     - name: git-clone-infra-deployments
       image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 150m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -52,6 +58,12 @@ spec:
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
       image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 100m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -91,6 +103,12 @@ spec:
         echo "$PATCHED_SCRIPT" | sh
     - name: get-diff-files
       image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 100m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -101,6 +119,12 @@ spec:
     # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-pr
       image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
       volumeMounts:
         - name: infra-deployments-pr-creator
           mountPath: /secrets/deploy-key

--- a/tasks/managed/update-ocp-tag/README.md
+++ b/tasks/managed/update-ocp-tag/README.md
@@ -17,6 +17,9 @@ occurs when the {{ OCP_VERSION }} placeholder is present.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.1.0
+* Added compute resource limits
+
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-ocp-tag
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -116,6 +116,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: update-ocp-tag
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 50m
       script: |
        #!/usr/bin/env bash
        set -eux

--- a/tasks/managed/update-trusted-tasks/README.md
+++ b/tasks/managed/update-trusted-tasks/README.md
@@ -11,5 +11,8 @@ If it is already in place, it will be used as an input to which the results will
 |------------|-------------------------------------------------------------------------|----------|---------------|
 | snapshotPath   | Path to the JSON string of the Snapshot spec in the data workspace | No       | -             |
 
+## Changes in 0.3.0
+* Added compute resource limits
+
 ## Changes in 0.2.0
 * Task's image (quay.io/konflux-ci/appstudio-utils) has been updated to the latest

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-trusted-tasks
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -25,6 +25,12 @@ spec:
   steps:
     - name: update-trusted-tasks
       image: quay.io/konflux-ci/appstudio-utils@sha256:591af845d7c700a178b3738e9725880e79cf63521a906325185bfe74d2a28407
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 1Gi
+          cpu: 500m
       script: |
         #!/bin/bash
         set -eux


### PR DESCRIPTION
This commit adds compute resource limits to some managed tasks. The tasks affected in this commit are: prepare-validation, publish-to-mrrc, push-rpm-to-koji, send-slack-notification, update-component-sbom, update-cr-status, update-infra-deployments, update-ocp-tag, and update-trusted-tasks.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

