### PR TITLE
feat(KFLUXVNGD-454): add oci version tag to apply-mapping

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -21,6 +21,8 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ digest_sha }}" -> The image digest of the respective component
 * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
   repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
+* "{{ oci_version }}" -> The version from OCI image annotations
+  (extracts org.opencontainers.image.version annotation and converts + to _ for tag compliance)
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -29,6 +29,8 @@ spec:
     * "{{ digest_sha }}" -> The image digest of the respective component
     * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
       repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
+    * "{{ oci_version }}" -> The version from OCI image annotations
+      (extracts org.opencontainers.image.version annotation and converts + to _ for tag compliance)
 
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
   params:
@@ -370,10 +372,33 @@ spec:
             # tags per arch. So, we just use the first digest listed.
             arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
             os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
-            image_metadata="$(skopeo inspect --retry-times 3 --no-tags --override-os "${os}" --override-arch "${arch}" \
-              docker://"${IMAGE_REF}" | jq -c)"
-            # For timestamp, use Labels.build-date and fallback to Created
-            build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
+
+            # Get configMediaType from architecture info to determine artifact type
+            config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
+
+            # Check if this is a Helm chart - handle Helm artifacts specifically
+            if [[ "$config_media_type" == "application/vnd.cncf.helm.config.v1+json" ]]; then
+                # This is a Helm chart - use raw manifest approach
+                echo "Detected Helm chart artifact for ${NAME}, using raw manifest"
+                raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${IMAGE_REF}" | jq -c)"
+                oci_version_raw="$(jq -r '.annotations."org.opencontainers.image.version" // ""' <<< "$raw_manifest")"
+                build_date="$(jq -r '.annotations."org.opencontainers.image.created" // ""' <<< "$raw_manifest")"
+                labels="{}"
+            else
+                # This is a regular container image - use standard skopeo inspect
+                image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
+                  --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
+                # For timestamp, use Labels.build-date and fallback to Created
+                build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
+                oci_version_raw="$(jq -r '.annotations."org.opencontainers.image.version" // ""' <<< "$image_metadata")"
+                labels="$(jq -c '.Labels' <<< "${image_metadata}")"
+            fi
+
+            # Transform version to OCI tag format: replace + with _ (convention for OCI compliance)
+            # Set default value if empty (common for regular container images without OCI annotations)
+            oci_version="${oci_version_raw//+/_}"
+            oci_version="${oci_version:-unknown}"
+
             if [ "${build_date}" = "" ] ; then
               timestamp=""
             else
@@ -386,8 +411,8 @@ spec:
               --arg git_sha "${git_sha}" \
               --arg git_short_sha "${git_sha:0:7}" \
               --arg digest_sha "${build_sha}" \
+              --arg oci_version "${oci_version}" \
               '$ARGS.named')"
-            labels="$(jq -c '.Labels' <<< "${image_metadata}")"
 
             # Also substitute filename values in the staged section of components
             STAGED_FILES=$(jq '.staged.files | length' <<< "$component")

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -9,16 +9,16 @@ metadata:
 spec:
   description: |-
     Tekton task to apply a mapping to a Snapshot.
-    
+
     The purpose of this task is to merge a mapping with the components contained in a Snapshot.
     The mapping is expected to be present in the data field of the ReleasePlanAdmission provided in
     the `releasePlanAdmissionPath`. If the data field does not contain a `mapping` key, the original
     Snapshot is returned. If there is a `mapping` key, it is merged with the `components` key in the
     Snapshot based on component name.
-    
+
     A `mapped` result is also returned from this task containing a simple true/false value that is
     meant to inform whether a mapped Snapshot is being returned or the original one.
-    
+
     This task supports variable expansion in tag values from the mapping. The currently supported variables are:
     * "{{ timestamp }}" -> The build-date label from the image in the format provided by timestampFormat or %s as the
       default.
@@ -29,7 +29,7 @@ spec:
     * "{{ digest_sha }}" -> The image digest of the respective component
     * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
       repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
