### PR TITLE
feat(RELEASE-1256): make upload sbom to atlast task idempotent

### DIFF
--- a/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
+++ b/tasks/managed/upload-sbom-to-atlas/tests/mocks.sh
@@ -16,6 +16,17 @@ curl() {
     return 0
   elif [[ "$params" =~ "AWS" ]]; then
     return 0
+  elif [[ "$params" =~ "GET" && "$params" =~ "/api/v2/sbom" ]]; then
+    # Check if this is for the idempotent test (by checking if identifier contains "existing-sbom")
+    if [[ "$params" =~ "existing-sbom" ]]; then
+      # Mock GET request to check if SBOM exists - return result indicating SBOM exists
+      echo '{"total":1,"results":[{"id":"existing-sbom-id","documentNamespace":"http://spdx.org/spdxdocs/existing-sbom"}]}'
+      return 0
+    else
+      # Mock GET request to check if SBOM exists - return empty result (SBOM doesn't exist)
+      echo '{"total":0,"results":[]}'
+      return 0
+    fi
   else
     return 1
   fi

--- a/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-idempotent.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/tests/test-upload-sbom-to-atlas-idempotent.yaml
@@ -2,12 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-upload-sbom-to-atlas-curl-fail
+  name: test-upload-sbom-to-atlas-idempotent
 spec:
   description: |
-    Tests that failure in uploading SPDX SBOMs to Atlas should not fail the
-    upload-sbom-to-atlas task and the failed sbom is copied to the correct
-    directory for retrying.
+    Tests that SBOMs that already exist in Atlas are not re-uploaded, 
+    verifying the idempotent behavior of the upload-sbom-to-atlas task.
   workspaces:
     - name: tests-workspace
   params:
@@ -68,15 +67,15 @@ spec:
               # creating working directory
               workdir="$(params.dataDir)/$(context.pipelineRun.uid)/workdir"
               mkdir -p "${workdir}"
-              sbomId="sha256:deadbeef"
+              sbomId="sha256:existing"
 
               cat > "$sbomsDir/$sbomId" << EOF
               {
                 "spdxVersion": "SPDX-2.3",
                 "dataLicense": "CC0-1.0",
                 "SPDXID": "SPDXRef-DOCUMENT",
-                "name": "Minimal SPDX SBOM for testing curl failure",
-                "documentNamespace": "http://spdx.org/spdxdocs/minimal-spdx-sbom",
+                "name": "Existing SPDX SBOM for testing idempotency",
+                "documentNamespace": "http://spdx.org/spdxdocs/existing-sbom",
                 "documentDescribes": []
               }
               EOF
@@ -197,22 +196,22 @@ spec:
               mkdir -p "${workdir}"
               mkdir -p "${sbomsDir}"
 
-              # Check count of curl calls is 4:
-              # token fetch, SBOM existence check (GET), attempted atlas push, S3 push
-              if [ "$(wc -l < "$workdir/mock_curl.txt")" -ne 4 ]; then
-                echo "TEST FAILED: curl was expected to be called 4 times. Actual calls:"
+              # Check count of curl calls is 2:
+              # token fetch, SBOM existence check (GET) - no POST or S3 upload
+              if [ "$(wc -l < "$workdir/mock_curl.txt")" -ne 2 ]; then
+                echo "TEST FAILED: curl was expected to be called 2 times for idempotent case. Actual calls:"
                 cat "$workdir/mock_curl.txt"
                 exit 1
               else
-                echo "TEST PASSED: Curl has been called 4 times"
+                echo "TEST PASSED: Curl has been called 2 times (idempotent behavior verified)"
               fi
 
               failedSbomDir="$(params.dataDir)/$(context.pipelineRun.uid)/failed-sboms"
 
-              if [[ -f "$failedSbomDir/sha256:deadbeef" ]]; then
-                echo "TEST PASSED: Failed SBOM was copied to retry directory."
-              else
-                echo "TEST FAILED: Failed SBOM not copied to retry directory."
-                ls -l "$failedSbomDir"
+              # In idempotent case, no SBOMs should be in failed directory
+              if [[ -f "$failedSbomDir/sha256:existing" ]]; then
+                echo "TEST FAILED: SBOM should not be in failed directory in idempotent case."
                 exit 1
-              fi
+              else
+                echo "TEST PASSED: No SBOMs in failed directory (idempotent behavior verified)."
+              fi 

--- a/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
+++ b/tasks/managed/upload-sbom-to-atlas/upload-sbom-to-atlas.yaml
@@ -182,6 +182,57 @@ spec:
         sso_account="$(cat /secrets/sso_account)"
         sso_token="$(cat /secrets/sso_token)"
 
+        # Function to extract SBOM identifier for checking existence
+        extract_sbom_identifier() {
+          local sbom_file="$1"
+          # Extract a unique identifier from SBOM - use document namespace for SPDX or name/version for CycloneDX
+          local identifier=""
+          
+          if jq -e '.spdxVersion' "$sbom_file" >/dev/null 2>&1; then
+            # SPDX format - use documentNamespace as identifier
+            identifier=$(jq -r '.documentNamespace // empty' "$sbom_file")
+          elif jq -e '.bomFormat == "CycloneDX"' "$sbom_file" >/dev/null 2>&1; then
+            # CycloneDX format - use metadata.component.name and version
+            local name=$(jq -r '.metadata.component.name // empty' "$sbom_file")
+            local version=$(jq -r '.metadata.component.version // empty' "$sbom_file")
+            if [[ -n "$name" && -n "$version" ]]; then
+              identifier="${name}@${version}"
+            fi
+          fi
+          
+          echo "$identifier"
+        }
+
+        # Function to check if SBOM already exists in Atlas
+        check_sbom_exists() {
+          local access_token="$1"
+          local identifier="$2"
+          local atlasApiUrl="$3"
+          
+          if [[ -z "$identifier" ]]; then
+            echo "false"
+            return
+          fi
+          
+          # Query Atlas to check if SBOM with this identifier already exists
+          # Using a simple search query - adjust based on actual Atlas API capabilities
+          local query_response
+          if query_response=$(curl -s -X GET "${curl_opts[@]}" \
+            -H "authorization: Bearer $access_token" \
+            -H "content-type: application/json" \
+            "$atlasApiUrl/api/v2/sbom?identifier=$(printf '%s' "$identifier" | jq -sRr @uri)" 2>/dev/null); then
+            
+            # Check if response contains any results
+            local count=$(echo "$query_response" | jq -r '.total // (.results | length) // 0' 2>/dev/null || echo "0")
+            if [[ "$count" -gt 0 ]]; then
+              echo "true"
+              return
+            fi
+          fi
+          
+          echo "false"
+        }
+
         for sbom_path in "${sboms_to_upload[@]}"; do
           echo "Processing $sbom_path"
 
@@ -206,6 +257,23 @@ spec:
           fi
 
           atlasApiUrl=$(params.atlasApiUrl)
+          
+          # Extract SBOM identifier for idempotency check
+          sbom_identifier=$(extract_sbom_identifier "$sbom_path")
+          
+          # Check if SBOM already exists in Atlas
+          if [[ -n "$sbom_identifier" ]]; then
+            echo "Checking if SBOM already exists in Atlas: $sbom_identifier"
+            sbom_exists=$(check_sbom_exists "$access_token" "$sbom_identifier" "$atlasApiUrl")
+            
+            if [[ "$sbom_exists" == "true" ]]; then
+              echo "SBOM $sbom_path already exists in Atlas (identifier: $sbom_identifier). Skipping upload."
+              continue
+            fi
+          else
+            echo "Warning: Could not extract identifier from SBOM $sbom_path. Proceeding with upload."
+          fi
+
           echo "Uploading SBOM $sbom_path to $atlasApiUrl"
 
           handle_atlas_failure () {


### PR DESCRIPTION
## Describe your changes
This task implements idempotent behavior by checking if an SBOM already exists in Atlas before attempting to upload it. The task extracts a unique identifier from each SBOM:

- **SPDX format**: Uses the `documentNamespace` field as the identifier
- **CycloneDX format**: Uses a combination of `metadata.component.name` and `metadata.component.version` as the identifier

If an SBOM with the same identifier already exists in Atlas, the upload is skipped, preventing duplicate submissions and making the task safe to retry.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
