### PR TITLE
fix: don't pass dest-creds for skopeo inspect

### DIFF
--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -71,7 +71,6 @@ spec:
 
         echo "Getting target image digest: $(params.targetIndex)"
         if TARGET_DIGEST=$(skopeo inspect \
-            "${TARGET_AUTH_ARGS[@]}" \
             "docker://$(params.targetIndex)" \
             --format '{{.Digest}}' \
             --retry-times "$(params.retries)"); then

--- a/tasks/internal/publish-index-image-task/tests/mocks.sh
+++ b/tasks/internal/publish-index-image-task/tests/mocks.sh
@@ -8,10 +8,10 @@ function skopeo() {
 
   if [[ "$1" == "inspect" ]]; then
     # Handle `skopeo inspect`
-    if [[ "$*" == *"--dest-creds target docker://quay.io/match-target-digest"* ]]; then
+    if [[ "$*" == *"docker://quay.io/match-target-digest"* ]]; then
       echo "sha256:match1234567890"  # Mock target digest for idempotency check
       return 0
-    elif [[ "$*" == *"--dest-creds target docker://quay.io/target"* ]]; then
+    elif [[ "$*" == *"docker://quay.io/target"* ]]; then
       echo "sha256:target1234567890"
       return 0
     elif [[ "$*" == *"--tls-verify=false --src-creds source docker://quay.io/source"* ]]; then


### PR DESCRIPTION
This commit stops the publish-index-image internal task from passing --dest-creds to the skopeo inspect call. It is not a skopeo inspect option, only skopeo copy.
`unknown flag: --dest-creds`

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
