### PR TITLE
fix: promotion script breaking on api rate-limit

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -143,9 +143,9 @@ COMMITS=($(git rev-list --first-parent --ancestry-path origin/"$TARGET_BRANCH"'.
 for COMMIT in "${COMMITS[@]}"
 do
   PR_INFO="$(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=sha:'"$COMMIT" | jq -r '.items[]
-    | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")')"
-  echo -n "$(jq -r '.pull_request | select(.merged_at!=null) | .html_url' <<< "$PR_INFO")"
-  LABEL="$(jq -r '.labels[].name | select(. | contains("breaking-change"))' <<< "$PR_INFO")"
+    | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")' || true)"
+  echo -n "$(jq -r '.pull_request | select(.merged_at!=null) | .html_url' <<< "$PR_INFO" || true)"
+  LABEL="$(jq -r '.labels[].name | select(. | contains("breaking-change"))' <<< "$PR_INFO" || true)"
   [[ -z "$LABEL" ]] || echo -n " ($LABEL)"
   echo
   git show --oneline --no-patch $COMMIT


### PR DESCRIPTION
## Describe your changes
Fixed a bug with the promotion script that was introduced with the breaking label change where it would exit and stop the promotion if GitHub API rate-limited the script.

The script wasn't failing before my changes because `echo` was outputting `jq: error (at <stdin>:3): Cannot iterate over null` instead of the error itself being displayed, which was avoiding `set -e`, since the `echo` command would succeed at outputting the error and the script would continue.

I fixed this by adding `|| true` to the `jq` commands, so that it won't exit when GitHub API rate-limits the script, which is how it behaved before.

I could try to find a way to get multiple pull requests from one API call at some point to prevent the rate-limiting issue, too.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
