### PR TITLE
refactor(RELEASE-1797): create-pyxis-image uses repositories

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -202,13 +202,8 @@ spec:
             local output_file="/tmp/component_${component_index}.json"
 
             CONTAINER_IMAGE=$(jq -r ".components[${component_index}].containerImage" "${SNAPSHOT_SPEC_FILE}")
-            REPOSITORY=$(jq -r ".components[${component_index}].repository" "${SNAPSHOT_SPEC_FILE}")
-            REPOSITORY=${REPOSITORY%:*} # strip tag just in case - it should not be there
             SOURCE_REPO=${CONTAINER_IMAGE%%@sha256:*}
             DIGEST="${CONTAINER_IMAGE##*@}"
-            PULLSPEC="${REPOSITORY}@${DIGEST}"
-            MEDIA_TYPE=$(skopeo inspect --retry-times 3 --raw "docker://${PULLSPEC}" | jq -r .mediaType)
-            TAGS=$(jq -r ".components[${component_index}].tags | join(\" \")" "${SNAPSHOT_SPEC_FILE}")
 
             # Create component-specific auth file to avoid conflicts
             local AUTH_FILE="/tmp/auth_${component_index}"
@@ -231,137 +226,147 @@ spec:
               echo "Unable to get Dockerfile for the image. Maybe it's not enabled in the build pipeline?"
             fi
 
-            select-oci-auth "${REPOSITORY}" > "$AUTH_FILE"
+            NUM_REPOSITORIES=$(jq ".components[${component_index}].repositories | length" "${SNAPSHOT_SPEC_FILE}")
+            for ((i = 0; i < NUM_REPOSITORIES; i++)) ; do
+                REPOSITORY_OBJECT=$(jq -c ".components[${component_index}].repositories[${i}]" "${SNAPSHOT_SPEC_FILE}")
+                REPOSITORY=$(jq -r '.url' <<< "$REPOSITORY_OBJECT")
+                REPOSITORY=${REPOSITORY%:*} # strip tag just in case - it should not be there
+                PULLSPEC="${REPOSITORY}@${DIGEST}"
+                TAGS=$(jq -r ".tags | join(\" \")" <<< "$REPOSITORY_OBJECT")
+                MEDIA_TYPE=$(skopeo inspect --retry-times 3 --raw "docker://${PULLSPEC}" | jq -r .mediaType)
 
-            ARCHITECTURES=$(get-image-architectures "${PULLSPEC}")
+                select-oci-auth "${REPOSITORY}" > "$AUTH_FILE"
 
-            # Initialize component JSON structure
-            local COMPONENT_JSON='{}'
-            COMPONENT_JSON=$(jq --argjson id "$component_index" --arg image "${CONTAINER_IMAGE}" \
-              '.containerImage = $image | .componentIndex = $id | .pyxisImages = []' <<< "$COMPONENT_JSON")
+                ARCHITECTURES=$(get-image-architectures "${PULLSPEC}")
 
-            index=0
-            while IFS= read -r ARCH_DETAIL;
-            do
-                OS=$(jq -r '.platform.os' <<< "$ARCH_DETAIL")
-                ARCH=$(jq -r '.platform.architecture' <<< "$ARCH_DETAIL")
-                ARCH_DIGEST=$(jq -r '.digest' <<< "$ARCH_DETAIL")
+                # Initialize component JSON structure
+                local COMPONENT_JSON='{}'
+                COMPONENT_JSON=$(jq --argjson id "$component_index" --arg image "${CONTAINER_IMAGE}" \
+                  '.containerImage = $image | .componentIndex = $id | .pyxisImages = []' <<< "$COMPONENT_JSON")
 
