### PR TITLE
feat(RELEASE-567): add computeResources to skip-ta-operations

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -104,6 +104,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -79,6 +79,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -70,6 +70,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -78,6 +78,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
@@ -72,6 +72,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -74,6 +74,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -86,6 +86,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
@@ -71,6 +71,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -118,6 +118,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -82,6 +82,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
+++ b/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
@@ -75,6 +75,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -69,6 +69,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -108,6 +108,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -84,6 +84,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -80,6 +80,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -99,6 +99,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -81,6 +81,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -84,6 +84,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -78,6 +78,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -91,6 +91,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -72,6 +72,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -72,6 +72,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -72,6 +72,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -77,6 +77,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -94,6 +94,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -98,6 +98,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -91,6 +91,12 @@ spec:
         value: "3"  # Default number of retries for cosign download
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -98,6 +98,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -82,6 +82,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -85,6 +85,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -102,6 +102,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -95,6 +95,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -79,6 +79,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -86,6 +86,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -95,6 +95,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -81,6 +81,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -79,6 +79,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -79,6 +79,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -105,6 +105,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -71,6 +71,12 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
This commit adds computeResources to the
skip-trusted-artifact-operations step in each task that calls it. It is not supported to define the computeResources in the stepaction itself, so it has to be added to each individual task using it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

