### PR TITLE
feat(RELEASE-567): add computeResources to create-trusted-artifact

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -374,6 +374,12 @@ spec:
           mv "$RESULTS_TEMP_FILE" "$RESULTS_FILE"
         fi
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -444,6 +444,12 @@ spec:
             fi
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -148,6 +148,12 @@ spec:
 
         check-jsonschema --output-format=text --schemafile "/tmp/schema"  "$(params.dataDir)/$(params.dataPath)"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -200,6 +200,12 @@ spec:
             fi
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -346,6 +346,12 @@ spec:
 
         exit $RC
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -457,6 +457,12 @@ spec:
         jq -n --arg url "$URL" --arg internal_url "$INTERNAL_URL" \
           '{"advisory": {"url": $url, "internal_url": $internal_url}}' | tee "$RESULTS_FILE"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -162,6 +162,12 @@ spec:
         - name: CONTENT_DIRECTORY
           value: $(params.content_directory)
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -137,6 +137,12 @@ spec:
 
         echo -n "$(params.sbomPath)" > "$(results.sbomPath.path)"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -362,6 +362,12 @@ spec:
         done
         echo "$JSON_OUTPUT" | tee "$(params.dataDir)/${PYXIS_DATA_PATH}"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -301,6 +301,12 @@ spec:
           exit 1
         fi
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -190,6 +190,12 @@ spec:
         - name: "IMAGE_PATH"
           value: "$(params.image_binaries_path)"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -139,6 +139,12 @@ spec:
         jq -n --arg image "$indexImage" --arg resolved "$indexImageResolved" \
           '{"index_image": {"index_image": $image, "index_image_resolved": $resolved}}' | tee "$RESULTS_FILE"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -288,6 +288,12 @@ spec:
           exit 1
         fi
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -163,6 +163,12 @@ spec:
         echo "Valid format."
         printf "%s" "$image_base_name" | tee "$(results.stored-version.path)"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -176,6 +176,12 @@ spec:
           fi
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -342,6 +342,12 @@ spec:
         # Remove duplicate references
         jq '.releaseNotes.references |= unique' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -237,6 +237,12 @@ spec:
 
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -190,6 +190,12 @@ spec:
           done
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -283,6 +283,12 @@ spec:
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -276,6 +276,12 @@ spec:
           fi
         fi
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -324,6 +324,12 @@ spec:
           fi
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -355,6 +355,12 @@ spec:
           subPath: ca-bundle.crt
           readOnly: true
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -139,6 +139,12 @@ spec:
       command: [reduce-snapshot.sh]
       onError: continue  # progress even if the step fails
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -353,6 +353,12 @@ spec:
         done
         echo "done"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -383,6 +383,12 @@ spec:
 
         echo "done"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -224,6 +224,12 @@ spec:
           echo -e "=== Finished ===\n"
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -202,6 +202,12 @@ spec:
           exit 1
         fi
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -176,6 +176,12 @@ spec:
         | gpg --dearmor \
         | tee "$(params.dataDir)/$(params.binariesPath)/${checksum_file_name}.sig"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -232,6 +232,12 @@ spec:
 
         echo "done"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -137,6 +137,12 @@ spec:
 
         echo -n "$(params.sbomPath)" > "$(results.sbomPath.path)"
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -169,6 +169,12 @@ spec:
         echo -n "$updatedTargetIndex" | tee "$(results.updated-targetIndex.path)"
         echo
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -271,6 +271,12 @@ spec:
           fi
         done
     - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
This commit adds computeResources to the create-trusted-artifact step in each task that calls it. It is not supported to define the computeResources in the stepaction itself, so it has to be added to each individual task using it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

