### PR TITLE
fix(RELEASE-377): add intention field to schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -21,7 +21,8 @@
               "pyxis",
               "mapping",
               "ootsign",
-              "conforma"
+              "conforma",
+              "intention"
             ]
           },
           "dynamic": {
@@ -424,6 +425,14 @@
     "infra-deployment-update-script": {
       "type": "string",
       "description": "A script that can alter files in the infra-deployment repo before a a PR is created"
+    },
+    "intention": {
+      "type": "string",
+      "enum": [
+        "production",
+        "staging"
+      ],
+      "description": "The intention of the release, e.g. production or staging."
     },
     "singleComponentMode": {
       "type": "boolean",
@@ -1649,6 +1658,22 @@
             }
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "const": "intention"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "intention"
+        ]
       }
     }
   ]


### PR DESCRIPTION
Advisory generation tasks for generic artifacts rely on the intention field in an RPA to determine if the target destination is stage or production.
This is because not all RPAs have the 'repository' field that can be used to determine the target.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

