### PR TITLE
fix(RELEASE-1748): use floating tag as source for index image copy

### DIFF
--- a/tasks/managed/publish-index-image/README.md
+++ b/tasks/managed/publish-index-image/README.md
@@ -7,7 +7,6 @@ Publish a built FBC index image using skopeo
 | Name                       | Description                                                                                                                | Optional | Default value           |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
 | dataPath                   | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |
-| sourceIndex                | Pullspec to pull the image from                                                                                            | No       | -                       |
 | targetIndex                | Pullspec to push the image to                                                                                              | No       | -                       |
 | internalRequestResultsFile | File containing the results of the build                                                                                   | No       | -                       |
 | retries                    | Number of skopeo retries                                                                                                   | Yes      | 0                       |

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -13,9 +13,6 @@ spec:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
       type: string
-    - name: sourceIndex
-      type: string
-      description: Pullspec to pull the image from
     - name: targetIndex
       type: string
       description: Pullspec to push the image to
@@ -162,7 +159,7 @@ spec:
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
           sourceIndex=$(jq -r  --argjson i "$i" \
-            '.components[$i].index_image_resolved' "$(params.dataDir)/$(params.internalRequestResultsFile)")
+            '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
           buildTimestamp=$(jq -r --argjson i "$i" '.components[$i].completion_time' \
             "$(params.dataDir)/$(params.internalRequestResultsFile)")

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -226,7 +226,7 @@ spec:
                 exit 1
               fi
 
-              if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+              if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib:01" ]; then
                 echo "sourceIndex image does not match"
                 exit 1
               fi

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -232,7 +232,7 @@ spec:
                     exit 1
                   fi
 
-                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib:01" ]; then
                     echo "sourceIndex image does not match"
                     exit 1
                   fi


### PR DESCRIPTION
This commit updates the publish-index-image managed task to pass the index_image (floating tag) value instead of index_image_resolved (image via digest) to the publish-index-image internal pipeline. This improves things because the digest may no longer exist if a new push overwrites it.

This commit also removes the sourceIndex parameter from the publish-index-image managed task because it was not used.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
