### PR TITLE
fix(RELEASE-1766): revise filter task advisory matching

### DIFF
--- a/pipelines/internal/filter-already-released-advisory-images/README.md
+++ b/pipelines/internal/filter-already-released-advisory-images/README.md
@@ -6,7 +6,7 @@ This pipeline filters out images from a snapshot that have already been publishe
 
 | Name                 | Description                                                                                       | Optional | Default value                                             |
 |----------------------|---------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| snapshot             | Base64 string of gzipped JSON representation of the snapshot spec                                 | No       | -                                                         |
+| transformedSnapshot  | Base64 string of gzipped JSON representation of architecture-specific images from snapshot        | No       | -                                                         |
 | origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path | No       | -                                                         |
 | advisory_secret_name | The name of the secret that contains the advisory creation metadata                               | No       | -                                                         |
 | taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored             | Yes      | https://github.com/konflux-ci/release-service-catalog.git |

--- a/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -10,9 +10,9 @@ spec:
   description: |-
     This pipeline filters out images from a snapshot that have already been published in advisories.  
   params:
-    - name: snapshot
+    - name: transformedSnapshot
       type: string
-      description: Base64 string of gzipped JSON representation of the snapshot spec
+      description: Base64 string of gzipped JSON representation of architecture-specific images from snapshot
     - name: origin
       type: string
       description: |
@@ -40,8 +40,8 @@ spec:
           - name: pathInRepo
             value: tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
       params:
-        - name: snapshot
-          value: $(params.snapshot)
+        - name: transformedSnapshot
+          value: $(params.transformedSnapshot)
         - name: origin
           value: $(params.origin)
         - name: advisory_secret_name

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -6,9 +6,9 @@ that still need to be released (i.e., not found in any advisory).
 
 ## Parameters
 
-| Name                           | Description                                                       | Optional | Default value |
-|--------------------------------|-------------------------------------------------------------------|----------|---------------|
-| snapshot                       | Base64 string of gzipped JSON representation of the snapshot spec | No       | -             |
-| origin                         | The origin workspace for the release CR                           | No       | -             |
-| advisory_secret_name           | Name of the secret containing advisory metadata                   | No       | -             |
-| internalRequestPipelineRunName | Name of the PipelineRun that requested this task                  | No       | -             |
+| Name                           | Description                                                                                | Optional | Default value |
+|--------------------------------|--------------------------------------------------------------------------------------------|----------|---------------|
+| transformedSnapshot            | Base64 string of gzipped JSON representation of architecture-specific images from snapshot | No       | -             |
+| origin                         | The origin workspace for the release CR                                                    | No       | -             |
+| advisory_secret_name           | Name of the secret containing advisory metadata                                            | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that requested this task                                           | No       | -             |

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -12,9 +12,9 @@ spec:
     stored in the GitLab advisory repo. Returns a list of component names
     that still need to be released (i.e., not found in any advisory).
   params:
-    - name: snapshot
+    - name: transformedSnapshot
       type: string
-      description: Base64 string of gzipped JSON representation of the snapshot spec
+      description: Base64 string of gzipped JSON representation of architecture-specific images from snapshot
     - name: origin
       description: The origin workspace for the release CR
       type: string
@@ -68,8 +68,8 @@ spec:
             secretKeyRef:
               name: $(params.advisory_secret_name)
               key: git_author_email
-        - name: SNAPSHOT
-          value: "$(params.snapshot)"
+        - name: TRANSFORMED_SNAPSHOT
+          value: "$(params.transformedSnapshot)"
       script: |
         #!/usr/bin/env bash
         set -eo pipefail
@@ -92,9 +92,9 @@ spec:
         }
         trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
 
-        SNAPSHOT_JSON=$(base64 -d <<< "$SNAPSHOT" | gunzip)
+        TRANSFORMED_SNAPSHOT_JSON=$(base64 -d <<< "$TRANSFORMED_SNAPSHOT" | gunzip)
 
