### PR TITLE
fix: change ownership when tar include root owned files

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -121,7 +121,7 @@ spec:
         echo "Inspecting layers to find OOT kernel modules and envfile"
         for LAYER in $(jq -r '.layers[].digest' "$tmp_dir/manifest.json"); do
             LAYER=${LAYER#sha256:}
-            tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir"
+            tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir" --no-same-owner
             if [ -d "$tmp_dir$KMODS_PATH" ]; then
                 echo "Found $KMODS_PATH in layer: $LAYER"
                 mkdir -p "$(params.dataDir)/$SIGNED_KMODS_PATH/"


### PR DESCRIPTION
`tar -xf ` fails with Permission denied
Adding `--no-same-owner` flag to tar command

```
for LAYER in $(jq -r '.layers[].digest' "$tmp_dir/manifest.json")
+ LAYER=d1626b5b9f7a59add02f7c14fb670e63a729a8b70a53b95f56bf7f5ee8dc12d8
+ tar -xf /tmp/tmp.vRZrPj8pUS/d1626b5b9f7a59add02f7c14fb670e63a729a8b70a53b95f56bf7f5ee8dc12d8 -C /tmp/tmp.vRZrPj8pUS
+ '[' -d /tmp/tmp.vRZrPj8pUS/opt/drivers/open-gpu-kernel-modules/kernel-open ']'
/opt/drivers/open-gpu-kernel-modules/kernel-open not found in d1626b5b9f7a59add02f7c14fb670e63a729a8b70a53b95f56bf7f5ee8dc12d8 so deleting layer...
+ echo '/opt/drivers/open-gpu-kernel-modules/kernel-open not found in d1626b5b9f7a59add02f7c14fb670e63a729a8b70a53b95f56bf7f5ee8dc12d8 so deleting layer...'
+ rm -rf /tmp/tmp.vRZrPj8pUS/d1626b5b9f7a59add02f7c14fb670e63a729a8b70a53b95f56bf7f5ee8dc12d8
+ for LAYER in $(jq -r '.layers[].digest' "$tmp_dir/manifest.json")
+ LAYER=0a73aee7e570194d6ace6157d6693b5439c872acf23a01d32c79489f3192264f
+ tar -xf /tmp/tmp.vRZrPj8pUS/0a73aee7e570194d6ace6157d6693b5439c872acf23a01d32c79489f3192264f -C /tmp/tmp.vRZrPj8pUS
tar: root/buildinfo: Cannot mkdir: Permission denied
tar: root/buildinfo: Cannot mkdir: Permission denied
tar: root/buildinfo/content_manifests: Cannot mkdir: No such file or directory
tar: root/buildinfo: Cannot mkdir: Permission denied
tar: root/buildinfo/content_manifests/sbom-cyclonedx.json: Cannot open: No such file or directory
tar: root/buildinfo: Cannot mkdir: Permission denied
tar: root/buildinfo/content_manifests/sbom-purl.json: Cannot open: No such file or directory
```

