### PR TITLE
fix: ignore the README.md files in integration-tests

### DIFF
--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -280,8 +280,11 @@ find_changed_tekton_tasks_pipelines() {
         SELECT_ALL_TESTCASES=true
         break
       else
-        IFS='/' read -ra parts <<< "$file"
-        INTEGRATION_SUITES+=("${parts[1]}")
+        filename=$(basename "$file")
+        if [[ ! $filename =~ \.md$ ]]; then
+          IFS='/' read -ra parts <<< "$file"
+          INTEGRATION_SUITES+=("${parts[1]}")
+        fi
       fi
     elif [[ "$file" =~ ^tasks/internal/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
       if grep -q -E 'kind: *Task' "$file"; then


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

The PR is to ignore the .md files in integration-tests directory for running e2e-tests

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
