### PR TITLE
feat(RELEASE-1785): use sparse checkout in create-advisory-task

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+      image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
       computeResources:
         limits:
           memory: 256Mi
@@ -139,6 +139,7 @@ spec:
           REPO_BRANCH=main
           ADVISORY_URL=""
           ADVISORY_INTERNAL_URL=""
+          ADVISORY_BASE_DIR="data/advisories/$(params.origin)"
           if [[ "${GIT_REPO}" == *"/rhtap-release/"* ]]; then
             ADVISORY_URL_PREFIX="https://access.stage.redhat.com/errata"
           else
@@ -157,7 +158,8 @@ spec:
           git_functions_init
 
           # This also cds into the git repo
-          git_clone_and_checkout --repository "$GIT_REPO" --revision "$REPO_BRANCH"
+          git_clone_and_checkout --repository "$GIT_REPO" --revision "$REPO_BRANCH" \
+            --sparse-dir "$ADVISORY_BASE_DIR" --sparse-dir schema
 
           if [ "$(params.contentType)" = "image" ]; then
             echo "Content type is image."
@@ -179,7 +181,6 @@ spec:
           SHIP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           YEAR=${SHIP_DATE%%-*} # derive the year from the ship date
           # Define advisory directory
-          ADVISORY_BASE_DIR="data/advisories/$(params.origin)"
           echo "Checking advisories in directory: ${ADVISORY_BASE_DIR}"
 
           # Check existing advisories across ALL years

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -5,7 +5,7 @@ set -eux
 function git() {
   echo "Mock git called with: $*"
 
-  if [[ "$*" == *"clone"* ]]; then
+  if [[ "$1" == "clone" ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     mkdir -p "$gitRepo"/schema
     echo '{"$schema": "http://json-schema.org/draft-07/schema#","type": "object", "properties":{}}' > "$gitRepo"/schema/advisory.json
@@ -19,7 +19,8 @@ function git() {
     touch -d "@1712012344" "$gitRepo"/data/advisories/dev-tenant/2024/1452
     touch -d "@1708012343" "$gitRepo"/data/advisories/dev-tenant/2025/1602
     touch -d "@1704012342" "$gitRepo"/data/advisories/dev-tenant/2024/1442
-
+  elif [[ "$1" == "sparse-checkout" ]]; then
+    : # no-op
   elif [[ "$*" == *"failing-tenant"* ]]; then
     echo "Mocking failing git command" && false
   else

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-create-advisory-stage
 spec:
   description: |
-    Run the create-advisory task and check that the advisory URL is pointing to the staging Errata 
+    Run the create-advisory task and check that the advisory URL is pointing to the staging Errata
     when the Git org is 'rhtap-release'. The result should be emitted as a task result.
   tasks:
     - name: run-task
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7addbf5630418cea87bf66df33a05fdd57e43728
+            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

As the advisories repo grows bigger we started seeing performance issues when cloning the repo.

New version of the git_clone_and_checkout function in the utils image supports sparse-checkout. This will make it much faster and use less resources.

This relies on https://github.com/konflux-ci/release-service-utils/pull/491

A similar change was done previously for the filter task: https://github.com/konflux-ci/release-service-catalog/pull/1287

## Relevant Jira

[RELEASE-1785](https://issues.redhat.com//browse/RELEASE-1785)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
