### PR TITLE
fix: gitlint run as part of merge queues

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,8 @@ jobs:
       - name: Run gitlint check
         run: |
           source venv/bin/activate
-          gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+          git fetch origin ${{ github.base_ref }}
+          gitlint --commits origin/${{ github.base_ref }}..HEAD
   checkton:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
github.event.pull_request.base.ref only works for PR events, but it's undefined in a merge queue. As a result the gitlint check would fail there with:

'origin/..HEAD': unknown revision

The extra fetch may or may not be needed, but it shouldn't hurt.

Note that when the CI runs directly in the PR,
github.event.pull_request.base.ref is the same as
github.base_ref.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
