### PR TITLE
fix(KFLUXSPRT-4135): remove product_version regex validation

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -136,8 +136,7 @@
         },
         "product_version": {
           "type": "string",
-          "description": "The product version e.g v1.0.0",
-          "pattern": "^fbc|(fbc[-]|[vV])?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*))?([-\\s]?([Aa]lpha|[Bb]eta|fast|tech[-\\s]preview)?)$"
+          "description": "The product version e.g v1.0.0"
         },
         "product_stream": {
           "type": "string",


### PR DESCRIPTION
 Allow whole-number product version for
 open stack and similar releases

## Describe your changes
Remove regex pattern for product_version field to trust the RPA approval
process rather than duplicate validation. This allows any version format
approved by releng and eliminates unnecessary validation complexity.

Slack Thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1752238983346699 
## Relevant Jira

[KFLUXSPRT-4135](https://issues.redhat.com//browse/KFLUXSPRT-4135)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

- Assisted by cursor.
