### PR TITLE
fix(KFLUXSPRT-4426): fix argument too long for tasks get-advisory-severity and set-advisory-severity

### DIFF
--- a/pipelines/internal/get-advisory-severity/README.md
+++ b/pipelines/internal/get-advisory-severity/README.md
@@ -7,6 +7,6 @@ for an advisory.
 
 | Name               | Description                                                                           | Optional | Default value                                             |
 |--------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| releaseNotesImages | Json array of image specific details for the advisory                                 | No       | -                                                         |
+| releaseNotesImages | Base64 string of gzipped JSON array of image specific details for the advisory        | No       | -                                                         |
 | taskGitUrl         | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision    | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |

--- a/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -13,7 +13,7 @@ spec:
   params:
     - name: releaseNotesImages
       type: string
-      description: Json array of image specific details for the advisory
+      description: Base64 string of gzipped JSON array of image specific details for the advisory
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored

--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -7,7 +7,7 @@ impact from all of the CVEs is returned as a task result.
 
 ## Parameters
 
-| Name                           | Description                                           | Optional | Default value |
-|--------------------------------|-------------------------------------------------------|----------|---------------|
-| releaseNotesImages             | Json array of image specific details for the advisory | No       | -             |
-| internalRequestPipelineRunName | name of the PipelineRun that called this task         | No       | -             |
+| Name                           | Description                                                                    | Optional | Default value |
+|--------------------------------|--------------------------------------------------------------------------------|----------|---------------|
+| releaseNotesImages             | Base64 string of gzipped JSON array of image specific details for the advisory | No       | -             |
+| internalRequestPipelineRunName | name of the PipelineRun that called this task                                  | No       | -             |

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -15,7 +15,7 @@ spec:
   params:
     - name: releaseNotesImages
       type: string
-      description: Json array of image specific details for the advisory
+      description: Base64 string of gzipped JSON array of image specific details for the advisory
     - name: internalRequestPipelineRunName
       type: string
       description: name of the PipelineRun that called this task
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               name: osidb-service-account
               key: osidb_url
-        - name: IMAGES
+        - name: IMAGES_ENCODED
           value: $(params.releaseNotesImages)
       script: |
           #!/usr/bin/env bash
@@ -84,6 +84,9 @@ spec:
           trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
 
           echo -n "" > "$(results.severity.path)"
+
+          # Decode and decompress the releaseNotesImages data
+          IMAGES=$(echo "${IMAGES_ENCODED}" | base64 --decode | gzip -d)
 
           # write keytab to file
           set +x

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -13,7 +13,10 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"repository":"component","cves":{"fixed":{"CVE-moderate":{"components":[]}}}}]'
+          value: >-
+            H4sIAAAAAAAAA4uuVipKLcgvzizJL6pUslJKzs8tyM9LzStR0lFKLkstVrKqVkrLrEhNATGcw1x1c/NTUosSS1JBfLhioLLo2FogiOUCAAt58ApRAAAA
+          # value before before `gzip -c|base64 -w 0` encoding:
+          # [{"repository":"component","cves":{"fixed":{"CVE-moderate":{"components":[]}}}}]
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -15,7 +15,10 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"repository":"component","cves":{"fixed":{"CVE-critical":{"components":[]}}}}]'
+          value: >-
+            H4sIAAAAAAAAA4uuVipKLcgvzizJL6pUslJKzs8tyM9LzStR0lFKLkstVrKqVkrLrEhNATGcw1x1k4sySzKTE3NAfLhioLLo2FogiOUCAHCfpTtRAAAA
+          # value before before `gzip -c|base64 -w 0` encoding:
+          # [{"repository":"component","cves":{"fixed":{"CVE-critical":{"components":[]}}}}]
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -13,7 +13,10 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"repository":"component","cves":{}}]'
+          value: >-
+            H4sIAAAAAAAAA4uuVipKLcgvzizJL6pUslJKzs8tyM9LzStR0lFKLkstVrKqrq2N5QIAcDxJ7ycAAAA=
+          # value before before `gzip -c|base64 -w 0` encoding:
+          # [{"repository":"component","cves":{}}]
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -13,7 +13,11 @@ spec:
         name: get-advisory-severity
       params:
         - name: releaseNotesImages
-          value: '[{"repository":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}},{"repository":"bar","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]'
+          value: >-
+            H4sIAAAAAAAAA4uuVipKLcgvzizJL6pUslJKy89X0lFKLkstVrKqVkrLrEhNATGcw1x1k4sySzKTE3NA/OT83IL8vNS8EqCy6NhaHbCC3PyU1KLEklQsCoBAB82mpMQiGtkUywUA4JaextYAAAA=
+          # value before before `gzip -c|base64 -w 0` encoding:
+          # [{"repository":"foo","cves":{"fixed":{"CVE-critical":{"components":[]},
+          # "CVE-moderate":{"components":[]}}}},{"repository":"bar","cves":{"fixed":{"CVE-critical":{"components":[]},"CVE-moderate":{"components":[]}}}}]
         - name: internalRequestPipelineRunName
           value: $(context.pipelineRun.name)
     - name: check-result

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -170,7 +170,7 @@ spec:
             exit 0
         fi
 
-        RELEASENOTESIMAGES=$(jq -c '.releaseNotes.content.images' "${DATA_FILE}")
+        RELEASENOTESIMAGES=$(jq -c '.releaseNotes.content.images' "${DATA_FILE}" | gzip -c | base64 -w 0)
 
         IR_FILE="$(params.dataDir)/$(context.task.name)/ir-result.txt"
         mkdir -p "$(dirname "$IR_FILE")"


### PR DESCRIPTION
## Describe your changes
- fix for tasks get-advisory-severity and set-advisory-severity
- Inspiration taken from #1126

Assisted-by: Cursor

## Relevant Jira
- [KFLUXSPRT-4426](https://issues.redhat.com//browse/KFLUXSPRT-4426)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
