### PR TITLE
fix: various fixes for release-to-github

### DIFF
--- a/pipelines/managed/release-to-github/README.md
+++ b/pipelines/managed/release-to-github/README.md
@@ -20,6 +20,8 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
 
+## Changes in 4.7.0
+* Pass taskGitUrl and taskGitRevision to validate-single-component task
 
 ## Changes in 4.6.0
 * Pass taskGitUrl and taskGitRevision to extract-binaries-from-image task

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: release-to-github
   labels:
-    app.kubernetes.io/version: "4.6.0"
+    app.kubernetes.io/version: "4.7.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -158,6 +158,10 @@ spec:
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -23,7 +23,7 @@ spec:
       description: Name of the user that requested the signing, for auditing purposes
     - name: requestTimeout
       type: string
-      default: "180"
+      default: "1800"
       description: InternalRequest timeout
     - name: binariesPath
       type: string
@@ -117,12 +117,12 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: sign-base64-blob
       image:
-        quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+        quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
       computeResources:
         limits:
-          memory: 256Mi
+          memory: 512Mi
         requests:
-          memory: 256Mi
+          memory: 512Mi
           cpu: 100m
       script: |
         #!/usr/bin/env bash
@@ -153,12 +153,11 @@ spec:
             -p config_map_name="${config_map_name}" \
             -p taskGitUrl="$(params.taskGitUrl)" \
             -p taskGitRevision="$(params.taskGitRevision)" \
-            -t "$(params.requestTimeout)" \
             -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
-            | tee "$IR_RESULT_FILE" || \
-            (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
+            -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" | tee "$IR_RESULT_FILE"
 
-        internalRequest=$(awk 'NR==1{ print $2 }' "$IR_RESULT_FILE" | xargs)
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' \
+          "$IR_RESULT_FILE")
         echo "done (${internalRequest})"
 
         payload=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results.signed_payload}')

--- a/tasks/managed/sign-base64-blob/tests/mocks.sh
+++ b/tasks/managed/sign-base64-blob/tests/mocks.sh
@@ -15,7 +15,7 @@ function internal-request() {
 }
 
 function kubectl() {
-  if [ $* != "get internalrequest internal-request -o=jsonpath='{.status.results.signed_payload}'" ]
+  if [[ $* != *"get internalrequest"* ]]
   then
     echo "Unexpected call to kubectl"
     exit 1
@@ -25,5 +25,5 @@ function kubectl() {
 }
 
 function gpg() {
-  echo -n "dummy-payload" 	
+  echo -n "dummy-payload"
 }

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -236,7 +236,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes
- Since the e2e test for release-to-github is disabled,
  we never caught that the pipeline was missing some
  required parameters for the validate-single-component task.
- increase timeout for sign-base64-blob task
- increase compute resources after OOMKilled was encountered.
- update release-service-utils image in sign-base64-blob task
- update mocks for sign-base64-blob task

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

