### PR TITLE
fix(RELEASE-1705): use /tmp for ssh data

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -462,13 +462,13 @@ spec:
         # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
         trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
 
-        mkdir -p /root/.ssh
-        chmod 700 /root/.ssh
-        cp "/mnt/secrets/mac_id_rsa" /root/.ssh/id_rsa
-        cp "/mnt/secrets/mac_fingerprint" /root/.ssh/known_hosts
-        chmod 600 /root/.ssh/id_rsa /root/.ssh/known_hosts
+        mkdir -p /tmp/.ssh
+        chmod 700 /tmp/.ssh
+        cp "/mnt/secrets/mac_id_rsa" /tmp/.ssh/id_rsa
+        cp "/mnt/secrets/mac_fingerprint" /tmp/.ssh/known_hosts
+        chmod 600 /tmp/.ssh/id_rsa /tmp/.ssh/known_hosts
 
-        SSH_OPTS=(-i /root/.ssh/id_rsa -o UserKnownHostsFile=/root/.ssh/known_hosts)
+        SSH_OPTS=(-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts)
 
         # shell check complains about the variable (unsigned_digest) not being used but it is used in the script
         # shellcheck disable=SC2034
@@ -591,15 +591,15 @@ spec:
         # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
         trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
 
-        mkdir -p /root/.ssh
-        chmod 700 /root/.ssh
-        cp "/mnt/secrets/windows_id_rsa" /root/.ssh/id_rsa
-        cp "/mnt/secrets/windows_fingerprint" /root/.ssh/known_hosts
-        chmod 600 /root/.ssh/known_hosts /root/.ssh/id_rsa
+        mkdir -p /tmp/.ssh
+        chmod 700 /tmp/.ssh
+        cp "/mnt/secrets/windows_id_rsa" /tmp/.ssh/id_rsa
+        cp "/mnt/secrets/windows_fingerprint" /tmp/.ssh/known_hosts
+        chmod 600 /tmp/.ssh/known_hosts /tmp/.ssh/id_rsa
 
-        SSH_OPTS="-i /root/.ssh/id_rsa -o UserKnownHostsFile=/root/.ssh/known_hosts -p ${WINDOWS_PORT} \
+        SSH_OPTS="-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -p ${WINDOWS_PORT} \
         ${WINDOWS_USER}@${WINDOWS_HOST}"
-        SCP_OPTS="-i /root/.ssh/id_rsa -o UserKnownHostsFile=/root/.ssh/known_hosts -P ${WINDOWS_PORT}"
+        SCP_OPTS="-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -P ${WINDOWS_PORT}"
 
         unsigned_digest=$(cat "$(results.unsignedWindowsDigest.path)")
         # Create the batch script
@@ -732,7 +732,7 @@ spec:
           exit 1
         fi
 
-        SSH_OPTS="-o UserKnownHostsFile=/root/.ssh/known_hosts \
+        SSH_OPTS="-o UserKnownHostsFile=/tmp/.ssh/known_hosts \
                     -o GSSAPIAuthentication=yes \
                     -o GSSAPIDelegateCredentials=yes"
 
@@ -759,10 +759,10 @@ spec:
         base64 -d /mnt/secrets_keytab/keytab > /tmp/sa.keytab
         retry 5 kinit -kt /tmp/sa.keytab "$(params.checksumUser)@$(params.kerberosRealm)"
 
-        mkdir -p /root/.ssh
-        chmod 700 /root/.ssh
-        cp "/mnt/secrets_fingerprint/fingerprint" /root/.ssh/known_hosts
-        chmod 600 root/.ssh/known_hosts
+        mkdir -p /tmp/.ssh
+        chmod 700 /tmp/.ssh
+        cp "/mnt/secrets_fingerprint/fingerprint" /tmp/.ssh/known_hosts
+        chmod 600 /tmp/.ssh/known_hosts
 
         # get all of the signed binaries into a common directory
         CONTENT_DIR=/shared/artifacts
@@ -942,7 +942,7 @@ spec:
 
         # export the variables used by the scripts in release-service-utils
         export CGW_USERNAME CGW_PASSWORD
-        
+
         set -x
 
         STDERR_FILE=/tmp/stderr.txt


### PR DESCRIPTION
## Describe your changes

In the app sre environment, we didn't have permissions to write to /root.

In Konflux common clusters, this may or may not be an issue, but it's still safer to use /tmp.

## Relevant Jira

[RELEASE-1705](https://issues.redhat.com//browse/RELEASE-1705)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

