### PR TITLE
feat: add finally clause for cleanup

### DIFF
--- a/integration-tests/collectors/test.env
+++ b/integration-tests/collectors/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="collector-e2e-test"
 

--- a/integration-tests/fbc-release/test.env
+++ b/integration-tests/fbc-release/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="fbc-release-e2e-test"
 

--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -83,6 +83,7 @@ spec:
           - name: PR_GIT_REVISION
           - name: VAULT_PASSWORD_SECRET_NAME
           - name: GITHUB_TOKEN_SECRET_NAME
+          - name: KUBECONFIG_SECRET_NAME
         results:
           - name: TEST_OUTPUT
             description: Test output
@@ -115,6 +116,8 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/branch']
+              - name: uuid
+                value: $(context.pipelineRun.uid)
             script: |
               #!/usr/bin/env bash
 
@@ -224,14 +227,8 @@ spec:
               if string_has_word "${PIPELINE}" "${AFFECTED_PIPELINES}" || \
                 [[ "${AFFECTED_PIPELINES}" == "release-pipelines" ]]; then
                 echo "This Test Suite is affected by changes in PR ${PR_NUMBER}"
-                # initially, there was a run-test.sh in every test suite directory.
-                # then we moved to have a generic run-test.sh in the root.
-                # support both cases.
-                if [ -f "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/run-test.sh" ]; then
-                  "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/run-test.sh"
-                else
-                  "/home/e2e/tests/run-test.sh" "$(params.PIPELINE_TEST_SUITE)"
-                fi
+  
+                "/home/e2e/tests/run-test.sh" "$(params.PIPELINE_TEST_SUITE)"
               else
                 echo "This Test Suite is not affected by changes in PR ${PR_NUMBER}"
                 exit 99
@@ -239,3 +236,120 @@ spec:
 
       runAfter:
         - get-snapshot-data
+  finally:
+    - name: cleanup-resources
+      params:
+        - name: STEP_IMAGE
+          value: $(tasks.get-snapshot-data.results.CONTAINER_IMAGE)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: $(params.GITHUB_TOKEN_SECRET_NAME)
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.KUBECONFIG_SECRET_NAME)
+        - name: VAULT_PASSWORD_SECRET_NAME
+          value: $(params.VAULT_PASSWORD_SECRET_NAME)
+      taskSpec:
+        params:
+          - name: STEP_IMAGE
+          - name: GITHUB_TOKEN_SECRET_NAME
+          - name: KUBECONFIG_SECRET_NAME
+          - name: VAULT_PASSWORD_SECRET_NAME
+        steps:
+          - name: cleanup-resources
+            image: $(params.STEP_IMAGE)
+            env:
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET_NAME)
+                    key: token
+              - name: KUBECONFIG
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.KUBECONFIG_SECRET_NAME)
+                    key: kubeconfig
+              - name: uuid
+                value: $(context.pipelineRun.uid)
+              - name: VAULT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.VAULT_PASSWORD_SECRET_NAME)
+                    key: password
+            script: |
+              #
+              # Why are we doing this?
+              # - When pushing new changes to a PR, the integration-service
+              #   will attempt to cancel any in-flight PR checks.
+              # - The trap catches the EXIT signal but sometimes the cleanup
+              #   function has not completed yet before the pod is killed.
+              # - This leaves many orphaned GH repos and k8s resources.
+              #
+              # Plan of attack
+              # - First, we need to know what the resources are.
+              # - The KRW tests are designed to be self-contained and therefore
+              #   there is uniqueness in resource names. We need to either store
+              #   the unique names generated in run-test or control how the uniqueness
+              #   is generated so we can accurately delete the resources.
+              #
+              # What other avenues were explored?
+              # - storing the resource names in a result created in run-test
+              #   (X) does not work since Tekton will not allow access to results
+              #       coming from a cancelled task.
+              # - using a workspace to store names in a file
+              #   (X) does not work since the integration service does not allow
+              #       a workspace to be passed to a pipeline.
+
+              # The solution involves:
+              # 1-) re-generating the variables needed by injecting
+              #     the uuid using a pipelinerun.uuid from tekton since that guarantees that
+              #     the same uuid is available in all tasks.
+              # 2-) re-generating the k8s resource files on disk (without applying)
+              #     and using those resources to perform a delete operation.
+
+              # source the test suite env file to get variables needed for resource deletion
+              #
+              # shellcheck source=/dev/null
+              . "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/test.env"
+
+              # source the lib functions
+              #
+              # shellcheck source=/dev/null
+              . "/home/e2e/tests/lib/test-functions.sh"
+              
+              # delete GH repo
+              "/home/e2e/tests/scripts/delete-repository.sh" "${component_repo_name:?}"
+
+              # prepare what's needed to delete k8s resources
+              VAULT_PASSWORD_FILE=$(mktemp)
+              export VAULT_PASSWORD_FILE
+              set +x
+              echo "${VAULT_PASSWORD:?}" > "${VAULT_PASSWORD_FILE}"
+              set -x
+              KUBECONFIG_FILE=$(mktemp)
+              set +x
+              echo "${KUBECONFIG:?}" > "${KUBECONFIG_FILE}"
+              set -x
+              KUBECONFIG="${KUBECONFIG_FILE}"
+              export KUBECONFIG
+
+              # decrypt the secrets since they are part of the resources to be deleted
+              #
+              decrypt_secrets "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)"
+
+              tmpDir=$(mktemp -d)
+              # we need to rebuild the resources (without applying them)
+              # so that we can use their names to delete them
+              #
+              echo "Building tenant resources to prepare for deletion..."
+              kustomize build "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/resources/tenant" \
+                | envsubst > "$tmpDir/tenant-resources.yaml"
+
+              echo "Building managed resources to prepare for deletion..."
+              kustomize build "/home/e2e/tests/$(params.PIPELINE_TEST_SUITE)/resources/managed" \
+                | envsubst > "$tmpDir/managed-resources.yaml"
+
+              # actually delete the k8s resources and ignore failures since
+              # they might be already deleted from the cleanup trap
+              #
+              echo "Deleting resources..."
+              kubectl delete -f "$tmpDir/tenant-resources.yaml" --ignore-not-found
+              kubectl delete -f "$tmpDir/managed-resources.yaml" --ignore-not-found

