### PR TITLE
feat(RELEASE-1619): use trusted artifacts in the create-github-release task

### DIFF
--- a/pipelines/managed/release-to-github/README.md
+++ b/pipelines/managed/release-to-github/README.md
@@ -24,6 +24,7 @@ Tekton release pipeline to release binaries extracted from the image built with 
 ## Changes in 4.6.0
 * Pass taskGitUrl and taskGitRevision to extract-binaries-from-image task
 * Pass taskGitUrl and taskGitRevision to base64-encode-checksum task
+* Pass taskGitUrl and taskGitRevision to create-github-release task
 
 ## Changes in 4.5.0
 * The `sign-base64-blob` task is now passed the `taskGitUrl` and `taskGitRevision` parameters

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -344,6 +344,10 @@ spec:
           value: $(tasks.extract-binaries-from-image.results.binaries_path)
         - name: resultsDirPath
           value: $(tasks.collect-data.results.resultsDir)
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
       runAfter:
         - collect-gh-params
         - sign-base64-blob

--- a/tasks/managed/create-github-release/README.md
+++ b/tasks/managed/create-github-release/README.md
@@ -7,13 +7,24 @@ a `release` dir.
 
 ## Parameters
 
-| Name              | Description                                                       | Optional | Default value |
-|-------------------|-------------------------------------------------------------------|----------|---------------|
-| githubSecret      | The kubernetes secret to use to authenticate to GitHub            | No       | -             |
-| repository        | The github repository to release to                               | No       | -             |
-| release_version   | The version string to use creating the release                    | No       | -             |
-| content_directory | The directory inside the workspace to find files for release      | No       | -             |
-| resultsDirPath    | Path to results directory in the data workspace                   | No       | -             |
+| Name                    | Description                                                                                                                | Optional | Default value           |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
+| githubSecret            | The kubernetes secret to use to authenticate to GitHub                                                                     | No       | -                       |
+| repository              | The github repository to release to                                                                                        | No       | -                       |
+| release_version         | The version string to use creating the release                                                                             | No       | -                       |
+| content_directory       | The directory inside the workspace to find files for release                                                               | No       | -                       |
+| resultsDirPath          | Path to results directory in the data workspace                                                                            | No       | -                       |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 3.0.0
+* This task now supports Trusted artifacts
 
 ## Changes in 2.3.0
 * Added compute resource limits

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-github-release
   labels:
-    app.kubernetes.io/version: "2.3.0"
+    app.kubernetes.io/version: "3.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -27,6 +27,37 @@ spec:
     - name: resultsDirPath
       type: string
       description: Path to the results directory in the data workspace
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
   workspaces:
     - name: data
       description: The workspace where the binaries to release reside
@@ -34,7 +65,54 @@ spec:
     - name: url
       type: string
       description: URL to inspect the created release
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
   steps:
+    - name: skip-trusted-artifact-operations
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
     - name: create-release-from-binaries
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       computeResources:
@@ -47,9 +125,9 @@ spec:
         #!/usr/bin/env bash
         set -ex
 
-        RESULTS_FILE="$(workspaces.data.path)/$(params.resultsDirPath)/create-github-release-results.json"
+        RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/create-github-release-results.json"
 
-        cd "$(workspaces.data.path)/$CONTENT_DIRECTORY"
+        cd "$(params.dataDir)/$CONTENT_DIRECTORY"
         set -o pipefail
         shopt -s failglob
 
@@ -77,3 +155,35 @@ spec:
           value: $(params.release_version)
         - name: CONTENT_DIRECTORY
           value: $(params.content_directory)
