### PR TITLE
fix(RELEASE-377): tests for intention field in schema

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -300,7 +300,8 @@ spec:
           value: |
             [
               {"systemName": "cdn", "dynamic": false},
-              {"systemName": "releaseNotes", "dynamic": false}
+              {"systemName": "releaseNotes", "dynamic": false},
+              {"systemName": "intention", "dynamic": false}
             ]
         - name: ociStorage
           value: $(params.ociStorage)

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-fail-missing-intention
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the check-data-keys task with the intention key missing in the data json and
+    verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "someOtherData": { # just dummy data to simulate no intention field
+                  "example": "value"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "intention", "dynamic": false}
+            ]
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -131,7 +131,8 @@ spec:
                 },
                 "cdn": {
                   "env": "qa"
-                }
+                },
+                "intention": "production"
               }
               EOF
           - name: create-trusted-artifact
@@ -154,7 +155,8 @@ spec:
           value: |
             [
               {"systemName": "releaseNotes", "dynamic": false},
-              {"systemName": "cdn", "dynamic": false}
+              {"systemName": "cdn", "dynamic": false},
+              {"systemName": "intention", "dynamic": false}
             ]
         - name: ociStorage
           value: $(params.ociStorage)


### PR DESCRIPTION
Advisory generation tasks for generic artifacts rely on the intention field in an RPA to determine if the target destination is stage or production.
This is because not all RPAs have the 'repository' field that can be used to determine the target.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

