### PR TITLE
feat(RELEASE-567): add computeResources to use-ta-array

### DIFF
--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -100,6 +100,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact-array
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
This commit adds computeResources to the use-trusted-artifact-array step in each task that calls it (just update-cr-status). It is not supported to define computeResources in the stepaction itself, so it has to be added to the task yaml.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

