### PR TITLE
fix(KFLUXSPRT-3846): critical typo in sign-index-image (#1098)

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -286,7 +286,7 @@ spec:
             --arg target_index "$target_index" \
             --arg ocp_version "$ocp_version" \
             --arg completion_time "$completion_time" \
-          '{ 
+          '{
             "fbc_fragment": $fragment,
             "target_index": $target_index,
             "ocp_version": $ocp_version,
@@ -367,6 +367,8 @@ spec:
           jq -r  '.components = [ .components | sort_by(.updated) | last ]' "$RESULTS_FILE" > "$RESULTS_TEMP_FILE"
           mv "$RESULTS_TEMP_FILE" "$RESULTS_FILE"
         fi
+        echo "Results file:"
+        cat "$RESULTS_FILE"
     - name: create-trusted-artifact
       ref:
         resolver: "git"

--- a/tasks/managed/sign-index-image/README.md
+++ b/tasks/managed/sign-index-image/README.md
@@ -18,11 +18,15 @@ Creates an InternalRequest to sign an index image
 | ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
 | ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
 | trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      | 
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
 | sourceDataArtifact       | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
 | dataDir                  | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | ""                      |
 | taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                             | No       | ""                      |
+
+## Changes in 5.0.1
+* Fix typo when reading manifest digests to sign: manifestDigests -> manifest_digests
+  * As a result, nothing got signed, because the script always thought there was nothing to sign
 
 ## Changes in 5.0.0
 * This task now supports Trusted artifacts

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: sign-index-image
   labels:
-    app.kubernetes.io/version: "5.0.0"
+    app.kubernetes.io/version: "5.0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -187,13 +187,13 @@ spec:
           reference_image=$(translate-delivery-repo "$reference_image" \
             | jq -r '.[] | select(.repo=="redhat.io") | .url')
 
-          digest_count=$(jq ".components[$i].imageDigests | length" "$RESULTS_FILE")
+          digest_count=$(jq ".components[$i].image_digests | length" "$RESULTS_FILE")
           for ((j = 0; j < digest_count; j++)); do
             while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
               wait -n
             done
 
-            manifest_digest=$(jq -r ".components[$i].imageDigests[$j]" "$RESULTS_FILE")
+            manifest_digest=$(jq -r ".components[$i].image_digests[$j]" "$RESULTS_FILE")
 
             echo "Creating ${requestType} to sign image:"
             echo "- reference=${reference_image}"

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -100,14 +100,14 @@ spec:
                   "components": [
                       {
                           "target_index": "registry.redhat.io/redhat/redhat-operator-index:v4.15",
-                          "imageDigests": [
+                          "image_digests": [
                               "sha256:6f9a420f660e73a",
                               "sha256:6f9a420f660e73b"
                           ]
                       },
                       {
                           "target_index": "registry.redhat.io/redhat/redhat-operator-index:v4.16",
-                          "imageDigests": [
+                          "image_digests": [
                               "sha256:6f9a420f660e73c"
                           ]
                       }

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -100,7 +100,7 @@ spec:
                   "components": [
                       {
                           "target_index": "quay.io/redhat/testimage:tag",
-                          "imageDigests": [
+                          "image_digests": [
                               "sha256:6f9a420f660e73a",
                               "sha256:6f9a420f660e73b"
                           ]

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -98,7 +98,7 @@ spec:
                   "components": [
                       {
                           "target_index": "quay.io/redhat/redhat----testimage:tag",
-                          "imageDigests": [
+                          "image_digests": [
                               "sha256:6f9a420f660e73b"
                           ]
                       }

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -98,7 +98,7 @@ spec:
                   "components": [
                       {
                           "target_index": "quay.io/testrepo/testimage:tag",
-                          "imageDigests": [
+                          "image_digests": [
                               "sha256:6f9a420f660e73a",
                               "sha256:6f9a420f660e73b"
                           ]


### PR DESCRIPTION
Fix typo when reading manifest digests to sign:
manifestDigests -> manifest_digests

Because of this typo, nothing was being signed.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

