### PR TITLE
feat(RELEASE-1823): remove workspaces from run-file-updates, send-slack-notification and set-advisory-severity tasks

### DIFF
--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -450,9 +450,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
-      workspaces:
-        - name: data
-          workspace: release-workspace
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -458,9 +458,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/set-advisory-severity/set-advisory-severity.yaml
         resolver: git
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - populate-release-notes
         - embargo-check
@@ -882,9 +879,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
-      workspaces:
-        - name: data
-          workspace: release-workspace
     - name: check-data-keys
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -529,9 +529,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
-      workspaces:
-        - name: data
-          workspace: release-workspace
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -623,9 +623,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
-      workspaces:
-        - name: data
-          workspace: release-workspace
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -540,9 +540,6 @@ spec:
         - input: $(tasks.collect-slack-notification-params.results.slack-notification-secret)
           operator: notin
           values: [""]
-      workspaces:
-        - name: data
-          workspace: release-workspace
       params:
         - name: message
           value: $(tasks.collect-slack-notification-params.results.message)

--- a/tasks/managed/run-file-updates/README.md
+++ b/tasks/managed/run-file-updates/README.md
@@ -5,21 +5,21 @@ from the field `spec.data.fileUpdates` in the ReleasePlanAdmission resource.
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| jsonKey                 | The json key containing the file updates                                                                                   | Yes      | .spec.data.fileUpdates  |
-| fileUpdatesPath         | The path to the file containing the file updates                                                                           | No       | -                       |
-| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                         | No       | -                       |
-| request                 | Name of the request                                                                                                        | Yes      | process-file-updates    |
-| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 900                     |
-| synchronously           | Whether to run synchronously or not                                                                                        | Yes      | true                    |
-| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                       |
-| resultsDirPath          | Path to the results directory in the data workspace                                                                        | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value          |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|------------------------|
+| jsonKey                 | The json key containing the file updates                                                                                   | Yes      | .spec.data.fileUpdates |
+| fileUpdatesPath         | The path to the file containing the file updates                                                                           | No       | -                      |
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                         | No       | -                      |
+| request                 | Name of the request                                                                                                        | Yes      | process-file-updates   |
+| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 900                    |
+| synchronously           | Whether to run synchronously or not                                                                                        | Yes      | true                   |
+| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                      |
+| resultsDirPath          | Path to the results directory in the data workspace                                                                        | No       | -                      |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                  |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                     |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                     |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                     |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                     |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release   |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                      |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                      |

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -63,7 +63,7 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
@@ -76,9 +76,6 @@ spec:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
       type: string
-  workspaces:
-    - name: data
-      description: Workspace where the file updates to apply are defined
   volumes:
     - name: workdir
       emptyDir: {}
@@ -94,27 +91,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -257,26 +233,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/run-file-updates/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/run-file-updates/tests/pre-apply-task-hook.sh
@@ -12,4 +12,4 @@ kubectl delete internalrequests --all -A
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the run-file-updates task for the osd-addons use case 
     and verify if the internalrequests were created and the replacements were done
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -100,14 +98,6 @@ spec:
                       }]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -118,17 +108,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: run-file-updates
@@ -161,13 +140,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
@@ -177,8 +150,6 @@ spec:
         params:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -194,14 +165,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the run-file-updates task for the osd-addons use case with multiple IR requests
     which has the first one failing. Ensure the result that an error is surfaced for the failing one
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -110,14 +108,6 @@ spec:
                       }]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -128,17 +118,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: run-file-updates
@@ -172,13 +151,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - run-task
       params:
@@ -188,8 +161,6 @@ spec:
         params:
           - name: result
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
@@ -8,8 +8,6 @@ spec:
     Run the run-file-updates task for the osd-addons use case with multiple IR requests
     which has the last one failing. Ensure the result shows the MR from the 1st passing
     request and that an error is surfaced for the failing one
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -111,14 +109,6 @@ spec:
                       }]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -129,17 +119,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: run-file-updates
@@ -173,13 +152,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - run-task
       params:
@@ -189,8 +162,6 @@ spec:
         params:
           - name: result
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   description: |
     Run the run-file-updates task and verify if the internalrequests were created and the replacements were done
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -108,14 +106,6 @@ spec:
                       }]
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -126,17 +116,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: run-file-updates
@@ -169,13 +148,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
@@ -185,8 +158,6 @@ spec:
         params:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -202,14 +173,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/send-slack-notification/README.md
