### PR TITLE
feat(RELEASE-1747): add public key for bugzilla issues

### DIFF
--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -190,11 +190,6 @@ spec:
                 continue
             fi
 
-            # Perform additional checks only for issues on issues.redhat.com
-            if [ "$server" != "issues.redhat.com" ] ; then
-                continue
-            fi
-
             # Public should be true if and only if the security field doesn't exist and the issue is accessible
             # without authentication
             public=false
@@ -209,6 +204,11 @@ spec:
             # Inject public key
             jq --argjson i "$i" --argjson public $public '.releaseNotes.issues.fixed[$i].public = $public' \
                 "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+
+            # Perform additional checks only for issues on issues.redhat.com
+            if [ "$server" != "issues.redhat.com" ] ; then
+                continue
+            fi
 
             # Perform cve id check only if the type is Vulnerability
             ISSUE_TYPE=$(jq -r '.fields.issuetype.name' <<< "$OUTPUT")

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -185,8 +185,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 3 ]; then
+                  echo Error: curl was expected to be called 3 times. Actual calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -185,8 +185,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 4 ]; then
+                  echo Error: curl was expected to be called 4 times. Actual calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -5,11 +5,10 @@ metadata:
   name: test-embargo-check-rh-issue-public-key-added
 spec:
   description: |
-    Test for embargo-check with 4 issues. One is not from issues.redhat.com so should have no
-    public key added. Two are private and should have the key added with false (one because
-    it has a security field, one because it can only be seen with authenticated curl). The final
-    one is public because it can be seen without authentication. Ensure the public keys are all
-    properly added.
+    Test for embargo-check with 4 issues. Two are private and should have the key added with
+    false (one because it has a security field, one because it can only be seen with
+    authenticated curl). The other two are public because they can be seen without authentication.
+    One is a jira issue and one is a bugzilla bug. Ensure the public keys are all properly added.
   workspaces:
     - name: tests-workspace
   params:
@@ -223,7 +222,7 @@ spec:
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-2") | .public' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == false
 
-              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="12345") | has("public")' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == false
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="12345") | .public' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
       runAfter:
         - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -208,8 +208,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 3 ]; then
+                  echo Error: curl was expected to be called 3 times. Actual calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -208,8 +208,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
-                  echo Error: curl was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 3 ]; then
+                  echo Error: curl was expected to be called 3 times. Actual calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi


### PR DESCRIPTION
Currently, only issues on the issues.redhat.com server have the public key added. This commit modifies the embargo-check task to add it for all issues. The goal of this is to ensure that bugzilla bzs have public added. This will enable us to make the public key required for each issue in the created advisory.yaml.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
