### PR TITLE
feat(ISV-6033): limit SBOM update concurrency

### DIFF
--- a/tasks/managed/update-component-sbom/README.md
+++ b/tasks/managed/update-component-sbom/README.md
@@ -18,6 +18,9 @@ Tekton task to update component-level SBOMs with purls containing release-time i
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 2.0.2
+* Limited concurrency to 8 SBOM updates
+
 ## Changes in 2.0.1
 * Fixed silent script failures
 * Fixed cosign authentication issue

--- a/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
+++ b/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3c46f48e30857e1e294f88f95192b8ad01849922
+            image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-component-sbom
   labels:
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -111,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-sboms
-      image: quay.io/konflux-ci/release-service-utils:3c46f48e30857e1e294f88f95192b8ad01849922
+      image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
       script: |
         #!/usr/bin/env bash
         set -eux


### PR DESCRIPTION
The SBOM update concurrency is limited to 8 updates to avoid getting OOM killed.

https://issues.redhat.com/browse/ISV-6033
