### PR TITLE
fix(RELEASE-1769): multi-components using always the same base image (#1253)

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -238,6 +238,7 @@ spec:
         for((i=0; i<LENGTH; i++)); do
           ocp_version=$(jq -cr --argjson i "$i" '.components[$i].ocpVersion' "${SNAPSHOT_PATH}")
           fbc_fragment=$(jq -cr --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
+          from_index=$(jq -cr --argjson i "$i" '.components[$i].updatedFromIndex' "${SNAPSHOT_PATH}")
 
           # the target_index is modified when the pipelinerun is a for `hotfix` or a `pre-GA` release
           target_index=$(jq -cr --argjson i "$i" '.components[$i].updatedTargetIndex' "${SNAPSHOT_PATH}")
@@ -267,7 +268,7 @@ spec:
           # If it fails (Failed, Rejected or Timed out) the script will exit and display the reason.
           echo "Creating InternalRequest to add FBC contribution to index image:"
           internal-request --pipeline "update-fbc-catalog" \
-              -p fromIndex="$(params.fromIndex)" \
+              -p fromIndex="${from_index}" \
               -p targetIndex="${target_index}" \
               -p fbcFragment="${fbc_fragment}" \
               -p iibServiceAccountSecret="${iib_service_account_secret}" \

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -66,6 +66,7 @@ spec:
                 "components": [
                   {
                     "name": "comp0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-hotfix.yaml
@@ -70,6 +70,7 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
                     "ocpVersion": "v4.12"
                   },
@@ -77,6 +78,7 @@ spec:
                     "name": "comp1",
                     "containerImage": "registry.io/image1@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components-same-ver.yaml
@@ -70,6 +70,7 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   },
@@ -77,6 +78,7 @@ spec:
                     "name": "comp1",
                     "containerImage": "registry.io/image1@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   },
@@ -84,6 +86,7 @@ spec:
                     "name": "comp2",
                     "containerImage": "registry.io/image2@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multiple-components.yaml
@@ -69,6 +69,7 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
                     "ocpVersion": "v4.12"
                   },
@@ -76,6 +77,7 @@ spec:
                     "name": "comp1",
                     "containerImage": "registry.io/image1@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-pre-ga.yaml
@@ -69,6 +69,7 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.13",
                     "ocpVersion": "v4.13"
                   }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -68,6 +68,7 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
+                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
                     "updatedTargetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
                     "ocpVersion": "v4.12"
                   }


### PR DESCRIPTION

HOTFIX

this PR fixes the case when the from_index is passed with the incorrect value instead of the one discovered by the prepare-fbc-release task.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
