### PR TITLE
feat(MMENG-4337): support MRRC signing through RADAS

### DIFF
--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -56,8 +56,8 @@ spec:
       description: The revision in the taskGitUrl repo to be used
       default: production
     - name: ociStorage
-      type: string
       description: The OCI repository where the Trusted Artifacts are stored
+      type: string
       default: "quay.io/konflux-ci/release-service-trusted-artifacts"
     - name: orasOptions
       description: oras options to pass to Trusted Artifacts calls
@@ -199,7 +199,7 @@ spec:
         - name: TIMEOUT
           value: $(params.enterpriseContractTimeout)
         - name: SOURCE_DATA_ARTIFACT
-          value: "$(tasks.check-data-keys.results.sourceDataArtifact)"
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
@@ -222,11 +222,13 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.verify-conforma.results.sourceDataArtifact)"
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
           value: "$(params.trustedArtifactsDebug)"
+        - name: releasePath
+          value: "$(tasks.collect-data.results.release)"
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
@@ -265,6 +267,8 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
+        - name: charonSignCASecret
+          value: "$(tasks.collect-mrrc-params.results.charonSignCASecret)"
       workspaces:
         - name: data
           workspace: release-workspace

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -723,6 +723,24 @@
           "type": "string",
           "description": "The k8s secret containing the aws credential for MRRC aws access"
         },
+        "sign": {
+          "type": "object",
+          "description": "The signing configuration through RADAS",
+          "properties": {
+            "signKey": {
+              "type": "string",
+              "description": "The signing key used to do signing"
+            },
+            "signCASecret": {
+              "type": "string",
+              "description": "The k8s secret containing ca files for radas access"
+            },
+            "signIgnores": {
+              "type": "array",
+              "description": "Patterns to filter the files which will not need to do signing"
+            }
+          }
+        },
         "charonConfig": {
           "type": "string",
           "description": "The charon configuration content which will be stored as file for charon tools"
@@ -1010,8 +1028,17 @@
               "environment",
               "release",
               "awsSecret",
-              "charonConfig"
-            ]
+              "charonConfig",
+              "signing"
+            ],
+            "properties": {
+              "signing": {
+                "required": [
+                  "signKey",
+                  "signCASecret"
+                ]
+              }
+            }
           },
           "releaseNotes": {
             "required": [

--- a/tasks/managed/collect-mrrc-params/README.md
+++ b/tasks/managed/collect-mrrc-params/README.md
@@ -21,3 +21,4 @@ other three for downstream tasks to use.
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| releasePath             | Path to the release data JSON file                                                                                         | No       | -                       |

--- a/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
@@ -52,6 +52,9 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: releasePath
+      type: string
+      description: Path to the release data JSON file      
   workspaces:
     - name: data
       description: The workspace where the extra config file containing the mapping and snapshot json reside
@@ -65,6 +68,8 @@ spec:
     - name: sourceDataArtifact
       type: string
       description: Produced trusted data artifact
+    - name: charonSignCASecret
+      description: the secret name for ca files for radas signing      
   volumes:
     - name: workdir
       emptyDir: {}
@@ -150,12 +155,21 @@ spec:
         echo "export MRRC_PRODUCT_NAME=$productName" >> "$MRRC_ENV_FILE_PATH"
         echo "export MRRC_PRODUCT_VERSION=$productVersion" >> "$MRRC_ENV_FILE_PATH"
 
+        sign_key="$(jq -re '.mrrc.signing.signKey' "$DATA_FILE")"
+        echo "export MRRC_SIGN_KEY=$sign_key" >> "$MRRC_ENV_FILE_PATH"
+
         SNAPSHOT_PATH="$WORK_DIR/$(params.snapshotPath)"
         zipRegistries="$(jq -re '[.components[].containerImage] | join("%")' "$SNAPSHOT_PATH")"
         echo "export MRRC_ZIP_REGISTRY=$zipRegistries" >> "$MRRC_ENV_FILE_PATH"
 
         awsSecret="$(jq -re '.mrrc.awsSecret' $DATA_FILE)"
         echo -n "$awsSecret" > "$(results.charonAWSSecret.path)"
+
+        sign_ca_secret="$(jq -re '.mrrc.signing.signCASecret' "$DATA_FILE")"
+        echo -n "$sign_ca_secret" > "$(results.charonSignCASecret.path)"
+
+        AUTHOR=$(jq -re '.status.attribution.author' "$WORK_DIR/$(params.releasePath)")
+        echo "export MRRC_AUTHOR=$AUTHOR" >> "$MRRC_ENV_FILE_PATH"
 
         echo -n "$MRRC_ENV_FILE_PATH" > "$(results.mrrcParamFilePath.path)"
 

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
@@ -122,6 +122,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: releasePath
+          value: $(context.pipelineRun.uid)/release.json
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
@@ -125,6 +125,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: releasePath
+          value: $(context.pipelineRun.uid)/release.json
       workspaces:
         - name: data
           workspace: tests-workspace

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
@@ -71,7 +71,21 @@ spec:
                   "charonConfig":"charon-config",
                   "awsSecret": "charon-aws-credentials",
                   "environment": "dev",
-                  "release": "ga"
+                  "release": "ga",
+                  "signing": {
+                    "signCASecret": "radas-sa-secret",
+                    "signKey": "testkey"
+                  }
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "testuser"
+                  }
                 }
               }
               EOF
