### PR TITLE
test: use the latest utils image everywhere

### DIFF
--- a/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
@@ -45,7 +45,7 @@ spec:
       description: The relative path in the workspace to the results directory
   steps:
     - name: collect-collectors-resources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       env:
         - name: "PREVIOUS_RELEASE"
           value: '$(params.previousRelease)'
@@ -75,7 +75,7 @@ spec:
         else
           get-resource "release" "${PREVIOUS_RELEASE}" | tee "$(workspaces.data.path)/$PREVIOUS_RELEASE_PATH"
         fi
-        
+
         RELEASE_PATH="$(params.subdirectory)/release.json"
         echo -n "$RELEASE_PATH" > "$(results.release.path)"
         get-resource "release" "${RELEASE}" | tee "$(workspaces.data.path)/$RELEASE_PATH"

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-empty-previous-release-value.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-empty-previous-release-value.yaml
@@ -14,11 +14,11 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -90,7 +90,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -103,7 +103,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
@@ -16,11 +16,11 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -68,7 +68,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -29,7 +29,7 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f previousrelease
-              
+
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -101,7 +101,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -112,7 +112,7 @@ spec:
               echo Test that previous Release CR was saved to workspace
               test "$(jq -r '.metadata.name' < "$(workspaces.data.path)/$(params.previousRelease)")" == \
                 previous-release-sample
-              
+
               echo Test that Release CR was saved to workspace
               test "$(jq -r '.metadata.name' < "$(workspaces.data.path)/$(params.release)")" == release-sample
 
@@ -124,7 +124,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -39,7 +39,7 @@ spec:
       description: Workspace where the CRs are stored
   steps:
     - name: run-collectors
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       script: |
         #!/usr/bin/env bash
         set -xeo pipefail
@@ -83,10 +83,10 @@ spec:
         fi
 
         cd /tmp
-        
+
         git clone "${COLLECTORS_REPOSITORY}" --branch "${COLLECTORS_REPOSITORY_REVISION}" collectors
         pushd collectors
-        
+
         # Set COLLECTOR_TYPE based on the value of COLLECTORS_RESOURCE_TYPE
         if [[ "$COLLECTORS_RESOURCE_TYPE" == "releaseplan" ]]; then
           COLLECTOR_TYPE="tenant"

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-fail-timeout.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-fail-timeout.yaml
@@ -16,13 +16,13 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir "$(workspaces.data.path)"/results
-              
+
               cat > "$(workspaces.data.path)"/test_release_plan.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-no-resource.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-no-resource.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-parallel.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-parallel.yaml
@@ -14,13 +14,13 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir "$(workspaces.data.path)"/results
-              
+
               cat > "$(workspaces.data.path)"/test_release_plan.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/run-collectors/tests/test-run-collectors.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors.yaml
@@ -13,13 +13,13 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir "$(workspaces.data.path)"/results
-              
+
               cat > "$(workspaces.data.path)"/test_release_plan.json << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -88,7 +88,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/save-collectors-results.yaml
@@ -32,7 +32,7 @@ spec:
       description: Workspace where the results directory is stored
   steps:
     - name: save-collectors-results
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -44,16 +44,16 @@ spec:
                 echo "Ignoring not JSON file: ${resultsFile}."
                 continue
             fi
-        
+
             fileName=$(basename "$resultsFile")
-        
+
             # Check if the file name does NOT match the pattern
             if ! [[ "$fileName" =~ ^(managed|tenant)-([a-zA-Z0-9_-]+)\.json$ ]]; then
                 echo "Ignoring invalid file name: $fileName"
-            else    
+            else
                 prefix="${BASH_REMATCH[1]}"
                 collector="${BASH_REMATCH[2]}"
-        
+
                 # Update RESULTS_JSON with the content of the current file under the correct key
                 RESULTS_JSON=$(jq --arg prefix "$prefix" --arg collector "$collector" \
                     --slurpfile content "$resultsFile" \

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -27,7 +27,7 @@ spec:
               json
               }
               EOF
-              
+
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -71,7 +71,7 @@ spec:
               echo Test that the Release.Status contains the expected data
               test "$(kubectl get release release-cr-status-multiple -n default \
                 -o jsonpath='{.status.collectors.managed.one.foo}')" == bar
-              
+
               test "$(kubectl get release release-cr-status-multiple -n default \
                 -o jsonpath='{.status.collectors.managed.two.baz}')" == qux
       runAfter:
@@ -81,7 +81,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -71,7 +71,7 @@ spec:
               echo Test that the Release.Status contains proper data
               test "$(kubectl get release release-cr-status -n default \
                   -o jsonpath='{.status.collectors.managed.one.foo}')" == bar
-              
+
               echo Test that invalid file names were ignored
               test -z "$(kubectl get release release-cr-status -n default \
                   -o jsonpath='{.status.collectors.managed.two.baz}' 2>/dev/null)"
@@ -83,7 +83,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -25,7 +25,7 @@ spec:
       description: Space separated string of embargoed CVEs if any are found, empty string otherwise
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -38,7 +38,7 @@ spec:
       description: UMB SSL key file name
   steps:
     - name: collect-simple-signing-params
-      image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/internal/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
           - name: sig_key_name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "sig_key_name"
                 value: '$(params.sig_key_name)'

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -35,7 +35,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory-oci-artifact
-      image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi
@@ -101,7 +101,7 @@ spec:
         tar_opts=(--create --use-compress-program='gzip -n' --file)
         tar_opts=(--verbose "${tar_opts[@]}")
         set -o xtrace
-  
+
         tar "${tar_opts[@]}" "${archive}" --directory="${path}" .
 
         sha256sum_output="$(sha256sum "${archive}")"

--- a/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-create-advisory-stage
 spec:
   description: |
-    Run the create-advisory task and check that the advisory URL is pointing to the staging Errata 
+    Run the create-advisory task and check that the advisory URL is pointing to the staging Errata
     when the Git org is 'rhtap-release'. The result should be emitted as a task result.
   tasks:
     - name: run-task
@@ -49,7 +49,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:20e010a0dde28e31826ce91914d5852d73437fc2
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -35,7 +35,7 @@ spec:
       description: List of components that still need to be released
   steps:
     - name: filter-images
-      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -30,7 +30,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -32,7 +32,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -32,7 +32,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -32,7 +32,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,7 +87,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -135,7 +135,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -86,7 +86,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: fileUpdatesInfo
                 value: "$(params.fileUpdatesInfo)"
@@ -114,7 +114,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,17 +87,17 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
-  
+
               echo "Test that status is Success"
               test "$(params.fileUpdatesState)" == "Success"
 
               cd "$(params.tempDir)/replace-idempotent"
               commits=$(git log --oneline | wc -l)
-              
+
               echo "Test no more commit created except the one in setup step"
               test "${commits}" == "1"
               rm -rf "$(params.tempDir)"

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
@@ -20,7 +20,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -86,7 +86,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: fileUpdatesInfo
                 value: "$(params.fileUpdatesInfo)"
@@ -114,7 +114,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -87,7 +87,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -128,7 +128,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
@@ -20,7 +20,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -66,7 +66,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -44,7 +44,7 @@ spec:
               key: targetIndexCredential
               name: $(params.publishingCredentials)
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
@@ -29,7 +29,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
@@ -29,7 +29,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -40,7 +40,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -263,7 +263,7 @@ spec:
         while IFS= read -r -d '' file ; do
             STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
               --arg version "$VERSION" \