-        echo "Snapshot JSON: $SNAPSHOT_JSON"
+        echo "Transformed Snapshot JSON (arch-specific): $TRANSFORMED_SNAPSHOT_JSON"
 
         ORIGIN="$(params.origin)"
         ADVISORY_BASE_DIR="data/advisories/${ORIGIN}"
@@ -117,24 +117,29 @@ spec:
           )
         fi
 
-        CONTENT_IMAGES=$(jq -c '.components' <<< "$SNAPSHOT_JSON")
-
         if [[ -z "$EXISTING_ADVISORIES" ]]; then
           echo "No existing advisories found. No components have been released yet."
-          UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES" | gzip -c | base64 -w 0)
+          # Extract unique original component names from transformed snapshot
+          UNRELEASED_COMPONENTS=$(echo "$TRANSFORMED_SNAPSHOT_JSON" \
+            | jq -c '[.[].originalComponent] | unique' \
+            | gzip -c \
+            | base64 -w 0)
           echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
           echo -n "Success" > "$(results.result.path)"
           exit 0
         fi
 
         EXISTING_CONTENT=/tmp/existing_content.json
+        # Use a mutable working set for progressive filtering across advisories
+        ARCH_IMAGES="$TRANSFORMED_SNAPSHOT_JSON"
         for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
           ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
           yq -o=json '.spec.content.images // []' "$ADVISORY_FILE" > "$EXISTING_CONTENT"
 
           echo "Comparing against: $ADVISORY_FILE"
 
-          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --slurpfile existing "$EXISTING_CONTENT" '
+          # Filter arch-specific images using original triple-match logic
+          ARCH_IMAGES=$(echo "$ARCH_IMAGES" | jq --slurpfile existing "$EXISTING_CONTENT" '
             map(select(
               .containerImage as $ci |
               .tags as $tags |
@@ -144,21 +149,22 @@ spec:
               )) | length == 0)
             ))')
 
-          # If after filtering, no images are left, then we can exit early
-          if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
-            echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
+          # If no arch images remain, all components are released
+          if jq -e 'length == 0' <<< "$ARCH_IMAGES" >/dev/null; then
+            echo "All arch images in the snapshot have already been released in advisories. Stopping pipeline."
             echo -n "[]" | gzip -c | base64 -w 0 > "$(results.unreleased_components.path)"
             echo -n "Success" > "$(results.result.path)"
             exit 0
           fi
         done
 
-        ORIGINAL_COUNT=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
-        NEW_COUNT=$(jq 'length' <<< "$CONTENT_IMAGES")
-        echo "Filtered out $((ORIGINAL_COUNT - NEW_COUNT)) image(s) already in advisories"
-        echo "Remaining unpublished images: $CONTENT_IMAGES"
+        # Extract unique original component names from remaining arch images (Martin's approach)
+        ORIGINAL_ARCH_COUNT=$(echo "$TRANSFORMED_SNAPSHOT_JSON" | jq 'length')
+        REMAINING_ARCH_COUNT=$(echo "$ARCH_IMAGES" | jq 'length')
+        echo "Filtered out $((ORIGINAL_ARCH_COUNT - REMAINING_ARCH_COUNT)) arch-specific image(s) already in advisories"
+        echo "Remaining unpublished arch images: $ARCH_IMAGES"
 
-        # Output the list of component names that still need to be released
-        UNRELEASED_COMPONENTS=$(jq -c '[.[].name]' <<< "$CONTENT_IMAGES" | gzip -c | base64 -w 0)
+        # Map back to original components and get unique names (Martin's approach)
+        UNRELEASED_COMPONENTS=$(echo "$ARCH_IMAGES" | jq -c '[.[].originalComponent] | unique' | gzip -c | base64 -w 0)
         echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
         echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
@@ -52,7 +52,12 @@ function yq() {
   if [[ "$2" == ".spec.content.images // []" ]]; then
     case "$advisory_num" in
       1601)
