### PR TITLE
feat(RELEASE-1711): add advisory_internal_url as a pipeline result

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,9 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.1.2
+* Add advisory_internal_url from create-advisory task as a pipeline result
+
 ## Changes in 2.1.1
 * Remove snippet to allow `close-advisory-issues` to fail
   * This was added temporarily in 2.0.1

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.1.1"
+    app.kubernetes.io/version: "2.1.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -85,6 +85,9 @@ spec:
     - name: advisory_url
       type: string
       value: $(tasks.create-advisory.results.advisory_url)
+    - name: advisory_internal_url
+      type: string
+      value: $(tasks.create-advisory.results.advisory_internal_url)
   tasks:
     - name: verify-access-to-resources
       taskRef:


### PR DESCRIPTION
This commit adds the advisory_internal_url result from the create-advisory task to the rh-advisories pipeline results.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

