### PR TITLE
fix: skip unit tests when only READMEs change

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           files: |
             tasks/*/**
+          files_ignore: |
+            **/*.md
           dir_names: "true"
           dir_names_max_depth: "3"
       - name: Show changed dirs


### PR DESCRIPTION
This commit updates the tekton unit test workflow to ignore changes to README.md files.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

