### PR TITLE
fix(RELEASE-1785): user sparse checkout in filter task

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -102,8 +102,11 @@ spec:
         cd /tmp
 
         echo "Cloning $GIT_REPO..."
-        git clone --depth=1 "$GIT_REPO" repo
+        # Use sparse checkout to only get the advisory directory
+        git clone --depth=1 --filter=blob:none --no-checkout "$GIT_REPO" repo
         cd repo
+        git sparse-checkout set "$ADVISORY_BASE_DIR"
+        git checkout
 
         echo "Checking existing advisories in ${ADVISORY_BASE_DIR}..."
         EXISTING_ADVISORIES=""

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
@@ -5,15 +5,15 @@ set -eux
 function git() {
   echo "Mock git called with: $*"
 
-  if [[ "$*" == *"clone"* ]]; then
-    gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
-    mkdir -p "$gitRepo"/schema
-    echo '{"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {}}' > "$gitRepo"/schema/advisory.json
-    mkdir -p "$gitRepo"/data/advisories/test-origin
-  elif [[ "$*" == *"failing-origin"* ]]; then
-    echo "Mocking failing git command" && false
+  if [[ "$1" == "clone" ]]; then
+    mkdir -p "$6"
+  elif [[ "$1" == "sparse-checkout" ]]; then
+    : # no-op
+  elif [[ "$1" == "checkout" ]]; then
+    mkdir -p data/advisories/test-origin
   else
-    : # no-op for other git commands
+    echo "Error: Unexpected git command: $*" >&2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
## Describe your changes

We started seeing issues when cloning the advisory repo in the filter internal task. The task would get stuck sometimes and eventually finish in ~40 minutes.
Based on my experiments, the memory should be sufficient. So it's more likely about disk IO.

Currently, cloning the full stage advisory repo generates about 17k files. With this change, it's drastically reduced depending on which tenant directory we need. For dev-release-team-tenant, it went down to 312 files.

Disk size of the cloned repo went down from 138Mi to 6Mi.

Note that we have the same potential issue in create-advisory-task internal task. That task uses a utils function for the clone and it's also pushing a commit back to gitlab, so it will be more complex and require more testing. My intention is to create a second PR for that later. Let me know if you'd prefer to have both changes in one PR.

Also, I am aware it's not ideal this isn't really covered with unit tests, but I'm not sure how I would do that - we probably don't want to pull a real git repo in our tests.

## Relevant Jira

[RELEASE-1785](https://issues.redhat.com//browse/RELEASE-1785)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
