### PR TITLE
fix: rebuild needed to ensure build despite skip

### DIFF
--- a/.tekton/release-service-catalog-pull-request.yaml
+++ b/.tekton/release-service-catalog-pull-request.yaml
@@ -41,7 +41,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+    # skip the checks since this is an image that will never
+    # be released.
   - name: skip-checks
+    value: true
+    # This is needed to ensure that the image is built despite the skip-checks flag.
+  - name: rebuild
     value: true
   pipelineSpec:
     description: |


### PR DESCRIPTION
## Describe your changes
- when skip-checks is true, rebuild needs to be true to guarantee that the init task continues.
- this scenario happens when a PR is requested to be retested. the image exists since the tag inspected is based on the git SHA which does not change for a retest.

See https://github.com/konflux-ci/build-definitions/blob/main/task/init/0.2/init.yaml#L50 for logic
