### PR TITLE
fix(RELEASE-1137): update-cr-status can union arrays

### DIFF
--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-array-union
+spec:
+  description: |
+    Run the update-cr-status task with rbac present and multiple result
+    files in the results directory that both specify the same key with
+    an array as its value. The array should be unioned in the resulting
+    status.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: resultArtifact1
+            type: string
+          - name: resultArtifact2
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/results/one.json" << EOF
+              {
+                  "test": [
+                      "one",
+                      "two"
+                  ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/results/two.json" << EOF
+              {
+                  "test": [
+                      "three",
+                      "four"
+                  ]
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-union
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact-array
+            ref:
+              name: create-trusted-artifact-array
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifacts
+                value:
+                  - $(results.resultArtifact1.path)=$(params.dataDir)
+                  - $(results.resultArtifact2.path)=$(params.dataDir)
+          - name: patch-source-data-artifact-result-array
+            # Note: Cannot convert to a StepAction due to https://github.com/tektoncd/pipeline/issues/2374
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              # this is needed to skip trusted-artifacts tasks
+              # when using PVC based workspaces.
+              if [ "$(params.ociStorage)" == "empty" ]; then
+                echo -n "$(params.ociStorage)" > "$(results.resultArtifact1.path)"
+                echo -n "$(params.ociStorage)" > "$(results.resultArtifact2.path)"
+              fi
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status-union
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.setup.results.resultArtifact1)=$(params.dataDir)"
+            - "$(tasks.setup.results.resultArtifact2)=$(params.dataDir)"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that the Release.Status contains the union of both test arrays
+              test "$(kubectl get release release-cr-status-union -n default \
+                -o jsonpath='{.status.artifacts.test}')" == '["one","two","three","four"]'
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-union

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -134,9 +134,25 @@ spec:
                 echo "Passed results JSON file ${resultsFile} in results directory was not proper JSON."
                 exit 1
             fi
-            # If two files have arrays with the same key, it will be overwritten. Otherwise, the jsons
-            # are merged (only arrays are not merged properly with this notation).
-            RESULTS_JSON=$(jq -c "${RESULTS_JSON} * ." "${resultsFile}")
+            # Merge with array concatenation for array fields and object merging
+            RESULTS_JSON=$(echo "$RESULTS_JSON" | jq --argjson new "$(cat "${resultsFile}")" '
+              # Store current values as $base and get all unique keys from both objects
+              . as $base | ($base | keys + ($new | keys)) | unique | 
+              # Process each key and build the merged result
+              reduce .[] as $key ({}; . + {($key): (
+                # Case 1: Both values are arrays - concatenate them
+                if ($new[$key] | type == "array") and ($base[$key] | type == "array")
+                then $base[$key] + $new[$key]
+                else 
+                  # Case 2: Both values are objects - merge them recursively
+                  if ($new[$key] | type == "object") and ($base[$key] | type == "object")
+                  then $base[$key] * $new[$key]
+                  # Case 3: Default - use new value or fall back to base value
+                  else $new[$key] // $base[$key]
+                  end
+                end
+              )})
+            ')
         done
 
         IFS='/' read -r namespace name <<< "$(params.resource)"


### PR DESCRIPTION
This commit updates the update-cr-status task to properly union arrays from multiple result files. Previously, if two result files each defined an array with the same key, one would take precedence instead of them being combined in the custom resource status.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
