### PR TITLE
fix: add missing uuid variable substitution for rh-push-to-registry-redhat-io and rhtap-service-push krw tests

### DIFF
--- a/integration-tests/rh-push-to-registry-redhat-io/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="rh-push-to-registry-redhat-io-e2e-test"
 

--- a/integration-tests/rhtap-service-push/test.env
+++ b/integration-tests/rhtap-service-push/test.env
@@ -1,4 +1,6 @@
-uuid=$(openssl rand -hex 4)
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
 
 export originating_tool="rhtap-service-push-e2e-test"
 


### PR DESCRIPTION
## Describe your changes
- rh-push-to-registry-redhat-io and rhtap-service-push tests were missing the uuid variable substitution that are needed to properly handle cleanup when an ITS is being cancelled

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
