### PR TITLE
feat(RELEASE-1665): add retries to skopeo commands in various tasks

### DIFF
--- a/tasks/internal/publish-index-image-task/README.md
+++ b/tasks/internal/publish-index-image-task/README.md
@@ -12,6 +12,9 @@ Tekton task to publish a built FBC index image using skopeo
 | publishingCredentials | The credentials used to access the registries | No       | -             |
 | requestUpdateTimeout  | Max seconds waiting for the status update     | Yes      | 360           |
 
+## Changes in 0.3.1
+* Add retry for skopeo inspect
+
 ## Changes in 0.3.0
 * Added compute resource limits
 

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: publish-index-image-task
   labels:
-    app.kubernetes.io/version: "0.3.0"
+    app.kubernetes.io/version: "0.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -75,7 +75,8 @@ spec:
         if TARGET_DIGEST=$(skopeo inspect \
             "${TARGET_AUTH_ARGS[@]}" \
             "docker://$(params.targetIndex)" \
-            --format '{{.Digest}}'); then
+            --format '{{.Digest}}' \
+            --retry-times "$(params.retries)"); then
             echo "Target image exists."
             echo "DEBUG: Source Digest - $SOURCE_DIGEST"
             echo "DEBUG: Target Digest - $TARGET_DIGEST"

--- a/tasks/internal/update-fbc-catalog-task/README.md
+++ b/tasks/internal/update-fbc-catalog-task/README.md
@@ -14,6 +14,9 @@ Tekton task to submit a IIB build request to add/update a fbc-fragment to an ind
 | hotfix                  | Whether this build is a hotfix build                                         | Yes      | "false"       |
 | stagedIndex             | Whether this build is for a staged index build                               | Yes      | "false"       |
 
+## Changes in 1.2.2
+* Add retry for skopeo inspect
+
 ## Changes in 1.2.1
 * Increased memory limit from 128Mi to 512Mi
 

--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -118,22 +118,22 @@ function skopeo() {
     tomorrow="$(date --date="tomorrow" --iso-8601="seconds")"
 
     shift
-    if [[ "$*" == "--raw docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib:1" ]]; then
+    if [[ "$*" == "--retry-times 3 --raw docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib:1" ]]; then
         echo '{"manifests": ['
         echo '{ "mediaType": "application/vnd.docker.distribution.manifest.v2+json", "digest": "sha256:000" },'
         echo '{ "mediaType": "application/vnd.docker.distribution.manifest.v2+json", "digest": "sha256:001" }'
         echo ']}'
     fi
 
-    if [[ "$*" == "--config docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib@sha256:0000" ]]; then
+    if [[ "$*" == "--retry-times 3 --config docker://registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib@sha256:0000" ]]; then
         echo '{"created": "'"${today}"'"}'
     fi
 
-    if [[ "$*" == "--config docker://quay.io/fbc/catalog:complete" ]]; then
+    if [[ "$*" == "--retry-times 3 --config docker://quay.io/fbc/catalog:complete" ]]; then
         echo '{"created": "'"${yesterday}"'"}'
     fi
 
-    if [[ "$*" == "--config docker://quay.io/fbc/catalog:outdated" ]]; then
+    if [[ "$*" == "--retry-times 3 --config docker://quay.io/fbc/catalog:outdated" ]]; then
         echo '{"created": "'"${tomorrow}"'"}'
     fi
 }

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-fbc-catalog-task
   labels:
-    app.kubernetes.io/version: "1.2.1"
+    app.kubernetes.io/version: "1.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -141,12 +141,14 @@ spec:
 
           if [ "$(jq -r '.state' <<< "${build}")" = "complete" ]; then
             indexImageResolved="$(jq -r '.index_image_resolved' <<<  "${build}")"
