### PR TITLE
fix(RELEASE-1840): stop saving sboms in trusted artifact

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -693,8 +693,6 @@ spec:
           value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: "$(tasks.create-pyxis-image.results.sourceDataArtifact)"
-        - name: subdirectory
-          value: $(tasks.collect-data.results.subdirectory)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -547,8 +547,6 @@ spec:
           value: $(params.ociStorage)
         - name: sourceDataArtifact
           value: "$(tasks.create-pyxis-image.results.sourceDataArtifact)"
-        - name: subdirectory
-          value: $(tasks.collect-data.results.subdirectory)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/README.md
+++ b/tasks/managed/push-rpm-data-to-pyxis/README.md
@@ -17,7 +17,6 @@ all repository_id strings found in rpm purl strings in the sboms.
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
 | orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
-| subdirectory            | Subdirectory inside the workspace to be used                                                                               | Yes      | ""                   |
 | dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -48,11 +48,6 @@ spec:
       type: string
       description: Location of trusted artifacts to be used to populate data directory
       default: ""
-    - name: subdirectory
-      # subdirectory is only needed for testing purposes
-      description: Subdirectory inside the workspace to be used
-      type: string
-      default: ""
     - name: dataDir
       description: The location where data will be stored
       type: string
@@ -143,11 +138,11 @@ spec:
           instances: .
         })' "${PYXIS_FILE}" > "${UNIQUE_IMAGES_FILE}"
 
-        SBOM_PATH="$(dirname "$(params.pyxisJsonPath)")/downloaded-sboms"
+        SBOM_PATH="/var/workdir/downloaded-sboms"
         # The dir might already exist in case of retries of the task.
         # No need for a cleanup - we will just override the files.