--- a/integration-tests/push-to-addons-registry/test.env
+++ b/integration-tests/push-to-addons-registry/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="push-to-addons-registry-e2e-test"
 

--- a/integration-tests/push-to-external-registry/test.env
+++ b/integration-tests/push-to-external-registry/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="push-to-external-registry-e2e-test"
 

--- a/integration-tests/release-to-github/test.env
+++ b/integration-tests/release-to-github/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="release-to-github-e2e-test"
 

--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -124,7 +124,7 @@ trap 'cleanup_resources $? $LINENO "$BASH_COMMAND"' EXIT
 check_env_vars "$@" # Pass all args for consistency, though check_env_vars doesn't use them
 parse_options "$@" # Parses options and sets CLEANUP, NO_CVE
 
-decrypt_secrets
+decrypt_secrets "${SUITE_DIR}"
 create_github_repository
 patch_component_source
 setup_namespaces # Ensures correct context before resource creation

--- a/integration-tests/scripts/delete-repository.sh
+++ b/integration-tests/scripts/delete-repository.sh
@@ -57,12 +57,12 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ -z "${REPO_CHECK}" ]; then
-  echo "🔴 error: repository ${repo_name} not found or not accessible"
+  echo "⚠️ warning: repository ${repo_name} not found or not accessible"
   echo "   Check that:"
   echo "   1. Repository name is correct"
   echo "   2. Repository exists"
   echo "   3. GITHUB_TOKEN has access to the repository"
-  exit 1
+  exit 0
 fi
 
 # Perform the deletion


### PR DESCRIPTION
## Describe your changes
Why are we doing this?
- When pushing new changes to a PR, the integration-service
  will attempt to cancel any in-flight PR checks.
- The trap catches the EXIT signal but sometimes the cleanup
  function has not completed yet before the pod is killed.
- This leaves many orphaned GH repos and k8s resources.

Plan of attack
- First, we need to know what the resources are.
- The KRW tests are designed to be self-contained and therefore
  there is uniqueness in resource names. We need to either store
  the unique names generated in run-test or control how the uniqueness
  is generated so we can accurately delete the resources.

What other avenues were explored?
- storing the resource names in a result created in run-test
  (X) does not work since Tekton will not allow access to results
      coming from a cancelled task.
- using a workspace to store names in a file
  (X) does not work since the integration service does not allow
      a workspace to be passed to a pipeline.

The solution involves:
1-) re-generating the variables needed by injecting
    the uuid using a pipelinerun.uuid from tekton since that guarantees that
    the same uuid is available in all tasks.
2-) re-generating the k8s resource files on disk (without applying)
    and using those resources to perform a delete operation.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
