### PR TITLE
fix: fix ta references for push-artifacts-to-cdn

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/README.md
+++ b/pipelines/managed/push-artifacts-to-cdn/README.md
@@ -26,6 +26,13 @@ It uses InternalRequests so that it can be run on both public and private cluste
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                              | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                              | Yes      | /var/workdir/release                                      |
 
+
+## Changes in 2.0.1
+* Fixed trusted artifacts references throughout the pipeline
+* Corrected `sourceDataArtifact` references in task parameters
+* Updated `update-cr-status` task to use `resultArtifacts` parameter instead of `sourceDataArtifact`
+* Fixed task execution order to ensure `update-cr-status` runs after all required results are available
+
 ## Changes in 2.0.0
 * **BREAKING**: Migrated to trusted artifacts architecture for enhanced security and traceability
 * Added trusted artifacts parameters: `ociStorage`, `orasOptions`, `trustedArtifactsDebug`, `dataDir`

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-artifacts-to-cdn
   labels:
-    app.kubernetes.io/version: "2.0.0"
+    app.kubernetes.io/version: "2.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -396,38 +396,6 @@ spec:
       runAfter:
         - verify-conforma
         - embargo-check
-    - name: update-cr-status
-      params:
-        - name: resource
-          value: $(params.release)
-        - name: resultsDirPath
-          value: $(tasks.collect-data.results.resultsDir)
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
-      runAfter:
-        - push-artifacts-to-cdn
     - name: create-advisory
       params:
         - name: releasePlanAdmissionPath
@@ -443,7 +411,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.update-cr-status.results.sourceDataArtifact)"
+          value: "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -465,7 +433,7 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - update-cr-status
+        - push-artifacts-to-cdn
     - name: close-advisory-issues
       params:
         - name: dataPath
@@ -493,6 +461,40 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - create-advisory
+    - name: update-cr-status
+      params:
+        - name: resource
+          value: $(params.release)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.create-advisory.results.sourceDataArtifact)=$(params.dataDir)"
+            - "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-cr-status/update-cr-status.yaml
       workspaces:
         - name: data
           workspace: release-workspace


### PR DESCRIPTION
## Describe your changes
* Fixed trusted artifacts references throughout the pipeline
* Corrected `sourceDataArtifact` references in task parameters
* Updated `update-cr-status` task to use `resultArtifacts` parameter instead of `sourceDataArtifact`
* Fixed task execution order to ensure `update-cr-status` runs after all required results are available

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

