### PR TITLE
feat(RELEASE-1825): remove workspaces from update-cr-status, update-infra-deployments and update-ocp-tag tasks

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -278,9 +278,6 @@ spec:
       runAfter:
         - verify-conforma
     - name: update-ocp-tag
-      workspaces:
-        - name: data
-          workspace: release-workspace
       taskRef:
         resolver: "git"
         params:
@@ -663,9 +660,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - extract-index-image
   finally:

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -497,9 +497,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - create-advisory
   finally:

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -364,9 +364,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - push-disk-images
   finally:

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -454,9 +454,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - push-snapshot
   finally:

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -467,9 +467,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - push-snapshot
         - run-file-updates

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -424,8 +424,5 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - push-snapshot

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -640,9 +640,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - close-advisory-issues
   finally:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -1053,9 +1053,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - create-advisory
   finally:

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -543,9 +543,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - run-file-updates
   finally:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -635,9 +635,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - run-file-updates
   finally:

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -474,9 +474,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - push-rpm-data-to-pyxis
     - name: update-cr-status
@@ -508,9 +505,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
-      workspaces:
-        - name: data
-          workspace: release-workspace
       runAfter:
         - infra-deployments-pr
   finally:

--- a/tasks/managed/update-cr-status/README.md
+++ b/tasks/managed/update-cr-status/README.md
@@ -4,17 +4,17 @@ A tekton task that updates the passed CR status with the contents stored in the 
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| resourceType            | The type of resource that is being patched                                                                                 | Yes      | release                 |
-| statusKey               | The top level key to overwrite in the resource status                                                                      | Yes      | artifacts               |
-| resource                | The namespaced name of the resource to be patched                                                                          | No       | -                       |
-| resultsDirPath          | Path to the directory containing the result files in the data workspace which will be added to the resource's status       | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| resultArtifacts         | Array of artifacts to use to obtain results                                                                                | Yes      | []                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| resourceType            | The type of resource that is being patched                                                                                 | Yes      | release              |
+| statusKey               | The top level key to overwrite in the resource status                                                                      | Yes      | artifacts            |
+| resource                | The namespaced name of the resource to be patched                                                                          | No       | -                    |
+| resultsDirPath          | Path to the directory containing the result files in the data workspace which will be added to the resource's status       | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| resultArtifacts         | Array of artifacts to use to obtain results                                                                                | Yes      | []                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
@@ -29,8 +29,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -39,8 +37,6 @@ spec:
             type: string
           - name: resultArtifact2
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -92,14 +88,6 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f release
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact-array
             ref:
               name: create-trusted-artifact-array
@@ -123,9 +111,6 @@ spec:
                 echo -n "$(params.ociStorage)" > "$(results.resultArtifact1.path)"
                 echo -n "$(params.ociStorage)" > "$(results.resultArtifact2.path)"
               fi
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -154,9 +139,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
       taskSpec:
         steps:
@@ -167,8 +149,13 @@ spec:
               set -eux
 
               echo Test that the Release.Status contains the union of both test arrays
-              test "$(kubectl get release release-cr-status-union -n default \
-                -o jsonpath='{.status.artifacts.test}')" == '["one","two","three","four"]'
+              # we also take the precaution of sorting the result to avoid
+              # ordering issues so we can compare the results properly
+              unsorted_result="$(kubectl get release release-cr-status-union -n default \
+                -o jsonpath='{.status.artifacts.test}')"
+              result=$(jq -c '. | sort' <<< "$unsorted_result")
+              test "$result" == '["four","one","three","two"]'
+
       runAfter:
         - run-task
   finally:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -29,16 +29,12 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -79,14 +75,6 @@ spec:
                 target: foo
               EOF
               kubectl apply -f releaseplan
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -97,17 +85,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -137,9 +114,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -27,8 +27,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -37,8 +35,6 @@ spec:
             type: string
           - name: resultArtifact2
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -94,14 +90,6 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f release
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact-array
             ref:
               name: create-trusted-artifact-array
