### PR TITLE
feat(RELEASE-1802): collect-index-images supports the repositories key

### DIFF
--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -127,6 +127,12 @@ spec:
             '{
               "containerImage": $image,
               "repository": $repository,
+              "repositories": [
+                {
+                  "url": $repository,
+                  "tags": $tags
+                }
+              ],
               "tags": $tags
             }'
           )

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
@@ -143,6 +143,20 @@ spec:
                 echo "containerImage does not match"
                 exit 1
               fi
+
+              if [ "$(jq -r '.components[0].repositories[0].url' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[0].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.12-12345-6789\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              # Remove from here to next comment when repository key support is removed
               if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
                 "quay.io/test/fbc-target-index" ]; then
                 echo "repository does not match"
@@ -152,5 +166,6 @@ spec:
                 echo "tags do not match"
                 exit 1
               fi
+              # End of block to be removed
       runAfter:
         - run-task

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
@@ -147,6 +147,20 @@ spec:
                 echo "containerImage does not match"
                 exit 1
               fi
+
+              if [ "$(jq -r '.components[0].repositories[0].url' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[0].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.12\",\"v4.12-1357\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              # Remove from here to next comment when repository key support is removed
               if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
                 "quay.io/test/fbc-target-index" ]; then
                 echo "repository does not match"
@@ -156,12 +170,27 @@ spec:
                 echo "tags do not match"
                 exit 1
               fi
+              # End of block to be removed
 
               if [ "$(jq -r '.components[1].containerImage' < "${SNAPSHOT_FILE}")" != \
                 "redhat.com/rh-stage/iib@sha256:lmnopqrstuv" ]; then
                 echo "containerImage does not match"
                 exit 1
               fi
+
+              if [ "$(jq -r '.components[1].repositories[0].url' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[1].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.13\",\"v4.13-1357\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              # Remove from here to next comment when repository key support is removed
               if [ "$(jq -r '.components[1].repository' < "${SNAPSHOT_FILE}")" != \
                 "quay.io/test/fbc-target-index" ]; then
                 echo "repository does not match"
@@ -171,5 +200,6 @@ spec:
                 echo "tags do not match"
                 exit 1
               fi
+              # End of block to be removed
       runAfter:
         - run-task

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
@@ -143,6 +143,20 @@ spec:
                 echo "containerImage does not match"
                 exit 1
               fi
+
+              if [ "$(jq -r '.components[0].repositories[0].url' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/test/fbc-target-index" ]; then
+                echo "repository does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[0].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.12\",\"v4.12-2468\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              # Remove from here to next comment when repository key support is removed
               if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
                 "quay.io/test/fbc-target-index" ]; then
                 echo "repository does not match"
@@ -152,5 +166,6 @@ spec:
                 echo "tags do not match"
                 exit 1
               fi
+              # End of block to be removed
       runAfter:
         - run-task


### PR DESCRIPTION
This commit modifies the collect-index-images managed task to emit a snapshot file that includes the repositories keys. It is backwards compatible for now, so the normal repository and tags keys still exist as well.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
