### PR TITLE
fix(KFLUXSPRT-4802): let stage iib builds be reused

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -146,24 +146,26 @@ spec:
               --retry-times 3 --config "docker://${indexImageResolved}" | \
               jq -r .created)" "+%s")"
 
-            # authentication is only required for the targetIndex
-            create_auth_file
-            targetIndexCreated="$(skopeo inspect --retry-times 3 --config "docker://$(params.targetIndex)" | \
-              jq -r .created)"
+            if [ -n "$(params.targetIndex)" ]; then
+              # authentication is only required for the targetIndex
+              create_auth_file
+              targetIndexCreated="$(skopeo inspect --retry-times 3 --config "docker://$(params.targetIndex)" | \
+                jq -r .created)"
 
-            if [ -z "${targetIndexCreated}" ]; then
-              # we cannot determine the target index created date, stop here. This causes the task to trigger
-              # a new build.
-              return 0
-            fi
+              if [ -z "${targetIndexCreated}" ]; then
+                # we cannot determine the target index created date, stop here. This causes the task to trigger
+                # a new build.
+                return 0
+              fi
 
-            upstreamCatalogCreatedDate="$(date --date "${targetIndexCreated}" "+%s")"
-            # checks if the index_image_resolved in the previous completed build is newer
-            # than the upstream catalog index.
-            # in case the new catalog index is older than the upstream, a new build is
-            # required to assure the catalog integrity.
-            if [ "${newCatalogCreatedDate}" -lt "${upstreamCatalogCreatedDate}" ]; then
-              return 0
+              upstreamCatalogCreatedDate="$(date --date "${targetIndexCreated}" "+%s")"
+              # checks if the index_image_resolved in the previous completed build is newer
+              # than the upstream catalog index.
+              # in case the new catalog index is older than the upstream, a new build is
+              # required to assure the catalog integrity.
+              if [ "${newCatalogCreatedDate}" -lt "${upstreamCatalogCreatedDate}" ]; then
+                return 0
+              fi
             fi
           fi
           echo "${build}"


### PR DESCRIPTION
Stage IIB builds do not have a targetIndex set. In order to let them be reused, we need to only compare creation timestamps if there is a targetIndex.

Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
