### PR TITLE
fix: add --depth=1 to git clone in filter-already-released-advisory-images task

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -102,7 +102,7 @@ spec:
         cd /tmp
 
         echo "Cloning $GIT_REPO..."
-        git clone "$GIT_REPO" repo
+        git clone --depth=1 "$GIT_REPO" repo
         cd repo
 
         echo "Checking existing advisories in ${ADVISORY_BASE_DIR}..."


### PR DESCRIPTION
Reduces clone time and network usage
by only fetching the latest commit, which
is sufficient for advisory filtering operations

Related Slack Thread : [Link](https://redhat-internal.slack.com/archives/C031USXS2FJ/p1753795661740389)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