@@ -135,6 +149,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: releasePath
+          value: $(context.pipelineRun.uid)/release.json
       workspaces:
         - name: data
           workspace: tests-workspace
@@ -155,6 +171,8 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
+        - name: charonSignCASecret
+          value: $(tasks.run-task.results.charonSignCASecret)
       taskSpec:
         params:
           - name: mrrcParamFilePath
@@ -164,6 +182,7 @@ spec:
             type: string
           - name: dataDir
             type: string
+          - name: charonSignCASecret
         workspaces:
           - name: data
         volumes:
@@ -200,10 +219,12 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               test "$(params.charonAWSSecret)" == "charon-aws-credentials"
+
+              test "$(params.charonSignCASecret)" == "radas-sa-secret"
 
               MRRC_FILE="$(params.dataDir)/$(params.mrrcParamFilePath)"
               test -f "$MRRC_FILE"
@@ -213,6 +234,8 @@ spec:
               test "$MRRC_TARGET" == "dev-maven-ga"
               test "$MRRC_PRODUCT_NAME" == "test"
               test "$MRRC_PRODUCT_VERSION" == "0.0.1"
+              test "$MRRC_SIGN_KEY" == "testkey"
+              test "$MRRC_AUTHOR" == "testuser"
 
               CHARON_CFG_FILE="$(params.dataDir)/$(params.charonConfigFilePath)"
               test -f "$CHARON_CFG_FILE"

--- a/tasks/managed/publish-to-mrrc/README.md
+++ b/tasks/managed/publish-to-mrrc/README.md
@@ -12,6 +12,8 @@ and use the variables in it as parameters for the MRRC publishing task.
 
 | Name                    | Description                                                                                                                | Optional | Default value           |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca              |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt           |
 | mrrcParamFilePath       | path of the env file for mrrc parameters to use                                                                            | No       | -                       |
 | charonConfigFilePath    | path of the charon config file for charon to consume                                                                       | No       | -                       |
 | charonAWSSecret         | the secret name for charon aws credential file                                                                             | No       | -                       |
@@ -23,3 +25,4 @@ and use the variables in it as parameters for the MRRC publishing task.
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| charonSignCASecret      | the secret name for ca files for radas signing                                                                             | No       | -                       |

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -16,6 +16,14 @@ spec:
     [collect-mrrc-task](../collect-mrrc-params/README.md)
     and use the variables in it as parameters for the MRRC publishing task.
   params:
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
     - name: mrrcParamFilePath
       description: path of the env file for mrrc parameters to use
       type: string
@@ -56,6 +64,9 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: charonSignCASecret
+      description: the secret name for ca files for radas signing
+      type: string
   workspaces:
     - name: data
       description: The workspace where the extra config file containing the mapping and snapshot json reside
@@ -71,6 +82,16 @@ spec:
       emptyDir: {}
     - name: workdir
       emptyDir: {}
+    - name: "charon-signca-vol"
+      secret:
+        secretName: "$(params.charonSignCASecret)"
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -156,14 +177,18 @@ spec:
           echo "Downloading the maven repo zip $r"
           SOURCE_REPO=${r%%@sha256:*}
           AUTH_FILE=$(mktemp)