-              '.payload.files[.payload.files | length] = 
+              '.payload.files[.payload.files | length] =
               {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$STAGED_JSON")
         done < <(find * -type f -print0)
 

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -119,7 +119,7 @@ spec:
         secretName: checksum-keytab-secret
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -238,7 +238,7 @@ spec:
             wait -n
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -351,7 +351,7 @@ spec:
         echo "Digest for windows content: $windows_digest"
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -519,7 +519,7 @@ spec:
         # shellcheck disable=SC2029
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -657,7 +657,7 @@ spec:
         ssh $SSH_OPTS "Remove-Item -LiteralPath \
         C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -821,7 +821,7 @@ spec:
         mv "$SHA_SUM_PATH" "${SIGNED_DIR}/sha256sum.txt"
 
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi
@@ -897,7 +897,7 @@ spec:
         done
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7835e32b1974f956a6c942e24adbc79705cab12e
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwfileprefix.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -76,7 +76,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilesfilename.yaml
@@ -76,7 +76,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedfilessource.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -110,7 +110,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -74,7 +74,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-pulp-for-binary.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-pulp-for-binary.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -42,7 +42,7 @@ spec:
         value: "/tekton/home"
   steps:
     - name: request-advisory-oci-artifact
-      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/request-advisory-oci-artifact/tests/test-request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/tests/test-request-advisory-oci-artifact.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -43,7 +43,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-retries.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-retries.yaml
@@ -64,7 +64,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2ddb2b1e7b406674273a2aa3d3e4e92b78cdf625
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -34,7 +34,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
@@ -41,7 +41,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -x

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -63,7 +63,7 @@ spec:
   steps:
     - name: update-fbc-catalog-prepare-and-call-iib-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -285,7 +285,7 @@ spec:
           mountPath: /mnt/service-account-secret
     - name: update-fbc-catalog-wait-for-iib-build-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -144,7 +144,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: add-contribution
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -276,9 +276,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -154,9 +154,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -225,7 +225,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -303,9 +303,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -231,7 +231,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -309,9 +309,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -222,7 +222,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -294,9 +294,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga-and-hotfix-failure.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -273,9 +273,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-index.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -217,9 +217,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -210,9 +210,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               #
@@ -286,9 +286,9 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               kubectl delete internalrequests --all

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -119,7 +119,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -196,7 +196,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -266,7 +266,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -231,7 +231,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -244,7 +244,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -222,7 +222,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -111,7 +111,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: base64-encode-checksum
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -129,7 +129,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task to check that all required information is present to use the specified system(s) 
+    Tekton task to check that all required information is present to use the specified system(s)
     and the data is valid against the schema.
   params:
     - name: dataPath
@@ -118,7 +118,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi
@@ -147,7 +147,7 @@ spec:
         systemsJSON=$(echo "$@" | jq -R 'split(" ")')
 
         jq --argjson systems "$systemsJSON" '.systems += $systems' \
-            "$(params.dataDir)/$(params.dataPath)" > "/tmp/systems" 
+            "$(params.dataDir)/$(params.dataPath)" > "/tmp/systems"
         mv "/tmp/systems" "$(params.dataDir)/$(params.dataPath)"
 
         check-jsonschema --output-format=text --schemafile "/tmp/schema"  "$(params.dataDir)/$(params.dataPath)"

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with an incorrect type for the releaseNotes product_id key which should be an integer 
+    Run the check-data-keys task with an incorrect type for the releaseNotes product_id key which should be an integer
     and verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with an incorrect field in the releaseNotes.issues key 
+    Run the check-data-keys task with an incorrect field in the releaseNotes.issues key
     (using cves instead of fixed) and verify that the task failed.
   workspaces:
     - name: tests-workspace
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
+++ b/tasks/managed/check-fbc-packages/check-fbc-packages.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-contribution
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
+++ b/tasks/managed/check-fbc-packages/tests/test-check-fbc-packages-negative.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
+++ b/tasks/managed/check-fbc-packages/tests/test-check-fbc-packages-positive.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -15,7 +15,7 @@ spec:
       description: The uid of the current pipelineRun. It is only available at the pipeline level
   steps:
     - name: cleanup-internal-requests
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
@@ -18,11 +18,11 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               cat > irs << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: InternalRequest
@@ -65,7 +65,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -26,7 +26,7 @@ spec:
       description: Workspace where the directory to cleanup exists
   steps:
     - name: cleanup
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -20,11 +20,11 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               cat > irs << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: InternalRequest
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
@@ -19,7 +19,7 @@ spec:
           - name: input
         steps:
           - name: put-content-in-workspace
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -52,7 +52,7 @@ spec:
           - name: input
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,4 +70,4 @@ spec:
               then
                   echo File "${KEPT_DIR}/cleanup_check.txt" is expected to exist, but it does not
                   exit 1
-              fi   
+              fi

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -114,7 +114,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: close-issues
-      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -127,7 +127,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-atlas-params
       image:
-        quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -128,7 +128,7 @@ spec:
           - name: atlasApiUrl
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -140,7 +140,7 @@ spec:
           - name: retryS3Bucket
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -133,7 +133,7 @@ spec:
           - name: retryAWSSecretName
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -140,7 +140,7 @@ spec:
           - name: retryS3Bucket
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
+++ b/tasks/managed/collect-cosign-params/collect-cosign-params.yaml
@@ -111,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
+++ b/tasks/managed/collect-cosign-params/tests/test-collect-cosign-params-no-secret-in-data.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -126,7 +126,7 @@ spec:
           - name: cosign-secret-name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.cosign-secret-name)'

