### PR TITLE
feat: filter out helm from pyxis image

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -239,6 +239,17 @@ spec:
 
                 ARCHITECTURES=$(get-image-architectures "${PULLSPEC}")
 
+                # Check if this is a Helm chart - skip Helm artifacts
+                config_media_type="$(jq -rs '.[0].configMediaType // ""' <<< "$ARCHITECTURES")"
+                if [[ "$config_media_type" == "application/vnd.cncf.helm.config.v1+json" ]]; then
+                    echo "Detected Helm chart artifact for component ${component_index}, skipping Pyxis image creation"
+
+                    # Create a minimal component JSON to indicate this was skipped
+                    local JSON='{"skipped": true, "reason": "helm_chart", "componentIndex": '${component_index}'}'
+                    echo "$JSON" | tee "$output_file"
+                    return
+                fi
+
                 # Initialize component JSON structure
                 local COMPONENT_JSON='{}'
                 COMPONENT_JSON=$(jq --argjson id "$component_index" --arg image "${CONTAINER_IMAGE}" \
@@ -450,12 +461,23 @@ spec:
         for (( i=0; i < COMPONENTS; i++ )); do
             if [ -f "/tmp/component_${i}.json" ]; then
                 component_data=$(cat "/tmp/component_${i}.json")
+
+                # Skip components that were marked as skipped (e.g., Helm charts)
+                if [ "$(jq -r '.skipped // false' <<< "$component_data")" = "true" ]; then
+                    echo "Skipping component $i ($(jq -r '.reason' <<< "$component_data"))"
+                    continue
+                fi
+
                 component_index=$(jq -r '.componentIndex' <<< "$component_data")
                 JSON_OUTPUT=$(jq --argjson component_index "$component_index" --argjson \
                   component_data "$component_data" \
                   '.components[$component_index] = $component_data' <<< "$JSON_OUTPUT")
             fi
         done
+
+        # Filter out null entries (from skipped artifacts) to ensure downstream compatibility
+        JSON_OUTPUT=$(jq '.components |= map(select(. != null))' <<< "$JSON_OUTPUT")
+
         echo "$JSON_OUTPUT" | tee "$(params.dataDir)/${PYXIS_DATA_PATH}"
     - name: create-trusted-artifact
       computeResources:

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -83,6 +83,9 @@ function get-image-architectures() {
   elif [[ "$1" == *"registry.io/oci-artifact@sha256:mydigest"* ]]; then
     # This represents the OCI artifact test case - will include configMediaType
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg", "configMediaType": "application/vnd.oci.artifact.config.v1+json"}'
+  elif [[ "$1" == *"helm-chart"* ]]; then
+    # This represents Helm charts - will include Helm configMediaType
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg", "multiarch": false, "configMediaType": "application/vnd.cncf.helm.config.v1+json"}'
   else
     # Regular container images - no configMediaType in output
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-mixed-helm-containers
+spec:
+  description: |
+    Run the create-pyxis-image task with a snapshot containing both Helm charts and container images.
+    Verify that Helm charts are skipped and only container images are processed.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
+              {
+                "pyxis": {
+                  "server": "stage",
+                  "certified": false,
+                  "secret": "pyxis"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped_snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "web-frontend",
+                    "containerImage": "registry.io/web-frontend@sha256:webdigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/web-frontend",
+                        "tags": ["1.0", "latest"]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "helm-chart",
+                    "containerImage": "registry.io/helm-chart@sha256:helmdigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/helm-chart",
+                        "tags": ["1.0", "latest"]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "api-backend",
+                    "containerImage": "registry.io/api-backend@sha256:apidigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/api-backend",
+                        "tags": ["1.0", "latest"]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "database",
+                    "containerImage": "registry.io/database@sha256:dbdigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/database",
+                        "tags": ["1.0", "latest"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/mydata.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: dataDir
+            description: The location where data will be stored
+            type: string
+          - name: pyxisDataPath
+            type: string
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Verify pyxis.json structure
+              pyxis_file="$(params.dataDir)/$(params.pyxisDataPath)"
+              echo "Contents of pyxis.json:"
+              cat "$pyxis_file"
+
+              # Verify we have the expected number of components (3 containers, Helm chart filtered out)
+              component_count=$(jq '.components | length' "$pyxis_file")
+              if [ "$component_count" != "3" ]; then
+                echo "Error: Expected 3 components in pyxis.json (only container images), but got $component_count"
+                exit 1
+              fi
+
+              # Test downstream consumption pattern used by push-rpm-data-to-pyxis task
+              if ! unique_images_result=$(jq '
+                # This is the exact processing from push-rpm-data-to-pyxis.yaml line 132
+                [.components[] as $c | $c.pyxisImages[] | {
+                  imageId: .imageId,
+                  containerImage: $c.containerImage,
+                  pyxisImage: .
+                }]' "$pyxis_file"); then
+                echo "Error: Downstream consumption pattern failed"
+                exit 1
+              fi
+
+              # Verify downstream processing produces expected results
+              image_count=$(echo "$unique_images_result" | jq '. | length')
+              if [ "$image_count" != "3" ]; then
+                echo "Error: Expected 3 pyxis images from downstream processing, but got $image_count"
+                exit 1
+              fi
+
+              echo "SUCCESS: Downstream consumption pattern works correctly"
+
+              # Verify that all processed components are container images (not Helm charts)
+              # by checking that each component has the expected containerImage field and pyxisImages
+              processed_components=$(jq -r '.components[] | .containerImage' "$pyxis_file")
+
+              # Verify we have the expected container images (but not the helm chart)
+              if ! echo "$processed_components" | grep -q "web-frontend"; then
+                echo Error: web-frontend container image should be processed
+                exit 1
+              fi
+
+              if ! echo "$processed_components" | grep -q "api-backend"; then
+                echo Error: api-backend container image should be processed
+                exit 1
+              fi
+
+              if ! echo "$processed_components" | grep -q "database"; then
+                echo Error: database container image should be processed
+                exit 1
+              fi
+
+              # Verify helm-chart was NOT processed
+              if echo "$processed_components" | grep -q "helm-chart"; then
+                echo Error: helm-chart should NOT be processed \(should be skipped\)
+                exit 1
+              fi
+
+              echo "SUCCESS: Mixed Helm + container images handled correctly"
+              echo "  - Helm chart was skipped"
+              echo "  - All 3 container images were processed"
+              echo "  - Downstream consumption patterns work correctly"
+      runAfter:
+        - run-task


### PR DESCRIPTION
Helm artifacts will fail task push-rpm-data-to-pyxis, which is not relevant for such artifacts. To avoid that, we should have them filtered out during step create-pyxis-image.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