+          hash=${r##*@sha256:}
+          short_hash=${hash:0:6}
+          repodir="/workdir/mrrc/$short_hash"
+          mkdir -p "$repodir"
           select-oci-auth "${SOURCE_REPO}" > "$AUTH_FILE"
-          oras pull --registry-config "$AUTH_FILE" "$r" -o /workdir/mrrc
+          oras pull --registry-config "$AUTH_FILE" "$r" -o "$repodir"
         done
       volumeMounts:
         - name: mrrc-workdir
           mountPath: "/workdir"
     - name: upload-maven-repo
-      image: quay.io/konflux-ci/charon@sha256:95b22f4f0fc1d6bb984a2f63334c3f66a539e433d79cde4eafa7731d8924377f
+      image: quay.io/konflux-ci/charon@sha256:0d0e4a02e8c54fcc54bc359e960e0610c184f452d74b85bd8b2e95064ba1a119
       computeResources:
         limits:
           memory: 512Mi
@@ -186,19 +211,45 @@ spec:
         productName=$MRRC_PRODUCT_NAME
         productVersion=$MRRC_PRODUCT_VERSION
 
-        work_dir="/workdir/mrrc"
-        # Disable shell check sc2012 as find command is not installed
-        # shellcheck disable=SC2012
-        for r in $(ls "$work_dir"/*.zip | cat)
+        IFS='%' read -ra ADDR <<< "$MRRC_ZIP_REGISTRY"
+        for registry in "${ADDR[@]}"
         do
-          echo "Release $r with $productName-$productVersion into $target"
-          charon upload -p "$productName" -v "$productVersion" -t "$target" "$r"
+          echo "Release $registry with $productName-$productVersion into $target"
+          hash=${registry##*@sha256:}
+          short_hash=${hash:0:6}
+          repodir="/workdir/mrrc/$short_hash"
+
+          # start signing of the maven artifacts in maven zip
+          charon sign -r "$MRRC_AUTHOR" -p "$repodir" -k "$MRRC_SIGN_KEY" "$registry"
+
+          repo_zips=("$repodir"/*.zip)
+          repo_zip=${repo_zips[0]}
+          if [[ "$repo_zip" == "$repodir/*.zip" ]]
+          then
+            echo "No maven repository zip file found, will not publish."
+            exit 1
+          fi
+          sign_files=("$repodir"/*.json)
+          sign_file=${sign_files[0]}
+          if [[ "$sign_file" == "$repodir/*.json" ]]
+          then
+            echo "No signature result received from radas, will not publish."
+            exit 1
+          fi
+          echo "Release $repo_zip with $productName-$productVersion into $target"
+          charon upload -p "$productName" -v "$productVersion" -t "$target" -l "$sign_file" "$repo_zip"
         done
       volumeMounts:
         - name: "charon-aws-vol"
           mountPath: "/home/charon/.aws"
         - name: mrrc-workdir
           mountPath: "/workdir"
+        - name: "charon-signca-vol"
+          mountPath: "/home/charon/radasca"
+        - name: trusted-ca
+          mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/publish-to-mrrc/tests/mocks.sh
+++ b/tasks/managed/publish-to-mrrc/tests/mocks.sh
@@ -4,26 +4,30 @@ set -eux
 # mocks to be injected into task step scripts
 
 function oras(){
-  echo Mock oras called with: $*
-  echo $* >> "$(params.dataDir)/mock_oras.txt"
+  echo Mock oras called with: "$*"
+  echo "$*" >> "$(params.dataDir)/mock_oras.txt"
 
   if [[ "$*" == "pull --registry-config"* ]]
   then
-    echo Mock oras called with: $*
+    echo Mock oras called with: "$*"
     echo $4
     IFS='/' arrIN=(${4}); unset IFS;
     IFS='@' zip=(${arrIN[2]}); unset IFS;
-    touch /workdir/mrrc/$zip
+    registry="$4"
+    hash=${registry##*@sha256:}
+    short_hash=${hash:0:6}
+    chmod 777 /workdir/mrrc/"$short_hash"
+    touch /workdir/mrrc/"$short_hash"/"${zip[0]}"
   else
-    echo Mock oras called with: $*
+    echo Mock oras called with: "$*"
     echo Error: Unexpected call
     exit 1
   fi
 }
 
 function charon(){
-  echo Mock charon called with: $*
-  echo $* >> "$(params.dataDir)/mock_charon.txt"
+  echo Mock charon called with: "$*"
+  echo "$*" >> "$(params.dataDir)/mock_charon.txt"
 
   if [ ! -f "$HOME/.charon/charon.yaml" ]
   then
@@ -31,14 +35,35 @@ function charon(){
     exit 1
   fi
 
-  if [[ "$*" != "upload -p "*" -v "*" -t "*" "*"" ]]
+  if [[ "$*" != "sign -r "*" -p "*" -k "*" "*"" ]] && [[ "$*" != "upload -p "*" -v "*" -t "*" "*"" ]]
   then
+    echo Mock charon called with: "$*"
     echo Error: Unexpected call
     exit 1
+  fi
+
+  # generate signing file to pass test
+  if [[ "$*" == "sign -r "*" -p "*" -k "*" "*"" ]]
+  then
+    echo Mock charon sign called with: "$*"
+    registry="$8"
+    hash=${registry##*@sha256:}
+    short_hash=${hash:0:6}
+    touch /workdir/mrrc/"$short_hash"/signing.json
+  fi
+
+  # will use testcert as a symbol for ca mounted test
+  if [[ "$*" == "sign -r "*" -p "*" -k \"testcert\" "*"" ]]
+  then
+    if [[ $(cat /etc/ssl/certs/ca-custom-bundle.crt) != "mycert" ]]
+    then
+      echo Custom certificate not mounted
+      return 1
+    fi
   fi
 }
 
 function select-oci-auth() {
-  echo $* >> "$(params.dataDir)/mock_select-oci-auth.txt"
+  echo "$*" >> "$(params.dataDir)/mock_select-oci-auth.txt"
 }
 

--- a/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
@@ -15,6 +15,16 @@ EOF
 kubectl delete secret test-charon-aws-credentials --ignore-not-found
 kubectl create secret generic test-charon-aws-credentials --from-literal=credentials="$aws_creds"
 
+kubectl delete secret test-ca --ignore-not-found
+kubectl create secret generic test-ca \
+  --from-literal=client-key.pem="testkey" \
+  --from-literal=client-key.password="testpass" \
+  --from-literal=mrrc-signing.crt="testca"
+
 # Add mocks to the beginning of scripts
 yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
 yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
+
+# Create a dummy configmap (and delete it first if it exists)
+kubectl delete configmap trusted-ca --ignore-not-found
+kubectl create configmap trusted-ca --from-literal=cert=mycert

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
@@ -75,6 +75,8 @@ spec:
               export MRRC_TARGET=dev-maven-ga
               export MRRC_PRODUCT_NAME=test-prod
               export MRRC_PRODUCT_VERSION=0.0.1
+              export MRRC_SIGN_KEY=testkey
+              export MRRC_AUTHOR=testuser
               EOF
           - name: skip-trusted-artifact-operations
             ref:
@@ -126,6 +128,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: charonSignCASecret
+          value: test-ca
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
@@ -123,6 +123,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: charonSignCASecret
+          value: test-ca
       runAfter:
         - setup
       workspaces:

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-mount-certs.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-mount-certs.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-publish-to-mrrc
+  name: test-publish-to-mrrc-mount-certs
 spec:
   description: |
     Run the publish-to-mrrc task with required parameters - a happy path scenario.
@@ -73,7 +73,7 @@ spec:
               export MRRC_TARGET=dev-maven-ga
               export MRRC_PRODUCT_NAME=test-prod
               export MRRC_PRODUCT_VERSION=0.0.1
-              export MRRC_SIGN_KEY=testkey
+              export MRRC_SIGN_KEY=testcert # this will trigger ca exiting check
               export MRRC_AUTHOR=testuser
               EOF
 
@@ -132,6 +132,10 @@ spec:
           value: "main"
         - name: charonSignCASecret
           value: test-ca
+        - name: caTrustConfigMapName
+          value: test-use-custom-ca-cert
+        - name: caTrustConfigMapKey
+          value: cert
       runAfter:
         - setup
       workspaces:


### PR DESCRIPTION
This PR added signing function support through RADAS service in MRRC release pipeline:
  * Use new charon container which supports charon sign command
  * Support author fetching for signing command usage

see [MMENG-4337](https://issues.redhat.com//browse/MMENG-4337) for details


