### PR TITLE
fix(KONFLUX-9794): use correct oras cp flags

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -196,7 +196,8 @@ spec:
               if [[ "$COPY_ATTACHED_ARTIFACTS" == "true" && "${artifact_count}" -gt 0 ]]; then
                 # Copy the image and all attached artifacts
                 oras cp -r \
-                  --registry-config "$DOCKER_CONFIG/config.json" \
+                  --from-registry-config "$SOURCE_AUTH_FILE" \
+                  --to-registry-config "$DEST_AUTH_FILE" \
                   "${oras_args[@]}" \
                   "$3" \
                   "$4:$5" \

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -184,8 +184,9 @@ spec:
                 "$(params.dataDir)/mock_oras.txt"
               # Since mock returns 1 artifact for sha256:abcdefg, task should use oras cp -r for its tags
               grep -E \
-                'cp -r( --registry-config [^ ]+)?( --platform [^ ]+)? reg.io/test@sha256:abcdefg' \
-                "$(params.dataDir)/mock_oras.txt"
+                'cp -r( --from-registry-config [^ ]+ --to-registry-config [^ ]+)?' \
+                "$(params.dataDir)/mock_oras.txt" | \
+              grep -E 'reg.io/test@sha256:abcdefg'
               # For hijklmn (no artifacts), it should fall back to cosign copy
               # Count cosign copy calls (tag1, tag2, tag3)
               COPIES=$(grep -c \


### PR DESCRIPTION
## Describe your changes

Replace --registry-config with --from-registry-config and --to-registry-config flags. The old flag is not supported and was causing failures when copying attached artifacts.

[Related Slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1755606900088889)
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
