### PR TITLE
feat(RELEASE-1695): enable trusted artifacts in sign-base64-blob task

### DIFF
--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -4,17 +4,23 @@ Creates an InternalRequest to sign a base64 encoded blob
 
 ## Parameters
 
-| Name                 | Description                                                                                           | Optional | Default value         |
-|----------------------|-------------------------------------------------------------------------------------------------------|----------|-----------------------|
-| dataPath             | Path to the JSON string of the merged data to use in the data workspace                               | No       | -                     |
-| referenceImage       | The image to be signed                                                                                | No       | -                     |
-| manifestDigestImage  | Manifest Digest Image used to extract the SHA                                                         | Yes      | ""                    |
-| requester            | Name of the user that requested the signing, for auditing purposes                                    | No       | -                     |
-| requestTimeout       | InternalRequest timeout                                                                               | Yes      | 180                   |
-| binariesPath         | The directory inside the workspace where the binaries are stored                                      | Yes      | binaries              |
-| pipelineRunUid       | The uid of the current pipelineRun. Used as a label value when creating internal requests             | No       | -                     |
-| taskGitUrl           | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -                     |
-| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                        | No       | -                     |
+| Name                    | Description                                                                                                                | Optional  | Default value           |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------|
+| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No        | -                       |
+| referenceImage          | The image to be signed                                                                                                     | No        | -                       |
+| manifestDigestImage     | Manifest Digest Image used to extract the SHA                                                                              | Yes       | ""                      |
+| requester               | Name of the user that requested the signing, for auditing purposes                                                         | No        | -                       |
+| requestTimeout          | InternalRequest timeout                                                                                                    | Yes       | 180                     |
+| binariesPath            | The directory inside the workspace where the binaries are stored                                                           | Yes       | binaries                |
+| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No        | -                       |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                   |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                      |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                      |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes       | ""                      |
+| dataDir                 | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path) |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
 ## Signing data parameters
 
@@ -26,6 +32,9 @@ data:
         pipelineImage: <image pullspec>
         configMapName: <configmap name>
 ```
+
+## Changes in 3.0.0
+* This task now supports Trusted artifacts
 
 ## Changes in 2.6.0
 * Added compute resource limits

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-base64-blob
   labels:
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -32,6 +32,31 @@ spec:
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
@@ -41,7 +66,55 @@ spec:
   workspaces:
     - name: data
       description: workspace to read and save files
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
   steps:
+    - name: skip-trusted-artifact-operations
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
     - name: sign-base64-blob
       image:
         quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
@@ -55,7 +128,7 @@ spec:
         #!/usr/bin/env bash
         set -ex
 
-        DATA_FILE="$(workspaces.data.path)/$(params.dataPath)"
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
             exit 1
@@ -92,8 +165,40 @@ spec:
         decoded_payload=$(echo -n "$payload" | base64 -d)
 
         # Build .sig file
-        checksum_file_name=$(find "$(workspaces.data.path)/$(params.binariesPath)" -maxdepth 1 -name '*SHA256SUMS*' \
+        checksum_file_name=$(find "$(params.dataDir)/$(params.binariesPath)" -maxdepth 1 -name '*SHA256SUMS*' \
           -printf '%f\n')
         echo -n "$decoded_payload" \
         | gpg --dearmor \
-        | tee "$(workspaces.data.path)/$(params.binariesPath)/${checksum_file_name}.sig"
+        | tee "$(params.dataDir)/$(params.binariesPath)/${checksum_file_name}.sig"
+    - name: create-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/sign-base64-blob/tests/mocks.sh
+++ b/tasks/managed/sign-base64-blob/tests/mocks.sh
@@ -4,7 +4,7 @@ set -eux
 # mocks to be injected into task step scripts
 function internal-request() {
   echo Mock internal-request called with: $*
-  echo $* >> $(workspaces.data.path)/mock_internal-request.txt
+  echo $* >> "$(params.dataDir)/mock_internal-request.txt"
 
   # set to async
   /home/utils/internal-request $@ -s false

--- a/tasks/managed/sign-base64-blob/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/sign-base64-blob/tests/pre-apply-task-hook.sh
@@ -12,4 +12,4 @@ kubectl delete internalrequests --all -A
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -7,6 +7,26 @@ spec:
   description: Test creating a internal request to sign a blob
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
@@ -15,6 +35,23 @@ spec:
       taskSpec:
         workspaces:
           - name: data
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
@@ -22,7 +59,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > "$(workspaces.data.path)/data.json" << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "sign": {
                   "configMapName": "signing-config-map"
@@ -30,8 +68,34 @@ spec:
               }
               EOF
 
-              mkdir -p "$(workspaces.data.path)/binaries"
-              touch "$(workspaces.data.path)/binaries/foo_SHA256SUMS"
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/binaries"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/binaries/foo_SHA256SUMS"
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: sign-base64-blob
@@ -41,11 +105,21 @@ spec:
         - name: blob
           value: test-blob
         - name: binariesPath
-          value: binaries
+          value: $(context.pipelineRun.uid)/binaries
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
         - name: dataPath
-          value: data.json
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
         - name: taskGitUrl
           value: "http://localhost"
         - name: taskGitRevision
@@ -59,8 +133,54 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: binariesPath
+          value: $(context.pipelineRun.uid)/binaries
       taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: binariesPath
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
             script: |
@@ -95,7 +215,7 @@ spec:
                 exit 1
               fi
 
-              binaries_path="$(workspaces.data.path)/binaries"
+              binaries_path="$(params.dataDir)/$(params.binariesPath)"
               created_file=$(find "$binaries_path" -maxdepth 1 -name '*sig*' -printf '%f\n')
               if [ "$created_file" != "foo_SHA256SUMS.sig" ]
               then


### PR DESCRIPTION
## Describe your changes
- enable trusted artifacts in the sign-base64-blob task

## Relevant Jira
- [RELEASE-1695](https://issues.redhat.com//browse/RELEASE-1695)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

