### PR TITLE
fix: lint tektor action fails if CHANGED_FILES is empty

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -171,6 +171,7 @@ jobs:
             **/*.yml
 
       - name: Checkout Tektor action
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: konflux-ci/tektor
@@ -178,6 +179,7 @@ jobs:
           ref: main
 
       - name: Validate Tekton resources
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/tektor
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Describe your changes

We should only run the step in case any files have changed.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
