### PR TITLE
feat(RELEASE-1759): add copyAttachedArtifacts parameter to push-snapshot task

### DIFF
--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -331,6 +331,8 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
+        - name: copyAttachedArtifacts
+          value: "true"
       runAfter:
         - verify-conforma
     - name: collect-registry-token-secret

--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -21,3 +21,4 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
+| copyAttachedArtifacts   | Enable copying of attached artifacts                                                                                       | Yes      | false                |

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -66,6 +66,10 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: copyAttachedArtifacts
+      type: string
+      description: Enable copying of attached artifacts
+      default: "false"
   results:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
@@ -157,9 +161,50 @@ spec:
             # shellcheck disable=SC2128
             jq -s 'reduce .[] as $item ({}; . * $item)' \
               "$SOURCE_AUTH_FILE" "$DEST_AUTH_FILE" > "$DOCKER_CONFIG"/config.json
+            
+            # Check if we should copy attached artifacts
+            if [[ "$COPY_ATTACHED_ARTIFACTS" == "true" ]]; then
+              # Check for any attached artifacts using oras discover, with retries on failure
+              printf '* Checking for attached artifacts on %s\n' "$3"
+              artifact_count="0"
+              discover_attempt=0
+              discover_succeeded=false
+              until [ "$discover_attempt" -gt "$(params.retries)" ]; do # same retry style as copy loop
+                if oras discover \
+                  --registry-config "$SOURCE_AUTH_FILE" \
+                  "$3" \
+                  --format json \
+                  >/tmp/artifacts.json
+                then
+                  artifact_count=$(jq -r '.manifests | length' /tmp/artifacts.json || echo "0")
+                  echo "Found $artifact_count artifacts"
+                  discover_succeeded=true
+                  break
+                else
+                  rc=$?
+                  echo "oras discover failed (attempt $((discover_attempt+1))) with exit code $rc"
+                  discover_attempt=$((discover_attempt+1))
+                fi
+              done
+              if [ "$discover_succeeded" != true ]; then
+                echo "Max retries exceeded. Proceeding without attached artifacts (falling back to cosign copy)."
+              fi
+            fi
+            
             attempt=0
             until [ "$attempt" -gt "$(params.retries)" ] ; do # 0 retries by default which will execute this once
-              cosign copy -f "$3" "$4:$5" && break
+              if [[ "$COPY_ATTACHED_ARTIFACTS" == "true" && "${artifact_count}" -gt 0 ]]; then
+                # Copy the image and all attached artifacts
+                oras cp -r \
+                  --registry-config "$DOCKER_CONFIG/config.json" \
+                  "${oras_args[@]}" \
+                  "$3" \
+                  "$4:$5" \
+                  && break
+              else
+                # Fallback to classic image copy
+                cosign copy -f "$3" "$4:$5" && break
+              fi
               attempt=$((attempt+1))
             done
             if [ "$attempt" -gt "$(params.retries)" ] ; then
@@ -215,6 +260,7 @@ spec:
         TMP_RESULTS_DIR=$(mktemp -d)
 
         defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' "$DATA_FILE")
+        COPY_ATTACHED_ARTIFACTS="$(params.copyAttachedArtifacts)"
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-copy-artifacts
+spec:
+  description: |
+    Run the push-snapshot task with copyAttachedArtifacts enabled to test artifact copying functionality.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "reg.io/test@sha256:abcdefg",
+                    "repository": "registry.com/repository",
+                    "tags": [ "tag1", "tag2" ]
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "reg.io/test@sha256:hijklmn",
+                    "repository": "registry.com/repository",
+                    "tags": [ "tag3" ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": false
+                  },
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repository": "registry.com/repository"
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "registry.com/repository"
+                    }
+                  ]
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: "0"
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: copyAttachedArtifacts
+          value: "true"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: ociStorage
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              # Verify oras discover was called on both source images
+              grep 'discover --registry-config .* reg.io/test@sha256:abcdefg --format json' \
+                "$(params.dataDir)/mock_oras.txt"
+              grep 'discover --registry-config .* reg.io/test@sha256:hijklmn --format json' \
+                "$(params.dataDir)/mock_oras.txt"
+              # Since mock returns 1 artifact for sha256:abcdefg, task should use oras cp -r for its tags
+              grep -E \
+                'cp -r( --registry-config [^ ]+)?( --platform [^ ]+)? reg.io/test@sha256:abcdefg' \
+                "$(params.dataDir)/mock_oras.txt"
+              # For hijklmn (no artifacts), it should fall back to cosign copy
+              # Count cosign copy calls (tag1, tag2, tag3)
+              COPIES=$(grep -c \
+                '^copy -f reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
+                "$(params.dataDir)/mock_cosign.txt" || true)
+              COPIES2=$(grep -c \
+                '^copy -f reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
+                "$(params.dataDir)/mock_cosign.txt" || true)
+              TOTAL=$((COPIES + COPIES2))
+              # We expect 1 cosign copy (tag3) and 0 for tag1/tag2 (handled by oras cp -r)
+              test "$TOTAL" -eq 1 || {
+                echo "Unexpected cosign copies: $TOTAL (expected 1 for tag3 only)"
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              }
+      runAfter:
+        - run-task


### PR DESCRIPTION

- Add new parameter to control copying of attached artifacts like migration scripts
- Use oras discover to detect artifacts and oras cp -r for recursive copying
- Fall back to cosign copy when no artifacts are found
- Add comprehensive test coverage for artifact copying functionality

This enables copying migration scripts attached
to task bundles from build repo to release repo
during the release process, supporting
decentralization of build-definitions tasks.

Fixes: [RELEASE-1759](https://issues.redhat.com//browse/RELEASE-1759)
Related: KONFLUX-2735, [STONEBLD-3642](https://issues.redhat.com//browse/STONEBLD-3642)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
