### PR TITLE
feat(ROK-890): add task to promote draft builds in Koji

### DIFF
--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -144,7 +144,8 @@ spec:
               {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
               {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"},
               {"resultIndex": 2, "key": ".pushOptions.pushKeytab.secret"},
-              {"resultIndex": 3, "key": ".pushOptions.pushPipelineImage"}
+              {"resultIndex": 3, "key": ".pushOptions.pushPipelineImage"},
+              {"resultIndex": 4, "key": ".pushOptions.pushType", "default": "import"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -262,6 +263,48 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - collect-task-params
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: notin
+          values: ["promote"]
+    - name: promote-koji-draft-build
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: pushSecret
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: pipelineImage
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - collect-task-params
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: in
+          values: ["promote"]
+
   finally:
     - name: cleanup-internal-requests
       taskRef:

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -839,6 +839,15 @@
         "pushPipelineImage": {
           "type": "string",
           "description": "The tekton runner for running push-rpm-to-koji tekton task"
+        },
+        "pushType": {
+          "type": "string",
+          "default": "import",
+          "description": "Type of the push operation. Can be 'import' (the default; import builds to Koji) or 'promote' (promote draft builds in Koji).",
+          "enum": [
+            "import",
+            "promote"
+          ]
         }
       }
     },

--- a/tasks/managed/promote-koji-draft-build/README.md
+++ b/tasks/managed/promote-koji-draft-build/README.md
@@ -1,0 +1,20 @@
+# promote-koji-draft-build
+
+Tekton task to promote draft build in koji instance.
+
+## Parameters
+
+| Name                    | Description                                                                                                                                                                        | Optional | Default value        |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath            | Path to the JSON file of the mapped Snapshot spec in the data workspace                                                                                                            | No       | -                    |
+| dataPath                | Path to the JSON file of the merged data to use in the data workspace                                                                                                              | No       | -                    |
+| pushSecret              | The secret that is used for login koji instance                                                                                                                                    | No       | -                    |
+| pipelineImage           | The image url with koji (1.34 or higher), jq and kinit installed for running the promote-koji-draft-build task, please make sure you have such image or you build this image first | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                                                                          | Yes      | empty                |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                                                                                | Yes      | ""                   |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire                                                         | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                                                                             | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                                                                                    | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                                                                             | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                                                                              | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                                     | No       | -                    |

--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -2,13 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: push-rpm-to-koji
+  name: promote-koji-draft-build
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: push-koji
+    tekton.dev/tags: promote-koji
 spec:
   description: |-
-    Tekton task to push konflux build rpms to koji instance.
+    Tekton task to promote draft build in koji instance.
   params:
     - name: snapshotPath
       type: string
@@ -26,7 +26,7 @@ spec:
       type: string
       description: |
         The image url with koji (1.34 or higher), jq and kinit installed for
-        running the push-rpm-to-koji task, please make sure you have such image
+        running the promote-koji-draft-build task, please make sure you have such image
         or you build this image first
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored
@@ -104,7 +104,7 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
-    - name: push-rpm-to-koji
+    - name: promote-koji-draft-build
       # The pipelineImage will be fetching from get-secrets task with koji installed there
       image: "$(params.pipelineImage)"
       computeResources:
@@ -138,8 +138,6 @@ spec:
         PRINCIPAL=$(jq --exit-status -r '.pushOptions.pushKeytab.principal' "${DATA_FILE}")
         KEYTAB_FILE=$(jq --exit-status -r '.pushOptions.pushKeytab.name' "${DATA_FILE}")
         KOJI_PROFILE=$(jq --exit-status -r '.pushOptions.koji_profile' "${DATA_FILE}")
-        KOJI_TAGS=$(jq --exit-status -r '.pushOptions.koji_tags // [] | join(" ")' "${DATA_FILE}")
-        KOJI_IMPORT_DRAFT=$(jq -r '.pushOptions.koji_import_draft' "${DATA_FILE}")
 
         koji-cmd() {
             koji --profile="$KOJI_PROFILE" "$@"
@@ -189,8 +187,10 @@ spec:
         for ((i = 0; i < NUM_COMPONENTS; i++))
         do
           component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
-          containerImage=$(jq -r '.containerImage' <<< "$component")
           componentName=$(jq -r '.name' <<< "$component")
+          gitUrl=$(jq -r '.source.git.url' <<< "$component")
+          commitHash=$(jq -r '.source.git.revision' <<< "$component")
+          commitUrl="git+$gitUrl#$commitHash"
 
           # Use printf to join the array elements and grep to check for the presence of the variable
           if ! printf "%s\n" "${RELEASE_COMPONENTS[@]}" | grep -q -x "$componentName"; then
@@ -198,90 +198,19 @@ spec:
               continue
           fi
 
-          mkdir temp && cd temp
-
-          # The login serviceaccount should have the dockerconfig to pull the images.
-          # oras has very limited support for selecting the right auth entry,
-          # so create a custom auth file with just one entry
-          authFile=$(mktemp)
-          select-oci-auth "${containerImage}" > "$authFile"
-          oras pull --registry-config "$authFile" "$containerImage"
-
-          SRPM=$(ls ./*.src.rpm)
-          PACKAGE_NVR=$(basename "$SRPM" .src.rpm)
-
-          if [[ "$KOJI_IMPORT_DRAFT" == "false" ]]; then
-              if koji-cmd buildinfo "$PACKAGE_NVR" >/dev/null 2>&1;  then
-                  printf "Skip import %s into BREW as it's exist ...\n" "$PACKAGE_NVR"
-                  cd .. && rm -rf temp
-                  continue
-              fi
-              draft="false"
-              draft_flag=""
-          else
-              draft="true"
-              draft_flag="--draft"
-          fi
-
-          # Get Koji build target from the RPM image annotation to tag the
-          # imported build later.
-          koji_target=$(
-            oras manifest fetch "$containerImage" --registry-config "$authFile" |
-              jq --exit-status -r '.annotations."koji.build-target"'
+          builds=$(
+            koji-cmd call --json-output listBuilds \
+              userID="$USER_NAME" \
+              packageID="$componentName" \
+              state=1 \
+              source="$commitUrl" \
+              draft=True
           )
-          if [ -z "$koji_target" ]; then
-              echo "ERROR: No Koji build target found in the container image annotations."
-              exit 1
-          fi
-          # For draft builds, remove "-candidate" tag suffix if present and
-          # append "-draft".
-          if [[ "$draft" == "true" && "$koji_target" != *-draft ]]; then
-              koji_tag=${koji_target%-candidate}-draft
-          else
-              koji_tag=${koji_target}
-          fi
-          KOJI_TAGS="$koji_tag $KOJI_TAGS"
+          # Get the latest build ID
+          build_id=$(jq -r 'max_by(".creation_time").build_id' <<< "$builds")
 
-          printf "Import rpm %s with tags %s ...\n" "$PACKAGE_NVR" "$KOJI_TAGS"
-
-          # Reserve build ID and import build (as draft by default)
-          build_name=$(jq -r '.build.name' cg_import.json)
-          build_version=$(jq -r '.build.version' cg_import.json)
-          build_release=$(jq -r '.build.release' cg_import.json)
-          build_epoch=$(jq '.build.epoch' cg_import.json)
-          import_build_data=$(jq --compact-output <<EOD
-              {
-                "name": "$build_name",
-                "version": "$build_version",
-                "release": "$build_release",
-                "epoch": $build_epoch,
-                "draft": $draft
-              }
-        EOD
-          )
-          set +x  # Avoid leaking the token
-          buildinfo=$(koji-cmd call --json CGInitBuild '"konflux"' "$import_build_data")
-          build_id=$(jq --exit-status -r '.build_id' <<< "$buildinfo")
-          token=$(jq --exit-status -r '.token' <<< "$buildinfo")
-
-          echo "Importing build $build_id"
-          if ! koji-cmd import-cg $draft_flag cg_import.json --token="$token" --build-id="$build_id" .; then
-              echo "ERROR: Import failed"
-              koji-cmd call --json CGRefundBuild '"konflux"' "$build_id" "\"$token\""
-              exit 1
-          fi
-
-          set -x
-
-          for tag in $KOJI_TAGS; do
-              if ! koji-cmd list-pkgs --tag "$tag" --package "$build_name" >/dev/null 2>&1;  then
-                  koji-cmd --force add-pkg "$tag" "$build_name" --owner "$USER_NAME"
-              fi
-              koji-cmd call tagBuild "$tag" "$build_id"
-          done
-
-          # Clean up to handle next component
-          cd .. && rm -rf temp
+          printf "Promoting build %s ...\n" "$build_id"
+          koji-cmd call promoteBuild "$build_id"
         done
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$APPLICATION"

--- a/tasks/managed/promote-koji-draft-build/tests/mocks.sh
+++ b/tasks/managed/promote-koji-draft-build/tests/mocks.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function kinit() {
+    echo "kinit $@" >> "$(params.dataDir)/kinit_calls.txt"
+    call_count=$(wc -l < "$(params.dataDir)/kinit_calls.txt")
+    # Simulate kinit failures on first two calls
+    if [[ "$call_count" < 3 ]]; then
+        echo "kinit failed"
+        return 1
+    fi
+}
+
+function mktemp() {
+    echo /tmp/foobar
+}
+
+function select-oci-auth() {
+    echo "select-oci-auth $@" >> "$(params.dataDir)/select_oci_auth_calls.txt"
+    # This usually includes some auth details, but we're not really going to use it
+    echo "{}"
+}
+
+function oras() {
+    echo "oras $@" >> "$(params.dataDir)/oras_calls.txt"
+    if [[ "$1" == "manifest" && "$2" == "fetch" ]]; then
+        echo '{"annotations": {"koji.build-target": "mock-target"}}'
+    elif [[ "$1" == "pull" ]]; then
+        cat > "cg_import.json" <<EOF
+        {
+            "metadata_version": 0,
+            "build": {
+                "name": "libecpg",
+                "version": "16.1",
+                "release": "10.el10_0",
+                "epoch": null
+            }
+        }
+EOF
+        touch "test.src.rpm"
+    fi
+}
+
+function koji() {
+    echo "koji $@" >> "$(params.dataDir)/koji_calls.txt"
+    if [[ "$*" == *listBuilds*packageID=test-foo* ]]; then
+        echo '[{"build_id": 1001, "creation_time": "2025-01-01 00:00:00.000000"}, {"build_id": 1002, "creation_time": "2025-01-01 01:00:00.000000"}]'
+    elif [[ "$*" == *listBuilds*packageID=test-bar* ]]; then
+        echo '[{"build_id": 2001, "creation_time": "2025-01-01 00:00:00.000000"}]'
+    fi
+}

--- a/tasks/managed/promote-koji-draft-build/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/promote-koji-draft-build/tests/pre-apply-task-hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Delete existing secrets if they exist
+kubectl delete secret push-koji-test --ignore-not-found
+
+# Create the fake secrets for koji
+kubectl create secret generic push-koji-test \
+  --from-literal=base64_keytab="$(base64 <<< "some keytab")"

--- a/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
@@ -1,0 +1,299 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-promote-koji-draft-build
+spec:
+  description: |
+    Test the promote-koji-draft-build task.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "test-foo",
+                      "pushSourceContainer": false,
+                      "repository": "quay.io/test/test-foo"
+                    },
+                    {
+                      "name": "test-bar",
+                      "pushSourceContainer": false,
+                      "repository": "quay.io/test/test-bar"
+                    }
+                  ]
+                },
+                "pushOptions": {
+                  "koji_profile": "koji",
+                  "koji_import_draft": true,
+                  "koji_tags": [
+                    "test-rpm"
+                  ],
+                  "pushKeytab": {
+                    "name": "test.keytab",
+                    "principal": "test@test.com",
+                    "secret": "test-secrets"
+                  },
+                  "pushPipelineImage": "test-image"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/test@sha256:12345",
+                    "name": "test",
+                    "source": {
+                      "git": {
+                        "revision": "12345",
+                        "url": "https://gitlab.example.com/rpms/test"
+                      }
+                    }
+                  },
+                  {
+                    "containerImage": "quay.io/test/test-foo@sha256:12345",
+                    "name": "test-foo",
+                    "source": {
+                      "git": {
+                        "context": "./",
+                        "dockerfileUrl": "Containerfile",
+                        "revision": "12345",
+                        "url": "https://gitlab.example.com/rpms/test-foo"
+                      }
+                    }
+                  },
+                  {
+                    "containerImage": "quay.io/test/test-bar@sha256:12345",
+                    "name": "test-bar",
+                    "source": {
+                      "git": {
+                        "context": "./",
+                        "dockerfileUrl": "Containerfile",
+                        "revision": "12345",
+                        "url": "https://gitlab.example.com/rpms/test-bar"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: promote-koji-draft-build
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pushSecret
+          value: "push-koji-test"
+        - name: pipelineImage
+          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              exit_code=0
+
+              function assert_cmd_called_with() {
+                  calls_file="$(params.dataDir)/${1}_calls.txt"
+                  if ! grep -q "^$*$" "$calls_file"; then
+                      echo "Command call not found:"
+                      echo "  $*"
+                      echo "Actual calls:"
+                      sed 's/^/  /' "$calls_file"
+                      return 1
+                  fi
+              }
+
+              function assert_cmd_calls_count() {
+                  expected_count=$1
+                  shift
+                  calls_file="$(params.dataDir)/${1}_calls.txt"
+                  actual_count=$(grep -c "^$*" "$calls_file")
+                  if [[ "$expected_count" != "$actual_count" ]]; then
+                      echo "Expected $expected_count calls, but the actual number is $actual_count"
+                      echo "Matching calls:"
+                      grep "^$*" "$calls_file" | sed 's/^/  /'
+                      echo "Non-matching calls:"
+                      grep --invert-match "^$*" "$calls_file" | sed 's/^/  /'
+                      return 1
+                  fi
+              }
+
+              function test_list_builds() {
+                  packageID=$1
+                  if assert_cmd_called_with koji --profile=koji call --json-output listBuilds \
+                      userID=test \
+                      packageID="$packageID" \
+                      state=1 \
+                      source="git+https://gitlab.example.com/rpms/$packageID#12345" \
+                      draft=True
+                  then
+                      echo "TEST PASSED: Koji build for $packageID was listed."
+                  else
+                      echo "TEST FAILED: Koji build for $packageID was not listed."
+                      exit_code=1
+                  fi
+              }
+
+              function test_promote() {
+                  build_id=$1
+                  if assert_cmd_called_with koji --profile=koji call promoteBuild "$build_id"
+                  then
+                      echo "TEST PASSED: Koji build $build_id was promoted."
+                  else
+                      echo "TEST FAILED: Koji build $build_id was not promoted."
+                      exit_code=1
+                  fi
+              }
+
+              function test_kinit() {
+                  if assert_cmd_called_with kinit -kt "\./test.keytab" "test@test\.com"; then
+                      echo "TEST PASSED: kinit was called."
+                  else
+                      echo "TEST PASSED: kinit was not called."
+                      exit_code=1
+                  fi
+              }
+
+              function test_cmd_count() {
+                  count=$1
+                  shift
+                  if assert_cmd_calls_count "$count" "$@"; then
+                      echo "TEST PASSED: \"$*\" was called exactly $count times."
+                  else
+                      echo "TEST FAILED: \"$*\" was not called exactly $count times."
+                      exit_code=1
+                  fi
+              }
+
+              test_promote 1002
+              test_promote 2001
+              test_list_builds test-foo
+              test_list_builds test-bar
+              test_cmd_count 2 koji --profile=koji call promoteBuild
+              test_cmd_count 3 kinit -kt
+              test_kinit
+
+              exit $exit_code


### PR DESCRIPTION
## Describe your changes

Adds support for promoting draft builds in Koji. If the Release object has `.pushOptions.pushType` set to `promote`, the latest draft build for each component from the relate Snapshot will be promoted to normal build.

## Relevant Jira

[ROK-890](https://issues.redhat.com//browse/ROK-890)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
