### PR TITLE
fix: enforce required fields only for declared systems

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -837,7 +837,19 @@
       "if": {
         "required": [
           "releaseNotes"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "releaseNotes"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -904,7 +916,19 @@
       "if": {
         "required": [
           "cdn"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cdn"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -966,6 +990,16 @@
           "fbc"
         ],
         "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
           "fbc": {
             "properties": {
               "preGA": {
@@ -998,6 +1032,16 @@
           "fbc"
         ],
         "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
           "fbc": {
             "properties": {
               "hotfix": {
@@ -1029,6 +1073,16 @@
           "fbc"
         ],
         "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "fbc"
+                }
+              }
+            }
+          },
           "fbc": {
             "properties": {
               "stagedIndex": {
@@ -1082,7 +1136,19 @@
       "if": {
         "required": [
           "sign"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "sign"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1124,7 +1190,19 @@
       "if": {
         "required": [
           "mrrc"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mrrc"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1184,7 +1262,19 @@
       "if": {
         "required": [
           "github"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "github"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1217,21 +1307,21 @@
         }
       },
       "then": {
+        "required": [
+          "mapping"
+        ],
         "properties": {
           "mapping": {
+            "required": [
+              "components"
+            ],
             "properties": {
               "components": {
+                "type": "array",
                 "items": {
-                  "properties": {
-                    "contentGateway": {
-                      "required": [
-                        "productName",
-                        "productCode",
-                        "productVersionName",
-                        "contentType"
-                      ]
-                    }
-                  }
+                  "required": [
+                    "contentGateway"
+                  ]
                 }
               }
             }
@@ -1242,8 +1332,35 @@
     {
       "if": {
         "required": [
-          "contentGateway"
-        ]
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "required": [
+              "components"
+            ],
+            "properties": {
+              "components": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "contentGateway"
+                  ]
+                }
+              }
+            }
+          },
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "contentGateway"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1298,7 +1415,19 @@
       "if": {
         "required": [
           "pyxis"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pyxis"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1341,7 +1470,19 @@
       "if": {
         "required": [
           "ootsign"
-        ]
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "ootsign"
+                }
+              }
+            }
+          }
+        }
       },
       "then": {
         "properties": {
@@ -1367,7 +1508,49 @@
         "properties": {
           "systems": {
             "contains": {
-              "const": "mapping"
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mapping"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "type": "object",
+            "required": [
+              "components"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "mapping"
+                }
+              }
             }
           }
         }
@@ -1377,6 +1560,8 @@
           "mapping": {
             "properties": {
               "components": {
+                "type": "array",
+                "minItems": 1,
                 "items": {
                   "required": [
                     "name",


### PR DESCRIPTION
## Describe your changes
Only validate required fields when a system is listed in `systems[]`. This change prevents the schema from errors when a system is defined in the JSON but is not apart of the systems check.

## Relevant Jira
Slack disscusion [here](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1752873810452739?thread_ts=1752717243.312609&cid=C04PZ7H0VA8)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
