### PR TITLE
fix: correct parameters in push-oot-kmods

### DIFF
--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -370,8 +370,6 @@ spec:
           value: $(tasks.collect-task-params.results.extractedValues[7])
         - name: snapshot
           value: $(params.snapshot)
-        - name: remoteRegistry
-          value: ""
         - name: sourceDataArtifact
           value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: ociStorage
@@ -452,6 +450,8 @@ spec:
           value: $(tasks.collect-task-params.results.extractedValues[9])
         - name: artifactBranch
           value: $(tasks.collect-task-params.results.extractedValues[10])
+        - name: artifactRepoToken
+          value: $(tasks.collect-task-params.results.extractedValues[11])
         - name: sourceDataArtifact
           value: "$(tasks.sign-oot-kmods.results.sourceDataArtifact)"
         - name: ociStorage


### PR DESCRIPTION
Running tektor showed some more incosistencies in params:
```
Processing pipeline task 10: push-oot-kmods
Error: 2 errors occurred:
	* ERROR: extract-oot-kmods PipelineTask: 1 error occurred:
	* "remoteRegistry" parameter is not defined by the Task


	* ERROR: push-oot-kmods PipelineTask: 1 error occurred:
	* "artifactRepoToken" parameter is required
```
Thanks @scoheb 



