### PR TITLE
fix: kubectl argument too long when updating release cr

### DIFF
--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -157,5 +157,12 @@ spec:
 
         IFS='/' read -r namespace name <<< "$(params.resource)"
 
+        # Create patch file to avoid "Argument list too long" error
+        PATCH_FILE="/tmp/patch-$(date +%s).json"
+        echo "status: {'$(params.statusKey)':${RESULTS_JSON}}" > "$PATCH_FILE"
+
         kubectl --warnings-as-errors=true patch "$(params.resourceType)" -n "$namespace" "$name" \
-          --type=merge --subresource status --patch "status: {'$(params.statusKey)':${RESULTS_JSON}}"
+          --type=merge --subresource status --patch-file "$PATCH_FILE"
+
+        # Clean up
+        rm -f "$PATCH_FILE"


### PR DESCRIPTION
## Describe your changes

Most of the development and CI has been done assuming smaller Snapshots. When releasing larger snapshots (i.e. 180 components), we start to encounter issues ranging from higher likelihood to hit timeouts, increased memory consumption, and long strings being processed.

This PR is focused on fixing an issue where `update-cr-status` could not process large snapshots, namely because we were passing too much information to `kubectl`.

Partially addresses: [KONFLUX-8821](https://issues.redhat.com//browse/KONFLUX-8821) in conjunction with #1218, #1219, #1220

Assisted-by: Cursor
Signed-off-by: arewm <arewm@users.noreply.github.com>

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
