### PR TITLE
fix: force runasuser for reduce-snapshot

### DIFF
--- a/stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+++ b/stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
@@ -27,5 +27,28 @@ spec:
     if [ "${ociStorage:?}" == "empty" ]; then
       echo "oci storage not detected via ociStorage...skipping trusted artifacts tasks"
       mkdir -p "${workDir:?}"
-      touch "${workDir:?}/.skip-trusted-artifacts"
+    
+      # Check if the skip file already exists to avoid permission issues
+      if [ -f "${workDir:?}/.skip-trusted-artifacts" ]; then
+        echo "Skip file already exists, continuing..."
+      else
+        # Try to create the file, handle permission issues gracefully
+        if ! touch "${workDir:?}/.skip-trusted-artifacts" 2>/dev/null; then
+          # If we can't create the file due to permissions, try to fix permissions
+          if [ -d "${workDir:?}" ]; then
+            # Try to make the directory writable by the current user
+            chmod u+w "${workDir:?}" 2>/dev/null || true
+            # Try again to create the file
+            if ! touch "${workDir:?}/.skip-trusted-artifacts" 2>/dev/null; then
+              echo "ERROR: Cannot create .skip-trusted-artifacts file due to permissions"
+              echo "       This may cause issues with trusted artifacts operations"
+              # Exit with error to surface the permission issue
+              exit 1
+            fi
+          else
+            echo "ERROR: Work directory ${workDir:?} does not exist"
+            exit 1
+          fi
+        fi
+      fi
     fi

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -78,6 +78,13 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+      # This is a workaround for a problem observed on a particular cluster where the
+      # use-trusted-artifacts step runs with root user causing a docker credential file
+      # to not be readable in later steps. There might be solution coming related to the
+      # security context constraints on the cluster, but setting this explicitly here
+      # should probably be harmless either way.
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: skip-trusted-artifact-operations
       computeResources:

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -48,6 +48,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -55,7 +58,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > snapshot << EOF
+              # Write to writable directory
+              cat > /var/workdir/snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -72,7 +76,7 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f snapshot
+              kubectl apply -f /var/workdir/snapshot
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
@@ -169,6 +173,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: skip-trusted-artifact-operations
             ref:

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -49,6 +49,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -56,7 +59,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > snapshot << EOF
+              # Write to writable directory
+              cat > /var/workdir/snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -73,7 +77,7 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f snapshot
+              kubectl apply -f /var/workdir/snapshot
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
@@ -170,6 +174,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: skip-trusted-artifact-operations
             ref:

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -48,6 +48,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -55,7 +58,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > snapshot << EOF
+              # Write to writable directory
+              cat > /var/workdir/snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -69,7 +73,7 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f snapshot
+              kubectl apply -f /var/workdir/snapshot
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | \
@@ -166,6 +170,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: skip-trusted-artifact-operations
             ref:

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -48,6 +48,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -55,7 +58,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > snapshot << EOF
+              # Write to writable directory
+              cat > /var/workdir/snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -72,7 +76,7 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f snapshot
+              kubectl apply -f /var/workdir/snapshot
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
@@ -167,6 +171,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: skip-trusted-artifact-operations
             ref:

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -49,6 +49,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: create-crs
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -56,7 +59,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              cat > snapshot << EOF
+              # Write to writable directory
+              cat > /var/workdir/snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -73,7 +77,7 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f snapshot
+              kubectl apply -f /var/workdir/snapshot
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
@@ -170,6 +174,9 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: skip-trusted-artifact-operations
             ref:


### PR DESCRIPTION
## Describe your changes
- This is a workaround for a problem observed on a particular cluster where the use-trusted-artifacts step runs with root user causing a file or folder to not be readable in later steps. There might be solution coming related to the security context constraints on the cluster, but setting this explicitly here should probably be harmless either way.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
