### PR TITLE
fix: extract-oot-kmods paths and image handling

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -114,26 +114,23 @@ spec:
         KMODS_PATH=$(params.kmodsPath)
         SIGNED_KMODS_PATH=$(params.signedKmodsPath)
         snapshot_json=$(cat "$(params.dataDir)/$(params.snapshotPath)")
-        sha_image=$(jq -r '.metadata.annotations["build.appstudio.redhat.com/commit_sha"]' <<< "$snapshot_json")
-        source_image=$(jq -r '.spec.components[].containerImage' <<< "$snapshot_json" | sed 's/@.*$//')
-        jq -r '.spec.components[].containerImage' <<< "$snapshot_json"
-        SRC_IMAGE="$source_image:$sha_image"
-        TMP_DIR=$(mktemp -d)
-        echo "Copying $SRC_IMAGE to $TMP_DIR..."
-        skopeo copy docker://"$SRC_IMAGE" dir:"$TMP_DIR"
+        source_image=$(jq -r '.components[0].containerImage' <<< "$snapshot_json")
+        tmp_dir=$(mktemp -d)
+        echo "Copying $source_image to $tmp_dir..."
+        skopeo copy docker://"$source_image" dir:"$tmp_dir"
         echo "Inspecting layers to find OOT kernel modules and envfile"
-        for LAYER in $(jq -r '.layers[].digest' "$TMP_DIR/manifest.json"); do
+        for LAYER in $(jq -r '.layers[].digest' "$tmp_dir/manifest.json"); do
             LAYER=${LAYER#sha256:}
-            tar -xf "$TMP_DIR/$LAYER" -C "$TMP_DIR"
-            if [ -d "$TMP_DIR$KMODS_PATH" ]; then
+            tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir"
+            if [ -d "$tmp_dir$KMODS_PATH" ]; then
                 echo "Found $KMODS_PATH in layer: $LAYER"
                 mkdir -p "$(params.dataDir)/$SIGNED_KMODS_PATH/"
-                cp -r "$TMP_DIR$KMODS_PATH"/*.ko "$(params.dataDir)/$SIGNED_KMODS_PATH/"
+                cp -r "$tmp_dir$KMODS_PATH"/*.ko "$(params.dataDir)/$SIGNED_KMODS_PATH/"
                 echo "Copying envfile to get versions data..."
-                cp "$TMP_DIR/envfile" "$(params.dataDir)/$SIGNED_KMODS_PATH/"
+                cp "$tmp_dir/envfile" "$(params.dataDir)/$SIGNED_KMODS_PATH/"
             else
                 echo "$KMODS_PATH not found in $LAYER so deleting layer..."
-                rm -rf "${TMP_DIR:?}/${LAYER:?}"
+                rm -rf "${tmp_dir:?}/${LAYER:?}"
             fi
         done
     - name: create-trusted-artifact

--- a/tasks/managed/extract-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/extract-oot-kmods/tests/mocks.sh
@@ -6,18 +6,11 @@ echo "Creating snapshot.json file for task to read..."
 mkdir -p "$(params.dataDir)"
 cat > "$(params.dataDir)/snapshot.json" << 'EOF'
 {
-  "metadata": {
-    "annotations": {
-      "build.appstudio.redhat.com/commit_sha": "mocksha123"
+  "components": [
+    {
+      "containerImage": "quay.io/mock/image@sha256:dummy"
     }
-  },
-  "spec": {
-    "components": [
-      {
-        "containerImage": "quay.io/mock/image@sha256:dummy"
-      }
-    ]
-  }
+  ]
 }
 EOF
 
@@ -26,18 +19,11 @@ function get-resource() {
    case "$1" in
      "snapshot")
        echo '{
-         "metadata": {
-           "annotations": {
-             "build.appstudio.redhat.com/commit_sha": "mocksha123"
+         "components": [
+           {
+             "containerImage": "quay.io/mock/image@sha256:dummy"
            }
-         },
-         "spec": {
-           "components": [
-             {
-               "containerImage": "quay.io/mock/image@sha256:dummy"
-             }
-           ]
-         }
+         ]
        }'
        ;;
      *)
@@ -56,9 +42,9 @@ skopeo() {
   echo "$*" >> "$(params.dataDir)/mock_skopeo.txt"
 
   case "$*" in
-    "copy docker://quay.io/mock/image@sha256:dummy dir:"* | "copy docker://quay.io/mock/image:mocksha123 dir:"*)
+    "copy docker://quay.io/mock/image@sha256:dummy dir:"*)
       # Create a proper manifest.json with layers
-      cat > "$TMP_DIR/manifest.json" << 'EOF'
+      cat > "$tmp_dir/manifest.json" << 'EOF'
 {
   "layers": [
     {"digest": "sha256:mocklayer123"}
@@ -83,14 +69,14 @@ EOF
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
       
       # Create the layer tar file with the complete structure
-      (cd "$LAYER_BUILD_DIR" && tar -cf "$TMP_DIR/mocklayer123" .)
+      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/mocklayer123" .)
       
       # Clean up the temporary build directory
       rm -rf "$LAYER_BUILD_DIR"
       
       # Debug: Let's see what we actually created
-      echo "Debug: Contents of TMP_DIR after tar creation:"
-      ls -la "$TMP_DIR/"
+      echo "Debug: Contents of tmp_dir after tar creation:"
+      ls -la "$tmp_dir/"
       ;;
     *)
       echo "Error: Unexpected skopeo call: $*"


### PR DESCRIPTION
This commit:

- Fixes snapshot JSON path
- Simplifies image handling
- Makes consistent variable naming
