### PR TITLE
fix: the git url of check-if-related-test

### DIFF
--- a/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
@@ -77,7 +77,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/release-service-catalog
+            value: https://github.com/konflux-ci/community-catalog
           - name: revision
             value: development
           - name: pathInRepo


### PR DESCRIPTION
The task of check-if-related-test is moved to community-catalog repo and it's not modified in the e2e-tests-stage-pipeline.yaml.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