-        echo '[{"containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]'
+        # Include entries that match our get-image-architectures mock digests
+        echo '[
+          {"containerImage":"registry.redhat.io/test@sha256:releasedarch123","tags":["v1.0"],"repository":"registry.redhat.io/test"},
+          {"containerImage":"registry.redhat.io/test@sha256:amd64digest123","tags":["v1.0"],"repository":"registry.redhat.io/test"},
+          {"containerImage":"registry.redhat.io/test@sha256:arm64digest456","tags":["v1.0"],"repository":"registry.redhat.io/test"}
+        ]'
         ;;
       1602)
         echo '[{"containerImage":"quay.io/test/other-image:1.0.0","tags":["stable"],"repository":"quay.io/test"}]'

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images-multi-arch
+spec:
+  description: |
+    Test the filter-already-released-advisory-images-task with a multi-arch Image Index.
+    Verify that the task resolves Image Index to architecture-specific digests and 
+    correctly filters out components that are already in advisories.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: snapshot
+          # Snapshot with multi-arch image before `gzip -c|base64 -w 0` encoding:
+          # '{"components":[{"name":"multi-arch-component","version":"1.0.0","containerImage":"quay.io/test/multi-arch-image@sha256:indexdigest789","tags":["v1.0"],"repository":"quay.io/test","rh-registry-repo":"registry.redhat.io/test"}]}'
+          value: 'H4sIABaakWgAA13NzQ6CMAzA8buP0TMMNPGLk1efwXBYoNmauA27QiSEd3c7SIzHtb/+t0AX3BA8eonQPBbw2iE04ManUKm5s+UGoIAJOVLwCexVreo06YIXTR757rTJl69Rz4pCJRil+slQ3t+i1YfjqSHf47snk8z5ck0Z0Sb/D1PqQlsA4xAiSeD5L5ks25LRUBSey+yS+L4VY2+1bHht190HL/cbTeMAAAA='
+        - name: transformedSnapshot
+          # Transformed snapshot with multi-arch component resolved to
+          # arch-specific images before `gzip -c|base64 -w 0` encoding:
+          # '[
+          #   {"name":"multi-arch-component","containerImage":"registry.redhat.io/test@sha256:amd64digest123",
+          #    "tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test",
+          #    "originalComponent":"multi-arch-component","architecture":"amd64"},
+          #   {"name":"multi-arch-component","containerImage":"registry.redhat.io/test@sha256:arm64digest456",
+          #    "tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test",
+          #    "originalComponent":"multi-arch-component","architecture":"arm64"}
+          # ]'
+          value: 'H4sIAA1tk2gAA81Quw6CQBDs/YytORQECioTK7+BUGzgcmzC3Zm9xYQY/l3OBDusLGznlZlpnuDQaqjBTqOQQu4G1Xl79047gQQ67wTJab5ZNFHH2lAQnlPW/YCSkj+KDnIJA+ZlVaPtq6Ins0JZfl4DBE2AuoFHlp6gTVb/3QcSz/N+2GrjQW2kipavYs9kyOF4/RTf3RMBEt3JxHHNuy4syc9vYLvdUJTV/98Q68LSHl78/+B/EAIAAA=='
+        - name: origin
+          value: "test-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+        - name: unreleased_components
+          value: "$(tasks.run-filter-task.results.unreleased_components)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: unreleased_components
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating multi-arch filter task result..."
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo "Task result was not Success: $(params.result)"
+                exit 1
+              fi
+
+              # The multi-arch component should be filtered out (matches advisory),
+              # expect zero unreleased components since both resolved arch digests match advisory
+              UNRELEASED_COMPONENTS=$(base64 -d <<< "$(params.unreleased_components)" | gunzip)
+              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED_COMPONENTS")
+              if [[ "$UNRELEASED_COUNT" -ne 0 ]]; then
+                echo "Expected 0 unreleased components, but found $UNRELEASED_COUNT"
+                echo "Components: $UNRELEASED_COMPONENTS"
+                exit 1
+              fi
+
+              echo "Multi-arch filtering validation successful!"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -6,16 +6,17 @@ metadata:
 spec:
   description: |
     Test the filter-already-released-advisory-images-task by providing a snapshot with
