### PR TITLE
fix: processing of long argument list with jq

### DIFF
--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -17,8 +17,11 @@ internal request. The success/failure is handled in the task creating the intern
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 2.0.2
+* Use `--slurpfile` with `jq` since `--argfile` is deprecated
+
 ## Changes in 2.0.1
-*  Updated the `ADVISORY_URL_PREFIX` logic to select either `https://access.redhat.com/errata` or 
+*  Updated the `ADVISORY_URL_PREFIX` logic to select either `https://access.redhat.com/errata` or
   `https://access.stage.redhat.com/errata` based on the Git repository's org.
 
 ## Changes in 2.0.0

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -210,18 +210,18 @@ spec:
               # Update CONTENT by removing entries that already exist in the advisory
               if [ "$(params.contentType)" == "generic" ]; then
                 # Use purl as unique key for generic artifacts
-                jq --argfile existing "$EXISTING_CONTENT" '
+                jq --slurpfile existing "$EXISTING_CONTENT" '
                   map(select(
                     .purl as $p |
-                    ($existing | map(select(.purl == $p)) | length == 0)
+                    ($existing[0] | map(select(.purl == $p)) | length == 0)
                   ))' "$CONTENT_FILE" > /tmp/content_filtered.json
               else
-                jq --argfile existing "$EXISTING_CONTENT" '
+                jq --slurpfile existing "$EXISTING_CONTENT" '
                   map(select(
                     .containerImage as $ci |
                     .tags as $tags |
                     .repository as $repo |
-                    ($existing | map(select(
+                    ($existing[0] | map(select(
                       .containerImage == $ci and .tags == $tags and .repository == $repo
                     )) | length == 0)
                   ))' "$CONTENT_FILE" > /tmp/content_filtered.json
@@ -245,8 +245,8 @@ spec:
               fi
           done
 
-          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --argfile new_content "$CONTENT_FILE" \
-            "${spec_content_type} = \$new_content")
+          NEW_ADVISORY_JSON=$(echo "$ADVISORY_JSON" | jq --slurpfile new_content "$CONTENT_FILE" \
+            "${spec_content_type} = \$new_content[0]")
 
           signingKey=$(kubectl get configmap "$(params.config_map_name)" -o jsonpath="{.data.SIG_KEY_NAME}")
           advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -13,5 +13,10 @@ It returns a list of component names that still need to be released (i.e., not f
 | advisory_secret_name           | Name of the secret containing GitLab repo and token information                                        | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 
+## Changes in 0.2.1
+* Fix handling of long argument list with `jq`
+  * When a large number of objects was in the list, `jq` would fail with `Argument list too long`
+  * The solution is to use `--slurpfile` instead of `--argjson`
+
 ## Changes in 0.2.0
 * Added compute resource limits

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: filter-already-released-advisory-images-task
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -12,7 +12,7 @@ spec:
   description: |
     Filters out images from a snapshot if they are already published in an advisory
     stored in the GitLab advisory repo. Returns a list of component names
-    that still need to be released (i.e., not found in any advisory). 
+    that still need to be released (i.e., not found in any advisory).
   params:
     - name: snapshot_json
       type: string
@@ -122,18 +122,19 @@ spec:
           exit 0
         fi
 
+        EXISTING_CONTENT=/tmp/existing_content.json
         for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
           ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
-          EXISTING_CONTENT=$(yq -o=json '.spec.content.images // []' "$ADVISORY_FILE")
+          yq -o=json '.spec.content.images // []' "$ADVISORY_FILE" > "$EXISTING_CONTENT"
 
           echo "Comparing against: $ADVISORY_FILE"
 
-          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --argjson existing "$EXISTING_CONTENT" '
+          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --slurpfile existing "$EXISTING_CONTENT" '
             map(select(
               .containerImage as $ci |
               .tags as $tags |
               .repository as $repo |
-              ($existing | map(select(
+              ($existing[0] | map(select(
                 .containerImage == $ci and .tags == $tags and .repository == $repo
               )) | length == 0)
             ))')

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -229,7 +229,8 @@ spec:
               }'
 
               # Use jq to compare JSON objects
-              if ! echo "$EXPECTED_RESULTS" | jq --argfile actual "$RESULTS_FILE" -e '. == $actual' > /dev/null; then
+              if ! echo "$EXPECTED_RESULTS" | jq --slurpfile actual "$RESULTS_FILE" -e '. == $actual[0]' > /dev/null
+              then
                   echo "Error: Results do not match expected output."
                   echo "Expected: $EXPECTED_RESULTS"
                   echo "Actual: $(cat "$RESULTS_FILE")"

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -228,7 +228,8 @@ spec:
               }'
 
               # Use jq to compare JSON objects
-              if ! echo "$EXPECTED_RESULTS" | jq --argfile actual "$RESULTS_FILE" -e '. == $actual' > /dev/null; then
+              if ! echo "$EXPECTED_RESULTS" | jq --slurpfile actual "$RESULTS_FILE" -e '. == $actual[0]' > /dev/null
+              then
                   echo "Error: Results do not match expected output."
                   echo "Expected: $EXPECTED_RESULTS"
                   echo "Actual: $(cat "$RESULTS_FILE")"


### PR DESCRIPTION
## Describe your changes

When using `--argjson` with `jq`, it can fail with: Argument list too long

The fix is to use `--argfile` with a file instead.

Note: This was already fixed for create-advisory-task previously: https://github.com/konflux-ci/release-service-catalog/pull/942

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

