### PR TITLE
fix: increase resource limits for reduce-snapshot step

### DIFF
--- a/tasks/managed/reduce-snapshot/README.md
+++ b/tasks/managed/reduce-snapshot/README.md
@@ -20,6 +20,9 @@ Tekton task to reduce a snapshot to a single component based on the component th
 | taskGitUrl                          | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | Yes        | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision                     | The revision in the taskGitUrl repo to be used                                                                             | Yes        | production                                                |
 
+## Chnages in 1.1.1
+* Updates compute resource limits due to OOM kill
+
 ## Changes in 1.1.0
 * Added compute resource limits
 

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: reduce-snapshot
   labels:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -132,9 +132,9 @@ spec:
       image: quay.io/enterprise-contract/ec-cli@sha256:913c7dac3d41877b01835d2e55bcd970c6cdbf4944f8176e9e3de9548642a2b4
       computeResources:
         limits:
-          memory: 32Mi
+          memory: 128Mi
         requests:
-          memory: 32Mi
+          memory: 128Mi
           cpu: 10m
       command: [reduce-snapshot.sh]
       onError: continue  # progress even if the step fails


### PR DESCRIPTION
## Describe your changes
The reduce-snapshot step was being OOMKilled
for some users in single component mode.

## Relevant Jira
Slack : https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1750417030383389?thread_ts=1750410025.903279&cid=C04PZ7H0VA8
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