-    
+
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
   params:
     - name: snapshotPath
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-helm-chart
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot containing both container image components
+    and Helm chart components. Verify that oci_version expansion works for Helm charts.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "web-app",
+                      "repository": "registry.redhat.io/myorg/web-app",
+                      "tags": [
+                        "{{ timestamp }}",
+                        "build-{{ digest_sha }}",
+                        "{{ git_short_sha }}"
+                      ]
+                    },
+                    {
+                      "name": "helm-chart",
+                      "repository": "registry.redhat.io/myorg/helm-chart",
+                      "tags": [
+                        "{{ oci_version }}",
+                        "chart-{{ oci_version }}",
+                        "v{{ oci_version }}-stable"
+                      ]
+                    }
+                  ],
+                  "defaults": {
+                    "timestampFormat": "%Y.%m.%d",
+                    "tags": ["default"]
+                  }
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "mixed-app",
+                "components": [
+                  {
+                    "name": "web-app",
+                    "containerImage": "quay.io/myorg/web-app@sha256:abcdef123456789",
+                    "source": {
+                      "git": {
+                        "revision": "commit123abc",
+                        "url": "https://github.com/myorg/web-app.git"
+                      }
+                    }
+                  },
+                  {
+                    "name": "helm-chart",
+                    "containerImage": "quay.io/myorg/helm-chart@sha256:789abcdef123456",
+                    "source": {
+                      "git": {
+                        "revision": "commit789xyz",
+                        "url": "https://github.com/myorg/helm-chart.git"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that SNAPSHOT contains web-app component with expected tags
+              test "$(
+                jq -r '[ .components[] | select(.name=="web-app") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 1
+
+              web_app_tags="$(
+                jq -c '.components[] | select(.name=="web-app") | .tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )"
+              echo "Web-app tags: $web_app_tags"
+              test "$web_app_tags" == '["build-abcdef123456789","default","commit1","2024.07.29"]'
+
+              echo Test that SNAPSHOT contains helm-chart component with oci_version tags
+              test "$(
+                jq -r '[ .components[] | select(.name=="helm-chart") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" -eq 1
+
+              helm_tags="$(
+                jq -c '.components[] | select(.name=="helm-chart") | .tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )"
+              echo "Helm chart tags: $helm_tags"
+              test "$helm_tags" == '["chart-2.0.1_alpha","default","v2.0.1_alpha-stable","2.0.1_alpha"]'
+
+              echo Test that repositories were mapped correctly to Red Hat registry format
+              test "$(
+                jq -r '.components[] | select(.name=="web-app") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == "quay.io/redhat-prod/myorg----web-app"
+
+              test "$(
+                jq -r '.components[] | select(.name=="helm-chart") | .repository' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == "quay.io/redhat-prod/myorg----helm-chart"
+
+              echo Test that rh-registry-repo fields were set correctly
+              test "$(
+                jq -r '.components[] | select(.name=="web-app") | ."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == "registry.redhat.io/myorg/web-app"
+
+              test "$(
+                jq -r '.components[] | select(.name=="helm-chart") | ."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == "registry.redhat.io/myorg/helm-chart"
+
+              echo All tests passed!

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -11,11 +11,11 @@ spec:
     Tekton task that pushes metadata to Pyxis for all container images contained in a snapshot that is the
     result of the `apply-mapping` task. It first extracts the containerImages from the snapshot, then runs
     `skopeo inspect` on each, before finally pushing metadata to Pyxis.
-    
+
     The task includes protection against race conditions that could occur when multiple components have the same
     digest. Components with the same digest are processed in series while different digest groups are processed
     in parallel, ensuring optimal performance while preventing conflicts.
-    
+
     The relative path of the pyxis.json file in the data workspace is output as a task result named
     `pyxisDataPath`.
   params:
@@ -128,7 +128,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 3Gi
@@ -371,9 +371,9 @@ spec:
         process_digest_group() {
             local digest=$1
             local component_indices_string="$2"
-            
+
             echo "Processing components with digest: $digest"
-            
+
             # Process each component in the group in series
             for component_index in $component_indices_string; do
                 echo "Processing component $component_index for digest $digest"
@@ -388,7 +388,7 @@ spec:
         for (( i=0; i < COMPONENTS; i++ )); do
             CONTAINER_IMAGE=$(jq -r ".components[${i}].containerImage" "${SNAPSHOT_SPEC_FILE}")
             DIGEST="${CONTAINER_IMAGE##*@}"
-            
+
             if [[ -z "${digest_groups[$DIGEST]}" ]]; then
                 digest_groups[$DIGEST]="$i"
             else

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -149,7 +149,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -119,7 +119,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 512Mi
@@ -145,21 +145,21 @@ spec:
         echo "Transforming snapshot components using get-image-architectures..."
         SNAPSHOT_JSON=$(jq '.' "$SNAPSHOT_FILE")
         TRANSFORMED_COMPONENTS=$(mktemp)
-        
+
         echo "$SNAPSHOT_JSON" | jq -c '.components[]' | while IFS= read -r component; do
             CONTAINER_IMAGE=$(echo "$component" | jq -r '.containerImage')
             RH_REGISTRY_REPO=$(echo "$component" | jq -r '.["rh-registry-repo"] // .repository')
             COMPONENT_NAME=$(echo "$component" | jq -r '.name')
-            
+
             echo "Processing component: $COMPONENT_NAME with image: $CONTAINER_IMAGE" >&2
-            
+
             # Use get-image-architectures utility (same approach as populate-release-notes)
             if get-image-architectures "${CONTAINER_IMAGE}" | while IFS= read -r arch_json; do
                 if [[ -n "$arch_json" ]]; then
                     # Extract architecture-specific digest from arch_json
                     arch_digest=$(echo "$arch_json" | jq -r '.digest')
                     arch=$(echo "$arch_json" | jq -r '.platform.architecture')
-                    
+
                     # Create transformed component with registry format containerImage
                     TRANSFORMED_CONTAINER_IMAGE="${RH_REGISTRY_REPO}@${arch_digest}"
                     echo "$component" \
@@ -179,16 +179,16 @@ spec:
                 echo "Warning: Failed to resolve architectures for ${CONTAINER_IMAGE}, skipping component" >&2
             fi
         done > "$TRANSFORMED_COMPONENTS"
-        
+
         # Create transformed snapshot with arch-specific images
         transformedSnapshot=$(jq -s '.' "$TRANSFORMED_COMPONENTS" | gzip -c | base64 -w 0)
         rm -f "$TRANSFORMED_COMPONENTS"
-        
+
         if [ -z "$transformedSnapshot" ]; then
             echo "Failed to create transformed snapshot"
             exit 1
         fi
-        
+
         echo "Transformation complete. Arch-specific images created."
 
         RPA_FILE="$(params.dataDir)/$(params.releasePlanAdmissionPath)"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -48,7 +48,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -319,7 +319,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -51,7 +51,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -46,7 +46,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-rpa-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -46,7 +46,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-snapshot-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -51,7 +51,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -166,7 +166,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:6a1df8c94948c3f1e83eb9e92a38a8e6431baa3b
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -88,7 +88,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -139,7 +139,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -139,7 +139,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -102,7 +102,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-cve-issues-in-cves
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 32Mi
@@ -192,7 +192,7 @@ spec:
         fi
         exit $RC
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 64Mi
@@ -303,7 +303,7 @@ spec:
             done
         done
     - name: populate-release-notes-artifacts
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 32Mi
@@ -429,7 +429,7 @@ spec:
             fi
         done
     - name: populate-release-notes-github
-      image: quay.io/konflux-ci/release-service-utils:e85ceb962ee6f4d0672b4aa4e9946621ab302f20
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 32Mi
@@ -537,7 +537,7 @@ spec:
                 /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
         done
     - name: populate-release-notes-type-and-references
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -225,7 +225,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -242,7 +242,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/prepare-fbc-release.yaml
@@ -93,7 +93,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: prepare-fbc-release
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-fail-ocp-version-mismatch.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release-placeholder-replace.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
+++ b/tasks/managed/prepare-fbc-release/tests/test-prepare-fbc-release.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -118,7 +118,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
       computeResources:
         limits:
           memory: 1Gi
@@ -161,7 +161,7 @@ spec:
             # shellcheck disable=SC2128
             jq -s 'reduce .[] as $item ({}; . * $item)' \
               "$SOURCE_AUTH_FILE" "$DEST_AUTH_FILE" > "$DOCKER_CONFIG"/config.json
-            
+
             # Check if we should copy attached artifacts
             if [[ "$COPY_ATTACHED_ARTIFACTS" == "true" ]]; then
               # Check for any attached artifacts using oras discover, with retries on failure
@@ -190,7 +190,7 @@ spec:
                 echo "Max retries exceeded. Proceeding without attached artifacts (falling back to cosign copy)."
               fi
             fi
-            
+
             attempt=0
             until [ "$attempt" -gt "$(params.retries)" ] ; do # 0 retries by default which will execute this once
               if [[ "$COPY_ATTACHED_ARTIFACTS" == "true" && "${artifact_count}" -gt 0 ]]; then
@@ -373,12 +373,12 @@ spec:
         # Create a temporary file for the pushes data to avoid command line argument length limits
         PUSHES_FILE=$(mktemp)
         jq -s . "$TMP_RESULTS_DIR"/*.json > "$PUSHES_FILE"
-        
+
         # Use file input instead of command line arguments to avoid argument length limits
         jq --slurpfile PUSHES "$PUSHES_FILE" '
           reduce $PUSHES[0][] as $p (.; (.images[] | select(.name == $p.name).urls) += [$p.url])
         ' "$RESULTS_JSON_FILE" | tee "$RESULTS_FILE"
-        
+
         # Clean up temporary files
         rm -f "$RESULTS_JSON_FILE" "$RESULTS_JSON_FILE.tmp" "$PUSHES_FILE"
 

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -173,7 +173,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check
-            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eu

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -144,7 +144,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -167,7 +167,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -159,7 +159,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
To pull a Helm chart, we typically need it to be tagged based on the oci artifact version (rather than by digest or arbitrary tag).

To allow that, enhance apply-mapping task to be able to fetch the version from the artifact metadata and populate a variable that can be later used in RPAs templating.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
