### PR TITLE
fix: protect against large result values

### DIFF
--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -127,7 +127,9 @@ spec:
         #!/usr/bin/env bash
         set -ex
 
-        RESULTS_JSON="{}"
+        # Use temporary files to avoid command line argument length limits
+        RESULTS_JSON_FILE=$(mktemp)
+        echo '{}' > "$RESULTS_JSON_FILE"
         RESULTS_DIR="$(params.dataDir)/$(params.resultsDirPath)"
         for resultsFile in $([ -d "$RESULTS_DIR" ] && find "$RESULTS_DIR" -type f); do
             if ! jq . >/dev/null 2>&1 "${resultsFile}" ; then
@@ -136,10 +138,23 @@ spec:
             fi
             # If two files have arrays with the same key, it will be overwritten. Otherwise, the jsons
             # are merged (only arrays are not merged properly with this notation).
-            RESULTS_JSON=$(jq -c "${RESULTS_JSON} * ." "${resultsFile}")
+            TMP_RESULT=$(mktemp)
+            jq -c '. * $newData' --slurpfile newData <(jq -c '.' "${resultsFile}") "$RESULTS_JSON_FILE" > "$TMP_RESULT"
+            mv "$TMP_RESULT" "$RESULTS_JSON_FILE"
         done
+        
+        # Create patch file to avoid command line argument length limits
+        PATCH_FILE=$(mktemp)
+        jq -n --arg statusKey "$(params.statusKey)" --slurpfile resultsData "$RESULTS_JSON_FILE" \
+          '{"status": {($statusKey): $resultsData[0]}}' > "$PATCH_FILE"
+        
+        # Clean up results file
+        rm -f "$RESULTS_JSON_FILE"
 
         IFS='/' read -r namespace name <<< "$(params.resource)"
 
         kubectl --warnings-as-errors=true patch "$(params.resourceType)" -n "$namespace" "$name" \
-          --type=merge --subresource status --patch "status: {'$(params.statusKey)':${RESULTS_JSON}}"
+          --type=merge --subresource status --patch-file "$PATCH_FILE"
+        
+        # Clean up patch file
+        rm -f "$PATCH_FILE"


### PR DESCRIPTION
## Describe your changes
- protect against large result values that are contributed
- Seen in ocp release pipeline:

/tekton/scripts/script-2-5fjfr: line 13: /usr/bin/jq: Argument list too long
+ RESULTS_JSON=

Assisted-by: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
