### PR TITLE
feat(RELEASE-567): add docs and checks for computeResources

### DIFF
--- a/.github/scripts/tkn_check_compute_resources.sh
+++ b/.github/scripts/tkn_check_compute_resources.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# This file was created with assistance from the AI tool Cursor
+
+set -euo pipefail
+
+fail=0
+
+echo Checking that computeResources are properly set for all steps in each modified managed or internal task
+
+for file in ${CHANGED_FILES}; do
+  # Only process non test files in tasks/managed and tasks/internal
+  if [[ "$file" == */tests/* ]] || [[ ! "$file" =~ ^tasks/(managed|internal)/ ]]; then
+    continue
+  fi
+
+  step_count=$(yq '.spec.steps | length' "$file")
+  for ((i=0; i<step_count; i++)); do
+
+    compute_resources=$(yq ".spec.steps[$i].computeResources" "$file")
+    step_name=$(yq ".spec.steps[$i].name" "$file")
+
+    if [[ "$compute_resources" == "null" ]]; then
+      echo "ERROR: $file step $step_name (index $i) does not have computeResources defined"
+      fail=1
+      continue
+    fi
+
+    # Extract limits and requests for this step
+    limits=$(yq '.limits' <<< "$compute_resources")
+    requests=$(yq '.requests' <<< "$compute_resources")
+
+    # Ensure limits.cpu is not defined
+    if yq -e 'has("cpu")' <<< "$limits" > /dev/null 2>&1; then
+      echo "ERROR: $file step $step_name (index $i) has limits.cpu defined. This should not be set"
+      fail=1
+    fi
+
+    # Ensure requests.cpu is defined
+    if ! yq -e 'has("cpu")' <<< "$requests" > /dev/null 2>&1; then
+      echo "ERROR: $file step $step_name (index $i) does not have requests.cpu defined"
+      fail=1
+    fi
+
+    # Ensure limits.memory equals requests.memory
+    limits_mem=$(yq '.memory' <<< "$limits")
+    requests_mem=$(yq '.memory' <<< "$requests")
+    if [[ "$limits_mem" == "null" || "$requests_mem" == "null" || "$limits_mem" != "$requests_mem" ]]; then
+      echo "ERROR: $file step $step_name (index $i) limits.memory and requests.memory must be defined and equal"
+      fail=1
+    fi
+
+    # Check no other keys exist in computeResources (order-agnostic)
+    if ! yq -e 'keys | contains(["limits","requests"]) and length == 2' <<< "$compute_resources" > /dev/null 2>&1; then
+      echo "ERROR: $file step $step_name (index $i) computeResources has extra or missing keys"
+      fail=1
+    else
+      # Check that limits only has memory and requests only has cpu and memory (order-agnostic)
+      if ! yq -e 'keys | contains(["memory"]) and length == 1' <<< "$limits" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory"
+        fail=1
+      fi
+      if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$requests" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.requests has keys other than cpu and memory"
+        fail=1
+      fi
+    fi
+  done
+done
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -79,3 +79,18 @@ jobs:
         run: |
           source venv/bin/activate
           check-jsonschema --check-metaschema schema/dataKeys.json
+  check-compute-resources:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files
+        uses: actions/checkout@v4
+      - name: Get changed files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v45.0.6
+        id: changed-files
+        with:
+          files: |
+            **/*.yaml
+      - name: Run computeResources check script
+        run: .github/scripts/tkn_check_compute_resources.sh
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,24 @@ For other images, the reference should always either specify an image by a non-m
 or by its digest (e.g. `registry.access.redhat.com/ubi8/ubi@sha256:c94bc309b197f9fc465052123ead92bf50799ba72055bd040477ded`).
 Floating tags like `latest` or `8.8` in the case of the ubi image should be avoided.
 
+### Compute Resources
+
+All steps in the [managed](tasks/managed) and [internal](tasks/internal) tasks have `computeResources` defined. This is because the namespace in which these run is often under a very high load.
+If you are contributing a new managed or internal task (or adding a step to an existing one), you must provide appropriate `computeResources`. If you do not do this, your PR will fail
+the linting check due to the check defined in [this script](.github/scripts/tkn_check_compute_resources.sh).
+
+When setting `computeResources`, you should set the `limits.memory` and `requests.memory` to the same value. No `limits.cpu` should be defined, but a `requests.cpu` should be.
+Here is an example
+```yaml
+- name: my-new-step
+  computeResources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+      cpu: 250m
+```
+
 ### Modes for Running Pipelines
 
 Note: There are currently 2 modes that may be used when running pipelines:


### PR DESCRIPTION
This commit updates the CONTRIBUTING.md file to mention that computeResources are required on all steps in the tasks/internal and tasks/managed directory. It also adds a CI check to the lint workflow that enforces this.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

