### PR TITLE
feat(RELEASE-1664): use --skopeo-retries for get-image-architectures

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -141,7 +141,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -196,7 +196,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -266,7 +266,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -231,7 +231,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -244,7 +244,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -222,7 +222,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -144,7 +144,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -193,7 +193,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -59,7 +59,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4477c5aa19a8cbb4fc79bf0381bcdbc992810424
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -188,7 +188,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:be3ad8aff2267f2b8caf475d1a5759980389aa1c
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -114,7 +114,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 64Mi
@@ -218,7 +218,7 @@ spec:
             done
         done
     - name: populate-release-notes-binaries
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 32Mi
@@ -303,7 +303,7 @@ spec:
         done
 
     - name: populate-release-notes-type-and-references
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -244,7 +244,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -264,7 +264,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -226,7 +226,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -221,7 +221,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -210,7 +210,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: prepare-fbc-release
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -7,7 +7,7 @@ spec:
   description: |
     Run the prepare-fbc-release task and verify
     that the task succesfully update the snapshot
-    with the ocpVersion, fromIndex and targetIndex 
+    with the ocpVersion, fromIndex and targetIndex
     for all the component in snapshot
   workspaces:
     - name: tests-workspace
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -138,7 +138,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -196,7 +196,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -193,7 +193,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -184,7 +184,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -55,7 +55,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Set --skopeo-retries for get-image-architectures command, to help mitigate transient failures when interacting with image registries.

Edit: The change is done just by updating the utils image, since get-image-architecture has a default value of 3 set for the --skopeo-retries flag.
## Relevant Jira

https://issues.redhat.com/browse/RELEASE-1664

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

