### PR TITLE
feat(RELEASE-1723): Enable trusted artifacts in publish-to-mrrc task

### DIFF
--- a/tasks/managed/publish-to-mrrc/README.md
+++ b/tasks/managed/publish-to-mrrc/README.md
@@ -5,7 +5,17 @@ This task will work with [collect-mrrc-task](../collect-mrrc-params/README.md) t
 
 ## Parameters
 
-| Name              | Description                                                                            | Optional | Default value |
-| ----------------- | -------------------------------------------------------------------------------------- | -------- | ------------- |
-| mrrcParamFilePath | Path of the mrrc.env file which contains the MRRC parameters as environment viariables | No       | -             |
-| charonAWSSecret   | The secret which contains the aws credential settings for the charon usage             | No       | -             |
+| Name                     | Description                                                                                                                         | Optional | Default value                                             |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| mrrcParamFilePath        | Path of the mrrc.env file which contains the MRRC parameters as environment variables                                              | No       | -                                                         |
+| charonConfigFilePath     | Path of the charon config file for charon to consume                                                                               | No       | -                                                         |
+| charonAWSSecret          | The secret name for charon aws credential file                                                                                     | No       | -                                                         |
+| ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                          | Yes      | empty                                                     |
+| ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire        | Yes      | 1d                                                        |
+| trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                                    | Yes      | ""                                                        |
+| sourceDataArtifact       | Location of trusted artifacts to be used to populate data directory                                                                | Yes      | ""                                                        |
+| dataDir                  | The location where data will be stored                                                                                             | Yes      | $(workspaces.data.path)                                   |
+| taskGitUrl               | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                             | No       | -                                                         |
+| taskGitRevision          | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
+

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -17,7 +17,113 @@ spec:
     - name: charonAWSSecret
       description: the secret name for charon aws credential file
       type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  workspaces:
+    - name: data
+      description: The workspace where the extra config file containing the mapping and snapshot json reside
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: "charon-aws-vol"
+      secret:
+        secretName: "$(params.charonAWSSecret)"
+    - name: mrrc-workdir
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    # This is a workaround for a problem observed on Konflux clusters where the
+    # a step runs with root user causing a file or folder to not be readable
+    # in later steps. There might be solution coming related to the
+    # security context constraints on the cluster, but setting this explicitly here
+    # should probably be harmless either way.
+    securityContext:
+      runAsUser: 1001
   steps:
+    - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
     - name: prepare-repo
       image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
       computeResources:
@@ -30,7 +136,7 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
-        MRRC_FILE="$(workspaces.data.path)/$(params.mrrcParamFilePath)"
+        MRRC_FILE="$(params.dataDir)/$(params.mrrcParamFilePath)"
         # shellcheck source=/dev/null
         . "$MRRC_FILE"
         mkdir -p /workdir/mrrc
@@ -46,7 +152,7 @@ spec:
           oras pull --registry-config "$AUTH_FILE" "$r" -o /workdir/mrrc
         done
       volumeMounts:
-        - name: workdir
+        - name: mrrc-workdir
           mountPath: "/workdir"
     - name: upload-maven-repo
       image: quay.io/konflux-ci/charon@sha256:95b22f4f0fc1d6bb984a2f63334c3f66a539e433d79cde4eafa7731d8924377f
@@ -60,11 +166,11 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
-        CHARON_CFG_FILE="$(workspaces.data.path)/$(params.charonConfigFilePath)"
+        CHARON_CFG_FILE="$(params.dataDir)/$(params.charonConfigFilePath)"
         mkdir -p "/home/charon/.charon"
         cp "$CHARON_CFG_FILE" /home/charon/.charon/charon.yaml
 
-        MRRC_FILE="$(workspaces.data.path)/$(params.mrrcParamFilePath)"
+        MRRC_FILE="$(params.dataDir)/$(params.mrrcParamFilePath)"
         # shellcheck source=/dev/null
         . "$MRRC_FILE"
 
@@ -83,13 +189,49 @@ spec:
       volumeMounts:
         - name: "charon-aws-vol"
           mountPath: "/home/charon/.aws"
-        - name: workdir
+        - name: mrrc-workdir
           mountPath: "/workdir"
