### PR TITLE
feat: add validation to ensure key and component are defined together

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -886,6 +886,40 @@
                     ]
                   }
                 ]
+              },
+              "cves": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "key",
+                        "component"
+                      ]
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "key"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "component"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "packages"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
               }
             }
           }


### PR DESCRIPTION
## Describe your changes
This adds to dataKeys JSON schema using a anyOf and not blocks to enforce that `releaseNotes.cves` `key` and `component` must be defined together, and that `packages` cannot be defined on their own without those fields.

 Valid Examples:
```
{
  "key": "CVE-2025-1234",
  "component": "something ",
  "packages": ["pkg:go/package@1.0.0"]
}

{
  "key": "CVE-2025-5678",
  "component": "something"
}
```

 Invalid Examples:
```
{
  "key": "CVE-2025-1111"
}
{
  "component": "something"
}
{
  "packages": ["pkg:go/package@1.0.0"]
}
```
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
