### PR TITLE
fix(KONFLUX-9590): let FBC stage requests be reused

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -133,7 +133,10 @@ spec:
           # if a previous build is found, but from_index and index_image are different, it means that the
           # previous build was a staging index build, then we should return here causing the task to call
           # IIB again, but with overwrite_from_index set to true.
-          if [ "$(jq '.from_index != .index_image' <<< "${build}")" == true ]; then
+          # However, if we are pushing to a stagedIndex, we want to ignore this condition and continue
+          # to determine whether we should reuse a previous build.
+          if [ "$(params.stagedIndex)" != "true" ] && \
+             [ "$(jq '.from_index != .index_image' <<< "${build}")" = true ]; then
             return 0
           fi
 


### PR DESCRIPTION
Stage requests don't have the from_index and index_image set to be the same value so they would never meet the criteria for reuse. We still want to reuse stage builds if the rest of the properties are the same between IIB requests.

Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

resolves: [KONFLUX-9590](https://issues.redhat.com/browse/KONFLUX-9590)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
