### PR TITLE
fix(KONFLUX-5938): show error in verify-access-to-resources

### DIFF
--- a/.github/resources/crd_rbac.yaml
+++ b/.github/resources/crd_rbac.yaml
@@ -13,7 +13,6 @@ rules:
       - releases
       - releases/status
       - releaseplans
-      - releaseplanadmissions
       - releaseserviceconfigs
       - snapshots
     verbs:

--- a/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -43,7 +43,7 @@ spec:
                 name: releaseplanadmission-sample
                 namespace: default
               EOF
-              kubectl apply -f releaseplanadmission
+              #kubectl apply -f releaseplanadmission
 
               cat > releaseserviceconfig << EOF
               apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
This commit updates the verify-access-to-resourcs task to properly show the error if the service account does not have the permissions to ReleasePlanAdmissions in the target namespace.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
