### PR TITLE
fix(KFLUXSPRT-4680): existing advisory num check with sparse checkout

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -274,10 +274,12 @@ spec:
           ADVISORY_NUM=$(printf "%04d" "$LIVE_ID")
 
           # Check if the advisory number is already used
-          FIND_RESULT=$(find data/advisories -type d -path "*/${YEAR}/${ADVISORY_NUM}")
-          if [[ -n "${FIND_RESULT}" ]]; then
+          GIT_RESULT_FILE=$(mktemp)
+          git ls-tree -r --name-only origin/main > "$GIT_RESULT_FILE"
+          GREP_RESULT=$(grep "data/advisories/.*/${YEAR}/${ADVISORY_NUM}/" "$GIT_RESULT_FILE" || true)
+          if [[ -n "${GREP_RESULT}" ]]; then
             echo "An advisory with number ${ADVISORY_NUM} already exists:" | tee -a "$STDERR_FILE"
-            echo "${FIND_RESULT}" | tee -a "$STDERR_FILE"
+            echo "${GREP_RESULT}" | tee -a "$STDERR_FILE"
             echo "Exiting." | tee -a "$STDERR_FILE"
             exit 1
           fi

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -21,6 +21,11 @@ function git() {
     touch -d "@1704012342" "$gitRepo"/data/advisories/dev-tenant/2024/1442
   elif [[ "$1" == "sparse-checkout" ]]; then
     : # no-op
+  elif [[ "$1" == "ls-tree" ]]; then
+    echo data/advisories/dev-tenant/2025/1602/advisory.yaml
+    echo data/advisories/dev-tenant/2025/1601/advisory.yaml
+    echo data/advisories/dev-tenant/2024/1452/advisory.yaml
+    echo data/advisories/dev-tenant/2024/1442/advisory.yaml
   elif [[ "$*" == *"failing-tenant"* ]]; then
     echo "Mocking failing git command" && false
   else

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
     Run the create-advisory task and have it fail. In this scenario it fails because an advisory with year 2024
-    and the live id 1352 already exists (created in the git clone mock)
+    and the live id 1452 already exists (returned in the git ls-tree mock)
   tasks:
     - name: run-task
       taskRef:


### PR DESCRIPTION
## Describe your changes

The check to see if an advisory number is already used got broken when we switched to sparse-checkout, because now we only see advisories for the current tenant, so we would find an existing advisory with the same number in another tenant dir.

In most cases this just means that we wouldn't notice a duplicate number, but otherwise the release would work.

But if the tenant directory does not exist in the repo yet (i.e. they haven't released anything yet), the `find` command would fail because data/advisories wouldn't exist (since the sparse checkout would only checkout their tenant dir and it wouldn't exist). So for these users the task would report an error.

The fix is to use ls-tree which lists files from the remote even if they are not checked out locally.

## Relevant Jira

[KFLUXSPRT-4680](https://issues.redhat.com//browse/KFLUXSPRT-4680)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
