### PR TITLE
fix(RELEASE-1749): remove the cell expression filters

### DIFF
--- a/.tekton/release-service-catalog-pull-request.yaml
+++ b/.tekton/release-service-catalog-pull-request.yaml
@@ -10,19 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "pull_request"
       && target_branch == "development"
-      && (!has(body.pull_request) || !body.pull_request.draft)
-      && (".tekton/*.yaml".pathChanged()  
-      || "tasks/internal/*/*.yaml".pathChanged()
-      || "tasks/managed/*/*.yaml".pathChanged()
-      || "pipelines/managed/*/*.yaml".pathChanged()
-      || "schema/dataKeys.json".pathChanged()
-      || "stepactions/*/*.yaml".pathChanged()
-      || "pipelines/internal/*/*.yaml".pathChanged()
-      || "tasks/collectors/*/*.yaml".pathChanged()
-      || "pipelines/run-collectors/*/*.yaml".pathChanged()
-      || "integration-tests/*".pathChanged()
-      || "Dockerfile".pathChanged()))
-      || (event == "push" && target_branch.startsWith("gh-readonly-queue/development/"))      
+      && (!has(body.pull_request) || !body.pull_request.draft))
+      || (event == "push" && target_branch.startsWith("gh-readonly-queue/development/"))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: release-service-catalog


### PR DESCRIPTION
Remove the cell expression filters in tekton config files because it's blocking the PRs with only e2e tests unrelated files being merged.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
