### PR TITLE
fix: support identical containerimage sboms

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -151,6 +151,21 @@ spec:
 
         NUM_COMPONENTS=$(jq '.components | length' "${PYXIS_FILE}")
 
+        # Create a mapping of unique imageIds to their SBOM files for efficient download
+        echo "Creating unique imageId mapping for efficient SBOM download..."
+        UNIQUE_IMAGES_FILE="$(mktemp)"
+        jq '
+        # Flatten all pyxisImages from all components and group by imageId
+        [.components[] | .pyxisImages[]]
+        | group_by(.imageId) |
+        map({
+          imageId: .[0].imageId,
+          pyxisImage: .[0],
+          containerImage: .[0].containerImage,
+          # Include all instances for later processing
+          instances: .
+        })' "${PYXIS_FILE}" > "${UNIQUE_IMAGES_FILE}"
+
         SBOM_PATH="$(dirname "$(params.pyxisJsonPath)")/downloaded-sboms"
         # The dir might already exist in case of retries of the task.
         # No need for a cleanup - we will just override the files.
@@ -180,38 +195,43 @@ spec:
             fi
         }
 
-        for (( i=0; i < NUM_COMPONENTS; i++ )); do
-          COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${PYXIS_FILE}")
-          IMAGEURL=$(jq -r '.containerImage' <<< "${COMPONENT}")
-          NUM_PYXIS_IMAGES=$(jq '.pyxisImages | length' <<< "${COMPONENT}")
+        # Download SBOMs only for unique imageIds
+        UNIQUE_IMAGES_COUNT=$(jq '. | length' "${UNIQUE_IMAGES_FILE}")
+        echo "Downloading SBOMs for $UNIQUE_IMAGES_COUNT unique images..."
+
+        for (( i=0; i < UNIQUE_IMAGES_COUNT; i++ )); do
+          UNIQUE_IMAGE=$(jq -c --argjson i "$i" '.[$i]' "${UNIQUE_IMAGES_FILE}")
+          IMAGEID=$(jq -r '.imageId' <<< "${UNIQUE_IMAGE}")
+          CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "${UNIQUE_IMAGE}")
+          PYXIS_IMAGE=$(jq -c '.pyxisImage' <<< "${UNIQUE_IMAGE}")
+          
+          FILE="${IMAGEID}.json"
+          DIGEST="$(jq -r '.digest' <<< "$PYXIS_IMAGE")"
+          ARCH_DIGEST="$(jq -r '.arch_digest' <<< "$PYXIS_IMAGE")"
+          
           # cosign has very limited support for selecting the right auth entry,
           # so create a custom auth file with just one entry
-          select-oci-auth "$IMAGEURL" > "$DOCKER_CONFIG"/config.json
-          for (( j=0; j < NUM_PYXIS_IMAGES; j++ )); do
-            PYXIS_IMAGE=$(jq -c --argjson j "$j" '.pyxisImages[$j]' <<< "${COMPONENT}")
-            FILE="$(jq -r '.imageId' <<< "$PYXIS_IMAGE").json"
-            DIGEST="$(jq -r '.digest' <<< "$PYXIS_IMAGE")"
-            ARCH_DIGEST="$(jq -r '.arch_digest' <<< "$PYXIS_IMAGE")"
-            # You can't pass --platform to a single arch image or cosign errors.
-            # If digest equals arch_digest, then it's a single arch image
-            if [ "$DIGEST" = "$ARCH_DIGEST" ] ; then
-              echo "Fetching sbom for single arch image: $IMAGEURL to: $FILE"
-              run_cosign download sbom --output-file "${FILE}" "${IMAGEURL}"
-            else
-              OS=$(jq -r '.os' <<< "$PYXIS_IMAGE")
-              ARCH=$(jq -r '.arch' <<< "$PYXIS_IMAGE")
-              PLATFORM="${OS}/${ARCH}"
-              echo "Fetching sbom for image: $IMAGEURL with platform: $PLATFORM to: $FILE"
-              run_cosign download sbom --output-file "${FILE}" --platform "${PLATFORM}" "${IMAGEURL}"
-            fi
-          done
+          select-oci-auth "$CONTAINER_IMAGE" > "$DOCKER_CONFIG"/config.json
+          
+          # You can't pass --platform to a single arch image or cosign errors.
+          # If digest equals arch_digest, then it's a single arch image
+          if [ "$DIGEST" = "$ARCH_DIGEST" ] ; then
+            echo "Fetching sbom for single arch image: $CONTAINER_IMAGE to: $FILE"
+            run_cosign download sbom --output-file "${FILE}" "${CONTAINER_IMAGE}"
+          else
+            OS=$(jq -r '.os' <<< "$PYXIS_IMAGE")
+            ARCH=$(jq -r '.arch' <<< "$PYXIS_IMAGE")
+            PLATFORM="${OS}/${ARCH}"
+            echo "Fetching sbom for image: $CONTAINER_IMAGE with platform: $PLATFORM to: $FILE"
+            run_cosign download sbom --output-file "${FILE}" --platform "${PLATFORM}" "${CONTAINER_IMAGE}"
+          fi
         done
 
