### PR TITLE
feat(RELEASE-1792): apply-mapping supports the repositories key

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -226,12 +226,13 @@ spec:
             echo "$result"
         }
 
-        # Expected arguments are [tags, substitute_map, labels_map]
+        # Expected arguments are [tags, substitute_map, labels_map, repo]
         # The tags argument is a json array
         translate_tags () {
             tags=$1
             substitute_map=$2
             labels_map=$3
+            repo=$4
             if [ "$tags" = '' ] ; then
                 echo ''
                 return
@@ -255,7 +256,6 @@ spec:
 
                   # Handle incrementer logic
                   if [[ "$var_name" == "incrementer" ]]; then
-                      repo=$(jq -r '.repository' <<< "$component")
                       tag=$(increment_tag "$tag" "$repo")
                   else
                       replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
@@ -372,6 +372,9 @@ spec:
         NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
         for ((i = 0; i < NUM_MAPPED_COMPONENTS; i++)) ; do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
+            componentTags=$(jq '.componentTags // []' <<< "$component")
+            defaultComponentTags=$(jq -n --argjson defaults "$defaultTags" --argjson componentTags \
+              "$componentTags" '$defaults? + $componentTags? | unique')
 
             # images are required to use sha reference - check this
             NAME=$(jq -r '.name' <<< "$component")
@@ -381,7 +384,6 @@ spec:
               exit 1
             fi
 
-            imageTags=$(jq '.tags // []' <<< "$component")
             git_sha=$(jq -r '.source.git.revision' <<< "$component") # this sets the value to "null" if it doesn't exist
             build_sha=$(echo "$IMAGE_REF" | cut -d ':' -f 2)
             passedTimestampFormat=$(jq -r --arg default "$defaultTimestampFormat" \
@@ -402,8 +404,6 @@ spec:
               timestamp="$(date -d "${build_date}" "+$passedTimestampFormat")"
             fi
 
-            allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultTags" --argjson imageTags \
-              "$imageTags" '$defaults? + $imageTags? | unique')
             substitute_map="$(jq -n -c \
               --arg timestamp "${timestamp}" \
               --arg release_timestamp "${release_timestamp}" \
@@ -413,19 +413,15 @@ spec:
               '$ARGS.named')"
             labels="$(jq -c '.Labels' <<< "${image_metadata}")"
 
-            tags=$(translate_tags "${allTagsPreSubstitution}" "${substitute_map}" "${labels}")
-            if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
-              jq --argjson i "$i" --argjson updatedTags "$tags" '.components[$i].tags = $updatedTags' \
-                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
-            fi
-
             # Also substitute filename values in the staged section of components
             STAGED_FILES=$(jq '.staged.files | length' <<< "$component")
             for ((j = 0; j < STAGED_FILES; j++)) ; do
                 file=$(jq -c --argjson j "$j" '.staged.files[$j]' <<< "$component")
                 filenameArrayPreSubstitution=$(jq '.filename' <<< "$file" | jq -cs)
+                # {{ incrementer }} is not supported in staged.files values, so we just pass
+                # "" as the repo argument
                 subbedFilename=$(translate_tags "${filenameArrayPreSubstitution}" \
-                  "${substitute_map}" "${labels}" | jq -r '.[0]')
+                  "${substitute_map}" "${labels}" ""| jq -r '.[0]')
                 jq --argjson i "$i" --argjson j "$j" --arg filename "$subbedFilename" \
                   '.components[$i].staged.files[$j].filename = $filename' "${SNAPSHOT_SPEC_FILE}" > /tmp/temp \
                   && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
@@ -442,32 +438,97 @@ spec:
               "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 
-            # Determine the format of the original repository and update keys accordingly
-            repository=$(jq -r '.repository' <<< "$component")
-            echo "Processing component: $NAME"
-            echo "Original repository: $repository"
+            # *** Temporary code to maintain backwards compatibility and set .repositories[0] to .repository ***
+            if [[ $(jq 'has("repository")' <<< "$component") == "true" ]] ; then
+              repository=$(jq -r '.repository' <<< "$component")
+              echo "Processing component: $NAME"
+              echo "Original repository: $repository"
 