-            newCatalogCreatedDate="$(date --date "$(skopeo inspect --config "docker://${indexImageResolved}" | \
+            newCatalogCreatedDate="$(date --date "$(skopeo inspect \
+              --retry-times 3 --config "docker://${indexImageResolved}" | \
               jq -r .created)" "+%s")"
 
             # authentication is only required for the targetIndex
             create_auth_file
-            targetIndexCreated="$(skopeo inspect --config "docker://$(params.targetIndex)" | jq -r .created)"
+            targetIndexCreated="$(skopeo inspect --retry-times 3 --config "docker://$(params.targetIndex)" | \
+              jq -r .created)"
 
             if [ -z "${targetIndexCreated}" ]; then
               # we cannot determine the target index created date, stop here. This causes the task to trigger
@@ -342,7 +344,7 @@ spec:
             # get the manifest digests
             indexImageCopy=$(jq -cr .internal_index_image_copy < "$(results.jsonBuildInfo.path)")
             # Use this to obtain the manifest digests for each arch in manifest list
-            indexImageDigestsRaw=$(skopeo inspect --raw "docker://${indexImageCopy}")
+            indexImageDigestsRaw=$(skopeo inspect --retry-times 3 --raw "docker://${indexImageCopy}")
             # according the IIB team,
             #  "all index images will always be multi-arch with a manifest list"
             #

--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -33,11 +33,14 @@ You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of im
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 2.1.1
+* Add retries for skopeo commands
 
 ## Changes in 2.1.0
 * Added compute resource limits

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: apply-mapping
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -164,7 +164,7 @@ spec:
             local repo="$2"
 
             # Use `skopeo list-tags` to fetch all tags from the repository
