### PR TITLE
fix(KONFLUX-8965): Add brief description for issues and CVEs fixed

### DIFF
--- a/pipelines/internal/enrich-cve-metadata/README.md
+++ b/pipelines/internal/enrich-cve-metadata/README.md
@@ -1,0 +1,19 @@
+# enrich-advisory-metadata (Pipeline)
+
+This internal Tekton pipeline runs the `enrich-advisory-metadata` task to enrich advisory metadata with issue and CVE titles. It is intended to be run in an internal context with access to Red Hat internal APIs and secrets.
+
+## Parameters
+
+| Name     | Description                                      | Required | Default                      |
+|----------|--------------------------------------------------|----------|------------------------------|
+| dataPath | Path to the JSON string of the merged data to use| Yes      | -                            |
+| dataDir  | The location where data will be stored           | No       | $(workspaces.data.path)      |
+
+## Workspaces
+
+- `data`: The workspace where the data JSON file resides
+
+## Description
+
+- Calls the `enrich-advisory-metadata` task to fetch and inject titles for issues and CVEs in the advisory data JSON.
+- Should be called from a managed/external pipeline via an internal request, before further processing or advisory creation. 

--- a/pipelines/internal/enrich-cve-metadata/enrich-cve-metadata.yaml
+++ b/pipelines/internal/enrich-cve-metadata/enrich-cve-metadata.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: enrich-cve-metadata
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: internal, enrichment
+spec:
+  description: >-
+    Pipeline to enrich CVE metadata with titles using the enrich-cve-metadata task.
+  params:
+    - name: cvesJson
+      type: string
+      description: JSON array of CVEs to enrich
+  results:
+    - name: enrichedCvesJson
+      value: $(tasks.enrich-cve-metadata.results.enrichedCvesJson)
+  tasks:
+    - name: enrich-cve-metadata
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/internal/enrich-advisory-metadata/enrich-cve-metadata.yaml
+      params:
+        - name: cvesJson
+          value: $(params.cvesJson) 

--- a/tasks/internal/enrich-cve-metadata/README.md
+++ b/tasks/internal/enrich-cve-metadata/README.md
@@ -1,0 +1,28 @@
+# enrich-cve-metadata
+
+This internal Tekton task enriches CVE metadata by fetching and injecting CVE titles into the provided CVE JSON array. It is intended to be run in an internal context with access to Red Hat internal APIs and secrets.
+
+## Parameters
+
+| Name     | Description                                      | Required | Default |
+|----------|--------------------------------------------------|----------|---------|
+| cvesJson | JSON array of CVEs to enrich                     | Yes      | -       |
+
+## Results
+
+| Name             | Description                        |
+|------------------|------------------------------------|
+| enrichedCvesJson | JSON array of enriched CVEs         |
+
+## Secrets
+
+- `osidb-api-token`: Used to authenticate to OSIDB (must contain `token` key)
+
+## Description
+
+- For each CVE in the input JSON array, fetches the title/summary from OSIDB (or a public CVE API) and injects it as the `title` field.
+- Outputs the enriched CVEs as a JSON array in the `enrichedCvesJson` result.
+
+## Example Usage
+
+This task should be called from an internal pipeline (e.g., `enrich-cve-metadata` pipeline) via an internal request from a managed pipeline. The managed pipeline should parse the result and inject the enriched CVEs back into its data JSON. 

--- a/tasks/internal/enrich-cve-metadata/enrich-cve-metadata.yaml
+++ b/tasks/internal/enrich-cve-metadata/enrich-cve-metadata.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: enrich-cve-metadata
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: internal, enrichment
+spec:
+  description: >-
+    Enriches CVE metadata by fetching and injecting CVE titles into the provided CVE JSON array.
+  params:
+    - name: cvesJson
+      description: JSON array of CVEs to enrich
+      type: string
+  results:
+    - name: enrichedCvesJson
+      description: JSON array of enriched CVEs
+  steps:
+    - name: enrich-cves-with-titles
+      image: quay.io/konflux-ci/release-service-utils:latest
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: '1'  # 1 is the max allowed by at least the staging cluster
+      env:
+        - name: OSIDB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: osidb-api-token
+              key: token
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        CVES_JSON="$(params.cvesJson)"
+        ENRICHED_CVES=()
+        NUM_CVES=$(echo "$CVES_JSON" | jq 'length')
+        for ((i = 0; i < NUM_CVES; i++)); do
+          cve=$(echo "$CVES_JSON" | jq -c --argjson i "$i" '.[$i]')
+          key=$(echo "$cve" | jq -r '.key')
+          title=""
+          # Fetch from OSIDB or CVE API
+          title=$(curl -s -H "Authorization: Bearer $OSIDB_TOKEN" \
+            "https://osidb/api/v1/flaws?cve_id=$key" | \
+            jq -r '.results[0].title // .results[0].cve_description // \
+              .results[0].description // .results[0].summary // empty')
+          if [ -n "$title" ] && [ "$title" != "null" ]; then
+            cve=$(echo "$cve" | jq --arg title "$title" '.title = $title')
+          fi
+          ENRICHED_CVES+=("$cve")
+        done
+        # Output enriched CVEs as a JSON array
+        echo -n "${ENRICHED_CVES[@]}" | jq -s '.' > "$(results.enrichedCvesJson.path)"

