### PR TITLE
feat: add pre-commit hook to protect vault encrypted files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: check-vault-encrypted
+        name: Check vault files are encrypted
+        entry: scripts/check-vault-encrypted.sh
+        language: script
+        files: '.*vault.*\.(yaml|yml)$'
+        pass_filenames: true
+        stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,27 @@ Here's a brief overview of what you can find in the different directories of thi
 Whenever a change is pushed to this repository and a pull request is created, a yaml lint task will run to ensure that the
 resource definition doesn't contain invalid yaml data. Refer to the [.yamllint file](.yamllint) to see the exact applied
 rules. For more information on yamllint, check the [official documentation](https://yamllint.readthedocs.io/en/stable).
+
+## Pre-commit Hooks
+
+This repository uses pre-commit hooks to ensure that sensitive vault files are always encrypted before being committed. The hook prevents accidental commits of unencrypted Ansible Vault files.
+
+### Setup for Team Members
+
+To set up the pre-commit hooks on your local machine:
+
+1. **Install pre-commit** (if not already installed):
+   ```bash
+   pip install pre-commit
+   ```
+
+2. **Install the hooks** in your local repository:
+   ```bash
+   pre-commit install
+   ```
+
+### What it does
+
+The pre-commit hook automatically checks all vault files (files matching `.*vault.*\.(yaml|yml)$`) to ensure they are encrypted with Ansible Vault before allowing the commit. If any vault files are found to be unencrypted, the commit will be rejected with helpful instructions on how to encrypt them.
+
+This prevents accidentally committing sensitive secrets in plain text to the repository.

--- a/scripts/check-vault-encrypted.sh
+++ b/scripts/check-vault-encrypted.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# check-vault-encrypted.sh - Pre-commit hook to ensure vault files are encrypted
+# This script checks that files matching vault patterns are encrypted with Ansible Vault
+
+set -e
+
+# Function to check if a file is encrypted
+is_vault_encrypted() {
+    local file="$1"
+
+    # Check if file exists and is readable
+    if [[ ! -f "$file" ]] || [[ ! -r "$file" ]]; then
+        echo "ERROR: Cannot read file: $file"
+        return 1
+    fi
+
+    # Check if file starts with Ansible Vault header
+    if head -n 1 "$file" | grep -q '^\$ANSIBLE_VAULT;'; then
+        return 0  # File is encrypted
+    else
+        return 1  # File is not encrypted
+    fi
+}
+
+# Main execution
+exit_code=0
+unencrypted_files=()
+
+# Check each file passed as argument
+for file in "$@"; do
+    if [[ -f "$file" ]]; then
+        if ! is_vault_encrypted "$file"; then
+            unencrypted_files+=("$file")
+            exit_code=1
+        fi
+    fi
+done
+
+# Report results
+if [[ ${#unencrypted_files[@]} -gt 0 ]]; then
+    echo "❌ ERROR: The following vault files are not encrypted:"
+    for file in "${unencrypted_files[@]}"; do
+        echo "  - $file"
+    done
+    echo ""
+    echo "To encrypt these files, use:"
+    echo "  ansible-vault encrypt <file>"
+    echo ""
+    echo "Or if you have a vault password file:"
+    echo "  ansible-vault encrypt --vault-password-file <password-file> <file>"
+    echo ""
+    echo "Commit aborted to prevent committing unencrypted secrets."
+else
+    echo "✅ All vault files are properly encrypted."
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Describe your changes
- Adds a pre-commit hook to ensure that sensitive vault files are always encrypted before being committed.
- The pre-commit hook automatically checks all vault files (files matching `.*vault.*\.(yaml|yml)$`) to ensure they are encrypted with Ansible Vault before allowing the commit
- To work on a user's local machine, pre-commit must be installed
- Added README instructions

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