--- a/tasks/managed/collect-cosign-params/tests/test-collect-cosign-params.yaml
+++ b/tasks/managed/collect-cosign-params/tests/test-collect-cosign-params.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -128,7 +128,7 @@ spec:
           - name: cosign-secret-name
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.cosign-secret-name)'

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -137,7 +137,7 @@ spec:
         - name: workDir
           value: $(params.dataDir)
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi
@@ -294,7 +294,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -48,7 +48,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -48,7 +48,7 @@ spec:
           - name: data
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -32,7 +32,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -118,7 +118,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -32,7 +32,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,7 +108,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -223,7 +223,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -238,13 +238,13 @@ spec:
                 cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi
-              
+
               org=$(jq -r '.org' <<< "$PIPELINE_METADATA")
               repo=$(jq -r '.repo' <<< "$PIPELINE_METADATA")
               revision=$(jq -r '.revision' <<< "$PIPELINE_METADATA")
               pathinrepo=$(jq -r '.pathinrepo' <<< "$PIPELINE_METADATA")
               sha=$(jq -r '.sha' <<< "$PIPELINE_METADATA")
-              
+
               test "${org}" == 'unknown'
               test "${repo}" == 'unknown'
               test "${revision}" == 'unknown'
@@ -256,7 +256,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -249,7 +249,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -74,7 +74,7 @@ spec:
               '
               kubectl patch Release release-with-data-sample --type=merge --subresource status --patch \
                 "status: $collectors"
-              
+
               cat > releaseplan << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
@@ -237,7 +237,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -258,7 +258,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -229,7 +229,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -237,16 +237,16 @@ spec:
               echo Test that data result was set properly
               test "$(cat "$(params.dataDir)/$(params.data)")" \
                == '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"},"singleComponentMode":true}'
-              
+
               echo Test that the singleComponentMode result was properly set
-              test "$(params.singleComponentMode)" == "true"  
+              test "$(params.singleComponentMode)" == "true"
 
   finally:
     - name: cleanup
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-overriding-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-overriding-collectors.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -70,7 +70,7 @@ spec:
                           source: "issues.redhat.com"
               EOF
               kubectl apply -f release
