### PR TITLE
feat: increase signing concurrency

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -125,7 +125,7 @@ spec:
           topic_listen_to: queue://Consumer.{creator}.${requester}-{task_id}.${umb_listen_topic}
           environment: prod
           service: ${umb_client_name}
-          timeout: 10
+          timeout: 60
           retries: 2
           send_retries: 2
           message_id_key: request_id

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -28,7 +28,7 @@ spec:
       default: "3"
     - name: concurrentLimit
       type: string
-      default: 5
+      default: 90
       description: The maximum number of concurrent cosign signing jobs
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -29,7 +29,7 @@ spec:
     - name: concurrentLimit
       type: string
       description: The maximum number of images to be processed at once
-      default: 16
+      default: 8
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
@@ -47,7 +47,7 @@ spec:
         size of batch attributes to send to internal-request. As internal request arguments are need to be
         strings, size here represent maximal string length of `references` and `manifest_digests` sent to
         internal request
-      default: 4096
+      default: 16384
     - name: signRegistryAccessPath
       type: string
       description: |


### PR DESCRIPTION
## Describe your changes

Signing requests can be slow, so we can speed up the release pipeline by generally increasing the parallelization. 

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
