### PR TITLE
feat(RELEASE-1240): add retry for kinit calls

### DIFF
--- a/.github/scripts/check_readme.sh
+++ b/.github/scripts/check_readme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script will verify that the README.md of all task and 
+# This script will verify that the README.md of all task and
 # pipeline directories provided matches the output of hack/readme_generator.sh
 # to ensure that README files are up to date.
 #
@@ -112,7 +112,7 @@ do
   fi
 
   if ! diff -u <(.github/scripts/readme_generator.sh --dry-run "$ITEM_DIR") "$README_PATH"; then
-    echo "  Error: README.md has not been updated. Please use hack/readme-generator.sh to" \
+    echo "  Error: README.md has not been updated. Please use .github/scripts/readme_generator.sh to" \
       "generate a new README.md to replace $ITEM/README.md"
     FAILED_ITEMS+=("$ITEM - outdated README.md")
   else

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -25,7 +25,7 @@ spec:
       description: Space separated string of embargoed CVEs if any are found, empty string otherwise
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 32Mi
@@ -80,7 +80,7 @@ spec:
           export KRB5_CONFIG
           export KRB5_TRACE=/dev/stderr
           sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
-          kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+          retry 5 kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
 
           RC=0
           for CVE in $(params.cves); do

--- a/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
@@ -27,3 +27,6 @@ function curl() {
     exit 1
   fi
 }
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 256Mi
@@ -267,7 +267,7 @@ spec:
             export KRB5_CONFIG
             export KRB5_TRACE=/dev/stderr
             sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
-            kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+            retry 5 kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
             REQUEST_URL="${ERRATA_API}/advisory/reserve_live_id"
             LIVE_ID=$(curl --retry 3 --negotiate -u : "${REQUEST_URL}" -XPOST | jq -r '.live_id')
           fi

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -129,3 +129,6 @@ function check-jsonschema() {
     /usr/local/bin/check-jsonschema $*
   fi
 }
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:11d0ab9eb55461dc7c757be49e03943651151ed4
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -30,7 +30,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 32Mi
@@ -99,7 +99,7 @@ spec:
           export KRB5_CONFIG
           export KRB5_TRACE=/dev/stderr
           sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
-          kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
+          retry 5 kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
 
           INCLUDE_FIELDS="cve_id,impact,affects.purl,affects.impact"
           ADVISORY_SEVERITY=""

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -24,3 +24,6 @@ function curl() {
     exit 1
   fi
 }
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -37,7 +37,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -1,10 +1,10 @@
 # push-artifacts-to-cdn-task
 
-Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+Tekton task to push artifacts to the Customer Portal using Pulp and optionally to
 the Developer Portal using exodus-rsync with optional signing. It uses logic based
-on the snapshot data to determine which targets to publish to: if components contain 
+on the snapshot data to determine which targets to publish to: if components contain
 both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
