### PR TITLE
fix: credential names for push-artifacts-to-cdn

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -1,10 +1,10 @@
 # push-artifacts-to-cdn-task
 
-Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+Tekton task to push artifacts to the Customer Portal using Pulp and optionally to
 the Developer Portal using exodus-rsync with optional signing. It uses logic based
-on the snapshot data to determine which targets to publish to: if components contain 
+on the snapshot data to determine which targets to publish to: if components contain
 both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
-(Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+(Pulp) and to CGW; if components contain `staged` data only, artifacts are
 pushed to the Customer Portal (Pulp); if components contain `contentGateway`
 data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -8,11 +8,11 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+    Tekton task to push artifacts to the Customer Portal using Pulp and optionally to
     the Developer Portal using exodus-rsync with optional signing. It uses logic based
-    on the snapshot data to determine which targets to publish to: if components contain 
+    on the snapshot data to determine which targets to publish to: if components contain
     both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
-    (Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+    (Pulp) and to CGW; if components contain `staged` data only, artifacts are
     pushed to the Customer Portal (Pulp); if components contain `contentGateway`
     data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
   params:
@@ -113,16 +113,16 @@ spec:
       emptyDir: {}
     - name: mac-ssh-key-vol
       secret:
-        secretName: mac-ssh-key-secret
+        secretName: mac-ssh-key
     - name: windows-ssh-key-vol
       secret:
-        secretName: windows-ssh-key-secret
+        secretName: windows-ssh-key
     - name: checksum-fingerprint-vol
       secret:
-        secretName: checksum-fingerprint-secret
+        secretName: checksum-fingerprint
     - name: checksum-keytab-vol
       secret:
-        secretName: checksum-keytab-secret
+        secretName: checksum-keytab
   steps:
     - name: extract-artifacts
       image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
@@ -1028,7 +1028,7 @@ spec:
         export DISK_IMAGE_DIR
         RELATIVE_PATHS=""
 
-        push_to_pulp() { 
+        push_to_pulp() {
           # use the 1st component's version for STAGED_JSON
           version=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
           # Check if staged.destination exists in any component
@@ -1052,7 +1052,7 @@ spec:
           echo "$staged_json" | yq -P -I 4 > staged.yaml
 
           pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
-            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" 
+            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL"
           RELATIVE_PATHS=$(jq -erc '.payload.files[].relative_path' <<< "$staged_json")
 
           # Clean up file to avoid uploading it in exodus-rsync as an artifact.
@@ -1105,14 +1105,14 @@ spec:
           for path in $RELATIVE_PATHS; do
             [[ $i -ge "$NUM_COMPONENTS" ]] && break  # stop once we've processed all components
             component_destination="${DISK_IMAGE_DIR}/$(dirname "$path")"
-            
+
             SNAPSHOT_JSON=$(
               jq --argjson i "$i" --arg dir "$component_destination" '
                 .components[$i] |=
                   if .contentGateway? then
                     .contentGateway.contentDir = $dir
                   else
-                    . # components without contentGateway will not be published. 
+                    . # components without contentGateway will not be published.
                   end
               ' <<<"$SNAPSHOT_JSON"
             )

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
@@ -40,19 +40,19 @@ kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfi
 # create ssh secrets
 
 # cleaning up secrets first
-for secret in checksum-fingerprint-secret checksum-keytab-secret quay-credentials windows-credentials mac-host-credentials mac-signing-credentials; do
+for secret in checksum-fingerprint checksum-keytab quay-credentials windows-credentials mac-host-credentials mac-signing-credentials; do
     kubectl delete secret "$secret" --ignore-not-found
 done
 
 TMPDIR=$(mktemp -d /tmp/XXXX.tmp)
 for OS in windows mac; do
     ssh-keygen -f "${TMPDIR}/${OS}" -N ""
-    kubectl delete secret "${OS}-ssh-key-secret" --ignore-not-found
-    kubectl create secret generic "${OS}-ssh-key-secret" --from-file="${OS}_id_rsa=${TMPDIR}/${OS}" --from-literal="${OS}"_fingerprint="$(ssh-keygen -lf "${TMPDIR}/${OS}.pub")"
+    kubectl delete secret "${OS}-ssh-key" --ignore-not-found
+    kubectl create secret generic "${OS}-ssh-key" --from-file="${OS}_id_rsa=${TMPDIR}/${OS}" --from-literal="${OS}"_fingerprint="$(ssh-keygen -lf "${TMPDIR}/${OS}.pub")"
 done
 ssh-keygen -f "${TMPDIR}/checksum" -N ""
-kubectl create secret generic "checksum-fingerprint-secret" --from-literal=fingerprint="$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
-kubectl create secret generic "checksum-keytab-secret" --from-literal=keytab=""
+kubectl create secret generic "checksum-fingerprint" --from-literal=fingerprint="$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
+kubectl create secret generic "checksum-keytab" --from-literal=keytab=""
 
 # create quay, windows and mac secrets
 kubectl create secret generic quay-credentials --from-literal=username="testuser" --from-literal=password="testpass"


### PR DESCRIPTION
The credential names do not have the -secret suffix in the vault. Running the task on the internal cluster fails as it can not locate these secrets.

- fixed credential names
- removed trailing whitespace

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