+        # Verify we downloaded the expected number of unique SBOMs
         sbom_files=(*.json)
         SBOM_COUNT=${#sbom_files[@]}
-        PYXIS_IMAGES=$(jq '[.components[].pyxisImages | length] | add' "${PYXIS_FILE}")
-        if [ "$SBOM_COUNT" != "$PYXIS_IMAGES" ]; then
-          echo "ERROR: Expected to fetch sbom for $PYXIS_IMAGES images, but only $SBOM_COUNT were saved"
+        if [ "$SBOM_COUNT" != "$UNIQUE_IMAGES_COUNT" ]; then
+          echo "ERROR: Expected to fetch sbom for $UNIQUE_IMAGES_COUNT unique images, but only $SBOM_COUNT were saved"
           exit 1
         fi
     - name: push-rpm-data-to-pyxis
@@ -263,17 +283,38 @@ spec:
         SBOM_PATH="$(dirname "$(params.pyxisJsonPath)")/downloaded-sboms"
         cd "$(params.dataDir)/${SBOM_PATH}"
 
+        # Create a list of all images to push to Pyxis (including duplicates)
+        echo "Creating list of all images to push to Pyxis..."
+        ALL_IMAGES_FILE="$(mktemp)"
+        jq '
+        # Flatten all pyxisImages from all components
+        [.components[] | .pyxisImages[]] |
+        map({
+          imageId: .imageId,
+          containerImage: .containerImage
+        })' "${PYXIS_FILE}" > "${ALL_IMAGES_FILE}"
+
+        TOTAL_IMAGES_TO_PUSH=$(jq '. | length' "${ALL_IMAGES_FILE}")
+        echo "Will push RPM data for $TOTAL_IMAGES_TO_PUSH total images"
+
         N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
         declare -a jobs=()
-        json_files=(*.json)
-        total=${#json_files[@]}
         count=0
         success=true
-        echo "Starting RPM data upload for $total files in total. " \
-          "Up to $N files will be uploaded at once..."
+        echo "Starting RPM data upload for $TOTAL_IMAGES_TO_PUSH images in total. " \
+          "Up to $N images will be uploaded at once..."
 
-        for FILE in *.json; do
-          IMAGEID=$(echo "$FILE" | cut -d '.' -f 1)
+        for (( i=0; i < TOTAL_IMAGES_TO_PUSH; i++ )); do
+          IMAGE_DATA=$(jq -c --argjson i "$i" '.[$i]' "${ALL_IMAGES_FILE}")
+          IMAGEID=$(jq -r '.imageId' <<< "$IMAGE_DATA")
+          CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "$IMAGE_DATA")
+
+          # Find the corresponding SBOM file
+          SBOM_FILE="${IMAGEID}.json"
+          if [ ! -f "$SBOM_FILE" ]; then
+            echo "ERROR: SBOM file $SBOM_FILE not found for image $IMAGEID"
+            exit 1
+          fi
 
           # Extract the format information using jq
           UPLOAD_SCRIPT=$(
@@ -284,23 +325,23 @@ spec:
                 "upload_rpm_data"
               else
                 empty
-              end end' "$FILE"
+              end end' "$SBOM_FILE"
           )
 
           # If UPLOAD_SCRIPT is empty, it's not a valid SBOM (CycloneDX or SPDX)
           if [ -z "$UPLOAD_SCRIPT" ]; then
-            echo "Error: ${FILE}: not a valid SBOM (CycloneDX or SPDX)"
+            echo "Error: ${SBOM_FILE}: not a valid SBOM (CycloneDX or SPDX)"
             exit 1
           fi
 
-          echo Uploading RPM data to Pyxis for IMAGE: "$IMAGEID" with SBOM: "$FILE using script: $UPLOAD_SCRIPT"
-          $UPLOAD_SCRIPT --retry --image-id "$IMAGEID" --sbom-path "$FILE" --verbose > "${IMAGEID}.out" 2>&1 &
+          echo "Uploading RPM data to Pyxis for IMAGE: $IMAGEID with SBOM: $SBOM_FILE using script: $UPLOAD_SCRIPT"
+          $UPLOAD_SCRIPT --retry --image-id "$IMAGEID" --sbom-path "$SBOM_FILE" --verbose > "${IMAGEID}.out" 2>&1 &
 
           jobs+=($!)  # Save the background process ID
           images+=("$IMAGEID")
           ((++count))
 
-          if [ $((count%N)) -eq 0 ] || [ $((count)) -eq "$total" ]; then
+          if [ $((count%N)) -eq 0 ] || [ $((count)) -eq "$TOTAL_IMAGES_TO_PUSH" ]; then
             echo Waiting for the current batch of background processes to finish
             for job_id in "${!jobs[@]}"; do
               if ! wait "${jobs[job_id]}"; then

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-push-rpm-data-to-pyxis-deduplication
+spec:
+  taskRef:
+    name: push-rpm-data-to-pyxis
+  params:
+    - name: pyxisJsonPath
+      value: "test-data/pyxis-data.json"
+    - name: pyxisSecret
+      value: "test-pyxis-secret"
+    - name: server
+      value: "stage"
+    - name: concurrentLimit
+      value: "2"
+    - name: taskGitUrl
+      value: "https://github.com/konflux-ci/release-service-catalog"
+    - name: taskGitRevision
+      value: "main"
+  workspaces:
+    - name: data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  timeout: 10m 

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-unique-filenames.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-unique-filenames.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: test-push-rpm-data-to-pyxis-unique-filenames
+spec:
+  taskRef:
+    name: push-rpm-data-to-pyxis
+  params:
+    - name: pyxisJsonPath
+      value: "test-data/pyxis-data.json"
+    - name: pyxisSecret
+      value: "test-pyxis-secret"
+    - name: server
+      value: "stage"
+    - name: concurrentLimit
+      value: "2"
+    - name: taskGitUrl
+      value: "https://github.com/konflux-ci/release-service-catalog"
+    - name: taskGitRevision
+      value: "main"
+  workspaces:
+    - name: data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  timeout: 10m 


### PR DESCRIPTION
When there are multiple components that have the same image in the Snapshot, we do not need to download every SBOM. We can instead download each SBOM once and then upload them multiple times.

This fixes an issue where the push-rpm-data-to-pyxis task incorrectly reported that it didn't download all SBOMs if components had the same images.

Assisted-by: Cursor
Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
