### PR TITLE
feat(RELEASE-567): add computeResources to use-trusted-artifact

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -125,6 +125,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -100,6 +100,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -91,6 +91,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -99,6 +99,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
@@ -93,6 +93,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -95,6 +95,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -107,6 +107,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
@@ -92,6 +92,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -103,6 +103,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
+++ b/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
@@ -96,6 +96,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -90,6 +90,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -129,6 +129,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -105,6 +105,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -101,6 +101,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -120,6 +120,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -102,6 +102,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -105,6 +105,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -99,6 +99,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -112,6 +112,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -93,6 +93,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -93,6 +93,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -93,6 +93,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -98,6 +98,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -115,6 +115,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -119,6 +119,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -110,6 +110,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -112,6 +112,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -119,6 +119,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -103,6 +103,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -106,6 +106,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -123,6 +123,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -116,6 +116,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -100,6 +100,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -107,6 +107,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -116,6 +116,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -102,6 +102,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -100,6 +100,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -126,6 +126,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -92,6 +92,12 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
This commit adds computeResources to the use-trusted-artifact step in each task that calls it. It is not supported to define computeResources in the stepaction itself, so it has to be added to each individual task using it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

