### PR TITLE
feat: remove rh-sign-image from rh-advisories

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -556,7 +556,10 @@ spec:
         - name: data
           workspace: release-workspace
       runAfter:
-        - rh-sign-image
+        - embargo-check
+        - verify-conforma
+        - publish-pyxis-repository
+        - extract-requester-from-release
     - name: collect-pyxis-params
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
@@ -591,63 +594,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-data
-    - name: rh-sign-image
-      timeout: "6h00m0s"
-      when:
-        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
-          operator: in
-          values: ["false"]
-      retries: 3
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/rh-sign-image/rh-sign-image.yaml
-      params:
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: dataPath
-          value: "$(tasks.collect-data.results.data)"
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
-        - name: requester
-          value: $(tasks.extract-requester-from-release.results.output-result)
-        - name: requestTimeout
-          # The RADAS timeout when it fails to receive a response is 5 mins.
-          # Give RADAS enough time to retry its request.
-          value: 1800
-        - name: pipelineRunUid
-          value: $(context.pipelineRun.uid)
-        - name: pyxisServer
-          value: $(tasks.collect-pyxis-params.results.server)
-        - name: pyxisSecret
-          value: $(tasks.collect-pyxis-params.results.secret)
-        - name: signRegistryAccessPath
-          value: $(tasks.publish-pyxis-repository.results.signRegistryAccessPath)
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.publish-pyxis-repository.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      workspaces:
-        - name: data
-          workspace: release-workspace
-      runAfter:
-        - embargo-check
-        - verify-conforma
-        - publish-pyxis-repository
-        - extract-requester-from-release
     - name: create-pyxis-image
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
@@ -1123,7 +1069,6 @@ spec:
         - embargo-check
         - push-rpm-data-to-pyxis
         - run-file-updates
-        - rh-sign-image
         - rh-sign-image-cosign
         - set-advisory-severity
     - name: close-advisory-issues


### PR DESCRIPTION
## Describe your changes

This is a custom change for the OCP team to see
if anything else would block their release pipelines from succeeding.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

