### PR TITLE
fix: gitlint check in merge queues take 3

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,8 @@ jobs:
       - name: Run gitlint check
         run: |
           source venv/bin/activate
-          BASE_REF="${{ github.base_ref || github.event.merge_group.base_ref }}"
+          RAW_BASE_REF="${{ github.base_ref || github.event.merge_group.base_ref }}"
+          BASE_REF="${RAW_BASE_REF#refs/heads/}"
           echo "Base ref: $BASE_REF"
           git fetch origin "$BASE_REF"
           gitlint --commits "origin/$BASE_REF"..HEAD


### PR DESCRIPTION
## Describe your changes

Another attempt at fixing gitlint when it runs as part of merge queues.

Previous attempts:
https://github.com/konflux-ci/release-service-catalog/pull/1341 https://github.com/konflux-ci/release-service-catalog/pull/1343

It still fails. The reason is that in the merge queue event the base_ref will be something like `refs/heads/develoment` and that will work for the fetch, but not as a branch name. So we need to strip `refs/heads` from the base_ref.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
