### PR TITLE
chore(deps): hotfix - update appstudio-utils image digest (production)

### DIFF
--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-trusted-tasks
-      image: quay.io/konflux-ci/appstudio-utils@sha256:591af845d7c700a178b3738e9725880e79cf63521a906325185bfe74d2a28407
+      image: quay.io/konflux-ci/appstudio-utils@sha256:8381b83a22b71fe5efad5dcc093352b17a62920743a7b578e2f523eb3f1aef9c
       computeResources:
         limits:
           memory: 1Gi


### PR DESCRIPTION
Hotfix!

Cherry-picked to production branch from
c9124a839e7c4f25389bb265d7644dab964a42f2 in PR #1388 .

This is the task runner image used in the update-trusted-tasks task.

It's possible that the recent problems with updating the quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles are related to using an older version of the Conforma cli.

In particular, the bad date parsing issue seems to be unreproducible on the latest ec, but can be reproduced on an old version of ec.

The version of ec in the appstudio-utils image being updated here is 14 weeks old. The new digest is the latest appstudio-utils image and it has a fresh version of ec, specifically this:

    Version            v0.7.148
    Source ID          5179146da9487c3d10c2dde2f0e1201609aeb8a9
    Change date        2025-08-21 02:25:32 +0000 UTC (12 hours ago)

Previously we had this:

    Version            v0.7.68
    Source ID          c127964ccd84f02a5907655f5d7af9773190678b
    Change date        2025-05-12 15:32:54 +0000 UTC (14 weeks ago)

This might not solve all the problems, but will likely help eliminate one potential cause of broken data-acceptable-bundles data.

Ref: https://issues.redhat.com/browse/EC-1441
Ref: https://issues.redhat.com/browse/KFLUXSPRT-4746
