### PR TITLE
feat(release-1680): add support for DP to push-artifacts

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -1,6 +1,12 @@
 # push-artifacts-to-cdn-task
 
-Tekton task to push artifacts to CDN and optionally Dev Portal with optional signing
+Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+the Developer Portal using exodus-rsync with optional signing. It uses logic based
+on the snapshot data to determine which targets to publish to: if components contain 
+both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
+(Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+pushed to the Customer Portal (Pulp); if components contain `contentGateway`
+data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 
 ## Parameters
 

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -8,7 +8,13 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    Tekton task to push artifacts to CDN and optionally Dev Portal with optional signing
+    Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+    the Developer Portal using exodus-rsync with optional signing. It uses logic based
+    on the snapshot data to determine which targets to publish to: if components contain 
+    both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
+    (Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+    pushed to the Customer Portal (Pulp); if components contain `contentGateway`
+    data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
   params:
     - name: snapshot_json
       type: string
@@ -998,6 +1004,7 @@ spec:
         # Setup required variables
         export EXODUS_GW_CERT=/tmp/exodus.crt
         export EXODUS_GW_KEY=/tmp/exodus.key
+        EXODUS_CONF_PATH=/tmp/exodus-rsync.conf
         export PULP_CERT_FILE=/tmp/pulp.crt
         export PULP_KEY_FILE=/tmp/pulp.key
         export UDCACHE_CERT=/tmp/udc.crt
@@ -1019,65 +1026,119 @@ spec:
 
         DISK_IMAGE_DIR="/shared/artifacts/compressed"
         export DISK_IMAGE_DIR
+        RELATIVE_PATHS=""
 
-        # use the 1st component's version for STAGED_JSON
-        VERSION=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
+        push_to_pulp() { 
+          # use the 1st component's version for STAGED_JSON
+          version=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
+          # Check if staged.destination exists in any component
+          has_staged_destination=$(jq 'any(.components[]?.staged?.destination; . != null)' <<< "$SNAPSHOT_JSON")
+          if [[ -z "$version" || "$has_staged_destination" != "true" ]]; then
+            echo "Error: Pulp push requires both staged.version and components[].staged.destination to be set" >&2
+            exit 1
+          fi
+
+          echo "Pushing to customer portal with pulp"
+          staged_json='{"header":{"version": "0.2"},"payload":{"files":[]}}'
+          # Add the files to the payload
+          # shell check wants us to find ./* but that adds `./` to the paths which breaks the script
+          # shellcheck disable=SC2035
+          while IFS= read -r -d '' file ; do
+              staged_json=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
+                --arg version "$version" \
+                '.payload.files[.payload.files | length] =
+                {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$staged_json")
+          done < <(find * -type f -print0)
+          echo "$staged_json" | yq -P -I 4 > staged.yaml
+
+          pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
+            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" 
+          RELATIVE_PATHS=$(jq -erc '.payload.files[].relative_path' <<< "$staged_json")
+
+          # Clean up file to avoid uploading it in exodus-rsync as an artifact.
+          rm -f staged.yaml
+         }
+
+        create_exodus_conf() {
+          echo "Creating Exodus configuration file....."
+          set +x
+          cat >"$EXODUS_CONF_PATH" <<EOF
+        gwcert:   $EXODUS_GW_CERT
+        gwkey:    $EXODUS_GW_KEY
+        gwurl:    $EXODUS_GW_URL
+        gwenv:    $EXODUS_GW_ENV
+
+        logger: file:/proc/1/fd/1
+        loglevel: info
+
+        environments:
+          - prefix: exodus
+        EOF
+          set -x
+        }
+
+        push_to_cdn () {
+            echo "Pushing to CDN with exodus-rsync"
+            create_exodus_conf
+            prefix="exodus:/content/origin/files/sha256"
+            files_output="{}"
+            # shell check wants us to find ./* but that adds `./` to the paths which breaks the script
+            # shellcheck disable=SC2035
+            while IFS= read -r -d '' file; do
+              set +x
+              file_name=$(basename "$file")
+              checksum=$(sha256sum "$file" | awk '{print $1}')
+              destination_path="$prefix/${checksum:0:2}/$checksum/$file_name"
+              files_output=$(jq --arg key "$file" \
+                --arg value "$destination_path" '.[$key]=$value' <<< "$files_output")
+              set -x
+
+              # We're using exodus-rsync as a drop-in replacement for rsync, by overriding the rsync binary.
+              rsync --exodus-conf "$EXODUS_CONF_PATH" "$file" "$destination_path"
+            done < <(find * -type f -print0)
+            RELATIVE_PATHS=$(jq -erc 'keys[]' <<< "$files_output")
+        }
+
+        publish_to_cgw() {
+          NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+          i=0
+          for path in $RELATIVE_PATHS; do
+            [[ $i -ge "$NUM_COMPONENTS" ]] && break  # stop once we've processed all components
+            component_destination="${DISK_IMAGE_DIR}/$(dirname "$path")"
+            
+            SNAPSHOT_JSON=$(
+              jq --argjson i "$i" --arg dir "$component_destination" '
+                .components[$i] |=
+                  if .contentGateway? then
+                    .contentGateway.contentDir = $dir
+                  else
+                    . # components without contentGateway will not be published. 
+                  end
+              ' <<<"$SNAPSHOT_JSON"
+            )
+            ((++i))
+          done
+
+          ## Process Files for Developer Portal / CGW
+          ## Validation of fields done inside CGW wrapper.
+          publish_to_cgw_wrapper \
+            --cgw_host "$(params.cgwHostname)" \
+            --data_json "$SNAPSHOT_JSON"
+        }
 
         # Change to the subdir with the images
         cd "${DISK_IMAGE_DIR}"
 
-        STAGED_JSON='{"header":{"version": "0.2"},"payload":{"files":[]}}'
-
-        # Add the files to the payload
-        # shell check wants us to find ./* but that adds `./` to the paths which breaks the script
-        # shellcheck disable=SC2035
-        while IFS= read -r -d '' file ; do
-            STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
-              --arg version "$VERSION" \
-              '.payload.files[.payload.files | length] =
-              {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$STAGED_JSON")
-        done < <(find * -type f -print0)
-        set -x
-
-        echo "$STAGED_JSON" | yq -P -I 4 > staged.yaml
-
-        # Check if staged.destination exists in any component
-        HAS_STAGED_DESTINATION=$(jq 'any(.components[]?.staged?.destination; . != null)' <<< "$SNAPSHOT_JSON")
-        if [[ -n "$VERSION" && "$HAS_STAGED_DESTINATION" = "true" ]]; then
-          echo "Pushing to customer portal (Pulp) with destination: $HAS_STAGED_DESTINATION"
-          pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
-            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
-            2> "$STDERR_FILE"
-        elif [[ -z "$VERSION" && "$HAS_STAGED_DESTINATION" != "true" ]]; then
-          echo "Skipping Pulp push: staged.version is empty and components[].staged.destination is not set"
-        else
-          (echo "Error: Pulp push requires both staged.version and" \
-          "components[].staged.destination to be set" >&2 && exit 1) 2> "$STDERR_FILE"
+        # Check if any component has staged defined further validation of fields done inside the function.
+        CUSTOMER_PORTAL_PUSH=$(jq 'any(.components[]?.staged?; length > 0)' <<< "$SNAPSHOT_JSON")
+        # Check if any component has contentGateway defined validaion of field done inside CGW wrapper.
+        CGW_PUSH=$(jq 'any(.components[]?.contentGateway?; length > 0)' <<< "$SNAPSHOT_JSON")
+        if [[ "$CUSTOMER_PORTAL_PUSH" == "true" && "$CGW_PUSH" == "true" ]]; then
+          push_to_pulp 2> "$STDERR_FILE"
+          publish_to_cgw 2> >(tee "$STDERR_FILE" >&2)
+        elif [[ "$CUSTOMER_PORTAL_PUSH" == "true" ]]; then
+          push_to_pulp 2> "$STDERR_FILE"
+        elif [[ "$CGW_PUSH" == "true" ]]; then
+          push_to_cdn > >(tee "$STDERR_FILE") 2>&1
+          publish_to_cgw 2> >(tee "$STDERR_FILE" >&2)
         fi
-
-        relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
-        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
-        i=0
-        for path in $relative_paths; do
-          [[ $i -ge "$NUM_COMPONENTS" ]] && break  # stop once we've processed all components
-          component_destination="${DISK_IMAGE_DIR}/$(dirname "$path")"
-          
-          SNAPSHOT_JSON=$(
-            jq --argjson i "$i" --arg dir "$component_destination" '
-              .components[$i] |=
-                if .contentGateway? then
-                  .contentGateway.contentDir = $dir
-                else
-                  . # components without contentGateway will not be published. 
-                end
-            ' <<<"$SNAPSHOT_JSON"
-          )
-          ((++i))
-        done
-          
-        ## Process Files for Developer Portal / CGW
-        ##
-        publish_to_cgw_wrapper \
-          --cgw_host "$(params.cgwHostname)" \
-          --data_json "$SNAPSHOT_JSON" \
-          2> >(tee "$STDERR_FILE" >&2)

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -24,6 +24,13 @@ function oras() {
             touch testproduct2-binary-darwin-amd64.tar.gz
             touch testproduct2-binary-linux-amd64.tar.gz
         fi
+
+        if [[ "$4" =~ "abelml6910" ]]; then
+            touch testproduct3-binary-windows-amd64.zip
+            touch testproduct3-binary-darwin-amd64.tar.gz
+            touch testproduct3-binary-linux-amd64.tar.gz
+        fi
+
         touch testproduct-binary-windows-amd64.zip
         touch testproduct-binary-darwin-amd64.tar.gz
         touch testproduct-binary-linux-amd64.tar.gz
@@ -38,6 +45,12 @@ function oras() {
             touch windows/testproduct2-binary-windows-amd64.exe
             touch linux/testproduct2-binary-linux-amd64
             touch macos/testproduct2-binary-darwin-amd64
+        fi
+
+        if [ -f "/shared/artifacts/linux/testproduct3-binary-linux-amd64" ]; then
+            touch windows/testproduct3-binary-windows-amd64.exe
+            touch linux/testproduct3-binary-linux-amd64
+            touch macos/testproduct3-binary-darwin-amd64
         fi
     fi
     touch testproduct-fail_gzip.raw.gz
@@ -85,6 +98,15 @@ function pulp_push_wrapper() {
 
     if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
         printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
+    fi
+}
+
+function rsync() {
+    echo Mock rsync called with: $*
+
+    if [[ "$3" = "testproduct3-binary-linux-amd64.tar.gz" ]]; then
+        printf "Mocked failure of exodus-rsync"
+        exit 1
     fi
 }
 

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -2,11 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-artifacts-to-cdn-fail-no-filesfilename
+  name: test-push-artifacts-to-cdn-exdous-rsync-push
 spec:
   description: |
-    Run the push-artifacts task with the component having a files entry without filename. This should
-    fail the task
+   Run the task with a binary component that does NOT have staged.destination
+   or staged.version. Uses an invalid Pulp secret to verify the Pulp push 
+   is skipped and artifacts are published via exodus-rsync instead.
   tasks:
     - name: run-task
       taskRef:
@@ -15,35 +16,36 @@ spec:
         - name: snapshot_json
           value: >-
             {
+
               "application": "amd-bootc-1-3-qcow2-disk-image",
               "artifacts": {},
               "components": [
                 {
                   "containerImage": "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
                   "contentGateway": {
+                    "filePrefix": "testproduct-",
                     "productCode": "Code",
-                    "productName": "Name",
+                    "productName": "MyName",
                     "productVersionName": "1.3-staging"
                   },
-                  "staged": {
-                    "destination": "test-product-amd64",
-                    "version": "1.3"
-                  },
+                  "name": "testproduct",
                   "files": [
                     {
-                      "filename": null,
-                      "source": "testproduct-binary-windows-amd64.zip"
+                      "filename": "testproduct-binary-windows-amd64.zip",
+                      "source": "testproduct-binary-windows-amd64.zip",
+                      "binary": "testproduct-binary-windows-amd64.exe"
                     },
                     {
-                      "filename": null,
-                      "source": "testproduct-binary-darwin-amd64.tar.gz"
+                      "filename": "testproduct-binary-darwin-amd64.tar.gz",
+                      "source": "testproduct-binary-darwin-amd64.tar.gz",
+                      "binary": "testproduct-binary-darwin-amd64"
                     },
                     {
-                      "filename": null,
-                      "source": "testproduct-binary-linux-amd64.tar.gz"
+                      "filename": "testproduct-binary-linux-amd64.tar.gz",
+                      "source": "testproduct-binary-linux-amd64.tar.gz",
+                      "binary": "testproduct-binary-linux-amd64"
                     }
-                  ],
-                  "name": "testproduct"
+                  ]
                 }
               ]
             }
@@ -52,7 +54,7 @@ spec:
         - name: exodusGwEnv
           value: "pre"
         - name: pulpSecret
-          value: "pulp-task-pulp-secret"
+          value: "pulp-task-bad-pulp-secret"
         - name: udcacheSecret
           value: "pulp-task-udc-secret"
         - name: cgwHostname
@@ -75,15 +77,12 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
-            env:
-              - name: "RESULT"
-                value: '$(params.result)'
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
             script: |
               #!/usr/bin/env bash
               set -ex
 
-              if [[ ${RESULT/*files*filename*/} ]] ; then
-                echo "Error: result task result should show failure from files[].filename but doesn't"
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
                 exit 1
               fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-artifacts-to-cdn-skip-pulp-for-binary
+  name: test-push-artifacts-to-cdn-fail-exdous-rsync-push
 spec:
-  description: |
-    Run the task with a binary component that does NOT have
-    staged.destination or staged.version and ensure Pulp push is skipped and the task succeeds.
+  description: |    
+    Run the push-artifacts task with the exodus-rsync script failing. This is done by having
+    the mock script call fail based on the file-path.
   tasks:
     - name: run-task
       taskRef:
@@ -20,29 +20,28 @@ spec:
               "artifacts": {},
               "components": [
                 {
-                  "containerImage": "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+                  "containerImage": "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abelml6910",
                   "contentGateway": {
-                    "filePrefix": "testproduct-",
                     "productCode": "Code",
                     "productName": "MyName",
                     "productVersionName": "1.3-staging"
                   },
-                  "name": "testproduct",
+                  "name": "testproduct3",
                   "files": [
                     {
-                      "filename": "testproduct-binary-windows-amd64.zip",
-                      "source": "testproduct-binary-windows-amd64.zip",
-                      "binary": "testproduct-binary-windows-amd64.exe"
+                      "filename": "testproduct3-binary-windows-amd64.zip",
+                      "source": "testproduct3-binary-windows-amd64.zip",
+                      "binary": "testproduct3-binary-windows-amd64.exe"
                     },
                     {
-                      "filename": "testproduct-binary-darwin-amd64.tar.gz",
-                      "source": "testproduct-binary-darwin-amd64.tar.gz",
-                      "binary": "testproduct-binary-darwin-amd64"
+                      "filename": "testproduct3-binary-darwin-amd64.tar.gz",
+                      "source": "testproduct3-binary-darwin-amd64.tar.gz",
+                      "binary": "testproduct3-binary-darwin-amd64"
                     },
                     {
-                      "filename": "testproduct-binary-linux-amd64.tar.gz",
-                      "source": "testproduct-binary-linux-amd64.tar.gz",
-                      "binary": "testproduct-binary-linux-amd64"
+                      "filename": "testproduct3-binary-linux-amd64.tar.gz",
+                      "source": "testproduct3-binary-linux-amd64.tar.gz",
+                      "binary": "testproduct3-binary-linux-amd64"
                     }
                   ]
                 }
@@ -53,7 +52,7 @@ spec:
         - name: exodusGwEnv
           value: "pre"
         - name: pulpSecret
-          value: "pulp-task-pulp-secret"
+          value: "pulp-task-bad-pulp-secret"
         - name: udcacheSecret
           value: "pulp-task-udc-secret"
         - name: cgwHostname
@@ -76,12 +75,15 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
             script: |
               #!/usr/bin/env bash
               set -ex
 
-              if [[ "$(params.result)" != "Success" ]]; then
-                echo Error: result task result expected to be Success but was not
+              if [[ ${RESULT/*Mocked failure of exodus-rsync*/} ]] ; then
+                echo "Error: result task result should show failure on exodus-rsync but doesn't"
                 exit 1
               fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -24,10 +24,6 @@ spec:
                     "productName": "MyName",
                     "productVersionName": "1.3-staging"
                   },
-                  "staged": {
-                    "destination": "test-product-amd64",
-                    "version": "1.3"
-                  },
                   "files": [
                     {
                       "filename": "testproduct-binary-windows-amd64.zip",

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -25,10 +25,6 @@ spec:
                     "productCode": "Code",
                     "productVersionName": "1.3-staging"
                   },
-                  "staged": {
-                    "destination": "test-product-amd64",
-                    "version": "1.3"
-                  },
                   "files": [
                     {
                       "filename": "testproduct-binary-windows-amd64.zip",


### PR DESCRIPTION
## Describe your changes
This PR updates the push-artifacts-to-cdn task by adding the developer portal CDN via exodus-rsync into push-artifacts step. When neither `staged.version` nor `staged.destination` is set, the script skips the customer portal (pulp) and uses rsync instead.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