+++ b/tasks/managed/send-slack-notification/README.md
@@ -4,17 +4,17 @@ Sends message to Slack using postMessage API
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| message                 | Message to be sent                                                                                                         | No       | -                       |
-| tasksStatus             | status of tasks execution                                                                                                  | No       | -                       |
-| secretName              | Name of secret which contains authentication token for app                                                                 | No       | -                       |
-| secretKeyName           | Name of key within secret which contains webhook URL                                                                       | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| message                 | Message to be sent                                                                                                         | No       | -                    |
+| tasksStatus             | status of tasks execution                                                                                                  | No       | -                    |
+| secretName              | Name of secret which contains authentication token for app                                                                 | No       | -                    |
+| secretKeyName           | Name of key within secret which contains webhook URL                                                                       | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -44,16 +44,13 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-  workspaces:
-    - name: data
-      description: The workspace where the data json file resides
   results:
     - name: sourceDataArtifact
       type: string
@@ -77,27 +74,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -201,26 +177,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/send-slack-notification/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/send-slack-notification/tests/pre-apply-task-hook.sh
@@ -5,7 +5,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy slack-notification-secret secret (and delete it first if it exists)
 kubectl delete secret my-secret --ignore-not-found

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   description: |
     Run the send-slack-notification task and verify the results
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -30,15 +28,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -62,14 +55,6 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               # No data files needed for this test - testing missing secret scenario
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -78,14 +63,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -114,15 +91,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
@@ -131,8 +102,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: sourceDataArtifact
             type: string
@@ -153,14 +122,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   description: |
     Run the send-slack-notification task and verify the results
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -30,15 +28,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -62,14 +55,6 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               # No data files needed for this test - testing basic message sending
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -78,14 +63,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -114,15 +91,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
@@ -131,8 +102,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: sourceDataArtifact
             type: string
@@ -153,14 +122,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -4,16 +4,16 @@ Tekton task to set the severity level in the releaseNotes key of the data.json. 
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |
-| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 2700                    |
-| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                    |
+| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 2700                 |
+| pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -47,7 +47,7 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
@@ -58,9 +58,6 @@ spec:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
       type: string
-  workspaces:
-    - name: data
-      description: The workspace where the snapshot spec json file resides
   volumes:
     - name: workdir
       emptyDir: {}
@@ -76,27 +73,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -226,26 +202,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
@@ -3,4 +3,4 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-fail-no-data-json.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-fail-no-data-json.yaml
@@ -7,8 +7,6 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: Test for set-advisory-severity where there is no data JSON
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -52,6 +50,3 @@ spec:
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
           value: $(params.trustedArtifactsDebug)
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   description: |
     Test that the task ensure generic artifacts are skipped
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -30,12 +28,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -96,14 +89,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -112,14 +97,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -144,15 +121,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - run-task
       params:
@@ -161,8 +132,6 @@ spec:
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: sourceDataArtifact
             type: string
@@ -181,14 +150,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
@@ -9,8 +9,6 @@ spec:
   description: |
     Test with the InternalRequest failing to ensure task fails. The mocks make the InternalRequest
     fail if the releaseNotes.content.images contains the string CVE-999
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -33,12 +31,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -99,14 +92,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -115,14 +100,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -147,8 +124,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
@@ -5,8 +5,6 @@ metadata:
   name: test-set-advisory-severity-no-release-notes
 spec:
   description: Test for set-advisory-severity where the data JSON has no releaseNotes key. The task should succeed
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -29,12 +27,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -65,14 +58,6 @@ spec:
                 "foo": "bar"
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -81,14 +66,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -113,8 +90,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Test for set-advisory-severity where the releaseNotes.type is not RHSA, but the user provided a severity.
     The task should remove the severity key from the data file
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,12 +29,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -70,14 +63,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -86,14 +71,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -118,15 +95,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - run-task
       params:
@@ -135,8 +106,6 @@ spec:
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: sourceDataArtifact
             type: string
@@ -155,14 +124,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Test for set-advisory-severity where the releaseNotes.type is not RHSA. The task should succeed
     without action
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,12 +29,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -69,14 +62,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -85,14 +70,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -117,8 +94,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
@@ -9,8 +9,6 @@ spec:
   description: |
     Test for set-advisory-severity where the releaseNotes.type is RHSA but no cves are listed.
     The task should fail
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -33,12 +31,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -78,14 +71,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -94,14 +79,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -126,8 +103,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Test that the task sets the releaseNotes.severity to IMPORTANT, which is what the mocks have the
     InternalRequest return when called with anything but CVE-999
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,12 +29,7 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
-        workspaces:
-          - name: data
         results:
           - name: sourceDataArtifact
             type: string
@@ -97,14 +90,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -113,14 +98,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -145,15 +122,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - run-task
       params:
@@ -162,8 +133,6 @@ spec:
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: sourceDataArtifact
             type: string
@@ -182,14 +151,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact


### PR DESCRIPTION
## Describe your changes
- remove workspace and workspace bindings from run-file-updates, send-slack-notification and set-advisory-severity
- update workspace usage for above tasks in pipelines in managed/
- remove skip and patch trusted artfacts steps in above tasks

## Relevant Jira
- [RELEASE-1823](https://issues.redhat.com//browse/RELEASE-1823)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
