### PR TITLE
fix: improve cleanup with longer window

### DIFF
--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -117,9 +117,9 @@ fi
 
 # --- Main Script Execution ---
 
-# Trap EXIT signal to call cleanup function
+# Trap EXIT SIGTERM SIGINT SIGKILL signals to call cleanup function
 # Pass error code, line number, and command to the cleanup function
-trap 'cleanup_resources $? $LINENO "$BASH_COMMAND"' EXIT
+trap 'cleanup_resources $? $LINENO "$BASH_COMMAND"' EXIT SIGTERM SIGINT SIGKILL
 
 check_env_vars "$@" # Pass all args for consistency, though check_env_vars doesn't use them
 parse_options "$@" # Parses options and sets CLEANUP, NO_CVE


### PR DESCRIPTION
## Describe your changes
* When pushing new changes to a PR, the integration-service will attempt to cancel any in-flight PR checks.
* The trap catches the EXIT signal but sometimes the cleanup function has not completed yet before the pod is killed.
* This leaves many orphaned GH repos.
* Kubernetes sends SIGTERM to each container’s PID 1 when Tekton cancels a PipelineRun (it deletes/terminates the TaskRun Pods).
* If the container hasn’t exited by the pod’s terminationGracePeriodSeconds (default ~30s), Kubernetes sends SIGKILL.
* This PR now catches EXIT SIGTERM SIGINT and SIGKILL to give the cleanup a better chance to complete.

* The more elegant solution would be to use taskRunTemplate.podTemplate.terminationGracePeriodSeconds, but that is only available in PipelineRuns which we have no exposure to since the integration service creates those.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
