### PR TITLE
feat(RELEASE-1570): stop populating updated_date in advisories

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Bump the utils image for a change in the template to stop populating the updated_date field in advisory yaml files.

We are removing the field from the advisory yaml files. Instead, this field will be injected in the Gitlab CI pipeline before the UMB message is sent. This is already implemented in both staging and production advisory repos.

Related utils PR:
https://github.com/konflux-ci/release-service-utils/pull/503

## Relevant Jira

[RELEASE-1570](https://issues.redhat.com//browse/RELEASE-1570)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
