### PR TITLE
fix(RELEASE-1829): graphQL API Optimization for promote_branch.sh

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -4,26 +4,49 @@
 #
 # The script promotes the development content into the staging branch, or the staging
 # content into the production branch. It starts by performing the following checks, then
-# it performs a git push. There is no pull request.
+# it performs a git force push. There is no pull request.
 #
 # Checks:
 #   - If there is content in the staging branch that is not yet in the production branch, the
 #     script will not git push to add more content to the staging branch. This can be overridden with
 #     --force-to-staging true
 #   - If promoting to production and the content has not been in the staging branch for at least 7 days,
-#     the script will exit without doing a push. Content is expected to sit in staging for at least a week
+#     the script will exit without doing a push. Content is expected to sit in staging for at least six days
 #     to provide sufficient testing time. This can be overridden with --override true
 #
 # Prerequisities:
 #   - An environment variable GITHUB_TOKEN is defined that provides access to the user's account. See
 #     https://github.com/konflux-ci/release-service-utils/blob/main/ci/promote-overlay/README.md#setup for help.
 #   - curl, git and jq installed.
+#
+# Environment Variables:
+#   GITHUB_TOKEN              - Required. GitHub token with repo access
+#   GITHUB_GRAPHQL_PAGE_SIZE  - Optional. GraphQL page size (1-100, default: 100)
 
 set -e
 
 # GitHub repository details
 ORG="konflux-ci"
 REPO="release-service-catalog"
+COMMIT_MAX_AGE_DAYS=6
+
+# Personal access token with appropriate permissions
+token="${GITHUB_TOKEN}"
+
+print_help(){
+    echo "Usage: $0 --branches branch1-to-branch2 [--force-to-staging false] [--override false] [--dry-run false]"
+    echo
+    echo "  --promotion-type:   The type of promotion to perform. Either development-to-staging"
+    echo "                      or staging-to-production."
+    echo "  --force-to-staging: If passed with value true, allow promotion to staging even"
+    echo "                      if staging and production differ."
+    echo "  --override:         If passed with value true, allow promotion to production"
+    echo "                      even if the change has not been in staging for six days."
+    echo "  --dry-run:          If passed with value true, print out the changes that would"
+    echo "                      be promoted but do not git push or delete the temp repo."
+    echo
+    echo "  --promotion-type has to be specified."
+}
 
 OPTIONS=$(getopt --long "promotion-type:,force-to-staging:,override:,dry-run:,help" -o "p:,h" -- "$@")
 eval set -- "$OPTIONS"
@@ -53,107 +76,65 @@ while true; do
             shift
             break
             ;;
-        *) echo "Error: Unexpected option: $1" % >2
+        *) echo "Error: Unexpected option: $1" >&2
+            exit 1
     esac
 done
 
-print_help(){
-    echo "Usage: $0 --branches branch1-to-branch2 [--force-to-staging false] [--override false] [--dry-run false]"
-    echo
-    echo "  --promotion-type:   The type of promotion to perform. Either development-to-staging"
-    echo "                      or staging-to-production."
-    echo "  --force-to-staging: If passed with value true, allow promotion to staging even"
-    echo "                      if staging and production differ."
-    echo "  --override:         If passed with value true, allow promotion to production"
-    echo "                      even if the change has not been in staging for one week."
-    echo "  --dry-run:          If passed with value true, print out the changes that would"
-    echo "                      be promoted but do not git push or delete the temp repo."
-    echo
-    echo "  --promotion-type has to be specified."
-}
-
+# Function to check if the branch differs from the target branch
 check_if_branch_differs() {
-    ACTUAL_DIFFERENT_LINES=$(git diff --numstat origin/$1 | wc -l)
-    if [ $ACTUAL_DIFFERENT_LINES -ne 0 ] ; then
+    ACTUAL_DIFFERENT_LINES=$(git diff --numstat "origin/$1" | wc -l)
+    if [ "$ACTUAL_DIFFERENT_LINES" -ne 0 ] ; then
         echo "Lines differ in branch $1"
-        echo "Actual differing lines: $(git diff --numstat origin/$1)"
+        echo "Actual differing lines:"
+        git diff --numstat "origin/$1"
         exit 1
     fi
 }
 
