### PR TITLE
feat(RELEASE-1722): add skipFilter option to bypass advisory image filtering

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -788,6 +788,10 @@
           "description": "The tekton runner for running push-rpm-to-koji tekton task"
         }
       }
+    },
+    "skipFilter": {
+      "type": "boolean",
+      "description": "If true, skip filtering of already-released images and process all components in the snapshot. Default: false."
     }
   },
   "allOf": [

--- a/tasks/managed/filter-already-released-advisory-images/README.md
+++ b/tasks/managed/filter-already-released-advisory-images/README.md
@@ -30,3 +30,4 @@ Downstream tasks continue to use the same snapshot path.
 | taskGitRevision          | Git revision to use for internal task                                                                                      | No       | -                       |
 | pipelineRunUid           | UID of the current pipelineRun                                                                                             | No       | -                       |
 | synchronously            | Whether to wait for the InternalRequest completion                                                                         | Yes      | true                    |
+| dataPath                 | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -68,6 +68,9 @@ spec:
       type: string
       description: Whether to wait for the InternalRequest completion
       default: "true"
+    - name: dataPath
+      description: Path to the JSON string of the merged data to use in the data workspace
+      type: string
   workspaces:
     - name: data
       description: Workspace to mount internal request outputs
@@ -222,6 +225,16 @@ spec:
         else
           advisorySecretName="create-advisory-prod-secret"
           printf "production" | tee "$(results.environment.path)"
+        fi
+
+        # Check if skipFilter is true in data.json
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+        if [ -f "$DATA_FILE" ] && [ "$(jq -r '.skipFilter' "$DATA_FILE")" = "true" ]; then
+          echo "skipFilter is true in data.json, skipping filtering and passing snapshot unchanged."
+          echo -n "false" > "$(results.skip_release.path)"
+          echo -n "Success" > "$(results.result.path)"
+          # Output the original snapshot unchanged (no filtering)
+          exit 0
         fi
 
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/filter-already-released-advisory-images-results.json"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
@@ -94,6 +94,10 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
           - name: skip-trusted-artifact-operations
             ref:
               name: skip-trusted-artifact-operations
@@ -131,6 +135,8 @@ spec:
           value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
         - name: resultsDirPath
           value: "$(context.pipelineRun.uid)/results"
         - name: synchronously

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -91,6 +91,10 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
           - name: skip-trusted-artifact-operations
             ref:
               name: skip-trusted-artifact-operations
@@ -148,6 +152,8 @@ spec:
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -70,6 +70,9 @@ spec:
               }
               EOF
               # Note: No RPA file created
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
           - name: skip-trusted-artifact-operations
             ref:
               name: skip-trusted-artifact-operations
@@ -130,6 +133,8 @@ spec:
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -64,6 +64,9 @@ spec:
               }
               EOF
               # Note: No snapshot file created
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
           - name: skip-trusted-artifact-operations
             ref:
               name: skip-trusted-artifact-operations
@@ -124,6 +127,8 @@ spec:
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -94,6 +94,10 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
           - name: skip-trusted-artifact-operations
             ref:
               name: skip-trusted-artifact-operations
@@ -151,6 +155,8 @@ spec:
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
@@ -2,13 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-already-released-advisory-no-prod-or-pending
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-filter-already-released-advisory-skip-filter
 spec:
   description: |
-    Run the filter-already-released-advisory-images task with a snapshot containing only non-prod and non-pending
-    repositories and verify the task fails as expected.
+    Test that filter-already-released-advisory-images task skips
+    filtering when skipFilter: true is set in the data file.
   workspaces:
     - name: tests-workspace
   params:
@@ -33,6 +31,9 @@ spec:
       type: string
   tasks:
     - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
@@ -59,9 +60,24 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "repository": "quay.io/redhat-prod/repo",
+                    "containerImage": "quay.io/redhat-prod/repo@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {
+                "skipFilter": true
+              }
+              EOF
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
               {
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
@@ -75,28 +91,6 @@ spec:
                   "origin": "dev"
                 }
               }
-              EOF
-
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
-              {
-                "application": "myapp",
-                "components": [
-                  {
-                    "name": "dev-component",
-                    "repository": "quay.io/redhat-dev/repo",
-                    "containerImage": "quay.io/redhat-dev/repo@sha256:abc123"
-                  },
-                  {
-                    "name": "other-component",
-                    "repository": "quay.io/other/repo",
-                    "containerImage": "quay.io/other/repo@sha256:def456"
-                  }
-                ]
-              }
-              EOF
-
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
-              {}
               EOF
           - name: skip-trusted-artifact-operations
             ref:
@@ -130,6 +124,8 @@ spec:
     - name: run-task
       taskRef:
         name: filter-already-released-advisory-images
+      runAfter:
+        - setup
       params:
         - name: snapshotPath
           value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
@@ -139,12 +135,14 @@ spec:
           value: "$(context.pipelineRun.uid)/results"
         - name: synchronously
           value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
         - name: taskGitUrl
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: pipelineRunUid
-          value: $(context.pipelineRun.uid)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -157,8 +155,91 @@ spec:
           value: $(params.dataDir)
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-      runAfter:
-        - setup
       workspaces:
         - name: data
           workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: result
+            type: string
+          - name: skip_release
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # When skipFilter is true, no InternalRequests should be created
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+
+              if [ "$requestsCount" -ne 0 ]; then
+                echo "When skipFilter is true, no InternalRequests should be created. Found: $requestsCount"
+                exit 1
+              fi
+
+              # Check that skip_release is set to false (pipeline should continue)
+              if [ "$(params.skip_release)" != "false" ]; then
+                echo "skip_release should be false when skipFilter is true"
+                exit 1
+              fi
+
+              # Check that the result was properly set to Success
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+
+              echo "All assertions passed: skipFilter=true correctly skipped filtering"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)" 


### PR DESCRIPTION
## Describe your changes

Add `skipFilter` boolean option in` data` to skip filtering of already-released advisory images. When enabled, the task passes the snapshot unchanged without creating internal requests, allowing reruns for missed component signing.

## Relevant Jira
[RELEASE-1722](https://issues.redhat.com//browse/RELEASE-1722)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

