### PR TITLE
feat(RELEASE-1732): update check-data-keys task to follow the new schema

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -192,9 +192,11 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - fbc
-            - sign
+          value: |
+            [
+              {"systemName": "fbc", "dynamic": false},
+              {"systemName": "sign", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -289,9 +289,11 @@ spec:
         - name: schema
           value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - cdn
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "cdn", "dynamic": false},
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -253,8 +253,10 @@ spec:
         - name: schema
           value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - cdn
+          value: |
+            [
+              {"systemName": "cdn", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -74,7 +74,7 @@ spec:
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
-      default: https://github.com/konflux-ci/release-service-catalog.git 
+      default: https://github.com/konflux-ci/release-service-catalog.git
   workspaces:
     - name: release-workspace
   tasks:
@@ -146,8 +146,10 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - ootsign
+          value: |
+            [
+              {"systemName": "ootsign", "dynamic": false}
+            ]
         - name: dataDir
           value: $(params.dataDir)
         - name: ociStorage
@@ -353,7 +355,7 @@ spec:
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: kmodsPath 
+        - name: kmodsPath
           value: $(tasks.collect-push-oot-params.results.kmodsPath)
         - name: signedKmodsPath
           value: $(tasks.collect-push-oot-params.results.signedKmodsPath)
@@ -394,13 +396,13 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
         - name: kerberosRealm
-          value: IPA.REDHAT.COM 
+          value: IPA.REDHAT.COM
         - name: signingAuthor
-          value: $(tasks.collect-push-oot-params.results.signingAuthor) 
+          value: $(tasks.collect-push-oot-params.results.signingAuthor)
         - name: signing-secret
           value: $(tasks.collect-push-oot-params.results.signing-secret)
         - name: sourceDataArtifact
-          value: "$(tasks.extract-oot-kmods.results.sourceDataArtifact)" 
+          value: "$(tasks.extract-oot-kmods.results.sourceDataArtifact)"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: dataDir
@@ -412,7 +414,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       workspaces:
-        - name: kmods 
+        - name: kmods
           workspace: release-workspace
       runAfter:
         - extract-oot-kmods

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -146,8 +146,10 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - mapping
+          value: |
+            [
+              {"systemName": "mapping", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -149,8 +149,10 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - mapping
+          value: |
+            [
+              {"systemName": "mapping", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -146,8 +146,10 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - mapping
+          value: |
+            [
+              {"systemName": "mapping", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -150,9 +150,11 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - github
-            - sign
+          value: |
+            [
+              {"systemName": "github", "dynamic": false},
+              {"systemName": "sign", "dynamic": false}
+            ]
         - name: sourceDataArtifact
           value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: ociStorage

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -144,8 +144,10 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - mrrc
+          value: |
+            [
+              {"systemName": "mrrc", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -925,11 +925,13 @@ spec:
         - name: schema
           value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - releaseNotes
-            - pyxis
-            - mapping
-            - sign
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false},
+              {"systemName": "pyxis", "dynamic": false},
+              {"systemName": "mapping", "dynamic": false},
+              {"systemName": "sign", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -146,9 +146,11 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - pyxis
-            - mapping
+          value: |
+            [
+              {"systemName": "pyxis", "dynamic": false},
+              {"systemName": "mapping", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -149,10 +149,12 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - pyxis
-            - mapping
-            - sign
+          value: |
+            [
+              {"systemName": "pyxis", "dynamic": false},
+              {"systemName": "mapping", "dynamic": false},
+              {"systemName": "sign", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -149,9 +149,11 @@ spec:
         - name: schema
           value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
-          value:
-            - mapping
-            - pyxis
+          value: |
+            [
+              {"systemName": "mapping", "dynamic": false},
+              {"systemName": "pyxis", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -12,10 +12,10 @@ spec:
     and correctly formatted. The system(s) passed into the `systems` parameter become required.
     The schema validation also applies to all data passed into the `dataPath` parameter,
     meaning all the data keys must be allowed and formatted correctly.
-    
+
     For example, if `releaseNotes` is passed as a system and the data file does not have all the required
     releaseNotes keys, the schema will give validation errors, and the task will fail.
-    
+
     Currently, `releaseNotes`, and `cdn` are the only supported systems.
   params:
     - name: dataPath
@@ -132,7 +132,6 @@ spec:
         requests:
           memory: 64Mi  # was exiting with code 137 when set to 32Mi
           cpu: 10m
-      args: ["$(params.systems[*])"]
       env:
         - name: "SCHEMA_FILE"
           value: "$(params.schema)"
@@ -151,10 +150,8 @@ spec:
             exit 1
         fi
 
-        systemsJSON=$(echo "$@" | jq -R 'split(" ")')
-
-        jq --argjson systems "$systemsJSON" '.systems += $systems' \
-            "$(params.dataDir)/$(params.dataPath)" > "/tmp/systems" 
+        jq --argjson systems "$(params.systems)" '.systems += $systems' \
+            "$(params.dataDir)/$(params.dataPath)" > "/tmp/systems"
         mv "/tmp/systems" "$(params.dataDir)/$(params.dataPath)"
 
         check-jsonschema --output-format=text --schemafile "/tmp/schema"  "$(params.dataDir)/$(params.dataPath)"

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -140,8 +140,10 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -104,8 +104,10 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - cdn
+          value: |
+            [
+              {"systemName": "cdn", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -138,8 +138,10 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -142,8 +142,10 @@ spec:
         - name: schema
           value: "https://raw.githubusercontent.com/konflux-ci/release-service-catalog/refs/heads/production/schema/non-existent-schema.json"
         - name: systems
-          value:
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -153,10 +153,12 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
-            - unsupported
-            - random
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false},
+              {"systemName": "unsupported", "dynamic": false},
+              {"systemName": "random", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with an incorrect type for the releaseNotes product_id key which should be an integer 
+    Run the check-data-keys task with an incorrect type for the releaseNotes product_id key which should be an integer
     and verify that the task fails as expected.
   workspaces:
     - name: tests-workspace
@@ -153,8 +153,10 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with an incorrect field in the releaseNotes.issues key 
+    Run the check-data-keys task with an incorrect field in the releaseNotes.issues key
     (using cves instead of fixed) and verify that the task failed.
   workspaces:
     - name: tests-workspace
@@ -163,8 +163,10 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
@@ -174,9 +174,11 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
-            - cdn
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false},
+              {"systemName": "cdn", "dynamic": false}
+            ]
         - name: schema
           value: "https://github.com/konflux-ci/release-service-catalog.git/raw/development/schema/dataKeys.json"
         - name: ociStorage

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -174,9 +174,11 @@ spec:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
         - name: systems
-          value:
-            - releaseNotes
-            - cdn
+          value: |
+            [
+              {"systemName": "releaseNotes", "dynamic": false},
+              {"systemName": "cdn", "dynamic": false}
+            ]
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions


### PR DESCRIPTION
## Describe your changes
This change updates the check-data-keys task and pipelines that use it, to follow the new data keys schema.

Relates to: https://github.com/konflux-ci/release-service-catalog/pull/1208
## Relevant Jira
https://issues.redhat.com/browse/RELEASE-1732

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
