### PR TITLE
test: add test with 2 repos with incrementer in apply-mapping

### DIFF
--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -38,12 +38,7 @@ function skopeo() {
       return
   fi
 
-  if [[ "$*" =~ inspect\ --retry-times\ 3\ --no-tags\ docker://repo1 ]]; then
-      echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
-      return
-  fi
-
-  if [[ "$*" =~ inspect\ --retry-times\ 3\ --no-tags\ docker://repo2 ]]; then
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://(repoa|repo2) ]]; then
       echo '{"Tags": []}'
       return
   fi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -71,13 +71,14 @@ spec:
                       "name": "comp1",
                       "repositories": [
                         {
-                          "url": "repo1a",
+                          "url": "repoa",
                           "tags": [
                             "tag1-{{timestamp}}",
                             "tag2-{{ timestamp }}",
                             "tag3-{{ timestamp }}-{{ git_short_sha }}",
                             "{{git_sha}}",
-                            "{{ git_sha }}-abc"
+                            "{{ git_sha }}-abc",
+                            "release-{{ incrementer }}"
                           ]
                         },
                         {
@@ -275,12 +276,12 @@ spec:
 
               echo Test that comp1 repo a has the proper tags
               test "$(
-                jq -c '.components[] | select(.name=="comp1").repositories[] | select(.url=="repo1a") | .tags' \
+                jq -c '.components[] | select(.name=="comp1").repositories[] | select(.url=="repoa") | .tags' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
-              )" == '["defaultTag","tag-labelvalue","tag-labelvalue-with-dash","tag1-2024-07-29",'\
+              )" == '["defaultTag","release-1","tag-labelvalue","tag-labelvalue-with-dash","tag1-2024-07-29",'\
               '"tag2-2024-07-29","tag3-2024-07-29-testrev","testrevision-abc","testrevision"]'
 
-              echo Test that comp1 repo b has the proper tags
+              echo Test that the second comp1 repo has the proper tags
               test "$(
                 jq -c '.components[] | select(.name=="comp1").repositories[] | select(.url=="repo1") | .tags' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"


### PR DESCRIPTION
## Describe your changes

This commit modifies a test in apply-mapping so that two repos in the
same component both use the incrementer variable in their tags. They
should be different per repo.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
