### PR TITLE
fix: protect against large result values

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -220,7 +220,8 @@ spec:
         fi
 
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/push-snapshot-results.json"
-        RESULTS_JSON="{\"images\":[]}"
+        RESULTS_JSON_FILE=$(mktemp)
+        echo '{"images":[]}' > "$RESULTS_JSON_FILE"
 
         RUNNING_JOBS="\j" # A Bash param for number of jobs running
         CONCURRENT_LIMIT=$(params.concurrentLimit)
@@ -278,10 +279,10 @@ spec:
           # we do not use oras_args here since we want to get the manifest index image digest
           origin_digest=$(oras resolve --registry-config "$SOURCE_AUTH_FILE" "${containerImage}")
 
-          RESULTS_JSON=$(jq --arg i "$i" --argjson arches "$arches" --argjson oses "$oses" --arg name "$name" \
+          jq --arg i "$i" --argjson arches "$arches" --argjson oses "$oses" --arg name "$name" \
             --arg sha "$origin_digest" \
             '.images[$i|tonumber] += {"arches": $arches, "oses": $oses, "name": $name, "shasum": $sha, "urls": []}' \
-              <<< "$RESULTS_JSON")
+              "$RESULTS_JSON_FILE" > "$RESULTS_JSON_FILE.tmp" && mv "$RESULTS_JSON_FILE.tmp" "$RESULTS_JSON_FILE"
 
           # Push source container if the component has pushSourceContainer: true or if the
           # pushSourceContainer key is missing from the component and the defaults has
@@ -350,7 +351,10 @@ spec:
         PUSHES=$(jq -s . "$TMP_RESULTS_DIR"/*.json)
         jq --argjson PUSHES "$PUSHES" '
           reduce $PUSHES[] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
-        ' <<< "$RESULTS_JSON" | tee "$RESULTS_FILE"
+        ' "$RESULTS_JSON_FILE" | tee "$RESULTS_FILE"
+
+        # Clean up temporary file
+        rm -f "$RESULTS_JSON_FILE" "$RESULTS_JSON_FILE.tmp"
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
       volumeMounts:


### PR DESCRIPTION
## Describe your changes
- protect against large result values in push-snapshot
- Seen in ocp release pipeline:

```
/tekton/scripts/script-2-tc4f4: line 203:  /usr/bin/jq: Argument list too long
```
Assisted-by: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

