### PR TITLE
fix: validate pac repositories

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -619,3 +619,27 @@ patch_component_source_before_merge() {
     echo "📝 Note: Test Suite may implement ${FUNCNAME[0]}" \
      "to patch the component source BEFORE MERGE in their test.sh file"
 }
+
+# Function to validate PAC Repository CRs and their secrets
+# Relies on global variables: component_git_url, tenant_namespace, SCRIPT_DIR
+validate_pac_repository() {
+    echo "Validating PAC Repository CRs..."
+    
+    # Set environment variables for the validation script
+    export TARGET_URL="${component_git_url}"
+    export NAMESPACE="${tenant_namespace}"
+    
+    # Path to the validation script
+    local validation_script="${SCRIPT_DIR}/scripts/validate-pac-repository.sh"
+    
+    if [ ! -f "$validation_script" ]; then
+        log_error "PAC repository validation script not found at: $validation_script"
+    fi
+    
+    # Run the validation script
+    if ! bash "$validation_script"; then
+        log_error "PAC repository validation failed"
+    fi
+    
+    echo "PAC repository validation completed successfully."
+}

--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -132,6 +132,7 @@ setup_namespaces # Ensures correct context before resource creation
 cleanup_old_resources "${originating_tool}"
 create_kubernetes_resources # tmpDir is set here
 
+validate_pac_repository # Validate PAC Repository CRs and their secrets
 wait_for_component_initialization # component_pr and pr_number are set here
 patch_component_source_before_merge
 merge_github_pr # SHA is set here

