### PR TITLE
fix: rename imprecise sbom processing tasks

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -754,7 +754,7 @@ spec:
       runAfter:
         - create-pyxis-image
         - collect-task-params
-    - name: augment-component-sbom
+    - name: process-component-sbom
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin
@@ -806,7 +806,7 @@ spec:
         - apply-mapping
         - collect-atlas-params
         - push-snapshot
-    - name: create-product-sbom
+    - name: process-product-sbom
       when:
         - input: "$(tasks.collect-atlas-params.results.secretName)"
           operator: notin


### PR DESCRIPTION
The SBOM processing tasks didn't just augment and create sboms, but they also upload the artifacts. Let's generalize the naming to process_*

Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
