### PR TITLE
fix: use default sa for push-artifacts pipeline

### DIFF
--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -159,7 +159,6 @@ spec:
         fi
 
         REQUESTTYPE=$(jq -r '.requestType // "internal-request"' "${DATA_FILE}")
-        service_account_name=$(jq -r '.spec.pipeline.serviceAccountName // "release-service-account"' "${RPA_FILE}")
         if [ "${REQUESTTYPE}" == "internal-pipelinerun" ] ; then
           requestType=internal-pipelinerun
           requestK8sType=pipelinerun
@@ -229,7 +228,7 @@ spec:
           -l ${TASK_LABEL}="${TASK_ID}" \
           -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
           -t "$(params.requestTimeout)" \
-          --service-account "${service_account_name}" \
+          --service-account release-service-account \
           --pipeline-timeout 24h0m0s \
           --task-timeout 23h50m0s \
           --finally-timeout 0h10m0s \


### PR DESCRIPTION
When the push-artifacts-to-cdn managed task invokes the internal-request
pipeline, it passes the service account propogated from the RPA. This
throws an error. It should use the default service account for this
internal request portion instead similar to the disk-image pipeline.

Error msg:
 "error looking up service account stonesoup-int-srvc/release-developer-portal:
  serviceaccount "release-developer-portal" not found."

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
