### PR TITLE
fix: adjust rh-sign-image computeResources

### DIFF
--- a/tasks/managed/rh-sign-image/README.md
+++ b/tasks/managed/rh-sign-image/README.md
@@ -25,6 +25,11 @@ Task to create internalrequests or pipelineruns to sign snapshot components
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                                                                                             | No       | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                                                                                                                                                    | No       | ""                      |
 
+## Changes in 6.0.2
+* Adjust computeResources to the guidance we were given
+  * Removed cpu limit
+  * Set memory request to be the same as memory limit
+
 ## Changes in 6.0.1
 * The default serviceAccount is changed from `appstudio-pipeline` to `release-service-account`
 

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: rh-sign-image
   labels:
-    app.kubernetes.io/version: "6.0.1"
+    app.kubernetes.io/version: "6.0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -142,9 +142,8 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
-          cpu: '2'
         requests:
-          memory: 2Gi
+          memory: 4Gi
           cpu: '2'
       env:
         - name: pyxisCert


### PR DESCRIPTION
Remove the cpu limit and set the memory request and limit to be equal. This is what we have been guided to do for task steps.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