+    - name: create-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/create-github-release/tests/mocks.sh
+++ b/tasks/managed/create-github-release/tests/mocks.sh
@@ -5,7 +5,7 @@ set -eux
 
 function gh() {
   echo "Mock gh called with: $*" >&2
-  echo "$*" >> $(workspaces.data.path)/mock_gh.txt
+  echo "$*" >> "$(params.dataDir)/mock_gh.txt"
   if [[ "$*" == "api repos/foo/repo_with_release/releases"* ]]; then
     echo "{"repodata": "lotsofdata"}"
     exit 0

--- a/tasks/managed/create-github-release/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/create-github-release/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
 
 # Create a dummy github secret (and delete it first if it exists)
 kubectl delete secret test-create-github-release-token --ignore-not-found

--- a/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
@@ -9,14 +9,51 @@ spec:
     It will not be recreated.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -24,14 +61,40 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              mkdir $(workspaces.data.path)/results
-              mkdir $(workspaces.data.path)/release/
-              cat > $(workspaces.data.path)/release/foo.json << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/release/"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo.json" << EOF
               { "example github release file": "just mock data" }
               EOF
-              touch $(workspaces.data.path)/release/foo.zip
-              touch $(workspaces.data.path)/release/foo_SHA256SUMS
-              touch $(workspaces.data.path)/release/foo_SHA256SUMS.sig
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo.zip"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo_SHA256SUMS"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo_SHA256SUMS.sig"
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: create-github-release
@@ -43,9 +106,23 @@ spec:
         - name: release_version
           value: 1.2.3
         - name: content_directory
-          value: release/
+          value: $(context.pipelineRun.uid)/release/
         - name: resultsDirPath
-          value: "results"
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -55,19 +132,59 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
       taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(workspaces.data.path)"/mock_gh.txt)" != 1 ]; then
+              if [ "$(wc -l < "$(params.dataDir)"/mock_gh.txt)" != 1 ]; then
                 echo Error: gh was expected to be called 1 times. Actual calls:
-                cat "$(workspaces.data.path)"/mock_gh.txt
+                cat "$(params.dataDir)"/mock_gh.txt
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-release.yaml
@@ -8,14 +8,51 @@ spec:
     Run the create-github-release task
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -23,14 +60,40 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              mkdir $(workspaces.data.path)/results
-              mkdir $(workspaces.data.path)/release/
-              cat > $(workspaces.data.path)/release/foo.json << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/release/"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo.json" << EOF
               { "example github release file": "just mock data" }
               EOF
-              touch $(workspaces.data.path)/release/foo.zip
-              touch $(workspaces.data.path)/release/foo_SHA256SUMS
-              touch $(workspaces.data.path)/release/foo_SHA256SUMS.sig
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo.zip"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo_SHA256SUMS"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/release/foo_SHA256SUMS.sig"
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: create-github-release
@@ -42,9 +105,23 @@ spec:
         - name: release_version
           value: 1.2.3
         - name: content_directory
-          value: release/
+          value: $(context.pipelineRun.uid)/release/
         - name: resultsDirPath
-          value: "results"
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -54,26 +131,66 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
       taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              if ! grep "release create v1.2.3" < "$(workspaces.data.path)"/mock_gh.txt 2> /dev/null
+              if ! grep "release create v1.2.3" < "$(params.dataDir)/mock_gh.txt" 2> /dev/null
               then
                 echo Error: release create v1.2.3 was expected. Actual call:
-                cat "$(workspaces.data.path)"/mock_gh.txt
+                cat "$(params.dataDir)/mock_gh.txt"
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(workspaces.data.path)"/mock_gh.txt)" != 2 ]; then
-                echo Error: gh was expected to be called 2 times. Actual calls:
-                cat "$(workspaces.data.path)"/mock_gh.txt
+              if [ "$(wc -l < "$(params.dataDir)/mock_gh.txt")" != 2 ]; then
+                echo "Error: gh was expected to be called 2 times. Actual calls:"
+                cat "$(params.dataDir)/mock_gh.txt"
                 exit 1
               fi
       runAfter:


### PR DESCRIPTION
- enable trusted artifacts in the create-github-release task
- add new required parameters from create-github-release to the release-to-github pipeline.

## Describe your changes
- [RELEASE-1619](https://issues.redhat.com//browse/RELEASE-1619)

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