-              
+
               collectors='
                 {"collectors":{"managed":{"foo":{"releaseNotes":{"cves":[{"key":"FOO-3444","component":"my-component"}]}},
                 "bar":{"releaseNotes":{"issues":{"fixed":[{"id":"FOO-1234","source":"issues.redhat.com"}]}}}},
@@ -230,7 +230,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -245,7 +245,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -247,7 +247,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -282,7 +282,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -123,7 +123,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-gh-params
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +150,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/collect-marketplacesvm-params/collect-marketplacesvm-params.yaml
+++ b/tasks/managed/collect-marketplacesvm-params/collect-marketplacesvm-params.yaml
@@ -26,7 +26,7 @@ spec:
   steps:
     - name: collect-marketplacesvm-params
       image:
-        quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params-fail-no-secret.yaml
+++ b/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params-fail-no-secret.yaml
@@ -21,7 +21,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params-pre-push.yaml
+++ b/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params-pre-push.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -65,7 +65,7 @@ spec:
           - name: prePush
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params.yaml
+++ b/tasks/managed/collect-marketplacesvm-params/tests/test-collect-marketplacesvm-params.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -64,7 +64,7 @@ spec:
           - name: prePush
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
@@ -23,7 +23,7 @@ spec:
       description: the secret name for charon aws credential file
   steps:
     - name: collect-mrrc-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
@@ -18,7 +18,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -78,7 +78,7 @@ spec:
           - name: charonAWSSecret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-push-rpm-params/collect-push-rpm-params.yaml
+++ b/tasks/managed/collect-push-rpm-params/collect-push-rpm-params.yaml
@@ -14,7 +14,7 @@ spec:
         Path to the JSON file of the merged data to use in the data workspace.
   steps:
     - name: collect-push-rpm-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-push-rpm-params/tests/test-collect-push-rpm-params.yaml
+++ b/tasks/managed/collect-push-rpm-params/tests/test-collect-push-rpm-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               set -eux
 
@@ -83,7 +83,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               set -eux
 

--- a/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
+++ b/tasks/managed/collect-pyxis-params/collect-pyxis-params.yaml
@@ -116,7 +116,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-pyxis-params
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-default-server.yaml
+++ b/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-default-server.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -130,7 +130,7 @@ spec:
           - name: server
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SERVER"
                 value: '$(params.server)'

--- a/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-data.yaml
+++ b/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-secret.yaml
+++ b/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params-fail-no-secret.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params.yaml
+++ b/tasks/managed/collect-pyxis-params/tests/test-collect-pyxis-params.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -134,7 +134,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SERVER"
                 value: '$(params.server)'

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -110,7 +110,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-secret
       image:
-        quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -136,7 +136,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -142,7 +142,7 @@ spec:
           - name: secret
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -173,7 +173,7 @@ spec:
           - name: message
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -183,7 +183,7 @@ spec:
           - name: slack-notification-secret-keyname
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -258,7 +258,7 @@ spec:
           .releaseNotes.content.artifacts = $updated
         ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
@@ -53,13 +53,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -241,14 +241,14 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
 
               # Count the number of InternalRequests
               requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
-              
+
               # Check if the number of InternalRequests is as expected
               if [ "$requestsCount" -ne 1 ]; then
                 echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
@@ -288,7 +288,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-both-prod-and-pending.yaml
@@ -55,13 +55,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -54,13 +54,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-prod-or-pending.yaml
@@ -55,13 +55,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-orphan.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-orphan.yaml
@@ -55,13 +55,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -55,13 +55,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -55,13 +55,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -53,13 +53,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -239,14 +239,14 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
 
               # Count the number of InternalRequests
               requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
-              
+
               # Check if the number of InternalRequests is as expected
               if [ "$requestsCount" -ne 1 ]; then
                 echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
@@ -259,7 +259,7 @@ spec:
               if [[ "$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value' )" != \
               "pipelines/internal/create-advisory"* ]]; then
                 echo "InternalRequest doesn't contain 'create-advisory' in 'pipeline' field"
-                exit 1 
+                exit 1
               fi
 
               # Check the application parameter
@@ -311,7 +311,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -328,7 +328,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -314,7 +314,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -395,7 +395,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -124,7 +124,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-release-from-binaries
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -177,7 +177,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-release.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -176,7 +176,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-product-sbom/create-product-sbom.yaml
+++ b/tasks/managed/create-product-sbom/create-product-sbom.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-sbom
-      image: quay.io/konflux-ci/release-service-utils:991c2db1fe04f2fddd940605b5383a17692eb4a5
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/create-product-sbom/tests/test-create-product-sbom-basic.yaml
+++ b/tasks/managed/create-product-sbom/tests/test-create-product-sbom-basic.yaml
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:991c2db1fe04f2fddd940605b5383a17692eb4a5
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -139,7 +139,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -193,7 +193,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -188,7 +188,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi
@@ -244,7 +244,7 @@ spec:
         fi
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -124,7 +124,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: extract-binaries-from-image
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -225,7 +225,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -213,7 +213,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -119,7 +119,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: extract-index-image
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -97,7 +97,7 @@ spec:
         - name: inputDataFile
           value: $(params.dataDir)/$(context.pipelineRun.uid)/file.json
         - name: resultsDirPath
-          value: $(context.pipelineRun.uid)/results 
+          value: $(context.pipelineRun.uid)/results
         - name: internalRequestResultsFile
           value: "internal-request-results.json"
         - name: ociStorage

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -254,7 +254,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -131,7 +131,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -52,7 +52,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -299,7 +299,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -55,7 +55,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -50,7 +50,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-rpa-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-snapshot-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -55,7 +55,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: make-repo-public
-      image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
+++ b/tasks/managed/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/make-repo-public/tests/test-make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/tests/test-make-repo-public.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -31,7 +31,7 @@ spec:
       description: The workspace where the snapshot spec json file resides
   steps:
     - name: pull-and-push-images-to-marketplaces
-      image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-pre-push.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-pre-push.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -115,7 +115,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -147,7 +147,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 64Mi
@@ -216,7 +216,7 @@ spec:
             done
         done
     - name: populate-release-notes-binaries
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi
@@ -301,7 +301,7 @@ spec:
         done
 
     - name: populate-release-notes-type-and-references
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -244,7 +244,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -264,7 +264,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -226,7 +226,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -221,7 +221,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -210,7 +210,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: prepare-fbc-release
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -7,7 +7,7 @@ spec:
   description: |
     Run the prepare-fbc-release task and verify
     that the task succesfully update the snapshot
-    with the ocpVersion, fromIndex and targetIndex 
+    with the ocpVersion, fromIndex and targetIndex
     for all the component in snapshot
   workspaces:
     - name: tests-workspace
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -21,7 +21,7 @@ spec:
   steps:
     - name: prepare-validation
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -135,7 +135,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: publish-index-image
       image: >-
-        quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -251,7 +251,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -203,7 +203,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -253,12 +253,12 @@ spec:
 
                   if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
                     echo "taskGitUrl image does not match"
-                    exit 1 
+                    exit 1
                   fi
 
                   if [ "$(jq -r '.taskGitRevision' <<< "${params}")" != "main" ]; then
                     echo "taskGitRevision image does not match"
-                    exit 1 
+                    exit 1
                   fi
               done
   finally:
@@ -266,7 +266,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -138,7 +138,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: publish-pyxis-repository
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-container-multiple-components.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -75,7 +75,7 @@ spec:
                   {
                     "repository": "quay.io/redhat-prod/my-product----my-image2",
                     "pushSourceContainer": "false"
-                  }, 
+                  },
                   {
                     "repository": "quay.io/redhat-prod/my-product----my-image3"
                   }
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -186,7 +186,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -190,7 +190,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -19,7 +19,7 @@ spec:
       type: string
   steps:
     - name: prepare-repo
-      image: quay.io/konflux-ci/release-service-utils:4576e1e2a30439129cb69c8a4f39f7ced2d44376
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -57,7 +57,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -129,7 +129,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -207,7 +207,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -315,7 +315,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -309,7 +309,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -270,7 +270,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -288,7 +288,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -268,7 +268,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -286,7 +286,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -309,7 +309,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -34,7 +34,7 @@ spec:
       description: Workspace where the json files are stored
   steps:
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -88,7 +88,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -91,7 +91,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -150,7 +150,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -91,7 +91,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -150,7 +150,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,7 +108,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -126,7 +126,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -91,7 +91,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -150,7 +150,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:10bd7e4323de6ace107bbed1fe40613f21684b01
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -132,7 +132,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi
@@ -216,7 +216,7 @@ spec:
         fi
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -64,7 +64,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
@@ -64,7 +64,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -62,7 +62,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:863fee5fdf48937dead6a2355c67eb3b4f469340
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               set -eux
 
@@ -108,7 +108,7 @@ spec:
         - name: subdirectory
           value: "./"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+          value: "quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152"
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -126,7 +126,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             workingDir: $(workspaces.data.path)
             script: |
               #!/usr/bin/env bash

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -138,7 +138,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -196,7 +196,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -193,7 +193,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -184,7 +184,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -203,7 +203,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -188,7 +188,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -204,7 +204,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -184,7 +184,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -206,7 +206,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -188,7 +188,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -204,7 +204,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -125,7 +125,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 2Gi

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -142,7 +142,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -186,7 +186,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -246,7 +246,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -317,7 +317,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -270,7 +270,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -325,7 +325,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -222,7 +222,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -267,7 +267,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -233,7 +233,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -254,7 +254,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -233,7 +233,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -300,7 +300,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -232,7 +232,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -309,7 +309,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -135,7 +135,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-run-file-updates-addons
 spec:
   description: |
-    Run the run-file-updates task for the osd-addons use case 
+    Run the run-file-updates task for the osd-addons use case
     and verify if the internalrequests were created and the replacements were done
   workspaces:
     - name: tests-workspace
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -211,7 +211,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -ex
@@ -268,7 +268,7 @@ spec:
                 # Check if an InternalRequest with the same repo exists
                 requestRepo=$(echo "$allRequests" | \
                               jq -r --arg repo "$repo" '.items[] | select(.spec.params.repo == $repo)')
-              
+
                 if [ -z "$requestRepo" ]; then
                   echo "No InternalRequest found with repo: $repo"
                   exit 1
@@ -303,7 +303,7 @@ spec:
                 replacements="$(echo "$requestPaths" | jq '.[] | select(.path == "foobar") | .replacements[]')"
                 if [ -n "${replacements}" ]; then
                   if [[ ! $(echo "${replacements}" | jq '.replacement') =~ "test/foo/bar" ]]; then
-                    echo "InternalRequest for repo: $repo has different 'replacement' for foobar. 
+                    echo "InternalRequest for repo: $repo has different 'replacement' for foobar.
                           Expected: 'test/foo/bar'"
                     exit 1
                   fi
@@ -314,7 +314,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -ex
@@ -233,7 +233,7 @@ spec:
               test "$MR" == ""
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -200,7 +200,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -ex
@@ -235,7 +235,7 @@ spec:
               test "$MR" == "https://g/r/-/merge_requests/18"
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -219,7 +219,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -ex
@@ -233,7 +233,7 @@ spec:
 
               # Fetch all the InternalRequest resources
               allRequests=$(kubectl get InternalRequest -o json)
-              
+
               # Count the number of InternalRequests
               requestsCount=$(echo "$allRequests" | jq -r '.items | length')
 
@@ -274,7 +274,7 @@ spec:
                 # Check if an InternalRequest with the same repo exists
                 requestRepo=$(echo "$allRequests" | \
                               jq -r --arg repo "$repo" '.items[] | select(.spec.params.repo == $repo)')
-              
+
                 if [ -z "$requestRepo" ]; then
                   echo "No InternalRequest found with repo: $repo"
                   exit 1
@@ -309,7 +309,7 @@ spec:
                 replacements="$(echo "$requestPaths" | jq '.[] | select(.path == "foobar") | .replacements[]')"
                 if [ -n "${replacements}" ]; then
                   if [[ ! $(echo "${replacements}" | jq '.replacement') =~ "test-container-foo:bar" ]]; then
-                    echo "InternalRequest for repo: $repo has different 'replacement' for foobar. 
+                    echo "InternalRequest for repo: $repo has different 'replacement' for foobar.
                           Expected: 'test-container-foo:bar'"
                     exit 1
                   fi
@@ -320,7 +320,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: send-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -170,7 +170,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -170,7 +170,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -119,7 +119,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: set-severity
-      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -127,7 +127,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: sign-base64-blob
       image:
-        quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+        quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -236,7 +236,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -135,7 +135,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-index-image
-      image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -245,7 +245,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -183,7 +183,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -180,7 +180,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -224,7 +224,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -236,7 +236,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:2d6f05c89fc619042a2be19d64ff48de9975397a
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
+++ b/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-sboms
-      image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -114,7 +114,7 @@ spec:
                   - $(results.resultArtifact2.path)=$(params.dataDir)
           - name: patch-source-data-artifact-result-array
             # Note: Cannot convert to a StepAction due to https://github.com/tektoncd/pipeline/issues/2374
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eu
@@ -163,7 +163,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -54,7 +54,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -143,7 +143,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -67,7 +67,7 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f release
-              
+
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
           - name: skip-trusted-artifact-operations
             ref:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -140,7 +140,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -137,7 +137,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -151,7 +151,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifacts
           value: $(params.resultArtifacts)
     - name: update-cr-status
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -135,7 +135,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: git-clone-infra-deployments
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 256Mi
@@ -152,7 +152,7 @@ spec:
         echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi
@@ -167,11 +167,11 @@ spec:
         #!/usr/bin/env bash
         set -ex
         cd cloned
-        
+
         echo "snapshot:"
         cat "$(params.dataDir)/$(params.snapshotPath)"
         echo ""
-        
+
         # We assume we only have one component in the service.
         revision="$(jq -r .components[0].source.git.revision "$(params.dataDir)/$(params.snapshotPath)")"
         echo "revision: $revision"
@@ -197,7 +197,7 @@ spec:
         echo "$PATCHED_SCRIPT"
         echo "$PATCHED_SCRIPT" | sh
     - name: get-diff-files
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi
@@ -213,7 +213,7 @@ spec:
         git status -s --porcelain | cut -c4- > ../updated_files.txt
     # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-pr
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 512Mi
@@ -440,7 +440,7 @@ spec:
                 sys.exit()
 
             key_path = os.environ.get('GITHUBAPP_KEY_PATH')
-                        
+
             if os.environ.get('GITHUBAPP_APP_ID'):
                 app_id = os.environ['GITHUBAPP_APP_ID']
             else:

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             env:
               - name: "UPDATED_FROMINDEX"
                 value: '$(params.updated-fromIndex)'

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -119,7 +119,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-ocp-tag
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-update-trusted-tasks-fail-ec
   annotations:
-    test/assert-task-failure: "run-task"  
+    test/assert-task-failure: "run-task"
 spec:
   description: |
     Run the update-trusted-tasks task and fail the ec command
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -71,8 +71,8 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
-            script: |  
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
+            script: |
               #!/bin/bash
               set -eux
 

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -21,13 +21,13 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
 
               mkdir "$(workspaces.data.path)/results"
-  
+
     - name: run-task
       taskRef:
         name: update-trusted-tasks
@@ -49,7 +49,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -eux
@@ -95,6 +95,6 @@ spec:
                 cat "$(workspaces.data.path)/mock_ec.txt"
                 exit 1
               fi
-              
+
       runAfter:
         - run-task

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -73,7 +73,7 @@ spec:
                     "tags": [
                       "0.3"
                     ]
-                  }                                    
+                  }
                 ]
               }
               EOF
