### PR TITLE
fix: verify that branch is created correctly

### DIFF
--- a/integration-tests/scripts/create-branch-from-base.sh
+++ b/integration-tests/scripts/create-branch-from-base.sh
@@ -50,3 +50,57 @@ echo "Current SHA for base branch $base_branch_name is  $SHA"
 echo "Creating new branch called ${new_branch_name} based on branch $base_branch_name"
 curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
  -d  "{\"ref\": \"refs/heads/${new_branch_name}\",\"sha\": \"$SHA\"}"  https://api.github.com/repos/${repo_name}/git/refs 2> /dev/null
+
+# Verify the branch exists and is pullable with retry logic
+echo "Verifying that branch ${new_branch_name} exists and is pullable..."
+
+max_attempts=5
+attempt=1
+verification_success=false
+
+while [ $attempt -le $max_attempts ]; do
+  echo "Verification attempt ${attempt}/${max_attempts}..."
+  
+  # Check if the branch exists by getting its ref
+  NEW_BRANCH_SHA=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${repo_name}/git/refs/heads/${new_branch_name} 2> /dev/null | jq -r '.object.sha // ""')
+  
+  if [ -n "${NEW_BRANCH_SHA}" ]; then
+    # Verify the SHA matches what we expected
+    if [ "${NEW_BRANCH_SHA}" = "${SHA}" ]; then
+      # Test if the branch is pullable by attempting to get its info
+      BRANCH_INFO=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${repo_name}/branches/${new_branch_name} 2> /dev/null)
+      BRANCH_EXISTS=$(echo "$BRANCH_INFO" | jq -r '.name // ""')
+      
+      if [ "${BRANCH_EXISTS}" = "${new_branch_name}" ]; then
+        echo "✅ Branch ${new_branch_name} successfully created and is pullable"
+        echo "   - SHA: ${NEW_BRANCH_SHA}"
+        echo "   - Based on: ${base_branch_name}"
+        echo "   - Verified on attempt: ${attempt}"
+        verification_success=true
+        break
+      else
+        echo "⚠️  Branch ${new_branch_name} exists but is not yet pullable (attempt ${attempt}/${max_attempts})"
+      fi
+    else
+      echo "⚠️  Branch ${new_branch_name} SHA (${NEW_BRANCH_SHA}) does not match expected SHA (${SHA}) (attempt ${attempt}/${max_attempts})"
+    fi
+  else
+    echo "⚠️  Branch ${new_branch_name} does not exist yet (attempt ${attempt}/${max_attempts})"
+  fi
+  
+  # Wait before retrying (except on the last attempt)
+  if [ $attempt -lt $max_attempts ]; then
+    echo "Waiting 3 seconds before retry..."
+    sleep 3
+  fi
+  
+  attempt=$((attempt + 1))
+done
+
+# Check if verification ultimately succeeded
+if [ "$verification_success" = false ]; then
+  echo "🔴 error: branch ${new_branch_name} verification failed after ${max_attempts} attempts"
+  echo "   - Branch may not have been created successfully"
+  echo "   - Branch may not be pullable or accessible"
+  exit 1
+fi


### PR DESCRIPTION
## Describe your changes
- when many krw tests are started at same time, we sometimes experience an error: "75: No resource for finishing the request" from PaC
- it is possible that the GH branch is not available yet when the build-service and PaC try to access it.
- this change verifies that the branch is there and pullable.

Assisted-by: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