-check_if_any_commits_in_last_week() {
+# Function to check if there are any commits in the last six days
+check_if_any_commits_in_last_six_days() {
     NEW_COMMITS=$(git log --oneline --since="$(date --date="6 days ago" +%Y-%m-%d)" | wc -l)
-    if [ $NEW_COMMITS -ne 0 ] ; then
-        echo "There are commits in staging that are less than a week old. Blocking promotion to production"
-        echo "Commits less than a week old: $(git log --oneline --since="$(date --date="6 days ago" +%Y-%m-%d)")"
+    if [ "$NEW_COMMITS" -ne 0 ] ; then
+        echo "There are commits in staging that are less than six days old. Blocking promotion to production"
+        echo "Commits less than six days old:"
+        git log --oneline  --no-decorate --since="$(date --date="6 days ago" +%Y-%m-%d)"
         exit 1
     fi
 }
 
-# GraphQL function to fetch all PRs in a time range
-fetch_prs_graphql() {
-    local since_date="$1"
-    local page_size="${2:-100}"
-    local cursor="${3:-null}"
-
-    # Calculate cursor parameter for pagination
-    local cursor_param=""
-    if [ "$cursor" != "null" ]; then
-        cursor_param=", after: \"$cursor\""
-    fi
-
-    # GraphQL query to fetch PRs with commits
-    local query=$(cat <<EOF
-{
-  "query": "query {
-    repository(owner: \"$ORG\", name: \"$REPO\") {
-      pullRequests(first: $page_size, states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}$cursor_param) {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        nodes {
-          number
-          title
-          url
-          mergedAt
-          commits(first: 250) {
-            nodes {
-              commit {
-                oid
-                messageHeadline
-              }
-            }
-          }
-        }
-      }
-    }
-  }"
-}
-EOF
-)
-
-    # Make GraphQL request
-    curl -s -X POST \
-        -H "Authorization: bearer $token" \
-        -H "Content-Type: application/json" \
-        --data "$query" \
-        https://api.github.com/graphql
-}
-
-# Function to get all PRs with pagination
+# Function to get all PRs since a given date with pagination
 get_all_prs_since_date() {
     local since_date="$1"
     local all_prs="[]"
     local has_next_page=true
     local cursor="null"
 
+    # Create a single temporary file for the entire function (reuse instead of creating new ones each iteration)
+    local temp_merge_file=$(mktemp)
+
     echo "Fetching all merged PRs since $since_date using GraphQL..." >&2
 
     while [ "$has_next_page" = true ]; do
         echo "Fetching page (cursor: $cursor)..." >&2
 
-        local response=$(fetch_prs_graphql "$since_date" 100 "$cursor")
+        # Calculate cursor parameter for pagination
+        local cursor_param=""
+        if [ "$cursor" != "null" ]; then
+            cursor_param=", after: \\\"$cursor\\\""
+        fi
+
+        # GraphQL query to fetch PRs with commits
+        local page_size="${GITHUB_GRAPHQL_PAGE_SIZE:-100}"
+        local query_string="query { repository(owner: \\\"$ORG\\\", name: \\\"$REPO\\\") { pullRequests(first: $page_size, states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}$cursor_param) { pageInfo { hasNextPage endCursor } nodes { number title url mergedAt mergeCommit { oid } labels(first: 20) { nodes { name color description } } commits(first: 250) { nodes { commit { oid messageHeadline } } } } } } }"
+        local query="{\"query\": \"$query_string\"}"
+
+        # Make GraphQL request
+        local response=$(curl -s -X POST \
+            -H "Authorization: bearer $token" \
+            -H "Content-Type: application/json" \
+            --data "$query" \
+            https://api.github.com/graphql)
 
         # Check for GraphQL errors
         local errors=$(echo "$response" | jq -r '.errors // empty')
@@ -163,11 +144,17 @@ get_all_prs_since_date() {
         fi
 
         # Extract PR data
-        local page_prs=$(echo "$response" | jq -r '.data.repository.pullRequests.nodes')
+        local page_prs=$(echo "$response" | jq -r '.data.repository.pullRequests.nodes // []')
+
+        # Check if we got valid data
+        if [ "$page_prs" = "null" ] || [ "$page_prs" = "" ]; then
+            echo "No PR data returned from GraphQL API" >&2
+            break
+        fi
 
         # Filter PRs by date (since GraphQL doesn't support date filtering directly)
         local filtered_prs=$(echo "$page_prs" | jq --arg since_date "$since_date" '
-            map(select(.mergedAt >= $since_date))
+            map(select(.mergedAt and (.mergedAt | split("T")[0] >= $since_date)))
         ')
 
         # If no PRs match our date criteria, we can stop
@@ -177,15 +164,21 @@ get_all_prs_since_date() {
             break
         fi
 
-        # Merge with existing PRs
-        all_prs=$(echo "$all_prs $filtered_prs" | jq -s 'add')
+        # Merge with existing PRs (reuse temp file to avoid argument length limits)
+        echo "$all_prs" > "$temp_merge_file"
+        echo "$filtered_prs" >> "$temp_merge_file"
+        all_prs=$(jq -s 'add' "$temp_merge_file")
 
         # Check pagination
         has_next_page=$(echo "$response" | jq -r '.data.repository.pullRequests.pageInfo.hasNextPage')
         cursor=$(echo "$response" | jq -r '.data.repository.pullRequests.pageInfo.endCursor')
 
-        echo "Found $(echo "$filtered_prs" | jq 'length') PRs in this page" >&2
+        page_count=$(echo "$filtered_prs" | jq 'length')
+        echo "Found $page_count PRs in this page (after date filtering)" >&2
     done
+
+    # Cleanup temporary file
+    rm "$temp_merge_file"
 
     echo "$all_prs"
 }
@@ -195,30 +188,52 @@ find_prs_for_commits() {
     local commits_json="$1"
     local prs_json="$2"
 
-    # Create a lookup map of commit SHA to PR
+    # Create a lookup map of commit SHA to PR (including both regular commits and merge commits)
     local commit_to_pr_map=$(echo "$prs_json" | jq -r '
         [
             .[] as $pr |
-            $pr.commits.nodes[] |
-            {
-                commit: .commit.oid,
-                pr: {
-                    number: $pr.number,
-                    title: $pr.title,
-                    url: $pr.url,
-                    mergedAt: $pr.mergedAt
-                }
-            }
+            (
+                # Regular commits from the PR
+                ($pr.commits.nodes[] | {
+                    commit: .commit.oid,
+                    pr: {
+                        number: $pr.number,
+                        title: $pr.title,
+                        url: $pr.url,
+                        mergedAt: $pr.mergedAt,
+                        labels: $pr.labels.nodes
+                    }
+                }),
+                # Merge commit (if exists)
+                (if $pr.mergeCommit and $pr.mergeCommit.oid then {
+                    commit: $pr.mergeCommit.oid,
+                    pr: {
+                        number: $pr.number,
+                        title: $pr.title,
+                        url: $pr.url,
+                        mergedAt: $pr.mergedAt,
+                        labels: $pr.labels.nodes
+                    }
+                } else empty end)
+            )
         ] |
         group_by(.commit) |
         map({key: .[0].commit, value: .[0].pr}) |
         from_entries
     ')
 
-    # Match commits to PRs
-    echo "$commits_json" | jq --argjson map "$commit_to_pr_map" '
-        map(. as $commit | $map[$commit] // {commit: $commit, pr: null})
-    '
+    # Match commits to PRs (use temp files to avoid argument length limits)
+    local temp_commits_file=$(mktemp)
+    local temp_map_file=$(mktemp)
+    echo "$commits_json" > "$temp_commits_file"
+    echo "$commit_to_pr_map" > "$temp_map_file"
+
+    local result=$(jq --slurpfile map "$temp_map_file" '
+        map(. as $commit | if $map[0][$commit] then {commit: $commit, pr: $map[0][$commit]} else {commit: $commit, pr: null} end)
+    ' "$temp_commits_file")
+
+    rm "$temp_commits_file" "$temp_map_file"
+    echo "$result"
 }
 
 if [ -z "${PROMOTION_TYPE}" ]; then
@@ -243,9 +258,6 @@ if [ -z "${GITHUB_TOKEN}" ]; then
     exit 1
 fi
 
-# Personal access token with appropriate permissions
-token="${GITHUB_TOKEN}"
-
 # Clone the repository
 tmpDir=$(mktemp -d)
 releaseServiceCatalogDir=${tmpDir}/release-service-catalog
@@ -253,13 +265,13 @@ mkdir -p ${releaseServiceCatalogDir}
 
 echo -e "---\nPromoting release-service-catalog ${SOURCE_BRANCH} to ${TARGET_BRANCH}\n---\n"
 
-git clone "https://oauth2:$GITHUB_TOKEN@github.com/$ORG/$REPO.git" ${releaseServiceCatalogDir}
-cd ${releaseServiceCatalogDir}
+git clone "https://oauth2:$token@github.com/$ORG/$REPO.git" "${releaseServiceCatalogDir}"
+cd "${releaseServiceCatalogDir}"
 
-# A change cannot go into production if the changes in staging are less than a week old
+# A change cannot go into production if the changes in staging are less than six days old
 if [[ "${TARGET_BRANCH}" == "production" && "${OVERRIDE}" != "true" ]] ; then
     git checkout origin/staging
-    check_if_any_commits_in_last_week
+    check_if_any_commits_in_last_six_days
 fi
 
 # A change cannot go into staging if staging and production differ
@@ -275,51 +287,89 @@ COMMITS=($(git rev-list --first-parent --ancestry-path origin/"$TARGET_BRANCH"'.
 
 if [ ${#COMMITS[@]} -eq 0 ]; then
     echo "No commits to promote from $SOURCE_BRANCH to $TARGET_BRANCH"
-    if [ "${DRY_RUN}" == "true" ] ; then
-        exit
-    fi
     exit 0
 fi
 
-# Get the oldest commit date to use as our since date for PR fetching
-OLDEST_COMMIT=${COMMITS[-1]}
-OLDEST_COMMIT_DATE=$(git show -s --format=%ci "$OLDEST_COMMIT" | cut -d' ' -f1)
+# Calculate oldest date based on constant days back from current date
+OLDEST_DATE=$(date --date="$COMMIT_MAX_AGE_DAYS days ago" +%Y-%m-%d)
 
-echo "Fetching PRs since $OLDEST_COMMIT_DATE (oldest commit being promoted)"
+echo "Fetching PRs from the last $COMMIT_MAX_AGE_DAYS days (since $OLDEST_DATE)"
 
-# Fetch all PRs since the oldest commit date using GraphQL
-ALL_PRS=$(get_all_prs_since_date "$OLDEST_COMMIT_DATE")
+# Fetch PRs since the calculated date using GraphQL
+ALL_PRS=$(get_all_prs_since_date "$OLDEST_DATE")
 
-echo "Found $(echo "$ALL_PRS" | jq 'length') PRs since $OLDEST_COMMIT_DATE"
+total_prs=$(echo "$ALL_PRS" | jq 'length')
+echo "Found $total_prs PRs since $OLDEST_DATE"
 
 # Convert commits array to JSON for processing
 COMMITS_JSON=$(printf '%s\n' "${COMMITS[@]}" | jq -R . | jq -s .)
 
+echo "Analyzing ${#COMMITS[@]} commits from development branch for PR matching..."
+
 # Find matching PRs for our commits
 MATCHED_RESULTS=$(find_prs_for_commits "$COMMITS_JSON" "$ALL_PRS")
 
-# Display results
-echo "$MATCHED_RESULTS" | jq -r '
-    .[] |
-    if .pr then
-        "PR #\(.pr.number): \(.pr.title)\n  URL: \(.pr.url)\n  Merged: \(.pr.mergedAt)\n  Commit: \(.commit)"
-    else
-        "Commit \(.commit): No associated PR found"
-    end
-'
+# Count relevant PRs (those with commits in development branch)
+relevant_prs=$(echo "$MATCHED_RESULTS" | jq -r '[.[] | select(.pr != null) | .pr.number] | unique | length')
+echo ""
+echo "📊 PR Analysis Summary:"
+echo "======================"
+echo "Total PRs found in $COMMIT_MAX_AGE_DAYS-day window: $total_prs"
+echo "Relevant PRs for promotion: $relevant_prs"
+echo "Commits to promote: ${#COMMITS[@]}"
+echo ""
 
-# Show git log for each commit for additional context
-echo -e "\nCommit details:"
+# Display results in the requested format: PR link above each commit message
+echo "Included PRs:"
 for COMMIT in "${COMMITS[@]}"; do
-  git show --oneline --no-patch $COMMIT
+    # Get PR info for this commit
+    COMMIT_PR_INFO=$(echo "$MATCHED_RESULTS" | jq -r --arg commit "$COMMIT" '
+        .[] | select(.commit == $commit) |
+        if .pr then
+            .pr.url
+        else
+            null
+        end
+    ')
+
+    # If no PR found via GraphQL, fall back to GitHub Search API (like original script)
+    if [ "$COMMIT_PR_INFO" = "null" ] || [ -z "$COMMIT_PR_INFO" ]; then
+        COMMIT_PR_INFO=$(curl -s -H 'Authorization: token '"$token" 'https://api.github.com/search/issues?q=sha:'"$COMMIT" | jq -r '.items[]
+            | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")
+            | .pull_request | select(.merged_at!=null) | .html_url' || true)
+    fi
+
+    # Show PR URL if found
+    if [ "$COMMIT_PR_INFO" != "null" ] && [ -n "$COMMIT_PR_INFO" ]; then
+        echo "$COMMIT_PR_INFO"
+    fi
+
+    # Show commit message
+    git show --oneline --no-patch --no-decorate "$COMMIT"
 done
+
+# Check if there are any breaking changes
+BREAKING_COUNT=$(echo "$MATCHED_RESULTS" | jq -r '
+    [.[] | select(.pr and (.pr.labels | map(select(.name | test("breaking[-_ ]change|breaking"; "i"))) | length > 0))] | length
+')
+
+# Only show breaking change summary if there are breaking changes
+if [ "$BREAKING_COUNT" -gt 0 ]; then
+    echo -e "\n📢 NOTICE: Promoting $BREAKING_COUNT breaking change(s) to $TARGET_BRANCH!"
+    BREAKING_CHANGES=$(echo "$MATCHED_RESULTS" | jq -r '
+        [.[] | select(.pr and (.pr.labels | map(select(.name | test("breaking[-_ ]change|breaking"; "i"))) | length > 0))] |
+        "⚠️  Found \(length) PR(s) with breaking changes:\n" +
+        (map("  - PR #\(.pr.number): \(.pr.title) (\(.pr.labels | map(select(.name | test("breaking[-_ ]change|breaking"; "i"))) | map(.name) | join(", ")))") | join("\n"))
+    ')
+    echo "$BREAKING_CHANGES"
+fi
 
 if [ "${DRY_RUN}" == "true" ] ; then
     exit
 fi
 
-git checkout $SOURCE_BRANCH
-git push origin $SOURCE_BRANCH:$TARGET_BRANCH
+git checkout "$SOURCE_BRANCH"
+git push origin "$SOURCE_BRANCH:$TARGET_BRANCH"
 
 cd -
 rm -rf ${tmpDir}

--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -90,6 +90,137 @@ check_if_any_commits_in_last_week() {
     fi
 }
 
+# GraphQL function to fetch all PRs in a time range
+fetch_prs_graphql() {
+    local since_date="$1"
+    local page_size="${2:-100}"
+    local cursor="${3:-null}"
+
+    # Calculate cursor parameter for pagination
+    local cursor_param=""
+    if [ "$cursor" != "null" ]; then
+        cursor_param=", after: \"$cursor\""
+    fi
+
+    # GraphQL query to fetch PRs with commits
+    local query=$(cat <<EOF
+{
+  "query": "query {
+    repository(owner: \"$ORG\", name: \"$REPO\") {
+      pullRequests(first: $page_size, states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}$cursor_param) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          number
+          title
+          url
+          mergedAt
+          commits(first: 250) {
+            nodes {
+              commit {
+                oid
+                messageHeadline
+              }
+            }
+          }
+        }
+      }
+    }
+  }"
+}
+EOF
+)
+
+    # Make GraphQL request
+    curl -s -X POST \
+        -H "Authorization: bearer $token" \
+        -H "Content-Type: application/json" \
+        --data "$query" \
+        https://api.github.com/graphql
+}
+
+# Function to get all PRs with pagination
+get_all_prs_since_date() {
+    local since_date="$1"
+    local all_prs="[]"
+    local has_next_page=true
+    local cursor="null"
+
+    echo "Fetching all merged PRs since $since_date using GraphQL..." >&2
+
+    while [ "$has_next_page" = true ]; do
+        echo "Fetching page (cursor: $cursor)..." >&2
+
+        local response=$(fetch_prs_graphql "$since_date" 100 "$cursor")
+
+        # Check for GraphQL errors
+        local errors=$(echo "$response" | jq -r '.errors // empty')
+        if [ -n "$errors" ]; then
+            echo "GraphQL Error: $errors" >&2
+            exit 1
+        fi
+
+        # Extract PR data
+        local page_prs=$(echo "$response" | jq -r '.data.repository.pullRequests.nodes')
+
+        # Filter PRs by date (since GraphQL doesn't support date filtering directly)
+        local filtered_prs=$(echo "$page_prs" | jq --arg since_date "$since_date" '
+            map(select(.mergedAt >= $since_date))
+        ')
+
+        # If no PRs match our date criteria, we can stop
+        local filtered_count=$(echo "$filtered_prs" | jq 'length')
+        if [ "$filtered_count" -eq 0 ]; then
+            echo "No more PRs found since $since_date, stopping pagination." >&2
+            break
+        fi
+
+        # Merge with existing PRs
+        all_prs=$(echo "$all_prs $filtered_prs" | jq -s 'add')
+
+        # Check pagination
+        has_next_page=$(echo "$response" | jq -r '.data.repository.pullRequests.pageInfo.hasNextPage')
+        cursor=$(echo "$response" | jq -r '.data.repository.pullRequests.pageInfo.endCursor')
+
+        echo "Found $(echo "$filtered_prs" | jq 'length') PRs in this page" >&2
+    done
+
+    echo "$all_prs"
+}
+
+# Function to match commits to PRs locally
+find_prs_for_commits() {
+    local commits_json="$1"
+    local prs_json="$2"
+
+    # Create a lookup map of commit SHA to PR
+    local commit_to_pr_map=$(echo "$prs_json" | jq -r '
+        [
+            .[] as $pr |
+            $pr.commits.nodes[] |
+            {
+                commit: .commit.oid,
+                pr: {
+                    number: $pr.number,
+                    title: $pr.title,
+                    url: $pr.url,
+                    mergedAt: $pr.mergedAt
+                }
+            }
+        ] |
+        group_by(.commit) |
+        map({key: .[0].commit, value: .[0].pr}) |
+        from_entries
+    ')
+
+    # Match commits to PRs
+    echo "$commits_json" | jq --argjson map "$commit_to_pr_map" '
+        map(. as $commit | $map[$commit] // {commit: $commit, pr: null})
+    '
+}
+
 if [ -z "${PROMOTION_TYPE}" ]; then
     echo -e "Error: missing '--promotion-type' argument\n"
     print_help
@@ -138,16 +269,48 @@ if [[ "${TARGET_BRANCH}" == "staging" && "${FORCE_TO_STAGING}" != "true" ]] ; th
 fi
 
 echo "Included PRs:"
+
+# Get commits to be promoted
 COMMITS=($(git rev-list --first-parent --ancestry-path origin/"$TARGET_BRANCH"'...'origin/"$SOURCE_BRANCH"))
-## now loop through the above array
-for COMMIT in "${COMMITS[@]}"
-do
-  PR_INFO="$(curl -s   -H 'Authorization: token  '"$token"  'https://api.github.com/search/issues?q=sha:'"$COMMIT" | jq -r '.items[]
-    | select(.repository_url=="https://api.github.com/repos/'"$ORG"'/'"$REPO"'")' || true)"
-  echo -n "$(jq -r '.pull_request | select(.merged_at!=null) | .html_url' <<< "$PR_INFO" || true)"
-  LABEL="$(jq -r '.labels[].name | select(. | contains("breaking-change"))' <<< "$PR_INFO" || true)"
-  [[ -z "$LABEL" ]] || echo -n " ($LABEL)"
-  echo
+
+if [ ${#COMMITS[@]} -eq 0 ]; then
+    echo "No commits to promote from $SOURCE_BRANCH to $TARGET_BRANCH"
+    if [ "${DRY_RUN}" == "true" ] ; then
+        exit
+    fi
+    exit 0
+fi
+
+# Get the oldest commit date to use as our since date for PR fetching
+OLDEST_COMMIT=${COMMITS[-1]}
+OLDEST_COMMIT_DATE=$(git show -s --format=%ci "$OLDEST_COMMIT" | cut -d' ' -f1)
+
+echo "Fetching PRs since $OLDEST_COMMIT_DATE (oldest commit being promoted)"
+
+# Fetch all PRs since the oldest commit date using GraphQL
+ALL_PRS=$(get_all_prs_since_date "$OLDEST_COMMIT_DATE")
+
+echo "Found $(echo "$ALL_PRS" | jq 'length') PRs since $OLDEST_COMMIT_DATE"
+
+# Convert commits array to JSON for processing
+COMMITS_JSON=$(printf '%s\n' "${COMMITS[@]}" | jq -R . | jq -s .)
+
+# Find matching PRs for our commits
+MATCHED_RESULTS=$(find_prs_for_commits "$COMMITS_JSON" "$ALL_PRS")
+
+# Display results
+echo "$MATCHED_RESULTS" | jq -r '
+    .[] |
+    if .pr then
+        "PR #\(.pr.number): \(.pr.title)\n  URL: \(.pr.url)\n  Merged: \(.pr.mergedAt)\n  Commit: \(.commit)"
+    else
+        "Commit \(.commit): No associated PR found"
+    end
+'
+
+# Show git log for each commit for additional context
+echo -e "\nCommit details:"
+for COMMIT in "${COMMITS[@]}"; do
   git show --oneline --no-patch $COMMIT
 done
 


### PR DESCRIPTION
## Describe your changes
Optimized version of promote_branch.sh using GraphQL API for better performance
This version fetches all PRs in a date range and filters locally, instead of making individual API calls per commit.

Key improvements:
1. Single GraphQL Query instead of N REST API calls
2. Bulk PR Fetching with pagination support
3. Local Filtering - build commit SHA → PR lookup map
4. Massive Performance Gains

Signed-off-by: elenagerman elgerman@redhat.com

## Relevant Jira
[RELEASE-1829](https://issues.redhat.com/browse/RELEASE-1829)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
