### PR TITLE
fix: add params to push-oot-kmods pipeline

### DIFF
--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -401,12 +401,18 @@ spec:
           - name: pathInRepo
             value: tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
       params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
         - name: signedKmodsPath
           value: $(tasks.collect-task-params.results.extractedValues[7])
         - name: kerberosRealm
           value: IPA.REDHAT.COM
         - name: signingAuthor
           value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: checksumFingerprint
+          value: $(tasks.collect-task-params.results.extractedValues[4])
+        - name: checksumKeytab
+          value: $(tasks.collect-task-params.results.extractedValues[5])
         - name: signing-secret
           value: $(tasks.collect-task-params.results.extractedValues[2])
         - name: sourceDataArtifact


### PR DESCRIPTION
Some params needed by the sign-oot-task are
missing, so pipeline fails when run.
Added: dataPath,checksumFingerprint and checksumKeytab



## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
