### PR TITLE
feat(RELEASE-1818): remove workspaces from populate-release-notes, prepare-fbc-release and prepare-validation tasks

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -317,9 +317,6 @@ spec:
         - collect-data
         - get-ocp-version
     - name: prepare-fbc-release
-      workspaces:
-        - name: data
-          workspace: release-workspace
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -303,9 +303,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/populate-release-notes/populate-release-notes.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - verify-conforma
     - name: check-data-keys

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -363,9 +363,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/populate-release-notes/populate-release-notes.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - collect-gh-params
         - extract-binaries-from-image

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -399,9 +399,6 @@ spec:
         resolver: git
       runAfter:
         - filter-already-released-advisory-images
-      workspaces:
-        - name: data
-          workspace: release-workspace
     - name: embargo-check
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"

--- a/tasks/managed/populate-release-notes/README.md
+++ b/tasks/managed/populate-release-notes/README.md
@@ -6,18 +6,18 @@ the releaseNotes data can use it.
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| dataPath                | Path to the JSON string of the merged data to use                                                                          | No       | -                       |
-| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
-| binaries_dir            | The location of github release binaries. Needed for PURL generation                                                        | Yes      | ""                      |
-| github_release_version  | The version string of the release (from collect-gh-params)                                                                 | Yes      | ""                      |
-| github_release_url      | The url of the release (from collect-gh-params)                                                                            | Yes      | ""                      |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| dataPath                | Path to the JSON string of the merged data to use                                                                          | No       | -                    |
+| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
+| binaries_dir            | The location of github release binaries. Needed for PURL generation                                                        | Yes      | ""                   |
+| github_release_version  | The version string of the release (from collect-gh-params)                                                                 | Yes      | ""                   |
+| github_release_url      | The url of the release (from collect-gh-params)                                                                            | Yes      | ""                   |

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -42,7 +42,7 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
@@ -65,9 +65,6 @@ spec:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
       type: string
-  workspaces:
-    - name: data
-      description: The workspace where the data JSON file resides
   volumes:
     - name: workdir
       emptyDir: {}
@@ -83,27 +80,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -410,7 +386,6 @@ spec:
                     /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
             done
         done
-
     - name: populate-release-notes-github
       image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
       computeResources:
@@ -519,7 +494,6 @@ spec:
             jq --argjson content "$jsonString" '.releaseNotes.content.artifacts += [$content]' "${DATA_FILE}" > \
                 /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
         done
-
     - name: populate-release-notes-type-and-references
       image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
       computeResources:
@@ -586,26 +560,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
 yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
-yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
@@ -10,8 +10,6 @@ spec:
     Run the populate-release-notes task with CVE validation that should fail.
     Tests the scenario where a CVE is listed in issues.fixed but
     releaseNotes.cves is empty, causing validation to fail.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -34,15 +32,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -124,14 +117,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -140,14 +125,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -172,8 +149,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
@@ -9,8 +9,6 @@ spec:
   description: |
     Run the populate-release-notes task with CVE validation that should fail.
     Tests that missing CVEs in releaseNotes.cves cause the validation to fail.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -33,15 +31,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -113,14 +106,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -131,16 +116,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-        workspaces:
-          - name: data
     - name: run-task
       taskRef:
         name: populate-release-notes
@@ -163,8 +138,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task with CVE validation that should pass.
     Tests that CVEs listed in issues.fixed are properly validated against releaseNotes.cves.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -129,14 +122,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -147,16 +132,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-        workspaces:
-          - name: data
     - name: run-task
       taskRef:
         name: populate-release-notes
