### PR TITLE
chore(KFLUXSPRT-3992): up memory in use-ta-array

### DIFF
--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -100,9 +100,9 @@ spec:
     - name: use-trusted-artifact-array
       computeResources:
         limits:
-          memory: 32Mi
+          memory: 64Mi
         requests:
-          memory: 32Mi
+          memory: 64Mi
           cpu: 20m
       ref:
         resolver: "git"


### PR DESCRIPTION
Users are reporting OOMKill in the use-trusted-artifacts-array step, which is only used in the update-cr-status task. This commit doubles the memory.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