-(Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+(Pulp) and to CGW; if components contain `staged` data only, artifacts are
 pushed to the Customer Portal (Pulp); if components contain `contentGateway`
 data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -8,11 +8,11 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    Tekton task to push artifacts to the Customer Portal using Pulp and optionally to 
+    Tekton task to push artifacts to the Customer Portal using Pulp and optionally to
     the Developer Portal using exodus-rsync with optional signing. It uses logic based
-    on the snapshot data to determine which targets to publish to: if components contain 
+    on the snapshot data to determine which targets to publish to: if components contain
     both `staged` and `contentGateway` data, artifacts are pushed to the Customer Portal
-    (Pulp) and to CGW; if components contain `staged` data only, artifacts are 
+    (Pulp) and to CGW; if components contain `staged` data only, artifacts are
     pushed to the Customer Portal (Pulp); if components contain `contentGateway`
     data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
   params:
@@ -125,7 +125,7 @@ spec:
         secretName: checksum-keytab-secret
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -244,7 +244,7 @@ spec:
             wait -n
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -357,7 +357,7 @@ spec:
         echo "Digest for windows content: $windows_digest"
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -525,7 +525,7 @@ spec:
         # shellcheck disable=SC2029
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -663,7 +663,7 @@ spec:
         ssh $SSH_OPTS "Remove-Item -LiteralPath \
         C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -766,7 +766,7 @@ spec:
         KRB5CCNAME=FILE:/tmp/krb5cc_$(id -u)
         export KRB5CCNAME
         base64 -d /etc/secrets_keytab/keytab > /tmp/sa.keytab
-        kinit -kt /tmp/sa.keytab "$(params.checksumUser)@$(params.kerberosRealm)"
+        retry 5 kinit -kt /tmp/sa.keytab "$(params.checksumUser)@$(params.kerberosRealm)"
 
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh
@@ -827,7 +827,7 @@ spec:
         mv "$SHA_SUM_PATH" "${SIGNED_DIR}/sha256sum.txt"
 
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 256Mi
@@ -903,7 +903,7 @@ spec:
         done
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -1028,7 +1028,7 @@ spec:
         export DISK_IMAGE_DIR
         RELATIVE_PATHS=""
 
-        push_to_pulp() { 
+        push_to_pulp() {
           # use the 1st component's version for STAGED_JSON
           version=$(jq -cr '.components[0].staged.version // ""' <<< "$SNAPSHOT_JSON")
           # Check if staged.destination exists in any component
@@ -1052,7 +1052,7 @@ spec:
           echo "$staged_json" | yq -P -I 4 > staged.yaml
 
           pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
-            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" 
+            --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL"
           RELATIVE_PATHS=$(jq -erc '.payload.files[].relative_path' <<< "$staged_json")
 
           # Clean up file to avoid uploading it in exodus-rsync as an artifact.
@@ -1105,14 +1105,14 @@ spec:
           for path in $RELATIVE_PATHS; do
             [[ $i -ge "$NUM_COMPONENTS" ]] && break  # stop once we've processed all components
             component_destination="${DISK_IMAGE_DIR}/$(dirname "$path")"
-            
+
             SNAPSHOT_JSON=$(
               jq --argjson i "$i" --arg dir "$component_destination" '
                 .components[$i] |=
                   if .contentGateway? then
                     .contentGateway.contentDir = $dir
                   else
-                    . # components without contentGateway will not be published. 
+                    . # components without contentGateway will not be published.
                   end
               ' <<<"$SNAPSHOT_JSON"
             )

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -12,7 +12,7 @@ function oras() {
     if [[ "$*" =~ login.* ]]; then
         echo Simulating oras quay login
     elif [[ "$*" =~ push.* ]]; then
-        echo Simulating oras push 
+        echo Simulating oras push
         echo "Digest: sha256:$(echo | sha256sum |awk '{ print $1}')"
     elif [[ "$*" == *"nonexistent-disk-image"* ]]; then
         echo Simulating failing oras pull call >&2
@@ -140,3 +140,6 @@ function kinit() {
         echo initialized
     fi
 }
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
    Run the task with a binary component that does NOT have staged.destination
-   or staged.version. Uses an invalid Pulp secret to verify the Pulp push 
+   or staged.version. Uses an invalid Pulp secret to verify the Pulp push
    is skipped and artifacts are published via exodus-rsync instead.
   tasks:
     - name: run-task
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-push-artifacts-to-cdn-fail-exdous-rsync-push
 spec:
-  description: |    
+  description: |
     Run the push-artifacts task with the exodus-rsync script failing. This is done by having
     the mock script call fail based on the file-path.
   tasks:
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -74,7 +74,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -73,14 +73,14 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'
             script: |
               #!/usr/bin/env bash
               set -ex
-              
+
               EXPECTED="Component 1 is missing 'name'"
               if [[ "$RESULT" != *"$EXPECTED"* ]]; then
                 echo "Error: result should be \"$EXPECTED\""

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'
@@ -89,4 +89,3 @@ spec:
                 echo "Error: result task result should show failure from missing staged.version but doesn't"
                 exit 1
               fi
-              

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
@@ -75,7 +75,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:937662a1ba4b345d3bd1f64b13ead1c31e7ac473
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -141,3 +141,6 @@ function skopeo() {
 # the watch_build_state can't reach some mocks by default, so exporting them fixes it.
 export -f curl
 export -f mock_build_progress
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -34,7 +34,7 @@ spec:
           value: $(tasks.run-task.results.buildState)
         - name: genericResult
           value: $(tasks.run-task.results.genericResult)
-        - name: indexImageDigests 
+        - name: indexImageDigests
           value: $(tasks.run-task.results.indexImageDigests)
         - name: iibLog
           value: $(tasks.run-task.results.iibLog)
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-prod.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-complete.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-in-progress.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-retry-outdated.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-timeout.yaml
@@ -41,7 +41,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/bin/bash
               set -x

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -63,7 +63,7 @@ spec:
   steps:
     - name: update-fbc-catalog-prepare-and-call-iib-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
@@ -192,7 +192,7 @@ spec:
         export KRB5_CONFIG="${KRB5_TEMP_CONF}"
         export KRB5_TRACE=/dev/stderr
 
-        kinit -V "${KRB5_PRINCIPAL}" -k -t "/tmp/keytab"
+        retry 5 kinit -V "${KRB5_PRINCIPAL}" -k -t "/tmp/keytab"
 
         set -x
         # check if this fbc fragment is opt-in
@@ -288,7 +288,7 @@ spec:
           mountPath: /mnt/service-account-secret
     - name: update-fbc-catalog-wait-for-iib-build-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -74,7 +74,7 @@ spec:
   volumes:
     - name: bs-keytab
       secret:
-        secretName: $(params.checksumKeytab)    
+        secretName: $(params.checksumKeytab)
     - name: checksum-fingerprint
       secret:
         secretName: $(params.checksumFingerprint)
@@ -135,20 +135,20 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-files
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
       computeResources:
         limits:
           memory: 512Mi
         requests:
           memory: 512Mi
-          cpu: 250m 
+          cpu: 250m
       volumeMounts:
         - name: checksum-fingerprint
           mountPath: "/etc/sec-checksum"
           readOnly: true
         - name: bs-keytab
           mountPath: "/etc/sec-keytab"
-          readOnly: true        
+          readOnly: true
       env:
         - name: signKey
           valueFrom:
@@ -168,13 +168,13 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -eux
-        
+
         signedKmodsPath="$(params.signedKmodsPath)"
         signingAuthor="$(params.signingAuthor)"
-        # Remove newline in signing variables 
+        # Remove newline in signing variables
         signUser="${signUser//$'\n'/}"
         signHost="${signHost//$'\n'/}"
-         
+
         echo "Signing OOT modules from $(params.dataDir)/$signedKmodsPath.."
         SIGNED_KMODS_PATH="$(params.dataDir)/$signedKmodsPath"
         SSH_OPTS=(
@@ -206,7 +206,7 @@ spec:
         }
         KRB5CCNAME=FILE:/tmp/krb5cc_$(id -u)
         export KRB5CCNAME
-        kinit -kt /etc/sec-keytab/keytab-build-and-sign.keytab "${signUser}@$(params.kerberosRealm)"
+        retry 5 kinit -kt /etc/sec-keytab/keytab-build-and-sign.keytab "${signUser}@$(params.kerberosRealm)"
 
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -5,7 +5,7 @@ set -eux
 
 function kinit() {
   echo "Mock kinit called with: $*"
-  
+
   # Write to both locations to support both modes
   if [ -d /workspace/kmods ]; then
     echo "$*" >> /workspace/kmods/mock_kinit.txt
@@ -26,7 +26,7 @@ function kinit() {
 
 function ssh() {
   echo "Mock ssh called with: $*"
-  
+
   # Write to both locations to support both modes
   if [ -d /workspace/kmods ]; then
     echo "$*" >> /workspace/kmods/mock_ssh.txt
@@ -47,7 +47,7 @@ function ssh() {
 
 function scp() {
   echo "Mock scp called with: $*"
-  
+
   # Write to both locations to support both modes
   if [ -d /workspace/kmods ]; then
     echo "$*" >> /workspace/kmods/mock_scp.txt
@@ -65,3 +65,6 @@ function scp() {
       ;;
   esac
 }
+
+# The retry script won't see the kinit function unless we export it
+export -f kinit

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -125,7 +125,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -137,7 +137,7 @@ spec:
               else
                 echo "INFO: ociStorage provided, checking dataDir for mock files"
                 FILE="$(params.dataDir)/mock_scp.txt"
-                
+
                 # Also verify that the signed kmods exist in the dataDir
                 if [ -d "$(params.dataDir)/$(params.signedKmodsPath)" ]; then
                   echo "SUCCESS: signed-kmods directory found in dataDir"
@@ -148,12 +148,12 @@ spec:
                   ls -la "$(params.dataDir)" || echo "dataDir does not exist"
                 fi
               fi
-              
+
               if [ -f "$FILE" ]; then
                 echo "Mock scp file found: $FILE"
                 echo "Contents:"
                 cat "$FILE"
-                
+
                 if grep -q 'mod1.ko' "$FILE" && grep -q 'mod2.ko' "$FILE"; then
                   echo "SUCCESS: Found both mod1.ko and mod2.ko in $FILE"
                 else
@@ -167,7 +167,7 @@ spec:
         - name: signedKmodsPath
           value: signed-kmods
         - name: dataDir
-          value: $(params.dataDir)  
+          value: $(params.dataDir)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact


### PR DESCRIPTION
## Describe your changes
All internal tasks that use kinit now have a retry.

The retry script was implemented here:
https://github.com/konflux-ci/release-service-utils/pull/501

Note: The task tests transparently call kinit via the retry script. I didn't add any special test to verify the retry script works, but I tested it manually.

## Relevant Jira

[RELEASE-1240](https://issues.redhat.com//browse/RELEASE-1240)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