-        mkdir -p "$(params.dataDir)/${SBOM_PATH}"
-        cd "$(params.dataDir)/${SBOM_PATH}"
+        mkdir -p "${SBOM_PATH}"
+        cd "${SBOM_PATH}"
 
         # Function to run cosign with retries. It will pass all arguments to cosign.
         run_cosign () {
@@ -174,24 +169,24 @@ spec:
         download_sbom_for_image() {
             local pyxis_image="$1"
             local image_url="$2"
-            
+
             local file
             local digest
             local arch_digest
             local os
             local arch
             local platform
-            
+
             file="$(jq -r '.imageId' <<< "$pyxis_image").json"
             digest="$(jq -r '.digest' <<< "$pyxis_image")"
             arch_digest="$(jq -r '.arch_digest' <<< "$pyxis_image")"
-            
+
             # cosign has very limited support for selecting the right auth entry,
             # so create a custom auth file with just one entry.
             DOCKER_CONFIG="$(mktemp -d)"
             export DOCKER_CONFIG
             select-oci-auth "${image_url}" > "${DOCKER_CONFIG}/config.json"
-            
+
             # You can't pass --platform to a single arch image or cosign errors.
             # If digest equals arch_digest, then it's a single arch image
             if [ "$digest" = "$arch_digest" ] ; then
@@ -214,13 +209,13 @@ spec:
         declare -a download_tasks=()
         declare -a task_images=()
         declare -a task_urls=()
-        
+
         for (( i=0; i < UNIQUE_IMAGES_COUNT; i++ )); do
           UNIQUE_IMAGE=$(jq -c --argjson i "$i" '.[$i]' "${UNIQUE_IMAGES_FILE}")
           IMAGEID=$(jq -r '.imageId' <<< "${UNIQUE_IMAGE}")
           CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "${UNIQUE_IMAGE}")
           PYXIS_IMAGE=$(jq -c '.pyxisImage' <<< "${UNIQUE_IMAGE}")
-          
+
           # Store task information for parallel execution
           download_tasks+=("$PYXIS_IMAGE")
           task_images+=("$IMAGEID")
@@ -239,12 +234,12 @@ spec:
           PYXIS_IMAGE="${download_tasks[idx]}"
           IMAGEID="${task_images[idx]}"
           IMAGEURL="${task_urls[idx]}"
-          
+
           # Limit concurrent jobs to N
           while (( ${RUNNING_JOBS@P} >= N )); do
             wait -n || success=false
           done
-          
+
           echo "Starting download for IMAGE: $IMAGEID from URL: $IMAGEURL"
           download_sbom_for_image "$PYXIS_IMAGE" "$IMAGEURL" > "${IMAGEID}.download.out" 2>&1 &
         done
@@ -329,8 +324,8 @@ spec:
             exit 1
         fi
 
-        SBOM_PATH="$(dirname "$(params.pyxisJsonPath)")/downloaded-sboms"
-        cd "$(params.dataDir)/${SBOM_PATH}"
+        SBOM_PATH="/var/workdir/downloaded-sboms"
+        cd "${SBOM_PATH}"
 
         # Create a list of all images to push to Pyxis (including duplicates)
         echo "Creating list of all images to push to Pyxis..."

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/mocks.sh
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/mocks.sh
@@ -29,7 +29,10 @@ function cosign() {
     SBOM_JSON='{"spdxVersion": "SPDX-2.3"}'
   fi
 
-  echo "$SBOM_JSON" > "$(params.dataDir)/$(params.subdirectory)/downloaded-sboms/${4}"
+  echo "$SBOM_JSON" > "/var/workdir/downloaded-sboms/${4}"
+  # Also save a copy in the dataDir for test verification
+  mkdir -p "$(params.dataDir)/downloaded-sboms"
+  echo "$SBOM_JSON" > "$(params.dataDir)/downloaded-sboms/${4}"
 }
 
 function upload_rpm_data() {

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-cyclonedx.yaml
@@ -30,15 +30,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -61,8 +55,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis_data.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis_data.json" << EOF
               {
                 "components": [
                   {
@@ -107,7 +101,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis_data.json
+          value: pyxis_data.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -118,8 +112,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
@@ -33,15 +33,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -64,8 +58,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis-data.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis-data.json" << EOF
               {
                 "components": [
                   {
@@ -170,7 +164,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis-data.json
+          value: pyxis-data.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -183,8 +177,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -237,7 +229,7 @@ spec:
               set -eux
 
               # Comprehensive test scenario covering all deduplication cases:
-              # 
+              #
               # 1. DEDUPLICATION TEST (same imageId, different containerImage):
               #    - myImageID1 appears 3 times with different containerImages
               #    - Should be downloaded once, uploaded 3 times
@@ -270,31 +262,31 @@ spec:
               fi
 
               # Check that unique filenames were created for all 4 unique imageIds
-              if [ ! -f "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/myImageID1.json" ]; then
+              if [ ! -f "$(params.dataDir)/downloaded-sboms/myImageID1.json" ]; then
                 echo Error: Expected SBOM file myImageID1.json not found
                 exit 1
               fi
 
-              if [ ! -f "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/myImageID2.json" ]; then
+              if [ ! -f "$(params.dataDir)/downloaded-sboms/myImageID2.json" ]; then
                 echo Error: Expected SBOM file myImageID2.json not found
                 exit 1
               fi
 
-              if [ ! -f "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/myImageID3.json" ]; then
+              if [ ! -f "$(params.dataDir)/downloaded-sboms/myImageID3.json" ]; then
                 echo Error: Expected SBOM file myImageID3.json not found
                 exit 1
               fi
 
-              if [ ! -f "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/myImageID4.json" ]; then
+              if [ ! -f "$(params.dataDir)/downloaded-sboms/myImageID4.json" ]; then
                 echo Error: Expected SBOM file myImageID4.json not found
                 exit 1
               fi
 
               # Verify exactly 4 files were created
-              SBOM_FILES=$(find "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/" -name "*.json" | wc -l)
+              SBOM_FILES=$(find "$(params.dataDir)/downloaded-sboms/" -name "*.json" | wc -l)
               if [ "$SBOM_FILES" != 4 ]; then
                 echo Error: Expected exactly 4 SBOM files, but found "$SBOM_FILES"
-                ls -la "$(params.dataDir)/$(context.pipelineRun.uid)/downloaded-sboms/"
+                ls -la "$(params.dataDir)/downloaded-sboms/"
                 exit 1
               fi
 

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -31,15 +31,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -62,8 +56,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(params.subdirectory)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis.json" << EOF
               {
                 "components": [
                   {
@@ -108,7 +102,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis.json
+          value: pyxis.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -119,8 +113,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -29,15 +29,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -60,8 +54,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(params.subdirectory)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis.json" << EOF
               {
                 "components": [
                   {
@@ -120,7 +114,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis.json
+          value: pyxis.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -131,8 +125,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
@@ -31,15 +31,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -68,7 +62,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/missing.json
+          value: missing.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -79,8 +73,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: ""
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -29,15 +29,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -60,8 +54,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis.json" << EOF
               {
                 "components": [
                   {
@@ -142,7 +136,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis.json
+          value: pyxis.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -155,8 +149,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -30,15 +30,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -61,8 +55,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(params.subdirectory)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis_data.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis_data.json" << EOF
               {
                 "components": [
                   {
@@ -95,7 +89,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis_data.json
+          value: pyxis_data.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -106,8 +100,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -122,15 +114,11 @@ spec:
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: "$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
-            type: string
-          - name: subdirectory
             type: string
           - name: dataDir
             type: string

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -29,15 +29,9 @@ spec:
       type: string
   tasks:
     - name: setup
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
       taskSpec:
         results:
           - name: sourceDataArtifact
-            type: string
-        params:
-          - name: subdirectory
             type: string
         volumes:
           - name: workdir
@@ -60,8 +54,8 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(params.subdirectory)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/pyxis_data.json" << EOF
+              mkdir -p "$(params.dataDir)"
+              cat > "$(params.dataDir)/pyxis_data.json" << EOF
               {
                 "components": [
                   {
@@ -106,7 +100,7 @@ spec:
         name: push-rpm-data-to-pyxis
       params:
         - name: pyxisJsonPath
-          value: $(context.pipelineRun.uid)/pyxis_data.json
+          value: pyxis_data.json
         - name: pyxisSecret
           value: test-push-rpm-data-to-pyxis-cert
         - name: server
@@ -117,8 +111,6 @@ spec:
           value: $(params.orasOptions)
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -133,15 +125,11 @@ spec:
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: subdirectory
-          value: "$(context.pipelineRun.uid)"
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
-            type: string
-          - name: subdirectory
             type: string
           - name: dataDir
             type: string


### PR DESCRIPTION
## Describe your changes

Some users reported OOM when creating trusted artifact in push-rpm-data-to-pyxis.

It turns out we were saving all the downloaded sboms in the generated trusted artifact which is completely necessary. In fact, this task wouldn't even need to generate any TA at all - no other task will consume it. But it's convenient for task tests, so I am not removing it completely. I am only changing it so that the sboms are saved to another directory inside the emptyDir volume.

Also, remove subdirectory from the task - it wasn't used for anything anymore - it was probably an ommission from when the task was transformed to support TA only.

## Relevant Jira

RELEASE-1840

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