-            existing_tags=$(skopeo list-tags docker://"${repo}" | jq -r '.Tags[]')
+            existing_tags=$(skopeo list-tags --retry-times 3 docker://"${repo}" | jq -r '.Tags[]')
 
             # Remove `{{ incrementer }}` placeholder to get the version prefix for regex pattern
             # shellcheck disable=SC2001
@@ -372,7 +372,7 @@ spec:
             # tags per arch. So, we just use the first digest listed.
             arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
             os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
-            image_metadata="$(skopeo inspect --no-tags --override-os "${os}" --override-arch "${arch}" \
+            image_metadata="$(skopeo inspect --retry-times 3 --no-tags --override-os "${os}" --override-arch "${arch}" \
               docker://"${IMAGE_REF}" | jq -c)"
             # For timestamp, use Labels.build-date and fallback to Created
             build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -33,34 +33,34 @@ function skopeo() {
   echo Mock skopeo called with: $* >&2
   echo $* >> $(params.dataDir)/mock_skopeo.txt
 
-  if [[ "$*" =~ list-tags\ docker://repo1 ]]; then
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo1 ]]; then
       echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
       return
   fi
 
-  if [[ "$*" =~ inspect\ --no-tags\ docker://repo1 ]]; then
+  if [[ "$*" =~ inspect\ --retry-times\ 3\ --no-tags\ docker://repo1 ]]; then
       echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
       return
   fi
 
-  if [[ "$*" =~ inspect\ --no-tags\ docker://repo2 ]]; then
+  if [[ "$*" =~ inspect\ --retry-times\ 3\ --no-tags\ docker://repo2 ]]; then
       echo '{"Tags": []}'
       return
   fi
 
-  if [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
+  if [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'
     return
-  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Goodlabel.with-dash": "labelvalue-with-dash", "Badlabel": "label with space"}}'
     return
-  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}, "Created": "2024-07-29T02:17:29"}'
     return
-  elif [[ "$*" == "inspect --no-tags --override-os linux --override-arch amd64 docker://"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'
     return

--- a/tasks/managed/create-pyxis-image/README.md
+++ b/tasks/managed/create-pyxis-image/README.md
@@ -27,6 +27,9 @@ The relative path of the pyxis.json file in the data workspace is output as a ta
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                                                                                                                                                                                       | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                                                                                                                                                                              | No       | ""                      |
 
+## Changes in 5.1.2
+* Add retry for skopeo inspect
+
 ## Changes in 5.1.1
 * Bump utils image
   * This includes a fix to the way we cleanup tags - if we end up with empty tags,

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-pyxis-image
   labels:
-    app.kubernetes.io/version: "5.1.1"
+    app.kubernetes.io/version: "5.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -220,7 +220,7 @@ spec:
             SOURCE_REPO=${CONTAINER_IMAGE%%@sha256:*}
             DIGEST="${CONTAINER_IMAGE##*@}"
             PULLSPEC="${REPOSITORY}@${DIGEST}"
-            MEDIA_TYPE=$(skopeo inspect --raw "docker://${PULLSPEC}" | jq -r .mediaType)
+            MEDIA_TYPE=$(skopeo inspect --retry-times 3 --raw "docker://${PULLSPEC}" | jq -r .mediaType)
             TAGS=$(jq -r ".components[${i}].tags | join(\" \")" "${SNAPSHOT_SPEC_FILE}")
 
             # oras has very limited support for selecting the right auth entry,

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -30,10 +30,10 @@ function cleanup_tags() {
 
 function skopeo() {
   echo $* >> $(params.dataDir)/mock_skopeo.txt
-  if [[ "$*" == "inspect --raw docker://registry.io/oci-artifact"* ]]
+  if [[ "$*" == "inspect --retry-times 3 --raw docker://registry.io/oci-artifact"* ]]
   then
     echo '{"mediaType": "application/vnd.oci.image.index.v1+json"}'
-  elif [[ "$*" == "inspect --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]
   then
     echo '{"mediaType": "my_media_type+gzip"}'
   else

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -240,7 +240,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --raw docker://registry.io/image@sha256:abcdef1234" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/image@sha256:abcdef1234" ]
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -214,7 +214,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
 
               # check that decompressed layers info is not included in the oras manifest fetch
               jq -e '. | has("uncompressed_layers") == false' \

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -227,9 +227,9 @@ spec:
               fi
 
               cat > "$(params.dataDir)/skopeo_expected_calls.txt" << EOF
-              inspect --raw docker://registry.io/multi-arch-image1@sha256:mydigest1
-              inspect --raw docker://registry.io/multi-arch-image2@sha256:mydigest2
-              inspect --raw docker://registry.io/multi-arch-image3@sha256:mydigest3
+              inspect --retry-times 3 --raw docker://registry.io/multi-arch-image1@sha256:mydigest1
+              inspect --retry-times 3 --raw docker://registry.io/multi-arch-image2@sha256:mydigest2
+              inspect --retry-times 3 --raw docker://registry.io/multi-arch-image3@sha256:mydigest3
               EOF
 
               # check that the actual calls match the expected calls

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -227,9 +227,9 @@ spec:
               fi
 
               cat > "$(params.dataDir)/skopeo_expected_calls.txt" << EOF
-              inspect --raw docker://registry.io/image1@sha256:mydigest1
-              inspect --raw docker://registry.io/image2@sha256:mydigest2
-              inspect --raw docker://registry.io/image3@sha256:mydigest3
+              inspect --retry-times 3 --raw docker://registry.io/image1@sha256:mydigest1
+              inspect --retry-times 3 --raw docker://registry.io/image2@sha256:mydigest2
+              inspect --retry-times 3 --raw docker://registry.io/image3@sha256:mydigest3
               EOF
 
               # check that the actual calls match the expected calls

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -243,7 +243,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)"/mock_skopeo.txt)" \
-                = "inspect --raw docker://registry.io/oci-artifact@sha256:mydigest" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/oci-artifact@sha256:mydigest" ]
 
               if [ "$(wc -l < "$(params.dataDir)/mock_select-oci-auth.txt")" != 2 ]; then
                 echo Error: select-oci-with was expected to be called 2 times. Actual calls:

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -233,7 +233,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-              = "inspect --raw docker://registry.io/multi-arch-image@sha256:mydigest" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/multi-arch-image@sha256:mydigest" ]
 
               if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 3 ]; then
                 echo Error: oras was expected to be called 3 times. Actual calls:

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -238,7 +238,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)"/mock_skopeo.txt)" \
-                = "inspect --raw docker://registry.io/image@sha256:mydigest" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/image@sha256:mydigest" ]
 
               # check if the correct arch and image id are set in the json file
               jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -216,7 +216,7 @@ spec:
               fi
 
               [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
+                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
 
               # check that the size of the decompressed layers is as expected
               jq -e '.uncompressed_layers[0].size == 21' \

--- a/tasks/managed/extract-binaries-from-image/README.md
+++ b/tasks/managed/extract-binaries-from-image/README.md
@@ -25,6 +25,9 @@ passed.
 | taskGitUrl                 | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No        | ""                      |
 | taskGitRevision            | The revision in the taskGitUrl repo to be used                                                                             | No        | ""                      |
 
+## Changes in 3.0.1
+* Add retry for skopeo copy
+
 ## Changes in 3.0.0
 * This task now supports Trusted artifacts
 

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: extract-binaries-from-image
   labels:
-    app.kubernetes.io/version: "3.0.0"
+    app.kubernetes.io/version: "3.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -172,7 +172,7 @@ spec:
           fi
 
           TMP_DIR=$(mktemp -d)
-          skopeo copy docker://"$IMAGE_URL" dir:"$TMP_DIR"
+          skopeo copy --retry-times 3 docker://"$IMAGE_URL" dir:"$TMP_DIR"
 
           cd "$TMP_DIR"
 

--- a/tasks/managed/extract-binaries-from-image/tests/mocks.sh
+++ b/tasks/managed/extract-binaries-from-image/tests/mocks.sh
@@ -6,9 +6,11 @@ set -ex
 function skopeo() {
   echo "Mock skopeo called with: $*"
   echo "$*" >> "$(params.dataDir)/mock_skopeo.txt"
-  
+
   case "$*" in
-    "copy docker://registry.io/image:tag dir:"* | "copy docker://registry.io/image2:tag dir:"* | "copy docker://registry.io/image3:tag dir:"*)
+    "copy --retry-times 3 docker://registry.io/image:tag dir:"* | \
+    "copy --retry-times 3 docker://registry.io/image2:tag dir:"* | \
+    "copy --retry-times 3 docker://registry.io/image3:tag dir:"*)
       # Extract tar files into the destination directory
       cp $(params.dataDir)/image_data/* $TMP_DIR/
       ;;

--- a/tasks/managed/get-ocp-version/README.md
+++ b/tasks/managed/get-ocp-version/README.md
@@ -6,15 +6,18 @@ Tekton task to collect OCP version tag from FBC fragment using `skopeo inspect`.
 
 | Name                    | Description                                                                                                                | Optional | Default value           |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                       | 
+| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                       |
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 2.1.1
+* Add retry for skopeo inspect
 
 ## Changes in 2.1.0
 * Added compute resource limits

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: get-ocp-version
   labels:
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "2.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -124,7 +124,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -eux
-        
+
         SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
             echo "Error: No valid snapshot file was provided."
@@ -135,7 +135,7 @@ spec:
         fbc_fragment="$(jq -r '.components[0].containerImage' < "${SNAPSHOT_SPEC_FILE}" | tr -d "\n")"
 
         # get image metadata
-        image_metadata=$(skopeo inspect --raw "docker://${fbc_fragment}")
+        image_metadata=$(skopeo inspect --retry-times 3 --raw "docker://${fbc_fragment}")
 
         media_type=$(jq -r .mediaType <<< "${image_metadata}")
         image_base_name=$(jq '.annotations."org.opencontainers.image.base.name"' <<< "${image_metadata}" \
@@ -154,7 +154,7 @@ spec:
           fbc_fragment="${fbc_fragment%@*}@${manifest_image_sha}"
 
           # fetch the image base name containing the version for the found manifest image
-          image_base_name=$(skopeo inspect --raw docker://"${fbc_fragment}" \
+          image_base_name=$(skopeo inspect --retry-times 3 --raw docker://"${fbc_fragment}" \
            | jq '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed 's/"//g')
         fi
 

--- a/tasks/managed/get-ocp-version/tests/mocks.sh
+++ b/tasks/managed/get-ocp-version/tests/mocks.sh
@@ -2,7 +2,7 @@
 set -eux
 
 function skopeo() {
-    if [[ "$*" == "inspect --raw docker://quay.io/fbc/multi-arch@sha256:index" ]]; then
+    if [[ "$*" == "inspect --retry-times 3 --raw docker://quay.io/fbc/multi-arch@sha256:index" ]]; then
         echo '{ "mediaType": "application/vnd.oci.image.index.v1+json" }'
     else
         echo '{ "mediaType": "application/vnd.oci.image.manifest.v1+json",

--- a/tasks/managed/prepare-fbc-release/README.md
+++ b/tasks/managed/prepare-fbc-release/README.md
@@ -16,11 +16,14 @@ to each component, so other task can use them.
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 2.0.1
+* Add retry for skopeo inspect
 
 ## Changes in 2.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: prepare-fbc-release
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -134,13 +134,13 @@ spec:
         if [ ! -f "${SNAPSHOT_PATH}" ] ; then
             echo "No valid snapshot file was provided."
             exit 1
-        fi        
-        
+        fi
+
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No data JSON was provided."
             exit 1
-        fi        
+        fi
 
         pattern="^v[0-9]+\.[0-9]+$"
 
@@ -186,7 +186,7 @@ spec:
             # which includes the OCP version, formatted as "registry:version".
             # Example: "registry.redhat.io/openshift4/ose-operator-registry:v4.12"
             # The script then isolates the version part (e.g., "v4.12") from this string.
-            image_metadata=$(skopeo inspect --raw "docker://${containerImage}")
+            image_metadata=$(skopeo inspect --retry-times 3 --raw "docker://${containerImage}")
             media_type=$(jq -r .mediaType <<< "${image_metadata}")
 
             # multiplatform images will not contain the base name with the OCP version, so it should fetch
@@ -204,7 +204,7 @@ spec:
               # replace the image sha with the manifests's one
               fbc_fragment="${containerImage%@*}@${manifest_image_sha}"
 
-              ocpVersion=$(skopeo inspect --raw docker://"${fbc_fragment}" \
+              ocpVersion=$(skopeo inspect --retry-times 3 --raw docker://"${fbc_fragment}" \
                   | jq '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed 's/"//g')
             fi
 

--- a/tasks/managed/prepare-fbc-release/tests/mocks.sh
+++ b/tasks/managed/prepare-fbc-release/tests/mocks.sh
@@ -9,7 +9,7 @@ function skopeo() {
   echo "$*" >> $(params.dataDir)/mock_skopeo.txt
 
 
-  if [[ "$*" == "inspect --raw docker://quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297" ]]; then
+  if [[ "$*" == "inspect --retry-times 3 --raw docker://quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297" ]]; then
     echo '{"annotations":{"org.opencontainers.image.base.name":"registry.redhat.io/openshift4/ose-operator-registry:v4.12"}}'
     return
   fi

--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -22,6 +22,9 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
 
+## Changes in 7.2.1
+* Add retry for skopeo inspect
+
 ## Changes in 7.2.0
 * Added compute resource limits
 

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "7.2.0"
+    app.kubernetes.io/version: "7.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -268,7 +268,7 @@ spec:
           os=$(jq -r '.[0]' <<< "$oses")
           arch=$(jq -r '.[0]' <<< "$arches")
           name=$(jq -r '.name' <<< "$component")
-          media_type=$(skopeo inspect --raw "docker://${containerImage}" | jq -r .mediaType)
+          media_type=$(skopeo inspect --retry-times 3 --raw "docker://${containerImage}" | jq -r .mediaType)
           oras_args=()
           platform=
           if [[ "$media_type" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]\

--- a/tasks/managed/push-snapshot/tests/mocks.sh
+++ b/tasks/managed/push-snapshot/tests/mocks.sh
@@ -55,10 +55,10 @@ function cosign() {
 function skopeo() {
   echo Mock skopeo called with: $* >&2
   echo $* >> "$(params.dataDir)/mock_skopeo.txt"
-  if [[ "$*" == "inspect --raw docker://reg.io/test@sha256:abcdefg" ]]; then
+  if [[ "$*" == "inspect --retry-times 3 --raw docker://reg.io/test@sha256:abcdefg" ]]; then
     echo '{"mediaType": "application/vnd.oci.image.index.v1+json", "manifests": [{"platform":{"os":"linux","architecture":"amd64"}}, {"platform":{"os":"linux","architecture":"ppc64le"}}]}'
     return
-  elif [[ "$*" == "inspect --raw docker://"* ]]; then
+  elif [[ "$*" == "inspect --retry-times 3 --raw docker://"* ]]; then
     echo '{"mediaType": "my_media_type"}'
     return
   fi

--- a/tasks/managed/rh-sign-image/README.md
+++ b/tasks/managed/rh-sign-image/README.md
@@ -19,11 +19,14 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                                                                                                                                         | Yes      | empty                   |
 | ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire                                                                                                                        | Yes      | 1d                      |
 | trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                                                                                                                                            | Yes      | ""                      |
-| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                                                                                                                                                   | Yes      | ""                      | 
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                                                                                                                                                   | Yes      | ""                      |
 | sourceDataArtifact       | Location of trusted artifacts to be used to populate data directory                                                                                                                                                                               | Yes      | ""                      |
 | dataDir                  | The location where data will be stored                                                                                                                                                                                                            | Yes      | $(workspaces.data.path) |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                             | No       | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                    | No       | ""                      |
+
+## Changes in 6.0.3
+* Add retry for skopeo inspect
 
 ## Changes in 6.0.2
 * Adjust computeResources to the guidance we were given

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "6.0.2"
+    app.kubernetes.io/version: "6.0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -252,7 +252,7 @@ spec:
             TAGS=$(jq -r ".components[${COMPONENTS_INDEX}].tags | join(\" \")" "${SNAPSHOT_PATH}")
 
             # check if multi-arch
-            RAW_OUTPUT=$(skopeo inspect --no-tags --raw "docker://${referenceContainerImage}")
+            RAW_OUTPUT=$(skopeo inspect --retry-times 3 --no-tags --raw "docker://${referenceContainerImage}")
             # Always sign the top level sha
             manifest_digests="${referenceContainerImage#*@}"
             # For multi arch, also sign all the manifests inside

--- a/tasks/managed/rh-sign-image/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image/tests/mocks.sh
@@ -154,13 +154,13 @@ EOF
 function skopeo() {
   echo $* >> $(params.dataDir)/mock_skopeo.txt
   echo Mock skopeo called with: $*  >> /dev/stderr
-  if [[ "$*" == "inspect --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]
+  if [[ "$*" == "inspect --retry-times 3 --raw docker://"* ]] || [[ "$*" == "inspect --no-tags --override-os linux --override-arch "*" docker://"* ]]
   then
     echo '{"mediaType": "my_media_type"}'
   else
-    if [[ "$*" != "inspect --no-tags docker://"* ]]
+    if [[ "$*" != "inspect --retry-times 3 --no-tags docker://"* ]]
     then
-      if [[ "$*" == "inspect --no-tags --raw docker://registry.io/multi-arch-image0"* ]]
+      if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/multi-arch-image0"* ]]
       then
         echo '{
                 "schemaVersion": 2,
@@ -188,7 +188,7 @@ function skopeo() {
               }
             '
       else
-        if [[ "$*" == "inspect --no-tags --raw docker://registry.io/image"* ]]
+        if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/image"* ]]
         then
           echo '{
                   "schemaVersion": 2,


### PR DESCRIPTION
Update skopeo commands to use the --retry-times flag to help mitigate transient failures when interacting with image registries.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

