### PR TITLE
fix(RELEASE-1715): argument list too long in filter task

### DIFF
--- a/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -10,9 +10,9 @@ spec:
   description: >-
     Pipeline to filter out already-released images from a snapshot
   params:
-    - name: snapshot_json
+    - name: snapshot
       type: string
-      description: JSON string of the Snapshot spec
+      description: Base64 string of gzipped JSON representation of the snapshot spec
     - name: origin
       type: string
       description: |
@@ -40,8 +40,8 @@ spec:
           - name: pathInRepo
             value: tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
       params:
-        - name: snapshot_json
-          value: $(params.snapshot_json)
+        - name: snapshot
+          value: $(params.snapshot)
         - name: origin
           value: $(params.origin)
         - name: advisory_secret_name

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -12,9 +12,9 @@ spec:
     stored in the GitLab advisory repo. Returns a list of component names
     that still need to be released (i.e., not found in any advisory).
   params:
-    - name: snapshot_json
+    - name: snapshot
       type: string
-      description: String containing a JSON representation of the snapshot spec
+      description: Base64 string of gzipped JSON representation of the snapshot spec
     - name: origin
       description: The origin workspace for the release CR
       type: string
@@ -68,8 +68,8 @@ spec:
             secretKeyRef:
               name: $(params.advisory_secret_name)
               key: git_author_email
-        - name: SNAPSHOT_JSON
-          value: "$(params.snapshot_json)"
+        - name: SNAPSHOT
+          value: "$(params.snapshot)"
       script: |
         #!/usr/bin/env bash
         set -eo pipefail
@@ -91,6 +91,10 @@ spec:
           exit 0
         }
         trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        SNAPSHOT_JSON=$(base64 -d <<< "$SNAPSHOT" | gunzip)
+
+        echo "Snapshot JSON: $SNAPSHOT_JSON"
 
         ORIGIN="$(params.origin)"
         ADVISORY_BASE_DIR="data/advisories/${ORIGIN}"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -12,8 +12,10 @@ spec:
       taskRef:
         name: filter-already-released-advisory-images-task
       params:
-        - name: snapshot_json
-          value: '{"components":[{"name":"released-component","version":"1.0.0","containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"},{"name":"new-component","version":"1.0.0","containerImage":"quay.io/test/new-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: snapshot
+          # Snapshot string before `gzip -c|base64 -w 0` encoding:
+          # '{"components":[{"name":"released-component","version":"1.0.0","containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"},{"name":"new-component","version":"1.0.0","containerImage":"quay.io/test/new-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+          value: 'H4sIAMbtXGgAA6WOMQ7CMAxFd47hOaRlzQ04A+pgFauyROySmKKq6t2bDGRghPU//f/fBqPGWYXEMoTbBoKRIECiB2Gm+7lhcLBQyqxS8MX3vi/JqGLIQukacaq95wtXz9oZZevaCFcaPiXDqX7BUgIYXPmaNbNpWr8GYHdNSOj9l0vt/6wx7KcDhTKALSkBAAA='
         - name: origin
           value: "test-origin"
         - name: advisory_secret_name

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -12,8 +12,10 @@ spec:
       taskRef:
         name: filter-already-released-advisory-images-task
       params:
-        - name: snapshot_json
-          value: '{"components":[{"name":"test-component","version":"1.0.0","containerImage":"quay.io/test/image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: snapshot
+          # Snapshot string before `gzip -c|base64 -w 0` encoding:
+          # '{"components":[{"name":"test-component","version":"1.0.0","containerImage":"quay.io/test/image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+          value: 'H4sIAFfuXGgAA12MMQ6DMBAE+zxjazCk9Q94Q0RxQid0he+IfUFCiL/HLkKRdmZnTyyWNlNWL4ivE0qJEeFcvL8VOuyci5hW9QxjGCtZTJ1EOU+J1ta8P3QEsaG1gzQYf1untd1jrwBzh8ybFXHLx1+Ha74eXyHcxUaVAAAA'
         - name: origin
           value: "not-existing-origin"
         - name: advisory_secret_name

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -147,7 +147,7 @@ spec:
             echo "No valid snapshot file was provided at $SNAPSHOT_FILE"
             exit 1
         fi
-        snapshot=$(jq -c '.' "$SNAPSHOT_FILE")
+        snapshot=$(jq -c '.' "$SNAPSHOT_FILE" | gzip -c | base64 -w 0)
         if [ -z "$snapshot" ]; then
             echo "Failed to read snapshot file"
             exit 1
@@ -219,7 +219,7 @@ spec:
         echo "Creating internal request for filtering already-released advisory images..."
         # Because of the tee, this will always succeed
         internal-request --pipeline "filter-already-released-advisory-images" \
-                         -p snapshot_json="$snapshot" \
+                         -p snapshot="$snapshot" \
                          -p origin="$origin" \
                          -p advisory_secret_name="$advisorySecretName" \
                          -p internalRequestPipelineRunName="$(params.pipelineRunUid)" \
@@ -268,21 +268,19 @@ spec:
                 )
               )
             )
-          ' <<< "$snapshot")
+          ' < "$SNAPSHOT_FILE")
 
           # Check if the filtered snapshot has any components
           if jq -e '.components | length == 0' <<< "$FILTERED_SNAPSHOT"; then
             echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
-            SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
-            echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_PATH"
+            echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
             echo -n "Success" > "$(results.result.path)"
             echo -n "true" > "$(results.skip_release.path)"
             jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
             exit 0
           fi
 
-          SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
-          echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_PATH"
+          echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
           echo -n "Success" > "$(results.result.path)"
           echo -n "false" > "$(results.skip_release.path)"
           jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -226,10 +226,10 @@ spec:
                 exit 1
               fi
 
-              # Check the snapshot_json parameter
-              snapshotJson=$(echo "$internalRequest" | jq -r '.spec.params.snapshot_json')
+              # Check the snapshot parameter
+              snapshotJson=$(echo "$internalRequest" | jq -r '.spec.params.snapshot' | base64 --decode | gzip -d)
               if [ "$(jq -r '.application' <<< "$snapshotJson")" != "myapp" ]; then
-                echo "InternalRequest has the wrong application in snapshot_json"
+                echo "InternalRequest has the wrong application in snapshot"
                 exit 1
               fi
 


### PR DESCRIPTION
## Describe your changes

The filter-already-released-advisory-images task is failing on argument list too long if the snapshot is very big (~200 components). The reason is that the full snapshot spec json is being passed to the internal-request script as a parameter and that can exceed the overall limit the OS has when creating a new process.

The solution is to compress the snapshot before passing it (using gzip and base64) and then decompress in the internal task. In the failing case, the original snapshot spec json string was ~160k long. After the compression, it is 29k.

## Relevant Jira

[RELEASE-1715](https://issues.redhat.com//browse/RELEASE-1715)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

