### PR TITLE
fix: improve pipeline visualization

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -441,6 +441,7 @@ spec:
       runAfter:
         - populate-release-notes
         - embargo-check
+        - push-snapshot
     - name: collect-cosign-params
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
@@ -475,6 +476,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-data
+        - push-snapshot
     - name: rh-sign-image-cosign
       timeout: "6h00m0s"
       when:
@@ -992,6 +994,7 @@ spec:
           workspace: release-workspace
       runAfter:
         - collect-data
+        - push-snapshot
     - name: create-product-sbom
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"


### PR DESCRIPTION
Tasks in a pipeline are displayed according to the runAfter property. When a task is configured to be able to run much earlier than the tasks that depend on it, the edge visualization becomes more complex. When these complexity-inducing tasks do not take much time to run, it doesn't make as much sense to try to evaluate the tasks as soon as possible.

This commit adjusts the runAfter for a couple tasks which are generally fast (seconds or less) in order to improve the overall visualization complexity. The adjusted tasks include set-advisory-severity, collect-cosign-params, and collect-atlas-params.

Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Describe your changes
Before:
<img width="1373" height="489" alt="pipeline_visualization_before" src="https://github.com/user-attachments/assets/9bc7ea81-42ef-4f0a-a5c0-764b73c4f44a" />
After:
<img width="1252" height="269" alt="pipeline_visualization_after_1" src="https://github.com/user-attachments/assets/6538a805-cc9f-45b2-8363-afde464f881b" />
<img width="1273" height="318" alt="pipeline_visualization_after_2" src="https://github.com/user-attachments/assets/2efe0d6a-8b5f-4b1d-b071-271c0551950d" />


## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