--- a/tasks/internal/enrich-cve-metadata/tests/test-enrich-cve-metadata.yaml
+++ b/tasks/internal/enrich-cve-metadata/tests/test-enrich-cve-metadata.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-enrich-cve-metadata
+spec:
+  params:
+    - name: cvesJson
+      type: string
+      default: '[{"key": "CVE-2024-0001", "component": "comp1"}, {"key": "CVE-2024-0002", "component": "comp2"}]'
+  tasks:
+    - name: run-task
+      taskRef:
+        name: enrich-cve-metadata
+      params:
+        - name: cvesJson
+          value: $(params.cvesJson)
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: enrichedCvesJson
+          value: $(tasks.run-task.results.enrichedCvesJson)
+      taskSpec:
+        params:
+          - name: enrichedCvesJson
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:latest
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              enriched_cves="$(params.enrichedCvesJson)"
+              title1=$(echo "$enriched_cves" | jq -r '.[0].title')
+              title2=$(echo "$enriched_cves" | jq -r '.[1].title')
+              if [ -z "$title1" ] || [ "$title1" == "null" ]; then
+                echo "Error: title field is missing for the first CVE"
+                exit 1
+              fi
+              if [ -z "$title2" ] || [ "$title2" == "null" ]; then
+                echo "Error: title field is missing for the second CVE"
+                exit 1
+              fi 

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -69,48 +69,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
-    - name: use-trusted-artifact
-      computeResources:
-        limits:
-          memory: 64Mi
-        requests:
-          memory: 64Mi
-          cpu: 30m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
-      params:
-        - name: workDir
-          value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(params.sourceDataArtifact)
     - name: populate-release-notes-images
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       computeResources:
@@ -299,7 +257,96 @@ spec:
                     /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
             done
         done
-
+    - name: enrich-metadata
+      image: quay.io/konflux-ci/release-service-utils:latest
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+      env:
+        - name: JIRA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-advisory-jira-secret
+              key: token
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+        # Enrich issue titles
+        NUM_ISSUES=$(jq '.releaseNotes.issues.fixed | length' "$DATA_FILE")
+        for ((i = 0; i < NUM_ISSUES; i++)); do
+          issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "$DATA_FILE")
+          id=$(jq -r '.id' <<< "$issue")
+          source=$(jq -r '.source' <<< "$issue")
+          title=""
+          if [[ "$source" == "issues.redhat.com" ]]; then
+            title=$(curl -s -H "Authorization: Bearer $JIRA_TOKEN" \
+              "https://$source/rest/api/2/issue/$id" | jq -r '.fields.summary')
+          elif [[ "$source" == "bugzilla.redhat.com" ]]; then
+            title=$(curl -s "https://$source/rest/bug/$id" | jq -r '.summary')
+          fi
+          if [ -n "$title" ] && [ "$title" != "null" ]; then
+            jq --argjson i "$i" --arg title "$title" \
+              '.releaseNotes.issues.fixed[$i].title = $title' "$DATA_FILE" > /tmp/data.tmp && \
+              mv /tmp/data.tmp "$DATA_FILE"
+          fi
+        done
+        # Enrich CVE titles via internal pipeline
+        CVES_JSON=$(jq -c '.releaseNotes.cves' "$DATA_FILE")
+        IR_FILE=$(mktemp)
+        internal-request --pipeline "enrich-cve-metadata" \
+          -p cvesJson="$CVES_JSON" \
+          -s true > "$IR_FILE"
+        ENRICHED_CVES=$(jq -r '.status.results[] | select(.name=="enrichedCvesJson") | .value' "$IR_FILE")
+        if [ -n "$ENRICHED_CVES" ] && [ "$ENRICHED_CVES" != "null" ]; then
+          jq --argjson cves "$ENRICHED_CVES" '.releaseNotes.cves = $cves' "$DATA_FILE" > /tmp/data.tmp && \
+            mv /tmp/data.tmp "$DATA_FILE"
+        fi
+    - name: skip-trusted-artifact-operations
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 20m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
     - name: populate-release-notes-type-and-references
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       computeResources:

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -257,5 +257,32 @@ spec:
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == "CVE-123CVE-456"
               test "$(jq '.releaseNotes.content.images[1].cves.fixed."CVE-123".packages | length' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == 0
+
+              # Check that the title field is present for the issues
+              title1=$(jq -r '.releaseNotes.issues.fixed[0].title' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              title2=$(jq -r '.releaseNotes.issues.fixed[1].title' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              if [ -z "$title1" ] || [ "$title1" == "null" ]; then
+                echo "Error: title field is missing for the first issue"
+                exit 1
+              fi
+              if [ -z "$title2" ] || [ "$title2" == "null" ]; then
+                echo "Error: title field is missing for the second issue"
+                exit 1
+              fi
+              # Check that the title field is present for the CVEs
+              cve_title1=$(jq -r '.releaseNotes.cves[0].title' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              cve_title2=$(jq -r '.releaseNotes.cves[1].title' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              if [ -z "$cve_title1" ] || [ "$cve_title1" == "null" ]; then
+                echo "Error: title field is missing for the first CVE"
+                exit 1
+              fi
+              if [ -z "$cve_title2" ] || [ "$cve_title2" == "null" ]; then
+                echo "Error: title field is missing for the second CVE"
+                exit 1
+              fi
       runAfter:
         - run-task


### PR DESCRIPTION
## Describe your changes
We currently only provide links/references to CVEs and issues. This would result in anyone viewing an advisory to have to click through these in order to find out more information about them. We can provide additional context to the advisory consumers to reduce their need to click through.

This change is not sufficient on its own, any rendering of the advisory metadata will need to also consume this same information when displaying.

Assisted-by: Cursor

## Relevant Jira

[KONFLUX-8965](https://issues.redhat.com//browse/KONFLUX-8965)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

