### PR TITLE
fix: ignore test directories in "check readme.md files" job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -124,6 +124,8 @@ jobs:
           files: |
             tasks/*/**
             pipelines/*/**
+          files_ignore: |
+            **/tests/*
           dir_names: "true"
           dir_names_max_depth: "3"
       - name: Check README.md files


### PR DESCRIPTION
## Describe your changes
The workflow shouldn't pick out test directories anyway, but in case something like tasks/task-name/tests is added in the future, the workflow will now ignore any changes in the tests directory of a task/pipeline.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
