### PR TITLE
feat(RELEASE-1666): add retries for cosign download sbom

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/README.md
+++ b/tasks/managed/push-rpm-data-to-pyxis/README.md
@@ -15,12 +15,15 @@ all repository_id strings found in rpm purl strings in the sboms.
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes       | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes       | ""                      |
 | subdirectory            | Subdirectory inside the workspace to be used                                                                               | Yes       | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes       | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
+
+## Changes in 3.2.0
+* Add retries when running `cosign download sbom`
 
 ## Changes in 3.1.0
 * Added compute resource limits

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-rpm-data-to-pyxis
   labels:
-    app.kubernetes.io/version: "3.1.0"
+    app.kubernetes.io/version: "3.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -87,6 +87,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+      - name: RETRIES
+        value: "3"  # Default number of retries for cosign download
   steps:
     - name: skip-trusted-artifact-operations
       ref:
@@ -147,6 +149,27 @@ spec:
         DOCKER_CONFIG="$(mktemp -d)"
         export DOCKER_CONFIG
 
+        # Function to run cosign with retries. It will pass all arguments to cosign.
+        run_cosign () {
+            attempt=0
+            backoff1=2
+            backoff2=3
+            until [ "$attempt" -gt "${RETRIES}" ] ; do # 3 retries by default
+                cosign "$@" && break
+                sleep $backoff2
+
+                # Fibbonaci backoff
+                old_backoff1=$backoff1
+                backoff1=$backoff2
+                backoff2=$((old_backoff1 + backoff2))
+                attempt=$((attempt+1))
+            done
+            if [ "$attempt" -gt "${RETRIES}" ] ; then
+              echo "Max retries exceeded."
+              exit 1
+            fi
+        }
+
         for (( i=0; i < NUM_COMPONENTS; i++ )); do
           COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
           IMAGEURL=$(jq -r '.containerImage' <<< "${COMPONENT}")
@@ -163,13 +186,13 @@ spec:
             # If digest equals arch_digest, then it's a single arch image
             if [ "$DIGEST" = "$ARCH_DIGEST" ] ; then
               echo "Fetching sbom for single arch image: $IMAGEURL to: $FILE"
-              cosign download sbom --output-file "${FILE}" "${IMAGEURL}"
+              run_cosign download sbom --output-file "${FILE}" "${IMAGEURL}"
             else
               OS=$(jq -r '.os' <<< "$PYXIS_IMAGE")
               ARCH=$(jq -r '.arch' <<< "$PYXIS_IMAGE")
               PLATFORM="${OS}/${ARCH}"
               echo "Fetching sbom for image: $IMAGEURL with platform: $PLATFORM to: $FILE"
-              cosign download sbom --output-file "${FILE}" --platform "${PLATFORM}" "${IMAGEURL}"
+              run_cosign download sbom --output-file "${FILE}" --platform "${PLATFORM}" "${IMAGEURL}"
             fi
           done
         done

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/mocks.sh
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/mocks.sh
@@ -7,9 +7,18 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> $(params.dataDir)/mock_cosign.txt
 
-  if [[ "$*" != "download sbom --output-file myImageID"[1-5]*".json imageurl"[1-5] && \
-     "$*" != "download sbom --output-file myImageID"[1-5]*".json --platform linux/"*" multiarch-"[1-5] ]]
-  then
+  if [[ "$*" == "download sbom --output-file myImageID"[1-5]*".json imageurl"[1-5] ]]; then
+    : # do nothing
+  elif [[ "$*" == "download sbom --output-file myImageID"[1-5]*".json --platform linux/"*" multiarch-"[1-5] ]]; then
+    : # do nothing
+  elif [[ "$*" == "download sbom --output-file myImageID"[1-5]*".json retryimage" ]]; then
+    if [[ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" -lt 3 ]]; then
+      echo "Error: simulated cosign download sbom failure" 1>&2
+      return 1
+    else
+      echo "Success: simulated cosign download sbom" 1>&2
+    fi
+  else
     echo Error: Unexpected call
     exit 1
   fi

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -1,0 +1,223 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpm-data-to-pyxis-retry
+spec:
+  description: |
+    Run the push-rpm-data-to-pyxis task with required parameters and one image.
+    Cosign will fail at first and retry will be triggered.
+    The task should succeed after the retry.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        params:
+          - name: subdirectory
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(params.subdirectory)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis_data.json" << EOF
+              {
+                "components": [
+                  {
+                    "containerImage": "retryimage",
+                    "pyxisImages": [
+                      {
+                        "arch": "amd64",
+                        "imageId": "myImageID1",
+                        "digest": "mydigest1",
+                        "arch_digest": "mydigest1",
+                        "os": "linux"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-rpm-data-to-pyxis
+      params:
+        - name: pyxisJsonPath
+          value: $(context.pipelineRun.uid)/pyxis_data.json
+        - name: pyxisSecret
+          value: test-push-rpm-data-to-pyxis-cert
+        - name: server
+          value: production
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 3 ]; then
+                echo Error: cosign was expected to be called 3 times. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_upload_rpm_data.txt")" != 1 ]; then
+                echo Error: upload_rpm_data was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_upload_rpm_data.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_select-oci-auth.txt")" != 1 ]; then
+                echo Error: select-oci-with was expected to be called 1 times. Actual calls:
+                cat "$(params.dataDir)/mock_select-oci-auth.txt"
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes

To mitigate exposure to potential quay instability when pulling sboms, we add a retry mechanism when calling cosign download sbom in push-rpm-data-to-pyxis.

## Relevant Jira

[RELEASE-1666](https://issues.redhat.com//browse/RELEASE-1666)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