@@ -179,9 +154,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -190,17 +162,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -216,14 +183,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task and ensure CVE information present in the data.json
     is properly included in the releaseNotes.content.images.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -142,14 +135,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -158,14 +143,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -190,9 +167,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -201,17 +175,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -227,14 +196,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task and ensure CVE information present in the data.json
     is properly included in the releaseNotes.content.artifacts.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -162,14 +155,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -178,14 +163,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -210,9 +187,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -221,17 +195,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -247,14 +216,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task and ensure CVE information present in the data.json
     is properly included in the releaseNotes.content.artifacts for github releases.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -173,14 +166,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -189,14 +174,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -227,9 +204,6 @@ spec:
           value: "https://github.com/some-org/some-repo/releases/tag/v1.0.0"
         - name: binaries_dir
           value: "$(context.pipelineRun.uid)/releases"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -238,17 +212,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -264,14 +233,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   description: |
     Run the populate-release-notes task without a data JSON and verify that the task fails as expected.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -80,14 +73,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -96,14 +81,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -128,8 +105,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   description: |
     Run the populate-release-notes task without a snapshot JSON and verify that the task fails as expected.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -95,14 +88,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -111,14 +96,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -143,8 +120,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task with multiple images in the snapshot JSON and verify
     the data JSON has the proper content
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -124,14 +117,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -140,14 +125,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -172,9 +149,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -183,17 +157,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -209,14 +178,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task and ensure existing information in the
     releaseNotes.content.images section of the data JSON is not overwritten
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -119,14 +112,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -135,14 +120,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -167,9 +144,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -178,17 +152,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -204,14 +173,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   description: |
     Run the populate-release-notes task with a type that is not RHSA. Ensure that references are []
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -30,15 +28,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -108,14 +101,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -124,14 +109,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -156,9 +133,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -167,17 +141,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -193,14 +162,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task with a releaseNotes.type that is not RHSA, but CVEs present in releaseNotes.
     The type should be overwritten to RHSA.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -143,14 +136,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -159,14 +144,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -191,9 +168,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -202,17 +176,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -228,14 +197,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task with a RHSA type. Ensure that references are added for each
     CVE, existing ones are maintained, and there are no duplicates.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -143,14 +136,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -159,14 +144,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -191,9 +168,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -202,17 +176,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -228,14 +197,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the populate-release-notes task with a single image in the snapshot JSON and verify
     the data JSON has the proper content
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -112,14 +105,6 @@ spec:
                 ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -128,14 +113,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -160,9 +137,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
@@ -171,17 +145,12 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -197,14 +166,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/prepare-fbc-release/README.md
+++ b/tasks/managed/prepare-fbc-release/README.md
@@ -9,15 +9,15 @@ to each component, so other task can use them.
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                         | No       | -                       |
-| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                         | No       | -                    |
+| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -45,16 +45,13 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-  workspaces:
-    - name: data
-      description: Workspace where the snapshot and data json is stored
   results:
     - name: sourceDataArtifact
       type: string
@@ -74,27 +71,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -261,26 +237,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/prepare-fbc-release/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/prepare-fbc-release/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   description: |
     Run the prepare-fbc-release task with no data file and verify the task fails as expected
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -84,14 +77,6 @@ spec:
                   ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -100,14 +85,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -134,6 +111,3 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-snapshot.yaml
@@ -9,8 +9,6 @@ spec:
   description: |
     Run the prepare-fbc-release task with no snapshot file present in the path specified by
     snapshotPath. The task should fail.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -44,6 +42,3 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   description: |
     Run the prepare-fbc-release task and fail as the ocp version mismatch.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -93,14 +86,6 @@ spec:
                   ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -109,14 +94,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -133,6 +110,3 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -8,8 +8,6 @@ spec:
     Run the prepare-fbc-release task and verify
     that the task succesfully update the snapshot
     with the ocpVersion, fromIndex, targetIndex for all the component in snapshot
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -106,14 +99,6 @@ spec:
                       ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -122,14 +107,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -156,13 +133,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
@@ -173,8 +144,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: snapshotPath
             type: string
@@ -197,14 +166,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -9,8 +9,6 @@ spec:
     that the task succesfully update the snapshot
     with the ocpVersion, fromIndex and targetIndex
     for all the component in snapshot
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -33,15 +31,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -94,14 +87,6 @@ spec:
                   ]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -110,14 +95,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -144,13 +121,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
@@ -161,8 +132,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: snapshotPath
             type: string
@@ -185,14 +154,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact


### PR DESCRIPTION
## Describe your changes
- remove workspace and workspace bindings from populate-release-notes, prepare-fbc-release and prepare-validation
- update workspace usage for above tasks in pipelines in managed/
- remove skip and patch trusted artfacts steps in above tasks

## Relevant Jira
- [RELEASE-1818](https://issues.redhat.com//browse/RELEASE-1818)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
