### PR TITLE
docs: fix example path to apply-mapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,8 @@ Tests are defined as Tekton Pipelines inside the `tests` subdirectory of the tas
 directory. Their filenames must match `test*.yaml` and the Pipeline name must be
 the same as the filename (sans `.yaml`).
 
-E.g. to add a test pipeline for `tasks/apply-mapping`, you can add a pipeline
-such as `tasks/apply-mapping/tests/test-apply-mapping.yaml`.
+E.g. to add a test pipeline for `tasks/managed/apply-mapping`, you can add a pipeline
+such as `tasks/managed/apply-mapping/tests/test-apply-mapping.yaml`.
 
 To reference the task under test in a test pipeline, use just the name - the test
 script will install the task CR locally. For example:
@@ -356,7 +356,7 @@ Once you have everything ready, you can run the test script and pass task versio
 as arguments, e.g.
 
 ```
-./.github/scripts/test_tekton_tasks.sh tasks/apply-mapping
+./.github/scripts/test_tekton_tasks.sh tasks/managed/apply-mapping
 ```
 
 This will install the task and run all test pipelines matching `tests/test*.yaml`.
@@ -364,7 +364,7 @@ This will install the task and run all test pipelines matching `tests/test*.yaml
 Another option is to run one or more tests directly:
 
 ```
-./.github/scripts/test_tekton_tasks.sh tasks/apply-mapping/tests/test-apply-mapping.yaml
+./.github/scripts/test_tekton_tasks.sh tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
 ```
 
 This will still install the task and run `pre-apply-task-hook.sh` if present, but it will then


### PR DESCRIPTION
It is tasks/managed/apply-mapping now, not tasks/apply-mapping.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
