### PR TITLE
fix: speedup cleanup in collectors pipeline

### DIFF
--- a/pipelines/run-collectors/run-collectors.yaml
+++ b/pipelines/run-collectors/run-collectors.yaml
@@ -141,6 +141,10 @@ spec:
           value: "$(context.pipelineRun.uid)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
+          # since no other tasks are defined in the finally
+          # section, we do not need to delay cleanup.
+        - name: delay
+          value: "0"
       workspaces:
         - name: input
           workspace: release-workspace


### PR DESCRIPTION
## Describe your changes
- since no other tasks are defined in the finally section, we do not need to delay cleanup.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
