### PR TITLE
feat(RELEASE-567): add computeResources to patch-source-data-artifact

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -397,6 +397,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -467,6 +467,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -171,6 +171,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -223,6 +223,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -369,6 +369,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -480,6 +480,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -185,6 +185,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -160,6 +160,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -385,6 +385,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -324,6 +324,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -213,6 +213,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -162,6 +162,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -311,6 +311,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -186,6 +186,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -199,6 +199,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -365,6 +365,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -260,6 +260,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -213,6 +213,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -306,6 +306,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -299,6 +299,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -347,6 +347,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -378,6 +378,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -162,6 +162,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -376,6 +376,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -406,6 +406,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -247,6 +247,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -225,6 +225,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -199,6 +199,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -255,6 +255,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -160,6 +160,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -192,6 +192,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -294,6 +294,12 @@ spec:
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
     - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
This commit adds computeResources to the
patch-source-data-artifact-result step in each task that calls it. It is not supported to define computeResources in the stepaction itself, so it has to be added to each individual taks using it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

