### PR TITLE
fix: remove deprecated service-account usage

### DIFF
--- a/integration-tests/collectors/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/collectors/resources/tenant/sa-rolebinding.yaml
@@ -15,8 +15,5 @@ subjects:
     name: ${managed_sa_name}
     namespace: ${managed_namespace}
   - kind: ServiceAccount
-    name: appstudio-pipeline
-    namespace: ${tenant_namespace}
-  - kind: ServiceAccount
     name: ${tenant_sa_name}
     namespace: ${tenant_namespace}

--- a/integration-tests/fbc-release/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/fbc-release/resources/tenant/sa-rolebinding.yaml
@@ -15,8 +15,5 @@ subjects:
     name: ${managed_sa_name}
     namespace: ${managed_namespace}
   - kind: ServiceAccount
-    name: appstudio-pipeline
-    namespace: ${tenant_namespace}
-  - kind: ServiceAccount
     name: ${tenant_sa_name}
     namespace: ${tenant_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/tenant/sa-rolebinding.yaml
@@ -14,6 +14,3 @@ subjects:
   - kind: ServiceAccount
     name: ${managed_sa_name}
     namespace: ${managed_namespace}
-  - kind: ServiceAccount
-    name: appstudio-pipeline
-    namespace: ${tenant_namespace}


### PR DESCRIPTION
## Describe your changes
- remove the use of the appstudio-pipeline service account as per introduction of KONFLUX-5207.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
