### PR TITLE
fix: update send-slack-notification to not expose secret

### DIFF
--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -130,7 +130,10 @@ spec:
         fi
 
         if [ -f "/etc/secrets/${KEYNAME}" ]; then
+          echo "Setting WEBHOOK_URL from secret...." 
+          set +x
           WEBHOOK_URL=$(cat "/etc/secrets/${KEYNAME}")
+          set -x
         else
           echo "Error: Secret not defined properly. The key to use (${KEYNAME}) is defined in the Release data \
               but the Secret does not contain the key"
@@ -154,8 +157,11 @@ spec:
         ${MESSAGE}
         EOF
 
+        echo "Calling Slack API with curl...."
+        set +x
         curl  -H "Content-type: application/json" --data-binary "@/tmp/release.json"  \
           "${WEBHOOK_URL}"
+        set -x
     - name: create-trusted-artifact
       computeResources:
         limits:


### PR DESCRIPTION
## Describe your changes
Previously, the send-slack-notification task printed the full WEBHOOK_URL in the logs, risking secret leakage. This change wraps the secret read and the `curl` with `set +x`/`set -x` so they are hidden from the logs output.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
