### PR TITLE
feat: use assignees endpoint

### DIFF
--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -1,9 +1,9 @@
 ---
-name: Assign Reviewers
+name: Assign PR
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, review_request_removed]
+    types: [opened, ready_for_review, unassigned]
 
 permissions:
   contents: read
@@ -18,6 +18,6 @@ jobs:
         with:
           event-type: ${{ github.event.action }}
           pr-number: ${{ github.event.pull_request.number }}
-          removed-reviewer: ${{ github.event.requested_reviewer.login || '' }}
+          removed-assignee: ${{ github.event.action == 'unassigned' && github.event.assignee.login || '' }}
           github-token: ${{ secrets.PR_ASSIGNER_PAT_TOKEN }}
           slack-webhook: ${{ secrets.PR_ASSIGNER_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Describe your changes

The PR assigner will use now the assignees endpoint.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
