### PR TITLE
fix: protect against large result values (#2)

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -348,13 +348,17 @@ spec:
             exit 1
         fi
 
-        PUSHES=$(jq -s . "$TMP_RESULTS_DIR"/*.json)
-        jq --argjson PUSHES "$PUSHES" '
-          reduce $PUSHES[] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
+        # Create a temporary file for the pushes data to avoid command line argument length limits
+        PUSHES_FILE=$(mktemp)
+        jq -s . "$TMP_RESULTS_DIR"/*.json > "$PUSHES_FILE"
+        
+        # Use file input instead of command line arguments to avoid argument length limits
+        jq --slurpfile PUSHES "$PUSHES_FILE" '
+          reduce $PUSHES[0][] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
         ' "$RESULTS_JSON_FILE" | tee "$RESULTS_FILE"
-
-        # Clean up temporary file
-        rm -f "$RESULTS_JSON_FILE" "$RESULTS_JSON_FILE.tmp"
+        
+        # Clean up temporary files
+        rm -f "$RESULTS_JSON_FILE" "$RESULTS_JSON_FILE.tmp" "$PUSHES_FILE"
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"
       volumeMounts:


### PR DESCRIPTION
## Describe your changes
- additional protection against large result values in push-snapshot
- Seen in ocp release pipeline:

"/tekton/scripts/script-2-nlctw: line 204:
 /usr/bin/jq: Argument list too long"

Assisted-by: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
