### PR TITLE
fix(KFLUXSPRT-3673): set timeouts for internal-request

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -258,6 +258,10 @@ spec:
             target_index="${target_index}-${product_name}-${product_version}-${timestamp}"
           fi
 
+          finally_task_timeout=300
+          pipeline_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(("${request_timeout_seconds}"+"${finally_task_timeout}")))
+          task_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(("${request_timeout_seconds}")))
+
           echo "Processing fragment: ${fbc_fragment}:"
           # The internal-request script will create the InternalRequest and wait until it finishes to get its status
           # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
@@ -277,6 +281,8 @@ spec:
               -p taskGitRevision="$(params.taskGitRevision)" \
               --service-account "${internal_request_service_account}" \
               -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+              --pipeline-timeout "${pipeline_timeout}" \
+              --task-timeout "${task_timeout}" \
               -t "${request_timeout_seconds}" |tee "$(params.dataDir)"/ir-"$(context.taskRun.uid)"-output.log
 
           internalRequest=$(awk -F"'" '/created/ { print $2 }' \

--- a/tasks/managed/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/managed/add-fbc-contribution/tests/mocks.sh
@@ -56,6 +56,12 @@ function date() {
       "+%s")
           echo "1696946200" | tee $(params.dataDir)/mock_date_epoch.txt
           ;;
+      "-u +%Hh%Mm%Ss -d @"*)
+          /usr/bin/date $*
+          ;;
+      "-u +%Hh%Mm%Ss -d @"*)
+          usr/bin/date $*
+          ;;
       "*")
           echo Error: Unexpected call
           exit 1


### PR DESCRIPTION
this PR adds the parameters --pipeline-timeout and --task-timeout in the internal-request command
line to control the timeouts of the internal
requests created by the add-fbc-contribution task

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

