### PR TITLE
fix: add retries to request-advisory-oci-artifact

### DIFF
--- a/pipelines/internal/request-advisory-oci-artifact/README.md
+++ b/pipelines/internal/request-advisory-oci-artifact/README.md
@@ -9,3 +9,6 @@ Pipeline to request an oci artifact containing an advisory json using an advisor
 | advisory_url        | URL pointing to the advisory                                                            | No       | -                                                           |
 | taskGitUrl          | The url to the git repo where the release-service-catalog tasks to be used are stored   | Yes      | https://github.com/konflux-ci/release-service-catalog.git   |
 | taskGitRevision     | The revision in the taskGitUrl repo to be used                                          | No       | -                                                           |
+
+## Changes in 0.0.2
+* Add retries to request-advisory-oci-artifact task call

--- a/pipelines/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/pipelines/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: request-advisory-oci-artifact
   labels:
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -24,6 +24,7 @@ spec:
       description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: request-advisory-oci-artifact
+      retries: 3
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
## Describe your changes
- make test more robust. add retry to call to request-advisory-oci-artifact

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