-    both released and new images. Expect only the new image after filtering.
+    both released and new images. The released component should be filtered out (matches advisory),
+    leaving only the new component.
   tasks:
     - name: run-filter-task
       taskRef:
         name: filter-already-released-advisory-images-task
       params:
-        - name: snapshot
-          # Snapshot string before `gzip -c|base64 -w 0` encoding:
-          # '{"components":[{"name":"released-component","version":"1.0.0","containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"},{"name":"new-component","version":"1.0.0","containerImage":"quay.io/test/new-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
-          value: 'H4sIAMbtXGgAA6WOMQ7CMAxFd47hOaRlzQ04A+pgFauyROySmKKq6t2bDGRghPU//f/fBqPGWYXEMoTbBoKRIECiB2Gm+7lhcLBQyqxS8MX3vi/JqGLIQukacaq95wtXz9oZZevaCFcaPiXDqX7BUgIYXPmaNbNpWr8GYHdNSOj9l0vt/6wx7KcDhTKALSkBAAA='
+        - name: transformedSnapshot
+          # Transformed snapshot with arch-specific images before `gzip -c|base64 -w 0` encoding:
+          # '[{"name":"released-component","containerImage":"registry.redhat.io/test@sha256:releasedarch123","tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test","originalComponent":"released-component","architecture":"amd64"},{"name":"new-component","containerImage":"registry.redhat.io/test@sha256:newarch456","tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test","originalComponent":"new-component","architecture":"amd64"}]'
+          value: 'H4sICAA5o2gAA2NvcnJlY3RfZGF0YS5qc29uAMWQsQ6CQAyGdx+jM6AgMDCZOPkMhKE5muMSuDO9qiHGd5eLgcGIi4Nz//9rv9Z3sDgQVMDUE3pqY+WGs7NkBSJQzgoaS3waUL9S2njhMWFqO5TEuK2Ql4PvMCvKaoYgqy7N9hNBUHuoarimyQ6aaAKcnTfieFynTTXu4nkYh8rXsGOjjcX+uFy+ohPOMkJKLhxkcGjLHB7R8gNLt5/0p35YkRflH83fJT5LN5snGb4uPvsBAAA='
         - name: origin
           value: "test-origin"
         - name: advisory_secret_name

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -12,10 +12,10 @@ spec:
       taskRef:
         name: filter-already-released-advisory-images-task
       params:
-        - name: snapshot
-          # Snapshot string before `gzip -c|base64 -w 0` encoding:
-          # '{"components":[{"name":"test-component","version":"1.0.0","containerImage":"quay.io/test/image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
-          value: 'H4sIAFfuXGgAA12MMQ6DMBAE+zxjazCk9Q94Q0RxQid0he+IfUFCiL/HLkKRdmZnTyyWNlNWL4ivE0qJEeFcvL8VOuyci5hW9QxjGCtZTJ1EOU+J1ta8P3QEsaG1gzQYf1untd1jrwBzh8ybFXHLx1+Ha74eXyHcxUaVAAAA'
+        - name: transformedSnapshot
+          # Transformed snapshot with arch-specific image before `gzip -c|base64 -w 0` encoding:
+          # '[{"name":"test-component","containerImage":"registry.redhat.io/test@sha256:testarch789","tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test","originalComponent":"test-component","architecture":"amd64"}]'
+          value: 'H4sIAC5tk2gAA32PzQrCMBCE7z7Gntv6g1bNSfDkM5QelnRJAiZbNqtQxHe3OehJvQ3MfMNM94CEkcCAUtbachw5UVKowHJSDInkEtGVhJALWWVqhAaP2gReFuiUPW52rSkaxfr94TjTii6D6eC+blbQVzM8cg7KMv1umjHx9dusC/I3zBJcSHg9f1Z/uVEmBSWrNyknMA7tFp794gX37gLJ+gAAAA=='
         - name: origin
           value: "not-existing-origin"
         - name: advisory_secret_name

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -141,6 +141,56 @@ spec:
             exit 1
         fi
 
