### PR TITLE
feat: support new fields in rpm data

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -132,7 +132,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+        quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
       computeResources:
         limits:
           memory: 128Mi
@@ -216,7 +216,7 @@ spec:
         fi
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+        quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -64,7 +64,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Bump utils image in push-rpm-data-to-pyxis.

The new image is able to extract two new fields (epoch, module) from rpm purls and save them in Pyxis.

Related utils PR: https://github.com/konflux-ci/release-service-utils/pull/413

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

