### PR TITLE
fix: another arg list too long in filter task

### DIFF
--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -284,33 +284,36 @@ spec:
             exit 1
           fi
 
-          UNRELEASED_COMPONENTS=$(echo "$UNRELEASED_COMPONENTS_RAW" | base64 -d | gunzip)
+          UNRELEASED_COMPONENTS=$(mktemp)
+          FILTERED_SNAPSHOT=$(mktemp)
+
+          echo "$UNRELEASED_COMPONENTS_RAW" | base64 -d | gunzip | tee "$UNRELEASED_COMPONENTS"
 
           # Filter the original snapshot using the unreleased components list
-          FILTERED_SNAPSHOT=$(jq --argjson unreleased "$UNRELEASED_COMPONENTS" '
+          jq --slurpfile unreleased "$UNRELEASED_COMPONENTS" '
             .components = (
               .components | map(
                 select(
-                  .name as $name | ($unreleased | contains([$name]))
+                  .name as $name | ($unreleased[0] | contains([$name]))
                 )
               )
             )
-          ' < "$SNAPSHOT_FILE")
+          ' "$SNAPSHOT_FILE" > "$FILTERED_SNAPSHOT"
 
           # Check if the filtered snapshot has any components
-          if jq -e '.components | length == 0' <<< "$FILTERED_SNAPSHOT"; then
+          if jq -e '.components | length == 0' < "$FILTERED_SNAPSHOT"; then
             echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
-            echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
+            cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
             echo -n "Success" > "$(results.result.path)"
             echo -n "true" > "$(results.skip_release.path)"
-            jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+            jq -n --rawfile snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
             exit 0
           fi
 
-          echo "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
+          cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
           echo -n "Success" > "$(results.result.path)"
           echo -n "false" > "$(results.skip_release.path)"
-          jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+          jq -n --rawfile snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
         else
           echo "Filtering failed. Results:"
           echo "$results"


### PR DESCRIPTION
## Describe your changes

We fixed this in a few other places in the past. Now this popped up. The resulting list of unreleased components can be very long.

So use jq --slurpfile instead of --arg or --argjson.

Slack: https://redhat-internal.slack.com/archives/C031USXS2FJ/p1751393392569299?thread_ts=1751291732.970599&cid=C031USXS2FJ

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

