### PR TITLE
fix: increase fbc default timeouts

### DIFF
--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -21,6 +21,9 @@ Task to create an internalrequest to add fbc contributions to index images
 | taskGitUrl                | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No         | ""                      |
 | taskGitRevision           | The revision in the taskGitUrl repo to be used                                                                             | No         | ""                      |
 
+## Changes in 5.0.2
+* Changed the default timeouts for the internal requests to 3600 seconds
+
 ## Changes in 5.0.1
 * The task now saves the `index_image` and `index_image_resolved` key/values in the results file.
 

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: add-fbc-contribution
   labels:
-    app.kubernetes.io/version: "5.0.1"
+    app.kubernetes.io/version: "5.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -162,8 +162,8 @@ spec:
         echo -n "$(params.dataDir)/$(context.pipelineRun.uid)/ir-$(context.taskRun.uid)-result.json" \
           > "$(results.requestResultsFile.path)"
 
-        default_build_timeout_seconds="1500"
-        default_request_timeout_seconds="1500"
+        default_build_timeout_seconds="3600"
+        default_request_timeout_seconds="3600"
 
         build_tags=$(jq '.fbc.buildTags // []' "${DATA_FILE}")
         add_arches=$(jq '.fbc.addArches // []' "${DATA_FILE}")


### PR DESCRIPTION
this PR increases the default timeouts for the
internal request to update the fbc fragment

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