+        # Transform snapshot components to architecture-specific images
+        echo "Transforming snapshot components using get-image-architectures..."
+        SNAPSHOT_JSON=$(jq '.' "$SNAPSHOT_FILE")
+        TRANSFORMED_COMPONENTS=$(mktemp)
+        
+        echo "$SNAPSHOT_JSON" | jq -c '.components[]' | while IFS= read -r component; do
+            CONTAINER_IMAGE=$(echo "$component" | jq -r '.containerImage')
+            RH_REGISTRY_REPO=$(echo "$component" | jq -r '.["rh-registry-repo"] // .repository')
+            COMPONENT_NAME=$(echo "$component" | jq -r '.name')
+            
+            echo "Processing component: $COMPONENT_NAME with image: $CONTAINER_IMAGE" >&2
+            
+            # Use get-image-architectures utility (same approach as populate-release-notes)
+            if get-image-architectures "${CONTAINER_IMAGE}" | while IFS= read -r arch_json; do
+                if [[ -n "$arch_json" ]]; then
+                    # Extract architecture-specific digest from arch_json
+                    arch_digest=$(echo "$arch_json" | jq -r '.digest')
+                    arch=$(echo "$arch_json" | jq -r '.platform.architecture')
+                    
+                    # Create transformed component with registry format containerImage
+                    TRANSFORMED_CONTAINER_IMAGE="${RH_REGISTRY_REPO}@${arch_digest}"
+                    echo "$component" \
+                      | jq \
+                        --arg ci "$TRANSFORMED_CONTAINER_IMAGE" \
+                        --arg repo "$RH_REGISTRY_REPO" \
+                        --arg orig_name "$COMPONENT_NAME" \
+                        --arg arch "$arch" \
+                        '.containerImage = $ci
+                         | .repository = $repo
+                         | .originalComponent = $orig_name
+                         | .architecture = $arch'
+                fi
+            done; then
+                echo "Successfully transformed component: $COMPONENT_NAME" >&2
+            else
+                echo "Warning: Failed to resolve architectures for ${CONTAINER_IMAGE}, skipping component" >&2
+            fi
+        done > "$TRANSFORMED_COMPONENTS"
+        
+        # Create transformed snapshot with arch-specific images
+        transformedSnapshot=$(jq -s '.' "$TRANSFORMED_COMPONENTS" | gzip -c | base64 -w 0)
+        rm -f "$TRANSFORMED_COMPONENTS"
+        
+        if [ -z "$transformedSnapshot" ]; then
+            echo "Failed to create transformed snapshot"
+            exit 1
+        fi
+        
+        echo "Transformation complete. Arch-specific images created."
+
         RPA_FILE="$(params.dataDir)/$(params.releasePlanAdmissionPath)"
         if [ ! -f "$RPA_FILE" ]; then
             echo "No valid ReleasePlanAdmission file was provided at $RPA_FILE"
@@ -220,7 +270,7 @@ spec:
         echo "Creating internal request for filtering already-released advisory images..."
         # Because of the tee, this will always succeed
         internal-request --pipeline "filter-already-released-advisory-images" \
-                         -p snapshot="$snapshot" \
+                         -p transformedSnapshot="$transformedSnapshot" \
                          -p origin="$origin" \
                          -p advisory_secret_name="$advisorySecretName" \
                          -p internalRequestPipelineRunName="$(params.pipelineRunUid)" \

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -3,6 +3,20 @@ set -ex
 
 # mocks to be injected into task step scripts
 