@@ -98,7 +98,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -eux
@@ -114,7 +114,7 @@ spec:
                 cat "$(workspaces.data.path)/mock_ec.txt"
                 exit 1
               fi
-              
+
               all_found=true
               outs=(
                 "track bundle --bundle quay.io/notexist/task-echo-v01:0.1@sha256:abcde \
@@ -128,7 +128,7 @@ spec:
               --input oci:quay.io/exists/data-acceptable-bundles:latest \
               --output oci:quay.io/exists/data-acceptable-bundles:latest"
               )
-              
+
               for out in "${outs[@]}"; do
                 if ! grep -qF -- "$out" "$(workspaces.data.path)/mock_ec.txt"; then
                   echo "Error: $out was not found in the ec command"

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,7 +70,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -eux
@@ -98,7 +98,7 @@ spec:
                 "track bundle --bundle quay.io/notexist/task-echo:stage@sha256:abcde \
               --output oci:quay.io/notexist/data-acceptable-bundles:latest"
               )
-              
+
               for out in "${outs[@]}"; do
                 if ! grep -qF -- "$out" "$(workspaces.data.path)/mock_ec.txt"; then
                   echo "Error: $out was not found in the ec command"
@@ -108,6 +108,6 @@ spec:
               if ! $all_found; then
                 cat "$(workspaces.data.path)/mock_ec.txt"
                 exit 1
