### PR TITLE
feat: use utils image with concurrency limit

### DIFF
--- a/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
+++ b/tasks/managed/update-component-sbom/tests/test-update-component-sbom-basic.yaml
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
+            image: quay.io/konflux-ci/release-service-utils:40c0e87369ee166f8f80fc4cf52fb59129dfa418
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-component-sbom
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.2"
+    tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: >-

--- a/tasks/managed/update-component-sbom/update-component-sbom.yaml
+++ b/tasks/managed/update-component-sbom/update-component-sbom.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: update-component-sbom
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/pipelines.minVersion: "0.12.2"
     tekton.dev/tags: release
 spec:
   description: >-
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-sboms
-      image: quay.io/konflux-ci/release-service-utils:f1796a941065d1ea8f32380045af56c98d4a8621
+      image: quay.io/konflux-ci/release-service-utils:40c0e87369ee166f8f80fc4cf52fb59129dfa418
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
The update-component-sbom task was using too much memory. Use updated version of the script with a concurrency limit.