+function get-image-architectures() {
+  echo "Mock get-image-architectures called with: $*" >&2
+  local image="$1"
+  # Produce a single-arch amd64 entry per input image index
+  if [[ "$image" == *"sha256:abc123"* ]]; then
+    echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_abc123"}'
+  elif [[ "$image" == *"sha256:def456"* ]]; then
+    echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_def456"}'
+  else
+    # Default deterministic output
+    echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_default"}'
+  fi
+}
+
 function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -207,10 +207,55 @@ spec:
                 exit 1
               fi
 
-              # Check the snapshot parameter
-              snapshotJson=$(echo "$internalRequest" | jq -r '.spec.params.snapshot' | base64 --decode | gzip -d)
-              if [ "$(jq -r '.application' <<< "$snapshotJson")" != "myapp" ]; then
-                echo "InternalRequest has the wrong application in snapshot"
+              # Check the transformedSnapshot parameter exists and decodes
+              transformedSnapshotB64=$(echo "$internalRequest" | jq -r '.spec.params.transformedSnapshot // empty')
+              if [ -z "$transformedSnapshotB64" ]; then
+                echo "InternalRequest missing transformedSnapshot parameter"
+                exit 1
+              fi
+              transformedSnapshotJson=$(echo "$transformedSnapshotB64" | base64 --decode | gzip -d)
+              if ! jq -e 'type=="array"' <<< "$transformedSnapshotJson" >/dev/null; then
+                echo "transformedSnapshot should be a JSON array"
+                exit 1
+              fi
+              if [ "$(jq 'length' <<< "$transformedSnapshotJson")" -lt 2 ]; then
+                echo "transformedSnapshot should contain at least one entry per component"
+                exit 1
+              fi
+              # Validate per-component transformed entries
+              oldEntry=$(jq -c '.[] | select(.originalComponent=="old-component")' <<< "$transformedSnapshotJson")
+              if [ -z "$oldEntry" ]; then
+                echo "Missing transformed entry for old-component"
+                exit 1
+              fi
+              if [ "$(jq -r '.repository' <<< "$oldEntry")" != "quay.io/redhat-pending/repo" ]; then
+                echo "Unexpected repository for old-component in transformedSnapshot"
+                exit 1
+              fi
+              if [[ "$(jq -r '.containerImage' <<< "$oldEntry")" != *"@sha256:amd64digest_abc123" ]]; then
+                echo "Unexpected digest for old-component in transformedSnapshot"
+                exit 1
+              fi
+              if [ "$(jq -r '.architecture' <<< "$oldEntry")" != "amd64" ]; then
+                echo "Unexpected architecture for old-component in transformedSnapshot"
+                exit 1
+              fi
+
+              newEntry=$(jq -c '.[] | select(.originalComponent=="new-component")' <<< "$transformedSnapshotJson")
+              if [ -z "$newEntry" ]; then
+                echo "Missing transformed entry for new-component"
+                exit 1
+              fi
+              if [ "$(jq -r '.repository' <<< "$newEntry")" != "quay.io/redhat-pending/repo2" ]; then
+                echo "Unexpected repository for new-component in transformedSnapshot"
+                exit 1
+              fi
+              if [[ "$(jq -r '.containerImage' <<< "$newEntry")" != *"@sha256:amd64digest_def456" ]]; then
+                echo "Unexpected digest for new-component in transformedSnapshot"
+                exit 1
+              fi
+              if [ "$(jq -r '.architecture' <<< "$newEntry")" != "amd64" ]; then
+                echo "Unexpected architecture for new-component in transformedSnapshot"
                 exit 1
               fi
 


### PR DESCRIPTION
Snapshot components use Image Index digests
while advisory entries use architecture-specific
manifest digests. Added skopeo resolution to
transform snapshot components to advisory format
before applying original filtering logic.

This ensures already-released components are correctly filtered out.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
