### PR TITLE
docs: consolidate common integration-test README instructions

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,194 @@
+# Integration Tests
+
+This directory contains end-to-end integration tests for the Release Service Catalog. These tests validate the functionality of release pipelines by simulating complete workflows including environment setup, secret decryption, GitHub interactions, Kubernetes resource management, and release verification.
+
+## Test Suites
+
+The following integration test suites are available:
+
+- **[collectors](collectors/)** - Tests for advisory data collection and processing
+- **[fbc-release](fbc-release/)** - Tests for File-Based Catalog (FBC) release pipeline
+- **[push-to-addons-registry](push-to-addons-registry/)** - Tests for pushing to addon registries
+- **[rh-push-to-external-registry](rh-push-to-external-registry/)** - Tests for pushing to external registries
+- **[release-to-github](release-to-github/)** - Tests for GitHub release pipeline
+- **[rhtap-service-push](rhtap-service-push/)** - Tests for RHTAP service push pipeline
+
+## Common Setup
+
+### Dependencies
+
+All integration tests require the following dependencies:
+
+* **GitHub Repository**: https://github.com/hacbs-release-tests/e2e-base
+* **GitHub Personal Access Token** (classic) for the above repository with the following scopes:
+  - `admin:repo_hook`
+  - `delete_repo`
+  - `repo`
+* **Vault Password**: The password to decrypt the vault files (contact a member of the Release team)
+* **Cluster Access**: Access to the target cluster and tenant/managed namespaces
+  - Tests use `stg-rh01` cluster
+  - Tenant namespace: `dev-release-team-tenant`
+  - Managed namespace: `managed-release-team-tenant`
+
+### Required Environment Variables
+
+All tests require these environment variables:
+
+- **`GITHUB_TOKEN`** - The GitHub personal access token for repository operations
+- **`VAULT_PASSWORD_FILE`** - Path to a file containing the ansible vault password needed to decrypt secrets
+- **`RELEASE_CATALOG_GIT_URL`** - The release service catalog URL to use in the ReleasePlanAdmission (provided when testing PRs)
+- **`RELEASE_CATALOG_GIT_REVISION`** - The release service catalog revision to use in the ReleasePlanAdmission (provided when testing PRs)
+
+### Optional Environment Variables
+
+- **`KUBECONFIG`** - The KUBECONFIG file used to login to the target cluster (provided when testing PRs)
+
+## Test Structure
+
+Each test suite follows a consistent structure:
+
+### Configuration Files
+
+- **`test.env`** - Contains resource names and configuration values specific to the test
+- **`test.sh`** - Contains test-specific variables and functions (may vary by test)
+
+### Shared Libraries
+
+- **`lib/test-functions.sh`** - Contains reusable functions shared across all tests
+
+### Secrets Management
+
+Tests use ansible vault files to store encrypted secrets:
+- **`vault/managed-secrets.yaml`** - Secrets for the managed namespace
+- **`vault/tenant-secrets.yaml`** - Secrets for the tenant namespace
+
+For the tests that require internal services, the tenant and managed namespaces should remain as configured
+
+## Running Tests
+
+### Basic Usage
+
+To run a specific test suite:
+
+```bash
+./run-test.sh <test-suite-name>
+```
+
+Example:
+```bash
+./run-test.sh fbc-release
+```
+
+### Command Line Options
+
+- **`--skip-cleanup`** or **`-sc`** - Skip cleanup operations after test completion (useful for debugging)
+
+### Examples
+
+```bash
+# Run fbc-release test
+./run-test.sh fbc-release
+
+# Run test with debugging (skip cleanup)
+./run-test.sh fbc-release --skip-cleanup
+```
+
+## Debugging
+
+### Debug Options
+
+When debugging test failures, use the `--skip-cleanup` option to preserve resources for examination:
+
+```bash
+./run-test.sh <test-suite-name> --skip-cleanup
+```
+
+### Manual Cleanup
+
+When debugging is complete, you can clean up resources using these scripts:
+
+- **`utils/cleanup-resources.sh`** - Cleans up Kubernetes resources
+- **`scripts/delete-branches.sh`** - Cleans up GitHub branches
+
+## Secret Management
+
+### Viewing Secrets
+
+To view encrypted secrets:
+
+```bash
+ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
+```
+
+### Updating Secrets
+
+To update encrypted secrets:
+
+1. Decrypt the vault file:
+   ```bash
+   ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
+   ```
+
+2. Edit the decrypted file:
+   ```bash
+   vi /tmp/tenant-secrets.yaml
+   ```
+
+3. Re-encrypt the file:
+   ```bash
+   ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
+   ```
+
+4. Remove the temporary file:
+   ```bash
+   rm /tmp/tenant-secrets.yaml
+   ```
+
+## Test Execution Flow
+
+The integration tests follow this general workflow:
+
+1. **Environment Setup** - Load test-specific configuration and validate required variables
+2. **Secret Decryption** - Decrypt and apply required secrets to the cluster
+3. **GitHub Operations** - Create branches, make commits, and manage pull requests
+4. **Kubernetes Resources** - Create and manage namespaces, applications, components, and releases
+5. **Pipeline Execution** - Monitor Konflux Components and Tekton PipelineRuns
+6. **Verification** - Validate Release custom resources and pipeline outcomes
+7. **Cleanup** - Remove created resources (unless `--skip-cleanup` is specified)
+
+## CI/CD Integration
+
+These integration tests are automatically executed in CI/CD pipelines:
+
+- **Pull Request Triggers** - Tests run when changes are made to relevant pipeline files or the `integration-tests/` directory
+- **E2E Pipeline** - Uses `integration-tests/pipelines/e2e-tests-staging-pipeline.yaml`
+- **Konflux E2E Pipeline** - Uses `integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml`
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors** - Verify GitHub token has correct permissions
+2. **Cluster Access** - Ensure KUBECONFIG is properly configured
+3. **Secret Errors** - Check vault password file exists and is correct
+4. **Resource Conflicts** - Use cleanup scripts to remove stale resources
+
+### Getting Help
+
+For issues with integration tests:
+
+1. Check the test-specific README files for additional details
+2. Review the test logs for specific error messages
+3. Use the `--skip-cleanup` option to examine resources after failure
+4. Contact the Release team for vault password or cluster access issues
+
+## Contributing
+
+When adding new integration tests:
+
+1. Follow the established directory structure
+2. Create test-specific `test.env` and `test.sh` files
+3. Use the common libraries in `lib/test-functions.sh`
+4. Store secrets in ansible vault files
+5. Update this README with test-specific information
+6. Add test-specific documentation to the individual test README

