### PR TITLE
fix(ROK-673): use correct data types for creating Koji builds

### DIFF
--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -265,14 +265,14 @@ spec:
           build_name=$(jq -r '.build.name' cg_import.json)
           build_version=$(jq -r '.build.version' cg_import.json)
           build_release=$(jq -r '.build.release' cg_import.json)
-          build_epoch=$(jq -r '.build.epoch' cg_import.json)
-          import_build_data=$(cat <<EOD
+          build_epoch=$(jq '.build.epoch' cg_import.json)
+          import_build_data=$(jq --compact-output <<EOD
               {
                 "name": "$build_name",
                 "version": "$build_version",
                 "release": "$build_release",
-                "epoch": "$build_epoch",
-                "draft": "$draft"
+                "epoch": $build_epoch,
+                "draft": $draft
               }
         EOD
           )

--- a/tasks/managed/push-rpm-to-koji/tests/mocks.sh
+++ b/tasks/managed/push-rpm-to-koji/tests/mocks.sh
@@ -17,7 +17,17 @@ function oras() {
     if [[ "$1" == "manifest" && "$2" == "fetch" ]]; then
         echo '{"annotations": {"koji.build-target": "mock-target"}}'
     elif [[ "$1" == "pull" ]]; then
-        touch "cg_import.json"
+        cat > "cg_import.json" <<EOF
+        {
+            "metadata_version": 0,
+            "build": {
+                "name": "libecpg",
+                "version": "16.1",
+                "release": "10.el10_0",
+                "epoch": null
+            }
+        }
+EOF
         touch "test.src.rpm"
     fi
 }

--- a/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
@@ -278,6 +278,27 @@ spec:
                   fi
               }
 
+              function test_init_build() {
+                  import_build_data=$(jq --compact-output <<EOD
+                      {
+                        "name": "libecpg",
+                        "version": "16.1",
+                        "release": "10.el10_0",
+                        "epoch": null,
+                        "draft": true
+                      }
+              EOD
+                  )
+                  if assert_cmd_called_with koji --profile=koji call --json CGInitBuild \
+                        '"konflux"' "$import_build_data"
+                  then
+                      echo "TEST PASSED: Koji build was initialized properly."
+                  else
+                      echo "TEST FAILED: Koji build was not initialized properly."
+                      exit_code=1
+                  fi
+              }
+
               function test_import() {
                   if assert_cmd_called_with koji --profile=koji import-cg \
                         --draft "cg_import\.json" --token=mock-token --build-id=12345 "\."
@@ -329,6 +350,7 @@ spec:
                   fi
               }
 
+              test_init_build
               test_import
               test_tag test-rpm
               test_tag mock-target-draft


### PR DESCRIPTION
The attributes for CGInitBuild Koji call are incorrect. The "draft" should be passed as boolean, and "epoch" should be either null or integer.

## Describe your changes

## Relevant Jira

[ROK-673](https://issues.redhat.com//browse/ROK-673)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

