### PR TITLE
fix: improve pipeline visualization

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -412,6 +412,7 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - verify-conforma
+        - update-ocp-tag
     - name: add-fbc-contribution-to-index-image
       retries: 3
       workspaces:
@@ -536,6 +537,7 @@ spec:
       runAfter:
         - extract-requester-from-release
         - add-fbc-contribution-to-index-image
+        - collect-pyxis-params
     - name: extract-index-image
       workspaces:
         - name: data
@@ -568,6 +570,8 @@ spec:
           value: "$(params.taskGitRevision)"
         - name: internalRequestResultsFile
           value: $(tasks.add-fbc-contribution-to-index-image.results.internalRequestResultsFile)
+      runAfter:
+        - add-fbc-contribution-to-index-image
     - name: publish-index-image
       workspaces:
         - name: data


### PR DESCRIPTION


Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Describe your changes

The PipelineRun UI organizes tasks based on the `runAfter` property. If we have task dependencies based on result/parameter relationships, we need to also ensure that the dependent tasks are present in `runAfter`.

## Relevant Jira

N/A

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

