### PR TITLE
feat(RELEASE-1697): convert update-infra-deployments to use trusted-artifacts

### DIFF
--- a/pipelines/managed/rhtap-service-push/README.md
+++ b/pipelines/managed/rhtap-service-push/README.md
@@ -25,6 +25,7 @@
 ## Changes in 4.8.0
 * Add required taskGit* parameters for collect-slack-notification-params task
 * Add required taskGit* parameters for send-slack-notification task
+* Add required taskGit* parameters for update-infra-deployments task
 
 ## Changes in 4.7.0
 * Add retries in the pipeline

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -385,9 +385,13 @@ spec:
             value: tasks/managed/update-infra-deployments/update-infra-deployments.yaml
       params:
         - name: snapshotPath
-          value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataJsonPath
-          value: "$(workspaces.data.path)/$(tasks.collect-data.results.data)"
+          value: "$(tasks.collect-data.results.data)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/managed/update-infra-deployments/README.md
+++ b/tasks/managed/update-infra-deployments/README.md
@@ -17,6 +17,21 @@
 | sharedSecret                   | Secret in the namespace which contains private key for the GitHub App                        | true     | infra-deployments-pr-creator                                                                                                                     |
 | defaultGithubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
 | defaultGithubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
+| ociStorage                     | The OCI repository where the Trusted Artifacts are stored.                                   | true     | empty                                                                                                                                            |
+| ociArtifactExpiresAfter        | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire. | true | 1d                                                                                                                                               |
+| trustedArtifactsDebug         | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.      | true     |                                                                                                                                                  |
+| orasOptions                    | oras options to pass to Trusted Artifacts calls                                              | true     |                                                                                                                                                  |
+| sourceDataArtifact            | Location of trusted artifacts to be used to populate data directory                          | true     |                                                                                                                                                  |
+| dataDir                        | The location where data will be stored                                                       | true     | $(workspaces.data.path)                                                                                                                         |
+| taskGitUrl                     | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | false |                                                                                                                                                  |
+| taskGitRevision                | The revision in the taskGitUrl repo to be used                                               | false    |                                                                                                                                                  |
+
+## Changes in 2.0.0
+* Updated task to use trusted artifacts for secure data flow between tasks
+* Added trusted artifacts parameters: `ociStorage`, `ociArtifactExpiresAfter`, `trustedArtifactsDebug`, `orasOptions`, `sourceDataArtifact`, `dataDir`, `taskGitUrl`, `taskGitRevision`
+* Added `sourceDataArtifact` result
+* Updated file paths to use `$(params.dataDir)` instead of direct workspace paths
+* Added trusted artifacts step actions: `skip-trusted-artifact-operations`, `use-trusted-artifact`, `create-trusted-artifact`, `patch-source-data-artifact-result`
 
 ## Changes in 1.4.0
 * Added compute resource limits

--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -10,14 +10,51 @@ spec:
     Run the update-infra-deployments task with the no data file present. The task should fail.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -25,7 +62,8 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
               {
                 "application": "myapp",
                 "components": [
@@ -35,23 +73,66 @@ spec:
                     "repository": "prod-registry.io/prod-location",
                     "tags": [
                       "tag"
-                    ]
+                    ],
+                    "source": {
+                      "git": {
+                        "revision": "production",
+                        "url": "repo"
+                      }
+                    }
                   }
                 ]
               }
               EOF
+              # Note: Intentionally NOT creating data.json file to test failure scenario
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: update-infra-deployments
       params:
         - name: snapshotPath
-          value: snapshot.json
+          value: $(context.pipelineRun.uid)/snapshot.json
         - name: dataJsonPath
-          value: data.json
-        - name: originRepo
-          value: repo
-        - name: revision
-          value: production
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "2.0.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
@@ -32,6 +32,47 @@ spec:
     - name: sharedSecret
       default: infra-deployments-pr-creator
       description: secret in the namespace which contains private key for the GitHub App
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  workspaces:
+    - name: artifacts
+      description: Workspace containing arbitrary artifacts used during the task run.
+      optional: true
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
   volumes:
     - name: infra-deployments-pr-creator
       secret:
@@ -39,7 +80,62 @@ spec:
         secretName: $(params.sharedSecret)
     - name: shared-dir
       emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
   steps:
+    - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
     - name: git-clone-infra-deployments
       image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
       computeResources:
@@ -53,7 +149,8 @@ spec:
           mountPath: /shared
       workingDir: /shared
       script: |
-        TARGET_GH_REPO="$(jq -r '.targetGHRepo // "$(params.defaultTargetGHRepo)"' "$(params.dataJsonPath)")"
+        TARGET_GH_REPO="$(jq -r '.targetGHRepo // "$(params.defaultTargetGHRepo)"' \
+          "$(params.dataDir)/$(params.dataJsonPath)")"
         echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
@@ -74,21 +171,21 @@ spec:
         cd cloned
         
         echo "snapshot:"
-        cat "$(params.snapshotPath)"
+        cat "$(params.dataDir)/$(params.snapshotPath)"
         echo ""
         
         # We assume we only have one component in the service.
-        revision="$(jq -r .components[0].source.git.revision "$(params.snapshotPath)")"
+        revision="$(jq -r .components[0].source.git.revision "$(params.dataDir)/$(params.snapshotPath)")"
         echo "revision: $revision"
         echo "$revision" > ../revision.txt
 
-        originRepo="$(jq -r .components[0].source.git.url "$(params.snapshotPath)")"
+        originRepo="$(jq -r .components[0].source.git.url "$(params.dataDir)/$(params.snapshotPath)")"
         echo "origin repo: $originRepo"
         echo "$originRepo" > ../originRepo.txt
 
         # Get SCRIPT from Data
-        echo "data: $(params.dataJsonPath)"
-        SCRIPT="$(jq -r '."infra-deployment-update-script" // empty' "$(params.dataJsonPath)")"
+        echo "data: $(params.dataDir)/$(params.dataJsonPath)"
+        SCRIPT="$(jq -r '."infra-deployment-update-script" // empty' "$(params.dataDir)/$(params.dataJsonPath)")"
 
         if [ "${SCRIPT}" == "" ] ; then
           echo "No script provided via 'infra-deployment-update-script' key in data"
@@ -137,7 +234,7 @@ spec:
         - name: GITHUB_API_URL
           value: https://api.github.com
         - name: DATA_JSON_PATH
-          value: "$(params.dataJsonPath)"
+          value: "$(params.dataDir)/$(params.dataJsonPath)"
         - name: DEFAULT_TARGET_GH_REPO
           value: "$(params.defaultTargetGHRepo)"
         - name: DEFAULT_GITHUB_APP_ID
@@ -376,10 +473,47 @@ spec:
 
         if __name__ == '__main__':
             main()
-
-  workspaces:
-    - name: artifacts
-      description: Workspace containing arbitrary artifacts used during the task run.
-      optional: true
-    - name: data
-      description: The workspace where the snapshot spec json file resides
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)


### PR DESCRIPTION
## Describe your changes
* Convert task update-infra-deployments to use trusted artifacts.
* Add new required parameters in the rhtap-service-push pipeline

## Relevant Jira
* [RELEASE-1697](https://issues.redhat.com//browse/RELEASE-1697)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