-              fi 
+              fi
       runAfter:
         - run-task

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -69,7 +69,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/bin/bash
               set -eux
@@ -85,10 +85,10 @@ spec:
                 cat "$(workspaces.data.path)/mock_ec.txt"
                 exit 1
               fi
-              
+
               out="track bundle --bundle quay.io/notexist/task-echo:0.1@sha256:abcde \
               --output oci:quay.io/notexist/data-acceptable-bundles:latest"
-              
+
               if ! grep -qF -- "$out" "$(workspaces.data.path)/mock_ec.txt"; then
                 echo "Error: $out was not found in the ec command"
                 cat "$(workspaces.data.path)/mock_ec.txt"

--- a/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:3eb493f6b7923e04fbb01b44b24e5491a2bbd1ec
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3eb493f6b7923e04fbb01b44b24e5491a2bbd1ec
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -145,7 +145,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: upload-sboms
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi
@@ -227,7 +227,7 @@ spec:
         done
 
     - name: push-to-s3
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: >-
-    Tekton task validates that the snapshot only contains a 
+    Tekton task validates that the snapshot only contains a
     single component. The task will fail otherwise.
   params:
     - name: snapshotPath
@@ -111,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-single-component
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -31,7 +31,7 @@ spec:
       default: "false"
   steps:
     - name: verify-access-to-resources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
         limits:
           memory: 100Mi