@@ -125,9 +113,6 @@ spec:
                 echo -n "$(params.ociStorage)" > "$(results.resultArtifact1.path)"
                 echo -n "$(params.ociStorage)" > "$(results.resultArtifact2.path)"
               fi
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -156,9 +141,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
       taskSpec:
         steps:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -28,16 +28,12 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -80,14 +76,6 @@ spec:
               kubectl apply -f release
               kubectl patch release release-cr-status-overwrite -n default \
                 --type=merge --subresource status --patch "status: {automated: false}"
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -98,17 +86,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -136,9 +113,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
       taskSpec:
         steps:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -27,8 +27,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -69,14 +67,6 @@ spec:
               kubectl apply -f release
               
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -87,17 +77,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -121,8 +100,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -29,8 +29,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -76,14 +74,6 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f release
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)/$(context.pipelineRun.uid)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -94,17 +84,6 @@ spec:
                 value: $(params.dataDir)/$(context.pipelineRun.uid)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -132,9 +111,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -29,8 +29,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -64,14 +62,6 @@ spec:
                   "automated": true
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -82,17 +72,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -118,6 +97,3 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -29,8 +29,6 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
@@ -66,14 +64,6 @@ spec:
               json
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -84,17 +74,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -120,6 +99,3 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
@@ -27,16 +27,12 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-  workspaces:
-    - name: tests-workspace
   tasks:
     - name: setup
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -76,14 +72,6 @@ spec:
                 releasePlan: foo
               EOF
               kubectl apply -f release
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -94,17 +82,6 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: run-task
       taskRef:
         name: update-cr-status
@@ -130,9 +107,6 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
       taskSpec:
         steps:

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -50,16 +50,13 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-  workspaces:
-    - name: data
-      description: Workspace where the results directory is stored
   volumes:
     - name: workdir
       emptyDir: {}
@@ -75,27 +72,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact-array
       computeResources:
         limits:

--- a/tasks/managed/update-infra-deployments/README.md
+++ b/tasks/managed/update-infra-deployments/README.md
@@ -21,6 +21,6 @@
 | trustedArtifactsDebug          | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                                 |
 | orasOptions                    | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                                 |
 | sourceDataArtifact             | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                                 |
-| dataDir                        | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path)            |
+| dataDir                        | The location where data will be stored                                                                                     | Yes      | /var/workdir/release               |
 | taskGitUrl                     | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                                  |
 | taskGitRevision                | The revision in the taskGitUrl repo to be used                                                                             | No       | -                                  |

--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   description: |
     Run the update-infra-deployments task with the no data file present. The task should fail.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,15 +30,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -85,14 +78,6 @@ spec:
               }
               EOF
               # Note: Intentionally NOT creating data.json file to test failure scenario
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -101,14 +86,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -133,8 +110,5 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -54,19 +54,13 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-  workspaces:
-    - name: artifacts
-      description: Workspace containing arbitrary artifacts used during the task run.
-      optional: true
-    - name: data
-      description: The workspace where the snapshot spec json file resides
   results:
     - name: sourceDataArtifact
       type: string
@@ -92,27 +86,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -492,26 +465,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/update-ocp-tag/README.md
+++ b/tasks/managed/update-ocp-tag/README.md
@@ -5,15 +5,15 @@ occurs when the {{ OCP_VERSION }} placeholder is present.
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value           |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                       |
-| ocpVersion              | OCP version tag to replace the current set tags on index images                                                            | No       | -                       |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                   |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                      |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                      |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                      |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                      |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | $(workspaces.data.path) |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                       |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                       |
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                    |
+| ocpVersion              | OCP version tag to replace the current set tags on index images                                                            | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-fail-on-ocp-version-mismatch.yaml
@@ -9,8 +9,6 @@ spec:
   description: |
     Run the update-ocp-tag task with sample values without the {{ OCP_VERSION }} placeholder
     and fails as the ocp version mismatch.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -33,15 +31,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -72,14 +65,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -88,14 +73,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -122,6 +99,3 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-no-placeholder.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the update-ocp-tag task with sample values without the {{ OCP_VERSION }} placeholder
     and verify that all tags keeps the OCP version.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -70,14 +63,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -86,14 +71,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -120,13 +97,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: updated-fromIndex
           value: $(tasks.run-task.results.updated-fromIndex)
