### PR TITLE
fix: result too long in filter-already-released task

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -32,7 +32,7 @@ spec:
     - name: internalRequestTaskRunName
       description: The name of the InternalRequest TaskRun
     - name: unreleased_components
-      description: List of components that still need to be released
+      description: List of components that still need to be released encoded as a gzipped base64 string
   steps:
     - name: filter-images
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
@@ -118,7 +118,7 @@ spec:
 
         if [[ -z "$EXISTING_ADVISORIES" ]]; then
           echo "No existing advisories found. No components have been released yet."
-          UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES")
+          UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES" | gzip -c | base64 -w 0)
           echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
           echo -n "Success" > "$(results.result.path)"
           exit 0
@@ -144,7 +144,7 @@ spec:
           # If after filtering, no images are left, then we can exit early
           if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
             echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
-            echo -n "[]" > "$(results.unreleased_components.path)"
+            echo -n "[]" | gzip -c | base64 -w 0 > "$(results.unreleased_components.path)"
             echo -n "Success" > "$(results.result.path)"
             exit 0
           fi
@@ -156,6 +156,6 @@ spec:
         echo "Remaining unpublished images: $CONTENT_IMAGES"
 
         # Output the list of component names that still need to be released
-        UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES")
+        UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES" | gzip -c | base64 -w 0)
         echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
         echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -51,13 +51,14 @@ spec:
               fi
 
               # Verify unreleased components list
-              UNRELEASED_COUNT=$(jq 'length' <<< '$(params.unreleased_components)')
+              UNRELEASED_COMPONENTS=$(base64 -d <<< "$(params.unreleased_components)" | gunzip)
+              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED_COMPONENTS")
               if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
                 echo "Expected 1 unreleased component, but found $UNRELEASED_COUNT"
                 exit 1
               fi
 
-              UNRELEASED_NAME=$(jq -r '.[0]' <<< '$(params.unreleased_components)')
+              UNRELEASED_NAME=$(jq -r '.[0]' <<< "$UNRELEASED_COMPONENTS")
               if [[ "$UNRELEASED_NAME" != "new-component" ]]; then
                 echo "Unexpected unreleased component name: $UNRELEASED_NAME"
                 exit 1

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -47,13 +47,14 @@ spec:
               [[ "$(params.result)" == "Success" ]]
 
               # Verify all components are marked as unreleased
-              UNRELEASED_COUNT=$(jq 'length' <<< '$(params.unreleased_components)')
+              UNRELEASED_COMPONENTS=$(base64 -d <<< "$(params.unreleased_components)" | gunzip)
+              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED_COMPONENTS")
               if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
                 echo "Expected 1 unreleased component, got $UNRELEASED_COUNT"
                 exit 1
               fi
 
-              UNRELEASED_NAME=$(jq -r '.[0]' <<< '$(params.unreleased_components)')
+              UNRELEASED_NAME=$(jq -r '.[0]' <<< "$UNRELEASED_COMPONENTS")
               if [[ "$UNRELEASED_NAME" != "test-component" ]]; then
                 echo "Unexpected unreleased component name: $UNRELEASED_NAME"
                 exit 1

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -252,12 +252,14 @@ spec:
           echo "Image filtering successful"
 
           # Get the unreleased components list
-          UNRELEASED_COMPONENTS=$(echo "$results" | jq -r '.unreleased_components // "[]"')
-          if [ -z "$UNRELEASED_COMPONENTS" ]; then
+          UNRELEASED_COMPONENTS_RAW=$(echo "$results" | jq -r '.unreleased_components // ""')
+          if [ -z "$UNRELEASED_COMPONENTS_RAW" ]; then
             echo "No unreleased components list found in results. Results:"
             echo "$results"
             exit 1
           fi
+
+          UNRELEASED_COMPONENTS=$(echo "$UNRELEASED_COMPONENTS_RAW" | base64 -d | gunzip)
 
           # Filter the original snapshot using the unreleased components list
           FILTERED_SNAPSHOT=$(jq --argjson unreleased "$UNRELEASED_COMPONENTS" '

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -7,9 +7,10 @@ function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
   then
+    UNRELEASED=$(echo -n '["new-component"]' | gzip -c | base64 -w 0)
     echo '{
       "result": "Success",
-      "unreleased_components": ["new-component"],
+      "unreleased_components": "'"$UNRELEASED"'",
       "internalRequestPipelineRunName": "test-pipeline-run",
       "internalRequestTaskRunName": "test-task-run"
     }'


### PR DESCRIPTION
## Describe your changes

We previously fixed the input to the IR being too long. That is no longer an issue. Now we failed when saving the result in the internal task.

So using the same approach (gzip + base64) here.

In the failing release, the original string was 7138 characters long. With the compression, it's 1873.

Previous change: https://github.com/konflux-ci/release-service-catalog/pull/1126

Slack: https://redhat-internal.slack.com/archives/C031USXS2FJ/p1751291732970599

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

