### PR TITLE
fix: use separate SA for collectors and tenant pipelines

### DIFF
--- a/integration-tests/collectors/resources/tenant/rp.yaml
+++ b/integration-tests/collectors/resources/tenant/rp.yaml
@@ -104,4 +104,4 @@ spec:
       - name: cve
         params: []
         type: cve
-    serviceAccountName: ${tenant_sa_name}
+    serviceAccountName: ${tenant_collector_sa_name}

--- a/integration-tests/collectors/resources/tenant/sa.yaml
+++ b/integration-tests/collectors/resources/tenant/sa.yaml
@@ -2,6 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${tenant_sa_name}
+  name: ${tenant_collector_sa_name}
 secrets:
   - name: jira-collectors-secret-${component_name}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${tenant_sa_name}

--- a/integration-tests/collectors/test.env
+++ b/integration-tests/collectors/test.env
@@ -18,7 +18,8 @@ export component_base_branch=collector-base
 export component_repo_name=scoheb/e2e-base #konflux-ci/release-service-catalog-e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
-export tenant_sa_name=collector-sa-${uuid}
+export tenant_collector_sa_name=collector-sa-${uuid}
+export tenant_sa_name=collector-tenant-sa-${uuid}
 export release_plan_name=collector-rp-${uuid}
 
 export managed_sa_name=collector-sa-${uuid}


### PR DESCRIPTION
## Describe your changes
After implementing auto  RB creation for collector pipelines, using the same SA for both tenant collectors and tenant pipelines causes failures. The operator cleans up collector RBs after finshing, removing access to `release-pipeline-resource-role` for the tenant pipeline.

This change adds separate SA to allow collectors and tenant pipelines to run independently.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