-            # This block is temporary to support both quay.io and registry.redhat.io
-            # It should be removed once all repositories are migrated to registry.redhat.io
-            if [[ "$repository" == quay.io/redhat-prod/* || "$repository" == quay.io/redhat-pending/* ]]; then
-                repository=$(convert_to_registry "$repository")
+              imageTags=$(jq '.tags // []' <<< "$component")
+              oldAllTagsPreSubstitution=$(jq -n --argjson defaults "$defaultComponentTags" --argjson imageTags \
+                "$imageTags" '$defaults? + $imageTags? | unique')
+              oldTags=$(translate_tags "${oldAllTagsPreSubstitution}" "${substitute_map}" "${labels}" "${repository}")
+              if [ "$(jq 'length' <<< "$oldTags")" -gt 0 ] ; then
+                jq --argjson i "$i" --argjson updatedTags "$oldTags" '.components[$i].tags = $updatedTags' \
+                  "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+              fi
+
+              if [[ "$repository" == quay.io/redhat-prod/* || "$repository" == quay.io/redhat-pending/* ]]; then
+                  repository=$(convert_to_registry "$repository")
+              fi
+
+              if [[ "$repository" == registry.redhat.io/* || "$repository" == registry.stage.redhat.io/* ]]; then
+                rh_registry_repo=$repository
+                registry_access_repo=$(convert_to_registry_access "$repository")
+                repository=$(convert_to_quay "$repository")
+
+                jq --argjson i "$i" \
+                  --arg repository "$repository" \
+                  --arg rh_registry_repo "$rh_registry_repo" \
+                  --arg registry_access_repo "$registry_access_repo" \
+                  '(.components[$i].repository = $repository) |
+                      .components[$i]["rh-registry-repo"] = $rh_registry_repo |
+                      .components[$i]["registry-access-repo"] = $registry_access_repo' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+
+                if [[ $(jq 'has("repositories")' <<< "$component") == "false" ]] ; then
+                  jq --argjson i "$i" --arg rh_registry_repo "$rh_registry_repo" \
+                    --arg registry_access_repo "$registry_access_repo" \
+                      '.components[$i].repositories[0]["rh-registry-repo"] = $rh_registry_repo |
+                      .components[$i].repositories[0]["registry-access-repo"] = $registry_access_repo' \
+                    "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+                fi
+              fi
+              if [[ $(jq 'has("repositories")' <<< "$component") == "false" ]] ; then
+                jq --argjson i "$i" --arg url "$repository" \
+                  --argjson tags "$oldTags" \
+                  '.components[$i].repositories[0].url = $url |
+                    .components[$i].repositories[0]["tags"] = $tags' \
+                  "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+              fi
             fi
+            # *** End of temporary code ***
 
-            # Convert to registry and quay format
-            if [[ "$repository" == registry.redhat.io/* || "$repository" == registry.stage.redhat.io/* ]]; then
-              rh_registry_repo=$repository
-              registry_access_repo=$(convert_to_registry_access "$repository")
-              repository=$(convert_to_quay "$repository")
+            NUM_REPOSITORIES=$(jq '.repositories | length' <<< "$component")
+            for ((j = 0; j < NUM_REPOSITORIES; j++)) ; do
+                repository=$(jq -c --argjson j "$j" '.repositories[$j]' <<< "$component")
+                repoTags=$(jq '.tags // []' <<< "$repository")
+                url=$(jq -r '.url' <<< "$repository")
+                echo "Processing component: $NAME, repository: $url"
 
-              jq --argjson i "$i" \
-                --arg repository "$repository" \
-                --arg rh_registry_repo "$rh_registry_repo" \
-                --arg registry_access_repo "$registry_access_repo" \
-                '(.components[$i].repository = $repository) |
-                    .components[$i]["rh-registry-repo"] = $rh_registry_repo |
-                    .components[$i]["registry-access-repo"] = $registry_access_repo' \
-              "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
-            fi
+                allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultComponentTags" --argjson repoTags \
+                  "$repoTags" '$defaults? + $repoTags? | unique')
+
+                tags=$(translate_tags "${allTagsPreSubstitution}" "${substitute_map}" "${labels}" "${url}")
+                if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
+                  jq --argjson i "$i" --argjson j "$j" --argjson updatedTags "$tags" \
+                    '.components[$i].repositories[$j].tags = $updatedTags' "${SNAPSHOT_SPEC_FILE}" > /tmp/temp \
+                    && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+                fi
+
+                # This block is temporary to support both quay.io and registry.redhat.io
+                # It should be removed once all repositories are migrated to registry.redhat.io
+                if [[ "$url" == quay.io/redhat-prod/* || "$url" == quay.io/redhat-pending/* ]]; then
+                    url=$(convert_to_registry "$url")
+                fi
+
+                # Convert to registry and quay format
+                if [[ "$url" == registry.redhat.io/* || "$url" == registry.stage.redhat.io/* ]]; then
+                  rh_registry_repo=$url
+                  registry_access_repo=$(convert_to_registry_access "$url")
+                  url=$(convert_to_quay "$url")
+
+                  jq --argjson i "$i" \
+                    --argjson j "$j" \
+                    --arg url "$url" \
+                    --arg rh_registry_repo "$rh_registry_repo" \
+                    --arg registry_access_repo "$registry_access_repo" \
+                    '.components[$i].repositories[$j].url = $url |
+                        .components[$i].repositories[$j]["rh-registry-repo"] = $rh_registry_repo |
+                        .components[$i].repositories[$j]["registry-access-repo"] = $registry_access_repo' \
+                  "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+                fi
+            done
         done
     - name: create-trusted-artifact
       computeResources:

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
@@ -2,11 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-other-formats
+  name: test-apply-mapping-both
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json where the repositories.url is in a format not specifically
-    handled by the task. Verify that the resulting json remains unchanged in the repositories.url field.
+    Run the apply-mapping task with a data file that contains both the repository and
+    repositories keys. This test should be deleted once support for the repository key is
+    removed.
   workspaces:
     - name: tests-workspace
   params:
@@ -36,8 +37,6 @@ spec:
           workspace: tests-workspace
       taskSpec:
         results:
-          - name: snapshot
-            type: string
           - name: sourceDataArtifact
             type: string
         workspaces:
@@ -64,18 +63,22 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
                     {
                       "name": "comp1",
+                      "repository": "legacy",
                       "repositories": [
                         {
-                          "url": "quay.io/my-sample/my-image"
+                          "url": "repo1a"
                         },
                         {
-                          "url": "quay.io/my-sample2/my-image"
+                          "url": "repo1b"
+                        },
+                        {
+                          "url": "repo1c"
                         }
                       ]
                     }
@@ -84,13 +87,19 @@ spec:
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1@sha256:123456"
+                    "containerImage": "imageurl1@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
                   }
                 ]
               }
@@ -126,9 +135,9 @@ spec:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/test_data_other_formats.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -204,32 +213,22 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              echo Test that SNAPSHOT contains component comp1
               test "$(
-                jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" -eq 1
+                jq -r '.components[] | select(.name=="comp1") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == legacy
 
-              echo Test that repository 1 of component comp1 stayed intact
               test "$(
                 jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample/my-image
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo1a
 
-              echo Test that rh-registry-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that registry-access-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that repository 2 of component comp1 stayed intact
               test "$(
                 jq -r '.components[] | select(.name=="comp1") | .repositories[1].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample2/my-image
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo1b
+
+              test "$(
+                jq -r '.components[] | select(.name=="comp1") | .repositories[2].url' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo1c

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
@@ -2,11 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-other-formats
+  name: test-apply-mapping-multi-redhat-components-old
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json where the repositories.url is in a format not specifically
-    handled by the task. Verify that the resulting json remains unchanged in the repositories.url field.
+    Run the apply-mapping task with a snapshot.spec json containing multiple components
+    and Red Hat specific repository formats. Verify that the resulting json contains the expected transformations.
+
+    To be deleted when component.repository is no longer supported
   workspaces:
     - name: tests-workspace
   params:
@@ -36,8 +38,6 @@ spec:
           workspace: tests-workspace
       taskSpec:
         results:
-          - name: snapshot
-            type: string
           - name: sourceDataArtifact
             type: string
         workspaces:
@@ -64,33 +64,60 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
                     {
                       "name": "comp1",
-                      "repositories": [
-                        {
-                          "url": "quay.io/my-sample/my-image"
-                        },
-                        {
-                          "url": "quay.io/my-sample2/my-image"
-                        }
-                      ]
+                      "repository": "quay.io/redhat-prod/product-name----image1"
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "registry.redhat.io/product-name/image2"
+                    },
+                    {
+                      "name": "comp3",
+                      "repository": "quay.io/redhat-pending/product-name----image3"
                     }
                   ]
                 }
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1@sha256:123456"
+                    "containerImage": "imageurl1@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "imageurl2@sha256:789012",
+                    "source": {
+                      "git": {
+                        "revision": "myrev2",
+                        "url": "myurl2"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "imageurl3@sha256:345678",
+                    "source": {
+                      "git": {
+                        "revision": "myrev3",
+                        "url": "myurl3"
+                      }
+                    }
                   }
                 ]
               }
@@ -126,9 +153,9 @@ spec:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/test_data_other_formats.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -204,32 +231,47 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              # Test for comp1
               echo Test that SNAPSHOT contains component comp1
-              test "$(
-                jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" -eq 1
+              test "$(jq -r '[ .components[] | select(.name=="comp1") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
 
-              echo Test that repository 1 of component comp1 stayed intact
-              test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample/my-image
+              echo Test that rh-registry-repo for comp1 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                registry.redhat.io/product-name/image1
 
-              echo Test that rh-registry-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
+              echo Test that registry-access-repo for comp1 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                registry.access.redhat.com/product-name/image1
 
-              echo Test that registry-access-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
+              # Test for comp2
+              echo Test that SNAPSHOT contains component comp2
+              test "$(jq -r '[ .components[] | select(.name=="comp2") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
 
-              echo Test that repository 2 of component comp1 stayed intact
-              test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[1].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample2/my-image
+              echo Test that quay.io repository for comp2 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                quay.io/redhat-prod/product-name----image2
+
+              echo Test that registry-access-repo for comp2 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp2") | ."registry-access-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                registry.access.redhat.com/product-name/image2
+
+              # Test for comp3
+              echo Test that SNAPSHOT contains component comp3
+              test "$(jq -r '[ .components[] | select(.name=="comp3") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
+
+              echo Test that rh-registry-repo for comp3 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp3") | ."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                registry.stage.redhat.io/product-name/image3
+
+              echo Test that registry-access-repo for comp3 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp3") | ."registry-access-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                registry.access.stage.redhat.com/product-name/image3

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -68,15 +68,27 @@ spec:
                   "components": [
                     {
                       "name": "comp1",
-                      "repository": "quay.io/redhat-prod/product-name----image1"
+                      "repositories": [
+                        {
+                          "url": "quay.io/redhat-prod/product-name----image1"
+                        }
+                      ]
                     },
                     {
                       "name": "comp2",
-                      "repository": "registry.redhat.io/product-name/image2"
+                      "repositories": [
+                        {
+                          "url": "registry.redhat.io/product-name/image2"
+                        }
+                      ]
                     },
                     {
                       "name": "comp3",
-                      "repository": "quay.io/redhat-pending/product-name----image3"
+                      "repositories": [
+                        {
+                          "url": "quay.io/redhat-pending/product-name----image3"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -235,12 +247,12 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
 
               echo Test that rh-registry-repo for comp1 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo"' \
+              test "$(jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 registry.redhat.io/product-name/image1
 
               echo Test that registry-access-repo for comp1 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo"' \
+              test "$(jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 registry.access.redhat.com/product-name/image1
 
@@ -250,12 +262,12 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
 
               echo Test that quay.io repository for comp2 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp2") | .repository' \
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repositories[0].url' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 quay.io/redhat-prod/product-name----image2
 
               echo Test that registry-access-repo for comp2 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp2") | ."registry-access-repo"' \
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repositories[0]."registry-access-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 registry.access.redhat.com/product-name/image2
 
@@ -265,11 +277,11 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
 
               echo Test that rh-registry-repo for comp3 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp3") | ."rh-registry-repo"' \
+              test "$(jq -r '.components[] | select(.name=="comp3") | .repositories[0]."rh-registry-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 registry.stage.redhat.io/product-name/image3
 
               echo Test that registry-access-repo for comp3 is correctly set
-              test "$(jq -r '.components[] | select(.name=="comp3") | ."registry-access-repo"' \
+              test "$(jq -r '.components[] | select(.name=="comp3") | .repositories[0]."registry-access-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
                 registry.access.stage.redhat.com/product-name/image3

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
@@ -2,11 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-other-formats
+  name: test-apply-mapping-old
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json where the repositories.url is in a format not specifically
-    handled by the task. Verify that the resulting json remains unchanged in the repositories.url field.
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data json file and verify that the resulting json contains the expected values.
+
+    To be deleted when component.repository is no longer supported
   workspaces:
     - name: tests-workspace
   params:
@@ -36,8 +38,6 @@ spec:
           workspace: tests-workspace
       taskSpec:
         results:
-          - name: snapshot
-            type: string
           - name: sourceDataArtifact
             type: string
         workspaces:
@@ -64,33 +64,58 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
                     {
                       "name": "comp1",
-                      "repositories": [
-                        {
-                          "url": "quay.io/my-sample/my-image"
-                        },
-                        {
-                          "url": "quay.io/my-sample2/my-image"
-                        }
-                      ]
+                      "repository": "repo1"
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "repo2"
+                    },
+                    {
+                      "name": "comp3",
+                      "repository": "repo3a"
+                    },
+                    {
+                      "name": "comp4",
+                      "customfield": "custom"
                     }
                   ]
                 }
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1@sha256:123456"
+                    "containerImage": "imageurl1@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "imageurl3@sha256:123456",
+                    "repository": "repo3"
+                  },
+                  {
+                    "name": "comp4",
+                    "containerImage": "imageurl4@sha256:123456",
+                    "repository": "repo4"
+                  },
+                  {
+                    "name": "comp5",
+                    "containerImage": "imageurl5@sha256:123456"
                   }
                 ]
               }
@@ -126,9 +151,9 @@ spec:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/test_data_other_formats.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -207,29 +232,41 @@ spec:
               echo Test that SNAPSHOT contains component comp1
               test "$(
                 jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1
 
-              echo Test that repository 1 of component comp1 stayed intact
+              echo Test that SNAPSHOT contains repository from the mapping file
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample/my-image
+                jq -r '.components[] | select(.name=="comp1") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo1
 
-              echo Test that rh-registry-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that registry-access-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that repository 2 of component comp1 stayed intact
+              echo Test that SNAPSHOT does not contain component comp2
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[1].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample2/my-image
+                jq -r '[ .components[] | select(.name=="comp2") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 0
+
+              echo Test that repository of component comp3 was overridden by mapping file
+              test "$(
+                jq -r '.components[] | select(.name=="comp3") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo3a
+
+              echo Test that repository of component comp4 stayed intact
+              test "$(
+                jq -r '.components[] | select(.name=="comp4") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo4
+
+              echo Test that customfield of component comp4 was added to its snapshot entry
+              test "$(
+                jq -r '.components[] | select(.name=="comp4") | .customfield' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == custom
+
+              echo Test that SNAPSHOT does not contain component comp5 as it was not included in the mapping file
+              test "$(
+                jq -r '[ .components[] | select(.name=="comp5") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 0

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
@@ -2,11 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-other-formats
+  name: test-apply-mapping-other-formats-old
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json where the repositories.url is in a format not specifically
-    handled by the task. Verify that the resulting json remains unchanged in the repositories.url field.
+    Run the apply-mapping task with a snapshot.spec json where the repository is in a format not specifically
+    handled by the task. Verify that the resulting json remains unchanged in the repository field.
+
+    To be deleted when component.repository is no longer supported
   workspaces:
     - name: tests-workspace
   params:
@@ -70,14 +72,7 @@ spec:
                   "components": [
                     {
                       "name": "comp1",
-                      "repositories": [
-                        {
-                          "url": "quay.io/my-sample/my-image"
-                        },
-                        {
-                          "url": "quay.io/my-sample2/my-image"
-                        }
-                      ]
+                      "repository": "quay.io/my-sample/my-image"
                     }
                   ]
                 }
@@ -210,26 +205,20 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )" -eq 1
 
-              echo Test that repository 1 of component comp1 stayed intact
+              echo Test that repository of component comp1 stayed intact
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
+                jq -r '.components[] | select(.name=="comp1") | .repository' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )" == quay.io/my-sample/my-image
 
-              echo Test that rh-registry-repo for comp1 repo 1 is not set because it was not in a known format
+              echo Test that rh-registry-repo for comp1 is not set because it was not in a known format
               test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo" // empty' \
+                jq -r '.components[] | select(.name=="comp1") | ."rh-registry-repo" // empty' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )"
 
-              echo Test that registry-access-repo for comp1 repo 1 is not set because it was not in a known format
+              echo Test that registry-access-repo for comp1 is not set because it was not in a known format
               test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // empty' \
+                jq -r '.components[] | select(.name=="comp1") | ."registry-access-repo" // empty' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
               )"
-
-              echo Test that repository 2 of component comp1 stayed intact
-              test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[1].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample2/my-image

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
@@ -2,11 +2,14 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-apply-mapping-other-formats
+  name: test-apply-mapping-tag-expansion-old
 spec:
   description: |
-    Run the apply-mapping task with a snapshot.spec json where the repositories.url is in a format not specifically
-    handled by the task. Verify that the resulting json remains unchanged in the repositories.url field.
+    Run the apply-mapping task with a snapshot.spec json and a custom mapping provided in
+    the data file with tags per component and verify that the resulting json
+    contains the expected values with tags expanded, including incrementer logic.
+
+    To be deleted when component.repository is no longer supported
   workspaces:
     - name: tests-workspace
   params:
@@ -36,8 +39,6 @@ spec:
           workspace: tests-workspace
       taskSpec:
         results:
-          - name: snapshot
-            type: string
           - name: sourceDataArtifact
             type: string
         workspaces:
@@ -64,33 +65,79 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
               {
                 "mapping": {
                   "components": [
                     {
                       "name": "comp1",
-                      "repositories": [
-                        {
-                          "url": "quay.io/my-sample/my-image"
-                        },
-                        {
-                          "url": "quay.io/my-sample2/my-image"
-                        }
+                      "repository": "repo1",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ timestamp }}",
+                        "tag3-{{ timestamp }}-{{ git_short_sha }}",
+                        "{{git_sha}}",
+                        "{{ git_sha }}-abc",
+                        "{{git_short_sha}}",
+                        "{{ git_short_sha }}-bar",
+                        "foo-{{digest_sha}}",
+                        "{{ digest_sha }}",
+                        "v2.0.0-{{ incrementer }}",
+                        "tag-{{ labels.Goodlabel }}",
+                        "tag-{{ labels.Goodlabel.with-dash }}",
+                        "tag1-2024-07-29"
                       ]
+                    },
+                    {
+                      "name": "comp2",
+                      "repository": "repo2",
+                      "tags": [
+                        "tag1-{{timestamp}}",
+                        "tag2-{{ release_timestamp }}",
+                        "tag4-{{release_timestamp}}",
+                        "v1.0.0-{{ incrementer }}",
+                        "v1-{{ incrementer }}-release"
+                      ],
+                      "timestampFormat": "%Y-%m"
+                    },
+                    {
+                      "name": "comp3",
+                      "repository": "repo3a"
                     }
-                  ]
+                  ],
+                  "defaults": {
+                    "timestampFormat": "%Y-%m-%d",
+                    "tags": [
+                      "defaultTag"
+                    ]
+                  }
                 }
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "imageurl1@sha256:123456"
+                    "containerImage": "registry.io/labels@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/onlycreated@sha256:123456",
+                    "repository": "repo2"
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image3@sha256:123456",
+                    "repository": "repo3"
                   }
                 ]
               }
@@ -126,9 +173,9 @@ spec:
         name: apply-mapping
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/test_data_other_formats.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -207,29 +254,37 @@ spec:
               echo Test that SNAPSHOT contains component comp1
               test "$(
                 jq -r '[ .components[] | select(.name=="comp1") ] | length' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1
 
-              echo Test that repository 1 of component comp1 stayed intact
+              echo Test that comp1 has the proper tags
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample/my-image
+                jq -c '.components[] | select(.name=="comp1") | .tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["defaultTag","foo-123456","tag-labelvalue","tag-labelvalue-with-dash",'\
+              '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","v2.0.0-5","123456",'\
+              '"testrevision-abc","testrev-bar","testrevision","testrev"]'
 
-              echo Test that rh-registry-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that registry-access-repo for comp1 repo 1 is not set because it was not in a known format
-              test -z "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // empty' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )"
-
-              echo Test that repository 2 of component comp1 stayed intact
+              echo Test that SNAPSHOT contains component comp2
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repositories[1].url' \
-                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec_other_formats.json"
-              )" == quay.io/my-sample2/my-image
+                jq -r '[ .components[] | select(.name=="comp2") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 1
+
+              echo Test that comp2 has the proper tags
+              test "$(
+                jq -c '.components[] | select(.name=="comp2") | .tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01","v1-1-release","v1.0.0-1"]'
+
+              echo Test that repository of component comp3 was overridden by mapping file
+              test "$(
+                jq -r '.components[] | select(.name=="comp3") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo3a
+
+              echo Test that comp3 has the 1 default tag
+              test "$(
+                jq -r '.components[] | select(.name=="comp3") | .tags | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 1

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -69,38 +69,56 @@ spec:
                   "components": [
                     {
                       "name": "comp1",
-                      "repository": "repo1",
-                      "tags": [
-                        "tag1-{{timestamp}}",
-                        "tag2-{{ timestamp }}",
-                        "tag3-{{ timestamp }}-{{ git_short_sha }}",
-                        "{{git_sha}}",
-                        "{{ git_sha }}-abc",
-                        "{{git_short_sha}}",
-                        "{{ git_short_sha }}-bar",
-                        "foo-{{digest_sha}}",
-                        "{{ digest_sha }}",
-                        "v2.0.0-{{ incrementer }}",
+                      "repositories": [
+                        {
+                          "url": "repo1a",
+                          "tags": [
+                            "tag1-{{timestamp}}",
+                            "tag2-{{ timestamp }}",
+                            "tag3-{{ timestamp }}-{{ git_short_sha }}",
+                            "{{git_sha}}",
+                            "{{ git_sha }}-abc"
+                          ]
+                        },
+                        {
+                          "url": "repo1",
+                          "tags": [
+                            "{{git_short_sha}}",
+                            "{{ git_short_sha }}-bar",
+                            "foo-{{digest_sha}}",
+                            "{{ digest_sha }}",
+                            "v2.0.0-{{ incrementer }}"
+                          ]
+                        }
+                      ],
+                      "componentTags": [
                         "tag-{{ labels.Goodlabel }}",
-                        "tag-{{ labels.Goodlabel.with-dash }}",
-                        "tag1-2024-07-29"
+                        "tag-{{ labels.Goodlabel.with-dash }}"
                       ]
                     },
                     {
                       "name": "comp2",
-                      "repository": "repo2",
-                      "tags": [
-                        "tag1-{{timestamp}}",
-                        "tag2-{{ release_timestamp }}",
-                        "tag4-{{release_timestamp}}",
-                        "v1.0.0-{{ incrementer }}",
-                        "v1-{{ incrementer }}-release"
+                      "repositories": [
+                        {
+                          "url": "repo2",
+                          "tags": [
+                            "tag1-{{timestamp}}",
+                            "tag2-{{ release_timestamp }}",
+                            "tag4-{{release_timestamp}}",
+                            "v1.0.0-{{ incrementer }}",
+                            "v1-{{ incrementer }}-release"
+                          ]
+                        }
                       ],
                       "timestampFormat": "%Y-%m"
                     },
                     {
                       "name": "comp3",
-                      "repository": "repo3a"
+                      "repositories": [
+                        {
+                          "url": "repo3a"
+                        }
+                      ]
                     }
                   ],
                   "defaults": {
@@ -255,13 +273,19 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1
 
-              echo Test that comp1 has the proper tags
+              echo Test that comp1 repo a has the proper tags
               test "$(
-                jq -c '.components[] | select(.name=="comp1") | .tags' \
+                jq -c '.components[] | select(.name=="comp1").repositories[] | select(.url=="repo1a") | .tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["defaultTag","tag-labelvalue","tag-labelvalue-with-dash","tag1-2024-07-29",'\
+              '"tag2-2024-07-29","tag3-2024-07-29-testrev","testrevision-abc","testrevision"]'
+
+              echo Test that comp1 repo b has the proper tags
+              test "$(
+                jq -c '.components[] | select(.name=="comp1").repositories[] | select(.url=="repo1") | .tags' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == '["defaultTag","foo-123456","tag-labelvalue","tag-labelvalue-with-dash",'\
-              '"tag1-2024-07-29","tag2-2024-07-29","tag3-2024-07-29-testrev","v2.0.0-5","123456",'\
-              '"testrevision-abc","testrev-bar","testrevision","testrev"]'
+              '"v2.0.0-5","123456","testrev-bar","testrev"]' # v2.0.0-5 because repo1 returns 4 tags via the mocks
 
               echo Test that SNAPSHOT contains component comp2
               test "$(
@@ -271,18 +295,18 @@ spec:
 
               echo Test that comp2 has the proper tags
               test "$(
-                jq -c '.components[] | select(.name=="comp2") | .tags' \
+                jq -c '.components[] | select(.name=="comp2") | .repositories[0].tags' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == '["defaultTag","tag1-1980-01","tag2-1980-01","tag4-1980-01","v1-1-release","v1.0.0-1"]'
 
               echo Test that repository of component comp3 was overridden by mapping file
               test "$(
-                jq -r '.components[] | select(.name=="comp3") | .repository' \
+                jq -r '.components[] | select(.name=="comp3") | .repositories[0].url' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == repo3a
 
               echo Test that comp3 has the 1 default tag
               test "$(
-                jq -r '.components[] | select(.name=="comp3") | .tags | length' \
+                jq -r '.components[] | select(.name=="comp3") | .repositories[0].tags | length' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -68,15 +68,33 @@ spec:
                   "components": [
                     {
                       "name": "comp1",
-                      "repository": "repo1"
+                      "repositories": [
+                        {
+                          "url": "repo1"
+                        }
+                      ]
                     },
                     {
                       "name": "comp2",
-                      "repository": "repo2"
+                      "repositories": [
+                        {
+                          "url": "repo2"
+                        }
+                      ]
                     },
                     {
                       "name": "comp3",
-                      "repository": "repo3a"
+                      "repositories": [
+                        {
+                          "url": "repo3a"
+                        },
+                        {
+                          "url": "repo3b"
+                        },
+                        {
+                          "url": "repo3c"
+                        }
+                      ]
                     },
                     {
                       "name": "comp4",
@@ -103,13 +121,11 @@ spec:
                   },
                   {
                     "name": "comp3",
-                    "containerImage": "imageurl3@sha256:123456",
-                    "repository": "repo3"
+                    "containerImage": "imageurl3@sha256:123456"
                   },
                   {
                     "name": "comp4",
-                    "containerImage": "imageurl4@sha256:123456",
-                    "repository": "repo4"
+                    "containerImage": "imageurl4@sha256:123456"
                   },
                   {
                     "name": "comp5",
@@ -233,11 +249,17 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1
 
-              echo Test that SNAPSHOT contains repository from the mapping file
+              echo Test that SNAPSHOT contains comp1 repository from the mapping file
               test "$(
-                jq -r '.components[] | select(.name=="comp1") | .repository' \
+                jq -r '.components[] | select(.name=="comp1") | .repositories[0].url' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == repo1
+
+              echo Test that revision of comp1 is correct
+              test "$(
+                jq -r '.components[] | select(.name=="comp1") | .source.git.revision' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == myrev
 
               echo Test that SNAPSHOT does not contain component comp2
               test "$(
@@ -245,17 +267,23 @@ spec:
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 0
 
-              echo Test that repository of component comp3 was overridden by mapping file
+              echo Test that repository 1 of component comp3 is correct
               test "$(
-                jq -r '.components[] | select(.name=="comp3") | .repository' \
+                jq -r '.components[] | select(.name=="comp3") | .repositories[0].url' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == repo3a
 
-              echo Test that repository of component comp4 stayed intact
+              echo Test that repository 2 of component comp3 is correct
               test "$(
-                jq -r '.components[] | select(.name=="comp4") | .repository' \
+                jq -r '.components[] | select(.name=="comp3") | .repositories[1].url' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
-              )" == repo4
+              )" == repo3b
+
+              echo Test that repository 3 of component comp3 is correct
+              test "$(
+                jq -r '.components[] | select(.name=="comp3") | .repositories[2].url' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == repo3c
 
               echo Test that customfield of component comp4 was added to its snapshot entry
               test "$(


### PR DESCRIPTION
This commit updates the apply-mapping managed task to support the mapping.component.repositories key. It behaves similar to the mapping.component.repository key, but it is a list instead of a singleton.

The commit maintains backwards compatibility with the repository key. Also, if the repository key is passed, but not repositories, repositories[0] will be set to what repository is.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