--- a/integration-tests/collectors/README.md
+++ b/integration-tests/collectors/README.md
@@ -1,84 +1,92 @@
-# Collector test
-## Setup
-### Dependencies
-* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
-* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
-* The password to the vault files. (Contact a member of the Release team should you want to run this
-  test suite.)
-* Access to the target cluster and tenant and managed namespaces
-  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
-* At least one JIRA issue that can be found via this query:
+# Collectors Test
+
+This test validates the advisory data collection and processing pipeline.
+
+## Test-Specific Dependencies
+
+In addition to the [common dependencies](../README.md#dependencies), this test requires:
+
+* **JIRA Issue**: At least one JIRA issue that can be found via this query:
   * `'project = "Konflux Release"  AND summary ~ "test issue for collector e2e testing"'`
-### Required Environment Variables
-- GITHUB_TOKEN
-  - The GitHub personal access token needed for repo operations
-  - The repo in question can be located in [test.env](test.env)
-- VAULT_PASSWORD_FILE
-  - This is the path to a file that contains the ansible vault
-    password needed to decrypt the secrets needed for testing.
-- RELEASE_CATALOG_GIT_URL
-  - The release service catalog URL to use in the RPA
-  - This is provided when testing PRs
-- RELEASE_CATALOG_GIT_REVISION
-  - The release service catalog revision to use in the RPA
-  - This is provided when testing PRs
-### Optional Environment Variables
-- KUBECONFIG
-  - The KUBECONFIG file to used to login to the target cluster
-  - This is provided when testing PRs 
-### Test Properties
-#### [test.env](test.env)
-- This file contains resource names and configuration values needed for testing.
-- Since this test requires internal services, the tenant and managed namespaces
-  should remain as-is.
-### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
-### Secrets
-- Secrets needed for testing are stored in ansible vault files.
-  - [vault/collector-managed-secrets.yaml](vault/collector-managed-secrets.yaml)
-  - [vault/collector-tenant-secrets.yaml](vault/collector-tenant-secrets.yaml)
-- Most secrets required are contained in the files above.
-- Some tests have their secret name hardcoded and therefore must exist prior to running this test:
-  - konflux-advisory-jira-secret
-### Running the test
 
-The test has 2 modes:
-* With a CVE included and involved. (default mode)
+## Test-Specific Secrets
 
-```shell
-run-test.sh
-```
- 
-* Without a CVE involved.
+This test uses specialized vault files with different naming:
 
-```shell
-run-test.sh --no-cve
+- **`vault/collector-managed-secrets.yaml`** - Secrets for the managed namespace
+- **`vault/collector-tenant-secrets.yaml`** - Secrets for the tenant namespace
+
+### Hardcoded Secrets
+
+Some tests have hardcoded secret names that must exist prior to running:
+
+- **`konflux-advisory-jira-secret`** - Required for JIRA integration
+
+## Test-Specific Command Line Options
+
+The collectors test supports an additional command line option:
+
+- **`--no-cve`** or **`-nocve`** - Skip CVE simulation and validation
+
+## Test Modes
+
+The collectors test supports two execution modes:
+
+### Default Mode (with CVE)
+Includes CVE simulation and processing:
+```bash
+../run-test.sh collectors
 ```
 
-### Debugging
-
-There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
-after a test has ended.
-
-Note: you can use these 2 scripts to clean up when you are completed debugging:
-* [utils/cleanup-resources.sh](utils/cleanup-resources.sh)
-* [../scripts/delete-branches.sh](../scripts/delete-branches.sh)
-
-### Maintenance
-- Should you require to add or update a secret, follow these steps:
-```shell
-ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
+### No-CVE Mode
+Excludes CVE simulation:
+```bash
+../run-test.sh collectors --no-cve
 ```
 
-```shell
-vi /tmp/tenant-secrets.yaml
-```
+## Test-Specific Configuration
 
-```shell
-ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
+### Files Structure
 
-```shell
-rm /tmp/tenant-secrets.yaml
-```
+- **`test.env`** - Contains resource names and configuration values
+- **`test.sh`** - Contains collectors-specific variables and functions
+
+Note: The collectors test does not follow the standard `test.sh` structure used by other tests.
+
+## Secret Management
+
+### Vault File Maintenance
+
+To update collectors-specific secrets:
+
+1. Decrypt the vault file:
+   ```bash
+   ansible-vault decrypt vault/collector-tenant-secrets.yaml --output "/tmp/collector-tenant-secrets.yaml" --vault-password-file <vault password file>
+   ```
+
+2. Edit the decrypted file:
+   ```bash
+   vi /tmp/collector-tenant-secrets.yaml
+   ```
+
+3. Re-encrypt the file:
+   ```bash
+   ansible-vault encrypt /tmp/collector-tenant-secrets.yaml --output "vault/collector-tenant-secrets.yaml" --vault-password-file <vault password file>
+   ```
+
+4. Remove the temporary file:
+   ```bash
+   rm /tmp/collector-tenant-secrets.yaml
+   ```
+
+Repeat the same process for `vault/collector-managed-secrets.yaml` as needed.
+
+## Test Workflow
+
+The collectors test follows this specific workflow:
+
+1. **JIRA Integration Setup** - Validates required JIRA issues exist
+2. **Advisory Data Collection** - Simulates advisory data gathering
+3. **CVE Processing** - Processes CVE data (if not using `--no-cve`)
+4. **Release Pipeline Execution** - Executes the advisory collection pipeline
+5. **Verification** - Validates collected advisory data and release outcomes

--- a/integration-tests/fbc-release/README.md
+++ b/integration-tests/fbc-release/README.md
@@ -1,73 +1,25 @@
-# fbc-release test
-## Setup
-### Dependencies
-* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
-* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
-* The password to the vault files. (Contact a member of the Release team should you want to run this
-  test suite.)
-* Access to the target cluster and tenant and managed namespaces
-  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
-### Required Environment Variables
-- GITHUB_TOKEN
-  - The GitHub personal access token needed for repo operations
-  - The repo in question can be located in [test.env](test.env)
-- VAULT_PASSWORD_FILE
-  - This is the path to a file that contains the ansible vault
-    password needed to decrypt the secrets needed for testing.
-- RELEASE_CATALOG_GIT_URL
-  - The release service catalog URL to use in the RPA
-  - This is provided when testing PRs
-- RELEASE_CATALOG_GIT_REVISION
-  - The release service catalog revision to use in the RPA
-  - This is provided when testing PRs
-### Optional Environment Variables
-- KUBECONFIG
-  - The KUBECONFIG file to used to login to the target cluster
-  - This is provided when testing PRs 
-### Test Properties
-#### [test.env](test.env)
-- This file contains resource names and configuration values needed for testing.
-- Since this test requires internal services, the tenant and managed namespaces
-  should remain as-is.
-#### [test.sh](test.sh)
-- This file contains specific variables and functions needed for the test.
-### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
-### Secrets
-- Secrets needed for testing are stored in ansible vault files.
-  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
-  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
-- The secrets required are contained in the files above.
-### Running the test
+# FBC Release Test
 
-```shell
+This test validates the File-Based Catalog (FBC) release pipeline functionality.
+
+## Test-Specific Configuration
+
+### Files Structure
+
+- **`test.env`** - Contains resource names and configuration values specific to FBC releases
+- **`test.sh`** - Contains FBC-specific variables and functions for the test
+
+## Running the Test
+
+```bash
 ../run-test.sh fbc-release
 ```
 
-### Debugging
+## Test Workflow
 
-There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
-after a test has ended.
+The FBC release test follows this specific workflow:
 
-Note: you can use these 2 scripts to clean up when you are completed debugging:
-* [utils/cleanup-resources.sh](utils/cleanup-resources.sh)
-* [../scripts/delete-branches.sh](../scripts/delete-branches.sh)
-
-### Maintenance
-- Should you require to add or update a secret, follow these steps:
-```shell
-ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-vi /tmp/tenant-secrets.yaml
-```
-
-```shell
-ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-rm /tmp/tenant-secrets.yaml
-```
+1. **FBC Catalog Setup** - Prepares File-Based Catalog resources
+2. **Release Pipeline Execution** - Executes the FBC release pipeline
+3. **Catalog Validation** - Validates the generated catalog structure
+4. **Release Verification** - Confirms successful FBC release deployment

--- a/integration-tests/push-to-addons-registry/README.md
+++ b/integration-tests/push-to-addons-registry/README.md
@@ -1,73 +1,25 @@
-# push-to-addons-registry test
-## Setup
-### Dependencies
-* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
-* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
-* The password to the vault files. (Contact a member of the Release team should you want to run this
-  test suite.)
-* Access to the target cluster and tenant and managed namespaces
-  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
-### Required Environment Variables
-- GITHUB_TOKEN
-  - The GitHub personal access token needed for repo operations
-  - The repo in question can be located in [test.env](test.env)
-- VAULT_PASSWORD_FILE
-  - This is the path to a file that contains the ansible vault
-    password needed to decrypt the secrets needed for testing.
-- RELEASE_CATALOG_GIT_URL
-  - The release service catalog URL to use in the RPA
-  - This is provided when testing PRs
-- RELEASE_CATALOG_GIT_REVISION
-  - The release service catalog revision to use in the RPA
-  - This is provided when testing PRs
-### Optional Environment Variables
-- KUBECONFIG
-  - The KUBECONFIG file to used to login to the target cluster
-  - This is provided when testing PRs 
-### Test Properties
-#### [test.env](test.env)
-- This file contains resource names and configuration values needed for testing.
-- Since this test requires internal services, the tenant and managed namespaces
-  should remain as-is.
-#### [test.sh](test.sh)
-- This file contains specific variables and functions needed for the test.
-### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
-### Secrets
-- Secrets needed for testing are stored in ansible vault files.
-  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
-  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
-- The secrets required are contained in the files above.
-### Running the test
+# Push to Addons Registry Test
 
-```shell
-../run-test.sh fbc-release
+This test validates the addon registry push pipeline functionality.
+
+## Test-Specific Configuration
+
+### Files Structure
+
+- **`test.env`** - Contains resource names and configuration values specific to addon registry push
+- **`test.sh`** - Contains addon registry-specific variables and functions for the test
+
+## Running the Test
+
+```bash
+../run-test.sh push-to-addons-registry
 ```
 
-### Debugging
+## Test Workflow
 
-There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
-after a test has ended.
+The addon registry push test follows this specific workflow:
 
-Note: you can use these 2 scripts to clean up when you are completed debugging:
-* [utils/cleanup-resources.sh](utils/cleanup-resources.sh)
-* [../scripts/delete-branches.sh](../scripts/delete-branches.sh)
-
-### Maintenance
-- Should you require to add or update a secret, follow these steps:
-```shell
-ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-vi /tmp/tenant-secrets.yaml
-```
-
-```shell
-ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-rm /tmp/tenant-secrets.yaml
-```
+1. **Addon Registry Setup** - Prepares addon registry configurations
+2. **Addon Package Preparation** - Creates addon packages and metadata
+3. **Registry Push Pipeline Execution** - Executes the addon registry push pipeline
+4. **Registry Verification** - Validates successful addon registration and availability

--- a/integration-tests/release-to-github/README.md
+++ b/integration-tests/release-to-github/README.md
@@ -1,73 +1,25 @@
-# release-to-github test
-## Setup
-### Dependencies
-* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
-* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
-* The password to the vault files. (Contact a member of the Release team should you want to run this
-  test suite.)
-* Access to the target cluster and tenant and managed namespaces
-  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
-### Required Environment Variables
-- GITHUB_TOKEN
-  - The GitHub personal access token needed for repo operations
-  - The repo in question can be located in [test.env](test.env)
-- VAULT_PASSWORD_FILE
-  - This is the path to a file that contains the ansible vault
-    password needed to decrypt the secrets needed for testing.
-- RELEASE_CATALOG_GIT_URL
-  - The release service catalog URL to use in the RPA
-  - This is provided when testing PRs
-- RELEASE_CATALOG_GIT_REVISION
-  - The release service catalog revision to use in the RPA
-  - This is provided when testing PRs
-### Optional Environment Variables
-- KUBECONFIG
-  - The KUBECONFIG file is used to login to the target cluster
-  - This is provided when testing PRs 
-### Test Properties
-#### [test.env](test.env)
-- This file contains resource names and configuration values needed for testing.
-- Since this test requires internal services, the tenant and managed namespaces
-  should remain as-is.
-#### [test.sh](test.sh)
-- This file contains specific variables and functions needed for the test.
-### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
-### Secrets
-- Secrets needed for testing are stored in ansible vault files.
-  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
-  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
-- The secrets required are contained in the files above.
-### Running the test
+# Release to GitHub Test
 
-```shell
+This test validates the GitHub release pipeline functionality.
+
+## Test-Specific Configuration
+
+### Files Structure
+
+- **`test.env`** - Contains resource names and configuration values specific to GitHub releases
+- **`test.sh`** - Contains GitHub release-specific variables and functions for the test
+
+## Running the Test
+
+```bash
 ../run-test.sh release-to-github
 ```
 
-### Debugging
+## Test Workflow
 
-There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
-after a test has ended.
+The GitHub release test follows this specific workflow:
 
-Note: you can use these 2 scripts to clean up when you are completed debugging:
-* [utils/cleanup-resources.sh](utils/cleanup-resources.sh)
-* [../scripts/delete-branches.sh](../scripts/delete-branches.sh)
-
-### Maintenance
-- Should you require to add or update a secret, follow these steps:
-```shell
-ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-vi /tmp/tenant-secrets.yaml
-```
-
-```shell
-ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-rm /tmp/tenant-secrets.yaml
-```
+1. **GitHub Repository Setup** - Prepares target GitHub repository
+2. **Release Asset Generation** - Creates release artifacts and checksums
+3. **Release Pipeline Execution** - Executes the GitHub release pipeline
+4. **Release Verification** - Validates the created GitHub release and assets

--- a/integration-tests/rhtap-service-push/README.md
+++ b/integration-tests/rhtap-service-push/README.md
@@ -1,74 +1,31 @@
-# rhtap-service-push test
-## Setup
-### Dependencies
-* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
-* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
-* The password to the vault files. (Contact a member of the Release team should you want to run this
-  test suite.)
-* Access to the target cluster and tenant and managed namespaces
-  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
-* GitHub repo: https://github.com/hacbs-release/infra-deployments 
-### Required Environment Variables
-- GITHUB_TOKEN
-  - The GitHub personal access token needed for repo operations
-  - The repo in question can be located in [test.env](test.env)
-- VAULT_PASSWORD_FILE
-  - This is the path to a file that contains the ansible vault
-    password needed to decrypt the secrets needed for testing.
-- RELEASE_CATALOG_GIT_URL
-  - The release service catalog URL to use in the RPA
-  - This is provided when testing PRs
-- RELEASE_CATALOG_GIT_REVISION
-  - The release service catalog revision to use in the RPA
-  - This is provided when testing PRs
-### Optional Environment Variables
-- KUBECONFIG
-  - The KUBECONFIG file to used to login to the target cluster
-  - This is provided when testing PRs 
-### Test Properties
-#### [test.env](test.env)
-- This file contains resource names and configuration values needed for testing.
-- Since this test requires internal services, the tenant and managed namespaces
-  should remain as-is.
-#### [test.sh](test.sh)
-- This file contains specific variables and functions needed for the test.
-### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
-### Secrets
-- Secrets needed for testing are stored in ansible vault files.
-  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
-  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
-- The secrets required are contained in the files above.
-### Running the test
+# RHTAP Service Push Test
 
-```shell
+This test validates the RHTAP service push pipeline functionality.
+
+## Test-Specific Dependencies
+
+In addition to the [common dependencies](../README.md#dependencies), this test requires:
+
+* **GitHub Repository**: https://github.com/hacbs-release/infra-deployments
+
+## Test-Specific Configuration
+
+### Files Structure
+
+- **`test.env`** - Contains resource names and configuration values specific to RHTAP service push
+- **`test.sh`** - Contains RHTAP service push-specific variables and functions for the test
+
+## Running the Test
+
+```bash
 ../run-test.sh rhtap-service-push
 ```
 
-### Debugging
+## Test Workflow
 
-There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
-after a test has ended.
+The RHTAP service push test follows this specific workflow:
 
-Note: you can use these 2 scripts to clean up when you are completed debugging:
-* [utils/cleanup-resources.sh](utils/cleanup-resources.sh)
-* [../scripts/delete-branches.sh](../scripts/delete-branches.sh)
-
-### Maintenance
-- Should you require to add or update a secret, follow these steps:
-```shell
-ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-vi /tmp/tenant-secrets.yaml
-```
-
-```shell
-ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
-```
-
-```shell
-rm /tmp/tenant-secrets.yaml
-```
+1. **RHTAP Service Setup** - Prepares RHTAP service configurations
+2. **Infra-Deployments Integration** - Integrates with infra-deployments repository
+3. **Service Push Pipeline Execution** - Executes the RHTAP service push pipeline
+4. **Deployment Verification** - Validates successful service deployment and updates


### PR DESCRIPTION
Consolidate common elements into a comprehensive top-level README and reduce individual test README files to contain only test-specific information.

Changes:
- Created comprehensive integration-tests/README.md with:
  * Common dependencies and environment variables
  * Shared test structure and execution flow
  * Universal debugging and secret management procedures
  * CI/CD integration overview
  * Troubleshooting guide and contributing guidelines

- Updated individual test README files to contain only:
  * Test-specific dependencies and configuration
  * Unique workflow details
  * Test-specific secrets or requirements

- Fixed incorrect run command in push-to-addons-registry/README.md
- Reduced duplication across 6 README files

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
