### PR TITLE
fix: add fix for handling dash in key names

### DIFF
--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -163,7 +163,8 @@ spec:
             fi
 
             # Extract the value from the data file using the specified key
-            VALUE=$(jq -r "$KEY" "$DATA_FILE" 2>/dev/null)
+            TRANSFORMED_KEY=$(echo "$KEY" | sed -E 's/\.([^\."\[]+|"[^"]+")/."\1"/g')
+            VALUE=$(jq -r "$TRANSFORMED_KEY" "$DATA_FILE" 2>/dev/null)
 
             # Check if the key exists in the data file
             if [ "$VALUE" = "null" ]; then


### PR DESCRIPTION
jq is failing to use keys with dashes '-'

