### PR TITLE
feat(RELEASE-186): breaking change as label

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -142,9 +142,12 @@ COMMITS=($(git rev-list --first-parent --ancestry-path origin/"$TARGET_BRANCH"'.
 ## now loop through the above array
 for COMMIT in "${COMMITS[@]}"
 do
-  echo $(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=sha:'"$COMMIT" | jq -r '.items[]
-    | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")
-    | .pull_request | select(.merged_at!=null) | .html_url')
+  PR_INFO="$(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=sha:'"$COMMIT" | jq -r '.items[]
+    | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")')"
+  echo -n "$(jq -r '.pull_request | select(.merged_at!=null) | .html_url' <<< "$PR_INFO")"
+  LABEL="$(jq -r '.labels[].name | select(. | contains("breaking-change"))' <<< "$PR_INFO")"
+  [[ -z "$LABEL" ]] || echo -n " ($LABEL)"
+  echo
   git show --oneline --no-patch $COMMIT
 done
 


### PR DESCRIPTION
## Describe your changes
`.github/scripts/promote_branch.sh` now fetches labels on PRs - this will make it more clear when a breaking change is being promoted if a PR has the new breaking change label.

## Relevant Jira
https://issues.redhat.com/browse/RELEASE-186

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
