### PR TITLE
fix: gitlint check in merge queues take 2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install gitlint into container
+          ref: ${{ github.sha }}
+      - name: Install gitlint
         run: |
           python3 -m venv venv
           source venv/bin/activate
@@ -49,8 +49,10 @@ jobs:
       - name: Run gitlint check
         run: |
           source venv/bin/activate
-          git fetch origin ${{ github.base_ref }}
-          gitlint --commits origin/${{ github.base_ref }}..HEAD
+          BASE_REF="${{ github.base_ref || github.event.merge_group.base_ref }}"
+          echo "Base ref: $BASE_REF"
+          git fetch origin "$BASE_REF"
+          gitlint --commits "origin/$BASE_REF"..HEAD
   checkton:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Another attempt at fixing gitlint when it runs
as part of merge queues.

Here's the first attempt:
https://github.com/konflux-ci/release-service-catalog/pull/1341

And it still fails - turns out github.base_ref is not available for merge_queue events either.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
