### PR TITLE
fix: mapping to run release-to-github e2e for advisory task

### DIFF
--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -122,7 +122,10 @@ _find_and_process_pipelines() {
     # remove leading spaces
     pipeline_name="${pipeline_name//[[:space:]]/}"
     case "$pipeline_name" in
-      "create-advisory"|"check-embargoed-cves"|"get-advisory-severity"|"filter-already-released-advisory-images")
+      "create-advisory")
+        TEMP_MANAGED_PIPELINENAMES+=("rh-advisories" "release-to-github")
+        ;;
+      "check-embargoed-cves"|"get-advisory-severity"|"filter-already-released-advisory-images")
         TEMP_MANAGED_PIPELINENAMES+=("rh-advisories")
         ;;
       "update-fbc-catalog"|"publish-index-image-pipeline")


### PR DESCRIPTION
## Describe your changes

The release-to-github pipeline creates advisories, so if the internal create-advisory-task is changed, the release-to-github tests should run.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