-  volumes:
-    - name: "charon-aws-vol"
-      secret:
-        secretName: "$(params.charonAWSSecret)"
-    - name: workdir
-      emptyDir: {}
-  workspaces:
-    - name: data
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/publish-to-mrrc/tests/mocks.sh
+++ b/tasks/managed/publish-to-mrrc/tests/mocks.sh
@@ -5,7 +5,7 @@ set -eux
 
 function oras(){
   echo Mock oras called with: $*
-  echo $* >> $(workspaces.data.path)/mock_oras.txt
+  echo $* >> "$(params.dataDir)/mock_oras.txt"
 
   if [[ "$*" == "pull --registry-config"* ]]
   then
@@ -23,9 +23,9 @@ function oras(){
 
 function charon(){
   echo Mock charon called with: $*
-  echo $* >> $(workspaces.data.path)/mock_charon.txt
+  echo $* >> "$(params.dataDir)/mock_charon.txt"
 
-  if [ ! test -f "$HOME/.charon/charon.yaml" ]
+  if [ ! -f "$HOME/.charon/charon.yaml" ]
   then
     echo Error: Missing charon config file
     exit 1
@@ -39,6 +39,6 @@ function charon(){
 }
 
 function select-oci-auth() {
-  echo $* >> $(workspaces.data.path)/mock_select-oci-auth.txt
+  echo $* >> "$(params.dataDir)/mock_select-oci-auth.txt"
 }
 

--- a/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
@@ -16,5 +16,5 @@ kubectl delete secret test-charon-aws-credentials --ignore-not-found
 kubectl create secret generic test-charon-aws-credentials --from-literal=credentials="$aws_creds"
 
 # Add mocks to the beginning of scripts
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
@@ -10,14 +10,58 @@ spec:
     Run the publish-to-mrrc task without charon-config file
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
@@ -25,22 +69,65 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > "$(workspaces.data.path)"/mrrc.env << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mrrc.env << EOF
               export MRRC_ZIP_REGISTRY=quay.io/testorg/test-prod.zip@sha256:0b15aad24f1b847
               export MRRC_TARGET=dev-maven-ga
               export MRRC_PRODUCT_NAME=test-prod
               export MRRC_PRODUCT_VERSION=0.0.1
               EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: publish-to-mrrc
       params:
         - name: mrrcParamFilePath
-          value: "mrrc.env"
+          value: $(context.pipelineRun.uid)/mrrc.env
         - name: charonConfigFilePath
-          value: "charon-config.yaml"
+          value: $(context.pipelineRun.uid)/charon-config.yaml
         - name: charonAWSSecret
           value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
@@ -10,14 +10,58 @@ spec:
     Run the publish-to-mrrc task without mrrc.env file
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
@@ -25,19 +69,62 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > "$(workspaces.data.path)"/charon-config.yaml << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
               charon-config
               EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: publish-to-mrrc
       params:
         - name: mrrcParamFilePath
-          value: "mrrc.env"
+          value: $(context.pipelineRun.uid)/mrrc.env
         - name: charonConfigFilePath
-          value: "charon-config.yaml"
+          value: $(context.pipelineRun.uid)/charon-config.yaml
         - name: charonAWSSecret
           value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
@@ -8,14 +8,58 @@ spec:
     Run the publish-to-mrrc task with required parameters - a happy path scenario.
   workspaces:
     - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
   tasks:
     - name: setup
       workspaces:
         - name: data
           workspace: tests-workspace
       taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
@@ -23,26 +67,67 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > "$(workspaces.data.path)"/mrrc.env << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mrrc.env << EOF
               export MRRC_ZIP_REGISTRY=quay.io/testorg/test-prod.zip@sha256:0b15aad24f1b847
               export MRRC_TARGET=dev-maven-ga
               export MRRC_PRODUCT_NAME=test-prod
               export MRRC_PRODUCT_VERSION=0.0.1
               EOF
 
-              cat > "$(workspaces.data.path)"/charon-config.yaml << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
               charon-config
               EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
         name: publish-to-mrrc
       params:
         - name: mrrcParamFilePath
-          value: "mrrc.env"
+          value: $(context.pipelineRun.uid)/mrrc.env
         - name: charonConfigFilePath
-          value: "charon-config.yaml"
+          value: $(context.pipelineRun.uid)/charon-config.yaml
         - name: charonAWSSecret
           value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
       runAfter:
         - setup
       workspaces:
@@ -52,25 +137,72 @@ spec:
       workspaces:
         - name: data
           workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
       taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
         workspaces:
           - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
         steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:4fc4e746955ed7b6d43f7a0e327b7f573980fd6d
             script: |
               #!/usr/bin/env sh
               set -eux
 
-              if [ "$(< "$(workspaces.data.path)"/mock_oras.txt wc -l)" != 1 ]; then
+              if [ "$(< "$(params.dataDir)"/mock_oras.txt wc -l)" != 1 ]; then
                 echo Error: oras was expected to be called 1 times. Actual calls:
-                cat "$(workspaces.data.path)"/mock_oras.txt
+                cat "$(params.dataDir)"/mock_oras.txt
                 exit 1
               fi
 
-              if [ "$(< "$(workspaces.data.path)"/mock_charon.txt wc -l)" != 1 ]; then
+              if [ "$(< "$(params.dataDir)"/mock_charon.txt wc -l)" != 1 ]; then
                 echo Error: charon was expected to be called 1 times. Actual calls:
-                cat "$(workspaces.data.path)"/mock_charon.txt
+                cat "$(params.dataDir)"/mock_charon.txt
                 exit 1
               fi
       runAfter:


### PR DESCRIPTION
## Describe your changes
- Enable trusted artifacts in publish-to-mrrc.
- Rename existing volume to be mrrc-workdir to avoid a clash with trusted artifacts volume.
- Force a `runAsUser` value to ensure all containers run with the same user ID to avoid permission denied errors.

## Relevant Jira
- [RELEASE-1723](https://issues.redhat.com//browse/RELEASE-1723)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