@@ -139,8 +110,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: updated-fromIndex
             type: string
@@ -165,14 +134,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag-staged-index.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the update-ocp-tag task with sample values
     and verify that all tags get updated to the new OCP version, except for the targetIndex when empty
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -71,14 +64,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -87,14 +72,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -121,13 +98,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: updated-fromIndex
           value: $(tasks.run-task.results.updated-fromIndex)
@@ -140,8 +111,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: updated-fromIndex
             type: string
@@ -166,14 +135,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/tests/test-update-ocp-tag.yaml
@@ -7,8 +7,6 @@ spec:
   description: |
     Run the update-ocp-tag task with sample values
     and verify that all tags get updated to the new OCP version.
-  workspaces:
-    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,15 +29,10 @@ spec:
       type: string
   tasks:
     - name: setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
-        workspaces:
-          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -70,14 +63,6 @@ spec:
                 }
               }
               EOF
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -86,14 +71,6 @@ spec:
                 value: $(params.ociStorage)
               - name: workDir
                 value: $(params.dataDir)
-              - name: sourceDataArtifact
-                value: $(results.sourceDataArtifact.path)
-          - name: patch-source-data-artifact-result
-            ref:
-              name: patch-source-data-artifact-result
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
@@ -120,13 +97,7 @@ spec:
           value: "main"
       runAfter:
         - setup
-      workspaces:
-        - name: data
-          workspace: tests-workspace
     - name: check-result
-      workspaces:
-        - name: data
-          workspace: tests-workspace
       params:
         - name: updated-fromIndex
           value: $(tasks.run-task.results.updated-fromIndex)
@@ -139,8 +110,6 @@ spec:
       runAfter:
         - run-task
       taskSpec:
-        workspaces:
-          - name: data
         params:
           - name: updated-fromIndex
             type: string
@@ -165,14 +134,6 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: skip-trusted-artifact-operations
-            ref:
-              name: skip-trusted-artifact-operations
-            params:
-              - name: ociStorage
-                value: $(params.ociStorage)
-              - name: workDir
-                value: $(params.dataDir)
           - name: use-trusted-artifact
             ref:
               name: use-trusted-artifact

--- a/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
+++ b/tasks/managed/update-ocp-tag/update-ocp-tag.yaml
@@ -41,16 +41,13 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
-      default: $(workspaces.data.path)
+      default: /var/workdir/release
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-  workspaces:
-    - name: data
-      description: The workspace where the extra config file containing the mapping and snapshot json reside
   results:
     - name: updated-fromIndex
       type: string
@@ -76,27 +73,6 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
   steps:
-    - name: skip-trusted-artifact-operations
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: workDir
-          value: $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:
@@ -193,26 +169,5 @@ spec:
           value: $(params.ociStorage)
         - name: workDir
           value: $(params.dataDir)
-        - name: sourceDataArtifact
-          value: $(results.sourceDataArtifact.path)
-    - name: patch-source-data-artifact-result
-      computeResources:
-        limits:
-          memory: 32Mi
-        requests:
-          memory: 32Mi
-          cpu: 20m
-      ref:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
-      params:
-        - name: ociStorage
-          value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)


### PR DESCRIPTION
## Describe your changes
- remove workspace and workspace bindings from update-cr-status, update-infra-deployments and update-ocp-tag
- update workspace usage for above tasks in pipelines in managed/
- remove skip and patch trusted artfacts steps in above tasks
- include fix to ensure repeatability for test  `test-update-cr-status-array-union`

## Relevant Jira
- [RELEASE-1825](https://issues.redhat.com//browse/RELEASE-1825)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
