### PR TITLE
feat: remove CODEOWNERS reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @konflux-ci/release-service-maintainers will be requested for
-# review when someone opens a pull request.
-*       @konflux-ci/release-service-maintainers


### PR DESCRIPTION
## Describe your changes

This is not needed anymore now that we are assigning PRs with the new automation.

## Checklist before requesting a review
- [x ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ x] My commit message includes `Signed-off-by: My name <email>`
- [ x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
