### PR TITLE
feat: set custom upload container name for marketplacesvm

### DIFF
--- a/tasks/managed/marketplacesvm-push-disk-images/README.md
+++ b/tasks/managed/marketplacesvm-push-disk-images/README.md
@@ -12,3 +12,4 @@ It currently supports images in `raw` and `vhd` formats for `AWS` and `Azure` re
 | cloudMarketplacesSecret | Env specific secret containing the marketplaces credentials.                           | No       | -               |
 | prePush                 | Whether perform a pre-push (true) or not (false). When true it will not publish PROD.  | Yes      | false           |
 | concurrentLimit         | The maximum number of images to be pulled at once.                                     | Yes      | 3               |
+| uploadContainerName     | The name of the container to upload the images to.                                     | Yes      | konfluxupload   |

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -26,6 +26,10 @@ spec:
       type: string
       description: The maximum number of images to be pulled at once.
       default: 3
+    - name: uploadContainerName
+      type: string
+      description: The name of the container to upload the images to.
+      default: "konfluxupload"
   workspaces:
     - name: data
       description: The workspace where the snapshot spec json file resides
@@ -44,6 +48,8 @@ spec:
             secretKeyRef:
               name: $(params.cloudMarketplacesSecret)
               key: key
+        - name: UPLOAD_CONTAINER_NAME  # pulled by the pubtools-marketplacesvm script.
+          value: $(params.uploadContainerName)
       script: |
         #!/usr/bin/env bash
         set -eux


### PR DESCRIPTION
This commit allows the `marketplacesvm-push-disk-images` task to have a custom container (S3 or Azure Storage) name to upload the images.

It defaults to `konfluxupload`

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