--- a/integration-tests/scripts/validate-pac-repository.sh
+++ b/integration-tests/scripts/validate-pac-repository.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+#
+# validate-pac-repository.sh - Validates PAC Repository CRs and their dependencies
+#
+# This script searches for Repository CRs with a specific URL in a given namespace
+# and validates that:
+#   1. The referenced git provider secret exists and contains expected keys
+#   2. All Component ownerReferences point to existing Components
+#
+# Why do we need this?
+#
+# When a Component is onboarded, it creates a Repository CR that points to the Component's git repository.
+# The Repository CR is used to fetch the Component's source code and metadata.
+#
+# However, if the Repository CR is not properly pruned, it may cause a Component onboarding to fail if the
+# Repository points to a secret that does not exist.
+#
+# Since multiple tests may run in parallel and since Pipelines-as-code attempts to re-use Repositories for
+# a given Github Url, we need to validate that the Repository CRs have the correct
+# referenced secrets and Components.
+#
+# Environment Variables:
+#   TARGET_URL  - The repository URL to search for (required)
+#   NAMESPACE   - The Kubernetes namespace to search in (required)
+#
+# Exit Codes:
+#   0 - All validations passed
+#   1 - One or more validation errors found
+#
+
+set -euo pipefail
+
+# Check required environment variables
+if [[ -z "${TARGET_URL:-}" ]]; then
+    echo "Error: TARGET_URL environment variable is required"
+    echo "Usage: TARGET_URL='https://github.com/owner/repo' NAMESPACE='namespace' $0"
+    exit 1
+fi
+
+if [[ -z "${NAMESPACE:-}" ]]; then
+    echo "Error: NAMESPACE environment variable is required"
+    echo "Usage: TARGET_URL='https://github.com/owner/repo' NAMESPACE='namespace' $0"
+    exit 1
+fi
+
+echo "Searching for Repository CRs with URL: ${TARGET_URL} in namespace: ${NAMESPACE}"
+echo "Will validate secrets and Component ownerReferences..."
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl is not installed or not in PATH"
+    exit 1
+fi
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed or not in PATH"
+    exit 1
+fi
+
+# Check if the user has permission to access repositories
+echo "🔒 Checking permissions to access Repository CRs..."
+if ! kubectl auth can-i get repositories --all-namespaces &>/dev/null; then
+    echo "Warning: User does not have permission to list repositories cluster-wide"
+    echo "         Trying namespace-specific permissions..."
+
+    if ! kubectl auth can-i get repositories -n "$NAMESPACE" &>/dev/null; then
+        echo "Error: User does not have permission to access repositories in namespace '${NAMESPACE}'"
+        echo "       Required permissions: get repositories"
+        exit 1
+    else
+        echo "✅ User has permission to access repositories in namespace '${NAMESPACE}'"
+    fi
+else
+    echo "✅ User has permission to access repositories cluster-wide"
+fi
+
+# Check if the namespace exists
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+    echo "Error: Namespace '${NAMESPACE}' does not exist"
+    exit 1
+fi
+
+# Find Repository CRs with the target URL in the specified namespace
+repositories=$(kubectl get repositories -n "$NAMESPACE" -o json | jq -r --arg url "$TARGET_URL" '
+    .items[] | 
+    select(.spec.url == $url) | 
+    "\(.metadata.name)|\(.spec.git_provider.secret.name // "none")|\(.metadata.ownerReferences // [] | map(select(.kind == "Component") | .name) | join(","))"
+')
+
+if [[ -z "$repositories" ]]; then
+    echo "No Repository CRs found with URL: ${TARGET_URL} in namespace: ${NAMESPACE}"
+    exit 0
+fi
+
+echo ""
+echo "Found Repository CRs:"
+
+# Track validation failures
+validation_failed=false
+component_validation_failed=false
+
+# Process each found repository
+while IFS='|' read -r repo_name secret_name component_names; do
+    if [[ -z "$repo_name" ]]; then
+        continue
+    fi
+    
+    echo "• Repository: ${repo_name}"
+    echo "  Secret: ${secret_name}"
+    if [[ -n "$component_names" ]]; then
+        echo "  Referenced Components: ${component_names}"
+    else
+        echo "  Referenced Components: none"
+    fi
+    
+    # Validate that the secret exists
+    if [[ "$secret_name" == "none" || -z "$secret_name" ]]; then
+        echo "  ❌ ERROR: No secret name specified in git_provider.secret.name"
+        validation_failed=true
+        continue
+    fi
+    
+    echo "  🔍 Checking if secret '${secret_name}' exists in namespace '${NAMESPACE}'..."
+    
+    if kubectl get secret "$secret_name" -n "$NAMESPACE" &>/dev/null; then
+        echo "  ✅ SUCCESS: Secret '${secret_name}' exists in namespace '${NAMESPACE}'"
+        
+        # Optional: Check if the secret has the expected key
+        secret_keys=$(kubectl get secret "$secret_name" -n "$NAMESPACE" -o jsonpath='{.data}' | jq -r 'keys[]' 2>/dev/null || echo "")
+        if [[ -n "$secret_keys" ]]; then
+            
+            # Check for common git provider secret keys
+            if echo "$secret_keys" | grep -q "password"; then
+                echo "  ✅ Secret contains 'password' key as expected"
+            else
+                echo "  ⚠️  WARNING: Secret does not contain 'password' key"
+                # Note: Not setting validation_failed=true for missing password key as it's just a warning
+            fi
+        fi
+    else
+        echo "  ❌ ERROR: Secret '${secret_name}' does not exist in namespace '${NAMESPACE}'"
+        echo ""
+        echo "     Note: This may cause a Component onboarding to fail if a Repository points to a secret that does not exist."
+        echo "           To fix, delete the Repository CR and re-run the test."
+        validation_failed=true
+    fi
+    
+    # Validate that referenced Components exist
+    if [[ -n "$component_names" ]]; then
+        echo "  🔍 Checking if referenced Components exist in namespace '${NAMESPACE}'..."
+        IFS=',' read -ra COMPONENTS <<< "$component_names"
+        for component_name in "${COMPONENTS[@]}"; do
+            # Skip empty component names
+            if [[ -z "$component_name" ]]; then
+                continue
+            fi
+            
+            if ! kubectl get component "$component_name" -n "$NAMESPACE" &>/dev/null; then
+                echo "    ❌ ERROR: Component '${component_name}' does not exist in namespace '${NAMESPACE}'"
+                echo ""
+                echo "       Note: This may cause a Component onboarding to fail if Repositories are not properly pruned."
+                echo "             To fix, update the ownerReferences of the Repository CR to remove the Component."
+                component_validation_failed=true
+            fi
+        done
+        if [[ "$component_validation_failed" == "true" ]]; then
+            echo "  ❌ ERROR: One or more Components do not exist."
+            validation_failed=true
+        else
+            echo "  ✅ SUCCESS: All Components exist in namespace '${NAMESPACE}'"
+        fi
+    else
+        echo "  ⚠️  WARNING: No Component ownerReferences found for this Repository"
+    fi
+    
+    echo ""
+done <<< "$repositories"
+
+# Exit with appropriate code based on validation results
+if [[ "$validation_failed" == "true" ]]; then
+    echo "Validation complete with errors - some secrets or Components are missing."
+    exit 1
+else
+    echo "Validation complete - all secrets and Components exist as expected."
+    exit 0
+fi 


### PR DESCRIPTION
## Describe your changes
- Why do we need this?
  - When a Component is onboarded, it creates a Repository CR that points to the Component's git repository. The Repository CR is used to fetch the Component's source code and metadata.

  - However, if the Repository CR is not properly pruned, it may cause a Component onboarding to fail if the Repository points to a secret that does not exist.

  - Since multiple tests may run in parallel and since Pipelines-as-code attempts to re-use Repositories for a given Github Url, we need to validate that the Repository CRs have the correct referenced secrets and Components.

- Debugging a problem with a faulty Repository CR is tricky involving scouring PaC and build-service logs

Assisted-by: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
