### PR TITLE
fix: error handling in request-and-upload-signature

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -252,9 +252,10 @@ spec:
           exit 1
         fi
         SIGNATURE_ERRORS=$(cat "$(workspaces.data.path)/${signature_data_file}" |\
-          jq -cM ".operation_results|.[]|.[0].msg.errors")
+          jq -c '[.operation_results[]?[0]?.msg?.errors? // [] | select(length > 0)]')
         if [ "$SIGNATURE_ERRORS" != "[]" ]; then
-          echo "Signing failed with error: ${SIGNATURE_ERRORS}"
+          echo "Signing failed with errors:"
+          jq . <<< "${SIGNATURE_ERRORS}"
           exit 1
         fi
 
@@ -264,7 +265,7 @@ spec:
             [.operation_results, .operation.references]|
             transpose|
             .[]|
-            {reference:.[1], 
+            {reference:.[1],
              manifest_digest:.[0][0].msg.manifest_digest,
              repository:.[0][0].msg.repo,
              signature_data:.[0][0].msg.signed_claim,

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -53,7 +53,36 @@ spec:
                      "content-type": "text/plain",
                      "amq6100_destination": "queue://Consumer.test-user.123456.VirtualTopic.eng.test.dist.sign.123456"
                     }
-                  ]],
+                  ],
+                  [
+                    {"i": 1,
+                     "msg": {
+                       "errors": [],
+                       "manifest_digest": "sha256:123456",
+                       "pub_task_id": "123456",
+                       "repo": "test-repo",
+                       "request_id": "2",
+                       "request_received_time": "3000-01-01T01:01:01.000000",
+                       "requested_by": "test-user",
+                       "sig_key_id": "test-signing-key",
+                       "sig_keyname": "test-signing-key",
+                       "signature_type": "container_signature",
+                       "signed_claim": "signed-data",
+                       "signing_server_requested": "3000-01-01T01:01:01.000000",
+                       "signing_server_responded": "3000-01-01T01:01:02.000000",
+                       "signing_status": "success"
+                     },
+                     "msg_id": "msg-id-1",
+                     "timestamp": 1738685708,
+                     "topic": "/topic/VirtualTopic.eng.test.dist.sign.123456",
+                     "username": "1001030000"
+                    },
+                    {"amq6100_originalDestination": "topic://VirtualTopic.eng.test.dist.sign.123456",
+                     "content-type": "text/plain",
+                     "amq6100_destination": "queue://Consumer.test-user.123456.VirtualTopic.eng.test.dist.sign.123456"
+                    }
+                  ]
+                ],
                 "operation": {
                   "digests": ["sha256:123456"],
                   "references": ["registry.redhat.io/myproduct/myrepo:abc"],

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failed-messages.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failed-messages.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the request-and-upload-signature task with use case when signer return error in messages. 
+    Run the request-and-upload-signature task with use case when signer return error in messages.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -49,7 +49,35 @@ spec:
                          "timestamp": 1738685708,
                          "topic": "/topic/VirtualTopic.eng.test.dist.sign.123456",
                          "username": "1001030000"
-                        }, 
+                        },
+                        {"amq6100_originalDestination": "topic://VirtualTopic.eng.test.dist.sign.123456",
+                         "content-type": "text/plain",
+                         "amq6100_destination": "queue://Consumer.test-user.123456.VirtualTopic.eng.test.dist.sign.123456"
+                        }
+                       ],
+                       [
+                         {"i": 1,
+                          "msg": {
+                            "errors": [],
+                            "manifest_digest": "sha256:123456",
+                            "pub_task_id": "123456",
+                            "repo": "test-repo",
+                            "request_id": "1",
+                            "request_received_time": "3000-01-01T01:01:01.000000",
+                            "requested_by": "test-user",
+                            "sig_key_id": "test-signing-key",
+                            "sig_keyname": "test-signing-key",
+                            "signature_type": "container_signature",
+                            "signed_claim": "signed-data",
+                            "signing_server_requested": "3000-01-01T01:01:01.000000",
+                            "signing_server_responded": "3000-01-01T01:01:02.000000",
+                            "signing_status": "success"
+                          },
+                         "msg_id": "msg-id-1",
+                         "timestamp": 1738685708,
+                         "topic": "/topic/VirtualTopic.eng.test.dist.sign.123456",
+                         "username": "1001030000"
+                        },
                         {"amq6100_originalDestination": "topic://VirtualTopic.eng.test.dist.sign.123456",
                          "content-type": "text/plain",
                          "amq6100_destination": "queue://Consumer.test-user.123456.VirtualTopic.eng.test.dist.sign.123456"


### PR DESCRIPTION
## Describe your changes

The original didn't work where there was more
than 1 operation_results in the signing response
as it would print a bunch of `[]`, each on a separate line.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

