### PR TITLE
fix(KONFLUX-9792): fix rh-sign-image for single-container docker manifests

### DIFF
--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -247,8 +247,10 @@ spec:
             RAW_OUTPUT=$(skopeo inspect --retry-times 3 --no-tags --raw "docker://${referenceContainerImage}")
             # Always sign the top level sha
             manifest_digests="${referenceContainerImage#*@}"
-            # For multi arch, also sign all the manifests inside
-            if [ "$(jq -r '.mediaType' <<< "$RAW_OUTPUT")" != "application/vnd.oci.image.manifest.v1+json" ] ; then
+            # For multi arch and index images, also sign all the manifests inside
+            MEDIATYPE="$(jq -r '.mediaType' <<< "$RAW_OUTPUT")"
+            if [ "$MEDIATYPE" != "application/vnd.oci.image.manifest.v1+json" ] && \
+               [ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.v2+json" ]; then
               nested_digests=$(jq -r '[.manifests[].digest] | join(" ")' <<< "$RAW_OUTPUT")
               manifest_digests="$manifest_digests $nested_digests"
             fi

--- a/tasks/managed/rh-sign-image/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image/tests/mocks.sh
@@ -222,13 +222,54 @@ function skopeo() {
                 }
             '
         else
-          if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
+          if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/docker-image"* ]]
           then
-            echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
+            echo '{
+                    "schemaVersion": 2,
+                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                    "config": {
+                      "mediaType": "application/vnd.docker.container.image.v1+json",
+                      "size": 34835,
+                      "digest": "sha256:ec00ee53ba9645b1a40eb1bfe7420f9e2bd1b0b532a37237bed5c3a8eb89d550"
+                    },
+                    "layers": [
+                      {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 79977606,
+                        "digest": "sha256:1e0d3859902320579031b75c16b7945d5a4ddafd9fae85b6f7f1128659f6f26e"
+                      },
+                      {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 140891286,
+                        "digest": "sha256:dd85c74d1fe73af400c04e0a9d8e1cd002c6ee532afead97f2620c67c15ec2e9"
+                      },
+                      {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 30676092,
+                        "digest": "sha256:34245d8761530577f1516e7b6264788c6dd1aae3c3d94e4c231d18157bd80510"
+                      },
+                      {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 27232395,
+                        "digest": "sha256:3f9ee708b8241757f09522f2a92484f8781bcff14ddbbc65a75241c629020bda"
+                      },
+                      {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 8886287,
+                        "digest": "sha256:f8266280a85062784021fc530598c6c9e3787792e3e118a2056213b8d31bc689"
+                      }
+                    ]
+                  }
+              '
           else
-            echo Error: Unexpected call
-            exit 1
-          fi
+            if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
+            then
+              echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
+            else
+              echo Error: Unexpected call
+              exit 1
+	    fi
+	  fi
         fi
       fi
     fi

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -89,6 +89,17 @@ spec:
                       "some-prefix-12345",
                       "some-prefix"
                     ]
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/docker-image3@sha256:0003",
+                    "repository": "quay.io/redhat-pending/prod----repo3",
+                    "rh-registry-repo": "registry.stage.redhat.io/prod/repo3",
+                    "registry-access-repo": "registry.access.stage.redhat.com/prod/repo3",
+                    "tags": [
+                      "some-prefix-12345",
+                      "some-prefix"
+                    ]
                   }
                 ]
               }
@@ -132,6 +143,7 @@ spec:
               prod/repo0
               prod/repo1
               prod/repo2
+              prod/repo3
               EOF
           - name: create-trusted-artifact
             ref:
@@ -219,7 +231,7 @@ spec:
 
               expectedReferences=()
               expectedDigests=()
-              for((i=0; i<3; i++)); do
+              for((i=0; i<4; i++)); do
                 expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix-12345")
                 expectedReferences+=("registry.access.stage.redhat.com/prod/repo${i}:some-prefix-12345")
                 expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix")


### PR DESCRIPTION
## Describe your changes

This makes the `rh-sign-image` task match `rh-sign-image-cosign` with respect to looking for child manifests only in list-type mediatypes.

Without this fix, the `rh-sign-image` task was only accepting single-container OCI manifests and assuming all others were list-type manifests, which was causing failures whenever the BUILDAH_FORMAT was set to `docker` for single containers.

## Relevant Jira

KONFLUX-9792

## Checklist before requesting a review
- [N/A] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
