### PR TITLE
fix(RELEASE-1765): use proper key index for conforma params

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -165,8 +165,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -191,8 +191,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "10m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "10m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -187,8 +187,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "10m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "10m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -187,7 +187,7 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.timeout", "default": "10m0s"}
+              {"resultIndex": 0, "key": ".conforma.timeout", "default": "10m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -149,8 +149,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -150,8 +150,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -149,8 +149,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "40m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "40m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -152,8 +152,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "40m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "40m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -149,8 +149,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -153,8 +153,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -151,7 +151,7 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.timeout", "default": "10m0s"}
+              {"resultIndex": 0, "key": ".conforma.timeout", "default": "10m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -162,8 +162,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -149,8 +149,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "8h0m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -152,8 +152,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "1h30m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "1h30m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -152,8 +152,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": "conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": "conforma.timeout", "default": "40m0s"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "40m0s"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"


### PR DESCRIPTION
The commit adding the collect-task-params for the conforma task was missing the . at the start of each key value.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
