### PR TITLE
chore: runasuser check only if files have changed

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -147,6 +147,8 @@ jobs:
           files: |
             **/*.yaml
       - name: Run task runAsUser check script
+        if: |
+          steps.changed-files.outputs.any_changed == 'true'
         run: .github/scripts/tkn_check_task_runasuser.sh
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Describe your changes
- only run the tkn_check_task_runasuser is files have changed.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