--- a/tasks/tenant/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
+++ b/tasks/tenant/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
@@ -19,7 +19,7 @@ spec:
       description: The imageRef from the Release.Status.Artifacts that uses the git sha tag
   steps:
     - name: get-git-sha-image-ref-from-release
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail

--- a/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-multiple-images.yaml
+++ b/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-multiple-images.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-cr
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -51,7 +51,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-label.yaml
+++ b/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-label.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-cr
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -51,7 +51,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-matching-imageref.yaml
+++ b/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-matching-imageref.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-cr
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -51,7 +51,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref.yaml
+++ b/tasks/tenant/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref.yaml
@@ -11,7 +11,7 @@ spec:
       taskSpec:
         steps:
           - name: create-cr
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -67,7 +67,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/tenant/update-manager-image-in-git/update-manager-image-in-git.yaml
+++ b/tasks/tenant/update-manager-image-in-git/update-manager-image-in-git.yaml
@@ -31,7 +31,7 @@ spec:
       description: The manager image to update to
   steps:
     - name: update-repo
-      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       env:
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
## Describe your changes

Let's see if the task tests succeed. They failed for Johnny here: https://github.com/konflux-ci/release-service-catalog/pull/1100

It ran out of disk space when pulling one of the utils images. The main issue is that today there are 32 different tags used, so that's a lot of pulling. If we use just one, that should help.

## Relevant Jira

[RELEASE-1714](https://issues.redhat.com/browse/RELEASE-1714)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

