### PR TITLE
chore: add docs for creating/updating e2e sa token

### DIFF
--- a/integration-tests/MAINTENANCE.md
+++ b/integration-tests/MAINTENANCE.md
@@ -1,5 +1,40 @@
 # Maintenance
 
+## Create the e2e service account k8s token and kubeconfig
+
+  * Since Secrets cannot be managed by argoCD and tenants-config, the e2e service account token must be manually created initially
+  * Apply integration-tests/setup/resources/tenant/service_account_token.yaml in the rhtap-release-2-tenant ns in rh01 prod
+
+```shell
+kubectl create -f integration-tests/setup/resources/tenant/service_account_token.yaml -n rhtap-release-2-tenant
+```
+  * You now have a long-lived token that can be used by the KRW tests.
+
+### Updating or creating the KUBECONFIG that is used to login to stg rh01 for KRW tests
+
+  * Login to stg rh01
+  * Generate the KUBECONFIG files using integration-tests/setup/scripts/get-kubeconfig-from-service-account.sh
+
+```shell
+cd integration-tests/setup/scripts/
+sh ./get-kubeconfig-from-service-account.sh
+```
+
+  * A kubeconfig file is created.
+
+```shell
+ls -l kubeconfig-sa
+```
+
+  * Copy the contents of that file and update the Vault at _stonesoup/staging/release/e2e/e2e-test-service-account-kubeconfig_ by creating a new version of the secret
+  * force refresh of ExternalSecret on rh01 prod
+
+```shell
+kubectl annotate es e2e-test-service-account-kubeconfig force-sync=$(date +%s) --overwrite -n rhtap-release-2-tenant
+```
+
+  * At this point, the new KUBECONFIG is available which contains the new token
+
 ## Rotating the Github secret
   * regenerate token from GH with scopes:
     * repo


### PR DESCRIPTION
## Describe your changes
- with the recent deletion and restoration of the dev-release-team-tenant ns on stg rh01, we had to reset and resync the SA token and kubeconfig needed for the krw testing.
- this PR adds some notes on the steps needed to reset and resync the token

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