-                ORAS_ARGS=()
-                if [[ "$MEDIA_TYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]\
-                  || [[ "$MEDIA_TYPE" == "application/vnd.oci.image.index.v1+json" ]]; then
-                  ORAS_ARGS+=(--platform "$OS/$ARCH")
-                fi
-
-                # Save the OCI manifest locally, to pass to a script to create the pyxis entry
-                # Use component-specific manifest file to avoid conflicts
-                MANIFEST_FILE="$(params.dataDir)/$(dirname \
-                  "$(params.snapshotPath)")/oras-manifest-fetch-${component_index}-${index}.json"
-                oras manifest fetch \
-                  --registry-config "$AUTH_FILE" \
-                  "${ORAS_ARGS[@]}" \
-                  "${PULLSPEC}" \
-                      | tee "${MANIFEST_FILE}"
-
-                # When building images without squashing, their final layer might always be bit-wise identical.
-                # This causes upload to pyxis to fail which cannot tolerate duplicate "top_layer_id" values.
-                # This flag allows to overcome this limitation by just deleting the layers so that no layer
-                # information is uploaded.
-                if [ "$includeLayers" != true ]; then
-                  echo ".pyxis.includeLayers is not true in data file, so delete the layers"
-                  jq '.layers = []' "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
-                  mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
-                fi
-
-                # Augment that manifest with further information about the layers, decompressed
-                # This requires pulling the layers to decompress and then measure them
-                while IFS= read -r BLOB_DETAIL;
+                index=0
+                while IFS= read -r ARCH_DETAIL;
                 do
-                    BLOB_TYPE=$(jq -r '.mediaType' <<< "$BLOB_DETAIL")
-                    BLOB_DIGEST=$(jq -r '.digest' <<< "$BLOB_DETAIL")
+                    OS=$(jq -r '.platform.os' <<< "$ARCH_DETAIL")
+                    ARCH=$(jq -r '.platform.architecture' <<< "$ARCH_DETAIL")
+                    ARCH_DIGEST=$(jq -r '.digest' <<< "$ARCH_DETAIL")
 
-                    # Normal images will always have the layers compressed.
-                    # If they are not compressed, this will not save the
-                    # uncompressed data in Pyxis.
-                    #
-                    # It's also possible that the layers are compressed with
-                    # some scheme other than gzip.  In that case, the
-                    # uncompressed layer information will also not be saved in
-                    # Pyxis.
-                    # https://github.com/konflux-ci/build-definitions/issues/1264
-
-                    if [[ "$BLOB_TYPE" =~ ^.*\.gzip$|^.*\+gzip$ ]]; then
-                        BLOB_FILE="/tmp/oras-blob-fetch-${component_index}-${BLOB_DIGEST}"
-                        BLOB_PULLSPEC="${PULLSPEC%%@*}@${BLOB_DIGEST}"
-
-                        # Save the blob
-                        oras blob fetch \
-                          --registry-config "$AUTH_FILE" \
-                          --output "${BLOB_FILE}.gz" \
-                          "${BLOB_PULLSPEC}"
-
-                        # Decompress it
-                        gunzip "${BLOB_FILE}.gz"
-
-                        # Measure it
-                        EXPANDED_DIGEST="sha256:$(sha256sum "${BLOB_FILE}" | cut -d " " -f 1)"
-                        EXPANDED_SIZE=$(wc --bytes "${BLOB_FILE}" | awk '{print $1}' | tr -d '\n')
-
-                        # Append this information to the parsed_data manifest
-                        jq \
-                          '.uncompressed_layers += [{"digest": "'"$EXPANDED_DIGEST"'", "size": '"$EXPANDED_SIZE"'}]' \
-                          "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
-                        mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
-
-                        # Clean up, in case we're dealing with large images
-                        rm "${BLOB_FILE}"
+                    ORAS_ARGS=()
+                    if [[ "$MEDIA_TYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]\
+                      || [[ "$MEDIA_TYPE" == "application/vnd.oci.image.index.v1+json" ]]; then
+                      ORAS_ARGS+=(--platform "$OS/$ARCH")
                     fi
-                done <<< "$(jq -c '.layers[]' "${MANIFEST_FILE}")"
 
-                PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
-                  --pyxis-url $PYXIS_URL \
-                  --certified "$(params.certified)" \
-                  --tags "$TAGS" \
-                  --is-latest "$(params.isLatest)" \
-                  --verbose \
-                  --oras-manifest-fetch "${MANIFEST_FILE}" \
-                  --name "$REPOSITORY" \
-                  --media-type "$MEDIA_TYPE" \
-                  --digest "$DIGEST" \
-                  --architecture-digest "$ARCH_DIGEST" \
-                  --architecture "$ARCH" \
-                  --rh-push "$(params.rhPush)" \
-                  --dockerfile "${DOCKERFILE_PATH}" | tee "/tmp/output_${component_index}_${index}"
-                # The rh-push-to-external-registry e2e test depends on this line being in the task log
-                IMAGEID=$(awk '/The image id is/{print $NF}' "/tmp/output_${component_index}_${index}" | head -1)
+                    # Save the OCI manifest locally, to pass to a script to create the pyxis entry
+                    # Use component-specific manifest file to avoid conflicts
+                    MANIFEST_FILE="$(params.dataDir)/$(dirname \
+                      "$(params.snapshotPath)")/oras-manifest-fetch-${component_index}-${index}.json"
+                    oras manifest fetch \
+                      --registry-config "$AUTH_FILE" \
+                      "${ORAS_ARGS[@]}" \
+                      "${PULLSPEC}" \
+                          | tee "${MANIFEST_FILE}"
 
-                # prepare the REPOSITORY string for cleanup_tags
-                TARGET_REPOSITORY="${REPOSITORY#*/}" # remove the host
-                TARGET_REPOSITORY="${TARGET_REPOSITORY//----/\/}"
-                TARGET_REPOSITORY="${TARGET_REPOSITORY#*/}"
+                    # When building images without squashing, their final layer might always be bit-wise identical.
+                    # This causes upload to pyxis to fail which cannot tolerate duplicate "top_layer_id" values.
+                    # This flag allows to overcome this limitation by just deleting the layers so that no layer
+                    # information is uploaded.
+                    if [ "$includeLayers" != true ]; then
+                      echo ".pyxis.includeLayers is not true in data file, so delete the layers"
+                      jq '.layers = []' "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
+                      mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
+                    fi
 
-                # Remove the new image tags from all previous images, but only if rhPush=true
-                if [ "$(params.rhPush)" = "true" ]; then
-                  PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key cleanup_tags \
-                    --verbose \
-                    --retry \
-                    --pyxis-graphql-api $PYXIS_GRAPHQL_URL \
-                    --repository "$TARGET_REPOSITORY" \
-                    "$IMAGEID"
-                fi
+                    # Augment that manifest with further information about the layers, decompressed
+                    # This requires pulling the layers to decompress and then measure them
+                    while IFS= read -r BLOB_DETAIL;
+                    do
+                        BLOB_TYPE=$(jq -r '.mediaType' <<< "$BLOB_DETAIL")
+                        BLOB_DIGEST=$(jq -r '.digest' <<< "$BLOB_DETAIL")
 
-                COMPONENT_JSON=$(jq --argjson arch_index $index \
-                  --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \
-                  --arg arch_digest "${ARCH_DIGEST}" --arg os "${OS}" \
-                    '.pyxisImages[$arch_index] += {
-                      "arch": $arch,
-                      "imageId": $imageId,
-                      "digest": $digest,
-                      "arch_digest": $arch_digest,
-                      "os": $os}' <<< "$COMPONENT_JSON")
+                        # Normal images will always have the layers compressed.
+                        # If they are not compressed, this will not save the
+                        # uncompressed data in Pyxis.
+                        #
+                        # It's also possible that the layers are compressed with
+                        # some scheme other than gzip.  In that case, the
+                        # uncompressed layer information will also not be saved in
+                        # Pyxis.
+                        # https://github.com/konflux-ci/build-definitions/issues/1264
 
-                index=$((index + 1))
-            done <<< "$ARCHITECTURES"
+                        if [[ "$BLOB_TYPE" =~ ^.*\.gzip$|^.*\+gzip$ ]]; then
+                            BLOB_FILE="/tmp/oras-blob-fetch-${component_index}-${BLOB_DIGEST}"
+                            BLOB_PULLSPEC="${PULLSPEC%%@*}@${BLOB_DIGEST}"
+
+                            # Save the blob
+                            oras blob fetch \
+                              --registry-config "$AUTH_FILE" \
+                              --output "${BLOB_FILE}.gz" \
+                              "${BLOB_PULLSPEC}"
+
+                            # Decompress it
+                            gunzip "${BLOB_FILE}.gz"
+
+                            # Measure it
+                            EXPANDED_DIGEST="sha256:$(sha256sum "${BLOB_FILE}" | cut -d " " -f 1)"
+                            EXPANDED_SIZE=$(wc --bytes "${BLOB_FILE}" | awk '{print $1}' | tr -d '\n')
+
+                            # Append this information to the parsed_data manifest
+                            jq \
+                              '.uncompressed_layers += [{"digest": "'"$EXPANDED_DIGEST"'",
+                              "size": '"$EXPANDED_SIZE"'}]' "${MANIFEST_FILE}" > "${MANIFEST_FILE}.tmp"
+                            mv "${MANIFEST_FILE}.tmp"  "${MANIFEST_FILE}"
+
+                            # Clean up, in case we're dealing with large images
+                            rm "${BLOB_FILE}"
+                        fi
+                    done <<< "$(jq -c '.layers[]' "${MANIFEST_FILE}")"
+
+                    PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
+                      --pyxis-url $PYXIS_URL \
+                      --certified "$(params.certified)" \
+                      --tags "$TAGS" \
+                      --is-latest "$(params.isLatest)" \
+                      --verbose \
+                      --oras-manifest-fetch "${MANIFEST_FILE}" \
+                      --name "$REPOSITORY" \
+                      --media-type "$MEDIA_TYPE" \
+                      --digest "$DIGEST" \
+                      --architecture-digest "$ARCH_DIGEST" \
+                      --architecture "$ARCH" \
+                      --rh-push "$(params.rhPush)" \
+                      --dockerfile "${DOCKERFILE_PATH}" | tee "/tmp/output_${component_index}_${index}"
+                    # The rh-push-to-external-registry e2e test depends on this line being in the task log
+                    IMAGEID=$(awk '/The image id is/{print $NF}' "/tmp/output_${component_index}_${index}" | head -1)
+
+                    # prepare the REPOSITORY string for cleanup_tags
+                    TARGET_REPOSITORY="${REPOSITORY#*/}" # remove the host
+                    TARGET_REPOSITORY="${TARGET_REPOSITORY//----/\/}"
+                    TARGET_REPOSITORY="${TARGET_REPOSITORY#*/}"
+
+                    # Remove the new image tags from all previous images, but only if rhPush=true
+                    if [ "$(params.rhPush)" = "true" ]; then
+                      PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key cleanup_tags \
+                        --verbose \
+                        --retry \
+                        --pyxis-graphql-api $PYXIS_GRAPHQL_URL \
+                        --repository "$TARGET_REPOSITORY" \
+                        "$IMAGEID"
+                    fi
+
+                    COMPONENT_JSON=$(jq --argjson arch_index $index \
+                      --arg arch "${ARCH}" --arg imageId "${IMAGEID}" --arg digest "${DIGEST}" \
+                      --arg arch_digest "${ARCH_DIGEST}" --arg os "${OS}" \
+                        '.pyxisImages[$arch_index] += {
+                          "arch": $arch,
+                          "imageId": $imageId,
+                          "digest": $digest,
+                          "arch_digest": $arch_digest,
+                          "os": $os}' <<< "$COMPONENT_JSON")
+
+                    index=$((index + 1))
+                done <<< "$ARCHITECTURES"
+            done
 
             # Save component result to file
             echo "$COMPONENT_JSON" | tee "$output_file"

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -63,9 +63,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "dockerfile-not-found@sha256:abcdef1234",
-                    "repository": "registry.io/image",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -62,65 +62,97 @@ spec:
                   {
                     "name": "comp1",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image1",
-                    "tags": [
-                      "testtag1"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image1",
+                        "tags": [
+                          "testtag1"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp2",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image2",
-                    "tags": [
-                      "testtag2"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image2",
+                        "tags": [
+                          "testtag2"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp3",
                     "containerImage": "source@sha256:differentdigest",
-                    "repository": "registry.io/image3",
-                    "tags": [
-                      "testtag3"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image3",
+                        "tags": [
+                          "testtag3"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp4",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image4",
-                    "tags": [
-                      "testtag4"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image4",
+                        "tags": [
+                          "testtag4"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp5",
                     "containerImage": "source@sha256:differentdigest5",
-                    "repository": "registry.io/image5",
-                    "tags": [
-                      "testtag5"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image5",
+                        "tags": [
+                          "testtag5"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp6",
                     "containerImage": "source@sha256:differentdigest6",
-                    "repository": "registry.io/image6",
-                    "tags": [
-                      "testtag6"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image6",
+                        "tags": [
+                          "testtag6"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp7",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image7",
-                    "tags": [
-                      "testtag7"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image7",
+                        "tags": [
+                          "testtag7"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp8",
                     "containerImage": "source@sha256:differentdigest8",
-                    "repository": "registry.io/image8",
-                    "tags": [
-                      "testtag8"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image8",
+                        "tags": [
+                          "testtag8"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -65,9 +65,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "dockerfile-file-missing@sha256:abcdef1234",
-                    "repository": "registry.io/image",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -64,9 +64,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/fail-get-image-architectures",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/fail-get-image-architectures",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -62,9 +62,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image-with-gzipped-layers",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image-with-gzipped-layers",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -62,25 +62,37 @@ spec:
                   {
                     "name": "comp1",
                     "containerImage": "source1@sha256:mydigest1",
-                    "repository": "registry.io/multi-arch-image1",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/multi-arch-image1",
+                        "tags": [
+                          "testtag1"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp2",
                     "containerImage": "source2@sha256:mydigest2",
-                    "repository": "registry.io/multi-arch-image2",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/multi-arch-image2",
+                        "tags": [
+                          "testtag2"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp3",
                     "containerImage": "source3@sha256:mydigest3",
-                    "repository": "registry.io/multi-arch-image3",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/multi-arch-image3",
+                        "tags": [
+                          "testtag3"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -62,25 +62,50 @@ spec:
                   {
                     "name": "comp1",
                     "containerImage": "source1@sha256:mydigest1",
-                    "repository": "registry.io/image1",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image1a",
+                        "tags": [
+                          "testtag1"
+                        ]
+                      },
+                      {
+                        "url": "registry.io/image1b",
+                        "tags": [
+                          "testtag1b1",
+                          "testtag1b2"
+                        ]
+                      },
+                      {
+                        "url": "registry.io/image1c",
+                        "tags": [
+                          "testtag1c"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp2",
                     "containerImage": "source2@sha256:mydigest2",
-                    "repository": "registry.io/image2",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image2",
+                        "tags": [
+                          "testtag2"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp3",
                     "containerImage": "source3@sha256:mydigest3",
-                    "repository": "registry.io/image3",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image3",
+                        "tags": [
+                          "testtag3"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -175,8 +200,8 @@ spec:
               set -eux
 
               if [ "$(wc -l < \
-                "$(params.dataDir)/mock_create_container_image.txt")" != 3 ]; then
-                echo Error: create_container_image was expected to be called 3 times. Actual calls:
+                "$(params.dataDir)/mock_create_container_image.txt")" != 5 ]; then
+                echo Error: create_container_image was expected to be called 5 times. Actual calls:
                 cat "$(params.dataDir)/mock_create_container_image.txt"
                 exit 1
               fi
@@ -188,7 +213,9 @@ spec:
               fi
 
               cat > "$(params.dataDir)/skopeo_expected_calls.txt" << EOF
-              inspect --retry-times 3 --raw docker://registry.io/image1@sha256:mydigest1
+              inspect --retry-times 3 --raw docker://registry.io/image1a@sha256:mydigest1
+              inspect --retry-times 3 --raw docker://registry.io/image1b@sha256:mydigest1
+              inspect --retry-times 3 --raw docker://registry.io/image1c@sha256:mydigest1
               inspect --retry-times 3 --raw docker://registry.io/image2@sha256:mydigest2
               inspect --retry-times 3 --raw docker://registry.io/image3@sha256:mydigest3
               EOF
@@ -202,12 +229,12 @@ spec:
                 echo Expected calls:
                 cat "$(params.dataDir)/skopeo_expected_calls.txt"
                 echo Actual calls:
-                cat "${mock_skopeo_calls}"
+                echo "${mock_skopeo_calls}"
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 6 ]; then
-                echo Error: oras was expected to be called 6 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 8 ]; then
+                echo Error: oras was expected to be called 8 times. Actual calls:
                 cat "$(params.dataDir)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -62,9 +62,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/oci-artifact",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/oci-artifact",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -62,9 +62,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/multi-arch-image",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/multi-arch-image",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -61,9 +61,22 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image1",
+                        "tags": [
+                          "testtag",
+                          "testtag2"
+                        ]
+                      },
+                      {
+                        "url": "registry.io/image2",
+                        "tags": [
+                          "a",
+                          "b",
+                          "c"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -158,8 +171,8 @@ spec:
               set -eux
 
               if [ "$(wc -l < "$(params.dataDir)"/mock_create_container_image.txt)" \
-                != 1 ]; then
-                echo Error: create_container_image was expected to be called 1 time. Actual calls:
+                != 2 ]; then
+                echo Error: create_container_image was expected to be called 2 time. Actual calls:
                 cat "$(params.dataDir)/mock_create_container_image.txt"
                 exit 1
               fi
@@ -186,27 +199,36 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)"/mock_skopeo.txt)" != 1 ]; then
-                echo Error: skopeo was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_skopeo.txt"
-                exit 1
-              fi
-
-              if [ "$(wc -l < "$(params.dataDir)"/mock_oras.txt)" != 2 ]; then
-                echo Error: oras was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)"/mock_oras.txt)" != 3 ]; then
+                echo Error: oras was expected to be called 3 times. Actual calls:
                 cat "$(params.dataDir)/mock_oras.txt"
                 exit 1
               fi
 
-              [ "$(head -n 1 < "$(params.dataDir)"/mock_skopeo.txt)" \
-                = "inspect --retry-times 3 --raw docker://registry.io/image@sha256:mydigest" ]
+              cat > "$(params.dataDir)/skopeo_expected_calls.txt" << EOF
+              inspect --retry-times 3 --raw docker://registry.io/image1@sha256:mydigest
+              inspect --retry-times 3 --raw docker://registry.io/image2@sha256:mydigest
+              EOF
+
+              mock_skopeo_calls="$(sort < "$(params.dataDir)/mock_skopeo.txt" | md5sum)"
+              # check that the actual calls match the expected calls
+              if [ "$(md5sum < "$(params.dataDir)/skopeo_expected_calls.txt")" \
+                != "${mock_skopeo_calls}" ]
+              then
+                echo "Error: Actual skopeo calls do not match expected calls."
+                echo Expected calls:
+                cat "$(params.dataDir)/skopeo_expected_calls.txt"
+                echo Actual calls:
+                echo "${mock_skopeo_calls}"
+                exit 1
+              fi
 
               # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )
                 and ( .os == "linux" )' "$(params.dataDir)/$(params.pyxisDataPath)"
 
-              if [ "$(wc -l < "$(params.dataDir)"/mock_select-oci-auth.txt)" != 2 ]; then
-                echo Error: select-oci-with was expected to be called 2 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)"/mock_select-oci-auth.txt)" != 3 ]; then
+                echo Error: select-oci-with was expected to be called 3 times. Actual calls:
                 cat "$(params.dataDir)/mock_select-oci-auth.txt"
                 exit 1
               fi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -62,10 +62,14 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "quay.io/redhat-prod/myproduct----myimage",
-                    "tags": [
-                      "myprefix-mytimestamp",
-                      "myprefix"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/myproduct----myimage",
+                        "tags": [
+                          "myprefix-mytimestamp",
+                          "myprefix"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -64,9 +64,13 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "source@sha256:mydigest",
-                    "repository": "registry.io/image-with-gzipped-layers",
-                    "tags": [
-                      "testtag"
+                    "repositories": [
+                      {
+                        "url": "registry.io/image-with-gzipped-layers",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
                     ]
                   }
                 ]


### PR DESCRIPTION
This commit updates the create-pyxis-image managed task to read the repositories key for each component instead of the repository key. This is part of a larger effort for each component to specify multiple repositories each instead of just one. Because apply-mapping emits both repository and repositories now, the change does not have to be backwards compatible.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
