### PR TITLE
fix: allow collect-task-params results to be empty

### DIFF
--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -166,7 +166,7 @@ spec:
         for i in $(seq 0 $((KEY_COUNT - 1))); do
             RESULT_INDEX=$(jq -r ".[$i].resultIndex" <<< "$KEYS_JSON")
             KEY=$(jq -r ".[$i].key" <<< "$KEYS_JSON")
-            DEFAULT_VALUE=$(jq -r ".[$i].default // empty" <<< "$KEYS_JSON")
+            DEFAULT_VALUE=$(jq -r ".[$i].default // null" <<< "$KEYS_JSON")
             
             if [ "$RESULT_INDEX" = "null" ] || [ "$KEY" = "null" ]; then
                 echo "Invalid key extraction specification at index $i: missing resultIndex or key"
@@ -191,7 +191,7 @@ spec:
 
             # Check if the key exists in the data file
             if [ "$VALUE" = "null" ]; then
-                if [ -n "$DEFAULT_VALUE" ]; then
+                if [ "$DEFAULT_VALUE" != "null" ]; then
                     echo "Key $KEY not found in data file, using default value: $DEFAULT_VALUE"
                     VALUE="$DEFAULT_VALUE"
                 else

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
@@ -111,7 +111,8 @@ spec:
               {"resultIndex": 1, "key": ".foo.bar"},
               {"resultIndex": 2, "key": ".simpleValue"},
               {"resultIndex": 3, "key": ".missingKey", "default": "default_value"},
-              {"resultIndex": 4, "key": ".numberValue", "default": "42"}
+              {"resultIndex": 4, "key": ".numberValue", "default": "42"},
+              {"resultIndex": 5, "key": ".missingemptydefault", "default": ""}
             ]
         - name: ociStorage
           value: $(params.ociStorage)
@@ -146,6 +147,8 @@ spec:
           value: $(tasks.run-task.results.extractedValues[3])
         - name: defaultNumberValue
           value: $(tasks.run-task.results.extractedValues[4])
+        - name: emptyDefaultValue
+          value: $(tasks.run-task.results.extractedValues[5])
       taskSpec:
         params:
           - name: arrayValue
@@ -153,6 +156,7 @@ spec:
           - name: simpleValue
           - name: defaultStringValue
           - name: defaultNumberValue
+          - name: emptyDefaultValue
         steps:
           - name: verify-results
             image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -182,5 +186,10 @@ spec:
 
               if [ "$(params.defaultNumberValue)" != "42" ]; then
                 echo "Error: Expected index 4 to be '42', got $(params.defaultNumberValue)"
+                exit 1
+              fi
+
+              if [ "$(params.emptyDefaultValue)" != "" ]; then
+                echo "Error: Expected index 5 to be '', got $(params.emptyDefaultValue)"
                 exit 1
               fi


### PR DESCRIPTION
Some collect-*-params task return the empty string as a result. This is not currently possible with collect-task-params; it sees a default value of the empty string as it missing. This commit fixes the task to allow the empty string to be used as a default value.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
