### PR TITLE
feat(RELEASE-1798): support multiple repos in publish-pyxis-repository

### DIFF
--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -209,31 +209,6 @@ spec:
             COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
             PAYLOAD='{"published":true}'
             COMPONENT_NAME=$(jq -r '.name' <<< "$COMPONENT")
-            REPOSITORY=$(jq -r '.repository' <<< "$COMPONENT")
-            PYXIS_REPOSITORY=${REPOSITORY##*/}
-            # Replace "----" with "/"
-            PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
-            PYXIS_REPOSITORY_JSON=$(curl --retry 5 --key /tmp/key --cert /tmp/crt \
-                "${PYXIS_URL}/v1/repositories/registry/${PYXIS_REGISTRY}/repository/${PYXIS_REPOSITORY}" -X GET)
-
-            PYXIS_REPOSITORY_ID=$(jq -r '._id // ""' <<< "$PYXIS_REPOSITORY_JSON")
-            if [ -z "$PYXIS_REPOSITORY_ID" ]; then
-                echo Error: Unable to get Container Repository object id from Pyxis
-                echo "Pyxis response for ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY}:"
-                echo "$PYXIS_REPOSITORY_JSON"
-                exit 1
-            fi
-
-            PYXIS_REPOSITORY_REQUIRES_TERMS=$(jq '.requires_terms' <<< "$PYXIS_REPOSITORY_JSON")
-            if [ "$PYXIS_REPOSITORY_REQUIRES_TERMS" = false ]; then
-              echo "$PYXIS_REPOSITORY" >> "$SIGN_REGISTRY_ACCESS_PATH"
-            fi
-
-            # Default to false
-            if [ "$skipRepoPublishing" = true ] ; then
-                echo "skipRepoPublishing is set to true, skipping publishing..."
-                continue
-            fi
 
             # Set source_container_image_enabled based on pushSourceContainer value in components or use default if
             # it is not set in the component
@@ -243,33 +218,63 @@ spec:
                 PAYLOAD=$(jq -c '. += {"source_container_image_enabled":true}' <<< "$PAYLOAD")
             fi
 
-            # verify that publish_on_push is set to true.
-            # otherwise, do not publish the image.
-            PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< "$PYXIS_REPOSITORY_JSON")
-            if [ "${PYXIS_REPOSITORY_PUBLISH_ON_PUSH}" != "true" ] ; then
-              echo "WARNING: repository ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY} is marked as publish_on_push = false"
-              echo "Skipping the setting of the published flag."
-              continue
-            fi
+            NUM_REPOSITORIES=$(jq '.repositories | length' <<< "$COMPONENT")
+            for ((j = 0; j < NUM_REPOSITORIES; j++))
+            do
+                REPOSITORY=$(jq -r --argjson j "$j" '.repositories[$j].url' <<< "$COMPONENT")
+                PYXIS_REPOSITORY=${REPOSITORY##*/}
+                # Replace "----" with "/"
+                PYXIS_REPOSITORY=${PYXIS_REPOSITORY//----//}
+                PYXIS_REPOSITORY_JSON=$(curl --retry 5 --key /tmp/key --cert /tmp/crt \
+                    "${PYXIS_URL}/v1/repositories/registry/${PYXIS_REGISTRY}/repository/${PYXIS_REPOSITORY}" -X GET)
 
-            curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
-                -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
+                PYXIS_REPOSITORY_ID=$(jq -r '._id // ""' <<< "$PYXIS_REPOSITORY_JSON")
+                if [ -z "$PYXIS_REPOSITORY_ID" ]; then
+                    echo Error: Unable to get Container Repository object id from Pyxis
+                    echo "Pyxis response for ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY}:"
+                    echo "$PYXIS_REPOSITORY_JSON"
+                    exit 1
+                fi
 
-            # Determine the correct CATALOG_BASE_URL based on the repository prefix
-            if [[ "$REPOSITORY" == quay.io/redhat-prod/* ]]
-            then
-              CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
-            elif [[ "$REPOSITORY" == quay.io/redhat-pending/* ]]
-            then
-              CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
-            else
-              echo "Unknown repository prefix. Exiting..."
-              exit 1
-            fi
+                PYXIS_REPOSITORY_REQUIRES_TERMS=$(jq '.requires_terms' <<< "$PYXIS_REPOSITORY_JSON")
+                if [ "$PYXIS_REPOSITORY_REQUIRES_TERMS" = false ]; then
+                  echo "$PYXIS_REPOSITORY" >> "$SIGN_REGISTRY_ACCESS_PATH"
+                fi
 
-            URL="${CATALOG_BASE_URL}/${PYXIS_REPOSITORY}/${PYXIS_REPOSITORY_ID}"
-            RESULTS_JSON=$(jq --arg name "$COMPONENT_NAME" --arg url "$URL" \
-              '.catalog_urls += [{"name": $name, "url": $url}]' <<< "$RESULTS_JSON")
+                # Default to false
+                if [ "$skipRepoPublishing" = true ] ; then
+                    echo "skipRepoPublishing is set to true, skipping publishing..."
+                    continue
+                fi
+
+                # verify that publish_on_push is set to true.
+                # otherwise, do not publish the image.
+                PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< "$PYXIS_REPOSITORY_JSON")
+                if [ "${PYXIS_REPOSITORY_PUBLISH_ON_PUSH}" != "true" ] ; then
+                  echo "WARNING: repository ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY} is marked as publish_on_push = false"
+                  echo "Skipping the setting of the published flag."
+                  continue
+                fi
+
+                curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
+                    -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
+
+                # Determine the correct CATALOG_BASE_URL based on the repository prefix
+                if [[ "$REPOSITORY" == quay.io/redhat-prod/* ]]
+                then
+                  CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
+                elif [[ "$REPOSITORY" == quay.io/redhat-pending/* ]]
+                then
+                  CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
+                else
+                  echo "Unknown repository prefix. Exiting..."
+                  exit 1
+                fi
+
+                URL="${CATALOG_BASE_URL}/${PYXIS_REPOSITORY}/${PYXIS_REPOSITORY_ID}"
+                RESULTS_JSON=$(jq --arg name "$COMPONENT_NAME" --arg url "$URL" \
+                  '.catalog_urls += [{"name": $name, "url": $url}]' <<< "$RESULTS_JSON")
+            done
         done
 
         jq <<< "${RESULTS_JSON}" | tee "$RESULTS_FILE"

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -61,7 +61,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image0"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image0"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -63,7 +63,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image9"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image9"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -63,7 +63,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -61,16 +61,28 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1",
-                    "name": "component1"
+                    "name": "component1",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image5",
-                    "name": "component2"
+                    "name": "component2",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image5"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image6",
-                    "name": "component3"
+                    "name": "component3",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image6"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -61,7 +61,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -61,7 +61,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -62,7 +62,11 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-multiple-components.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-multiple-components.yaml
@@ -62,15 +62,27 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1",
-                    "pushSourceContainer": "true"
+                    "pushSourceContainer": "true",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image2",
-                    "pushSourceContainer": "false"
+                    "pushSourceContainer": "false",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image2"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image3"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image3"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -64,12 +64,7 @@ spec:
                     "repositories": [
                       {
                         "url": "quay.io/redhat-prod/my-product----my-image1"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "component2",
-                    "repositories": [
+                      },
                       {
                         "url": "quay.io/redhat-prod/my-product----my-image2"
                       }
@@ -190,7 +185,7 @@ spec:
                     "url": "https://catalog.redhat.com/software/containers/my-product/my-image1/1"
                   },
                   {
-                    "name": "component2",
+                    "name": "component1",
                     "url": "https://catalog.redhat.com/software/containers/my-product/my-image2/3"
                   },
                   {

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -60,16 +60,28 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image1",
-                    "name": "component1"
+                    "name": "component1",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image2",
-                    "name": "component2"
+                    "name": "component2",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image2"
+                      }
+                    ]
                   },
                   {
-                    "repository": "quay.io/redhat-prod/my-product----my-image3",
-                    "name": "component3"
+                    "name": "component3",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/my-product----my-image3"
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
## Describe your changes

Switch to using .components[].repositories[] instead of a single .components[].repository entry.

skipRepoPublishing remains to be a global per-release flag and pushSourceContainer remains to be set as a default and per component, but not per repository.

## Relevant Jira

RELEASE-1798

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
