### PR TITLE
fix: task tests selection for non-ta tasks

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -45,10 +45,10 @@ jobs:
               if [ -n "${ociStageParam}" ]; then
                 echo "Found a trusted artifacts compatible task: ${taskFile}"
                 trustedArtifactsBasedTasks+=($dir)
-              else
-                echo "Found a legacy PVC-based task: ${taskFile}"
-                pvcBasedTasks+=($dir)
               fi
+            else
+              echo "Found a legacy PVC-based task: ${taskFile}"
+              pvcBasedTasks+=($dir)
             fi
           done
           echo "trustedArtifactsBasedTasks: ${trustedArtifactsBasedTasks[@]}"
@@ -123,4 +123,4 @@ jobs:
         run: .github/scripts/test_tekton_tasks.sh
         env:
           TEST_ITEMS: >-
-            ${{ steps.changed-dirs.outputs.pvcBasedTasks }}
+            ${{ steps.show-changed-dirs.outputs.pvcBasedTasks }}


### PR DESCRIPTION
## Describe your changes

The else was in the wrong place, so for tasks with no ociStorage param, no tests would run at all.

Also, the output reference in the step that runs PVC-based tests was invalid.

The bug was introduced here: https://github.com/konflux-ci/release-service-catalog/pull/1322

FYI, I noticed this when I was modifying a pvc-based task (create-advisory-task internal task) here: https://github.com/konflux-ci/release-service-catalog/pull/1362 and no tests ran. I was able to confirm the fix there as well.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
