### PR TITLE
fix: tolerate additional build-srv annotations

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -292,8 +292,6 @@ wait_for_component_initialization() {
             break
         else
             log_warning "Could not get component PR from annotations: ${component_annotations}"
-            echo "Requesting a new configure-pac..."
-            kubectl annotate components/${component_name} build.appstudio.openshift.io/request=configure-pac -n "${tenant_namespace}"
             echo "Waiting 10 seconds before retry..."
             sleep 10
         fi


### PR DESCRIPTION
## Describe your changes
- be more tolerant of build service annotations before failing during component onboarding

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
