### PR TITLE
feat(CLDX-272): add advisory tasks to disk-image marketplace pipeline

### DIFF
--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -259,6 +259,99 @@ spec:
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
         - apply-mapping
+    - name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/populate-release-notes/populate-release-notes.yaml
+      runAfter:
+        - verify-conforma
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "mapping", "dynamic": false},
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.populate-release-notes.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/check-data-keys/check-data-keys.yaml
+      runAfter:
+        - populate-release-notes
+    - name: embargo-check
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.check-data-keys.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/embargo-check/embargo-check.yaml
+      runAfter:
+        - check-data-keys
     - name: marketplacesvm-push-disk-images
       timeout: "12h00m0s"
       when:
@@ -284,7 +377,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.embargo-check.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -294,7 +387,105 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
+        - embargo-check
         - collect-task-params
+    - name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.marketplacesvm-push-disk-images.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: environment
+          value: ""
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/create-advisory/create-advisory.yaml
+      runAfter:
+        - marketplacesvm-push-disk-images
+    - name: close-advisory-issues
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: advisoryUrl
+          value: "$(tasks.create-advisory.results.advisory_url)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.create-advisory.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+      runAfter:
+        - create-advisory
+    - name: update-cr-status
+      params:
+        - name: resource
+          value: $(params.release)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.marketplacesvm-push-disk-images.results.sourceDataArtifact)=$(params.dataDir)"
+            - "$(tasks.create-advisory.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-cr-status/update-cr-status.yaml
+      runAfter:
+        - close-advisory-issues
   finally:
     - name: cleanup-internal-requests
       taskRef:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -163,8 +163,15 @@ spec:
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
 
+        # Skip update-purl for marketplace releases (they have no CGW content)
+        if [[ -n "$(jq -r '.mapping.cloudMarketplacesSecret // empty' "$DATA_FILE")" ]]; then
+          echo "Marketplace release detected. Skipping CGW PURL updates."
+          exit 0
+        fi
+
         # Try to extract the first contentType if it exists
-        content_type=$(jq -r '.mapping.components[]?.contentGateway?.contentType // empty' "$DATA_FILE" | head -n1)
+        content_type=$(jq -r '.mapping.components[]? |
+          (.contentGateway?.contentType // .contentType) // empty' "$DATA_FILE" | head -n1)
 
         # If no contentType is found, then we are not dealing with a generic type and can skip this step
         # But we will check if this is a github release for logging purposes

--- a/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
@@ -1,0 +1,310 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-marketplace-skip-purl
+spec:
+  description: |
+    Assert that the update-purl step is skipped for marketplace releases
+    when cloudMarketplacesSecret is present in the data.json file.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << 'EOF'
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "disk-images-azure-marketplace-amd-prod-1-5",
+                  "namespace": "rhtap-releng-tenant"
+                },
+                "spec": {
+                  "applications": ["amd-azure-disk-image-1-5"],
+                  "policy": "registry-rhel-ai-disk-images-prod",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "https://github.com/konflux-ci/release-service-catalog.git"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "production"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml"
+                        }
+                      ]
+                    }
+                  },
+                  "serviceAccountName": "release-stratosphere",
+                  "origin": "rhel-ai-tenant"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << 'EOF'
+              {
+                "application": "rhel-ai-app",
+                "components": [
+                  {
+                    "name": "amd-azure-disk-image-1-5",
+                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "amd-azure-disk-image-1-5",
+                      "contentType": "disk-image",
+                      "staged": {
+                        "destination": "rhelai-1_DOT_5-for-rhel-9-x86_64-isos",
+                        "version": "1.5",
+                        "files": [
+                          {
+                            "filename": "rhel-ai-amd-azure-1.5-20250101-x86_64.vhd.gz",
+                            "source": "disk.vhd.gz"
+                          }
+                        ]
+                      },
+                      "productInfo": {
+                        "filePrefix": "rhel-ai-amd-azure-1.5",
+                        "productCode": "RHELAI",
+                        "productName": "RHEL AI",
+                        "productVersionName": "1.5"
+                      },
+                      "starmap": [
+                        {
+                          "cloud": "azure",
+                          "mappings": {
+                            "azure-emea": {
+                              "destinations": [
+                                {
+                                  "architecture": null,
+                                  "destination": "rh-rhel-ai/rh-rhelai-amd-1gpu",
+                                  "overwrite": false,
+                                  "restrict_version": false,
+                                  "vhd_check_base_sas_only": false
+                                }
+                              ],
+                              "provider": null
+                            }
+                          },
+                          "meta": {"generation": "V2", "support_legacy": true},
+                          "name": "rhel-ai-amd-azure",
+                          "workflow": "stratosphere"
+                        }
+                      ]
+                    }
+                  ],
+                  "cloudMarketplacesSecret": "azure-stratosphere-secret",
+                  "cloudMarketplacesPrePush": false
+                },
+                "releaseNotes": {
+                  "product_name": "Red Hat Enterprise Linux AI",
+                  "product_version": "1.5",
+                  "product_id": [932],
+                  "cpe": "cpe:/a:redhat:enterprise_linux_ai:1.5",
+                  "type": "RHBA",
+                  "synopsis": "RHEL AI 1.5 Azure Marketplace Release",
+                  "topic": "RHEL AI 1.5 Azure Marketplace disk images",
+                  "description": "This release provides RHEL AI 1.5 disk images for Azure Marketplace",
+                  "solution": "Deploy using Azure Marketplace",
+                  "references": [],
+                  "content": {
+                    "artifacts": [
+                      {
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "pkg:generic/amd-azure-disk-image-1-5@1.5",
+                        "component": "amd-azure-disk-image-1-5"
+                      }
+                    ]
+                  }
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: environment
+          value: stage
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: request
+          value: "test-request"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # Verify that cloudMarketplacesSecret is present (this is what triggers the skip)
+              MARKETPLACE_SECRET=$(jq -r '.mapping.cloudMarketplacesSecret // empty' "$DATA_FILE")
+              if [ -z "$MARKETPLACE_SECRET" ]; then
+                echo "Error: Test setup failed - cloudMarketplacesSecret should be present"
+                exit 1
+              fi
+
+              # Verify that the PURL was NOT updated by create-advisory
+              # For marketplace releases, create-advisory should skip the update-purl step
+              # So the PURL should remain as set by populate-release-notes (with version, no checksum/URL)
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              EXPECTED_PURL="pkg:generic/amd-azure-disk-image-1-5@1.5"
+
+              if [ "$PURL" != "$EXPECTED_PURL" ]; then
+                echo "Error: PURL was updated when it should have been skipped for marketplace releases"
+                echo "Expected: $EXPECTED_PURL"
+                echo "Got: $PURL"
+                exit 1
+              fi
+
+              echo "Success: PURL was correctly left unchanged for marketplace release"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -210,7 +210,8 @@ spec:
         fi
 
         # Try to extract the first contentType if it exists
-        content_type=$(jq -r '.mapping.components[]?.contentGateway?.contentType // empty' "$DATA_FILE" | head -n1)
+        content_type=$(jq -r '.mapping.components[]? |
+          (.contentGateway?.contentType // .contentType) // empty' "$DATA_FILE" | head -n1)
 
         # Extract github field from data.json
         github_field=$(jq -r '.github // empty' "$DATA_FILE")
@@ -321,7 +322,8 @@ spec:
         fi
 
         # Try to extract the first contentType if it exists
-        content_type=$(jq -r '.mapping.components[]?.contentGateway?.contentType // empty' "$DATA_FILE" | head -n1)
+        content_type=$(jq -r '.mapping.components[]? |
+          (.contentGateway?.contentType // .contentType) // empty' "$DATA_FILE" | head -n1)
 
         if [ "$content_type" != "binary" ] && [ "$content_type" != "disk-image" ]; then
             echo "Not binary or disk-image content. Skipping artifact-specific logic."
@@ -352,6 +354,15 @@ spec:
               '.releaseNotes.content.artifacts += [$content]' \
               "${DATA_FILE}" > /tmp/data.tmp && \
               mv /tmp/data.tmp "${DATA_FILE}"
+        }
+
+        # Check if this is a marketplace release
+        is_marketplace_release() {
+          if [[ -n "$(jq -r '.mapping.cloudMarketplacesSecret // empty' "$DATA_FILE")" ]]; then
+            return 0
+          else
+            return 1
+          fi
         }
 
         NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
@@ -420,9 +431,17 @@ spec:
                     # Determine OS based on file extension
                     os="linux"  # Default for disk images
 
-                    # Create PURL placeholder for disk-image
-                    # Complete PURL with real CDN URLs will be built by create-advisory update-purl step
-                    purl="placeholder"
+                    # Create PURL for disk-image
+                    if is_marketplace_release; then
+                        # For marketplace releases, generate a PURL without checksum or download_url
+                        # since these images go to cloud marketplaces, not CDN
+                        version=$(jq -r --arg name "$name" \
+                          '.mapping.components[] | select(.name == $name) | .staged.version // "unknown"' "$DATA_FILE")
+                        purl="pkg:generic/$name@$version"
+                    else
+                        # For CDN releases, use placeholder that will be updated by create-advisory
+                        purl="placeholder"
+                    fi
 
                     append_artifact_entry "$name" "$arch" "$os" "$purl"
                 done

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-marketplace-disk-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-marketplace-disk-images.yaml
@@ -1,0 +1,294 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-marketplace-disk-images
+spec:
+  description: |
+    Run the populate-release-notes task and ensure marketplace disk image releases
+    generate PURLs with versions instead of placeholders.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                      {
+                        "name": "amd-azure-disk-image-1-5",
+                        "contentType": "disk-image",
+                        "staged": {
+                          "destination": "rhelai-1_DOT_5-for-rhel-9-x86_64-isos",
+                          "version": "1.5",
+                          "files": [
+                            {
+                              "filename": "rhel-ai-amd-azure-1.5-20250101-x86_64.vhd.gz",
+                              "source": "disk.vhd.gz"
+                            }
+                          ]
+                        },
+                        "productInfo": {
+                          "filePrefix": "rhel-ai-amd-azure-1.5",
+                          "productCode": "RHELAI",
+                          "productName": "RHEL AI",
+                          "productVersionName": "1.5"
+                        },
+                        "starmap": [
+                          {
+                            "cloud": "azure",
+                            "mappings": {
+                              "azure-emea": {
+                                "destinations": [
+                                  {
+                                    "architecture": null,
+                                    "destination": "rh-rhel-ai/rh-rhelai-amd-1gpu",
+                                    "overwrite": false,
+                                    "restrict_version": false,
+                                    "vhd_check_base_sas_only": false
+                                  }
+                                ],
+                                "provider": null
+                              }
+                            },
+                            "meta": {"generation": "V2", "support_legacy": true},
+                            "name": "rhel-ai-amd-azure",
+                            "workflow": "stratosphere"
+                          }
+                        ]
+                      }
+                    ],
+                  "cloudMarketplacesSecret": "azure-stratosphere-secret",
+                  "cloudMarketplacesPrePush": false
+                },
+                "releaseNotes": {
+                  "cves": [
+                    {
+                      "component": "amd-azure-disk-image-1-5",
+                      "packages": [
+                        "pkg1",
+                        "pkg2"
+                      ],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "product_id": [
+                    932
+                  ],
+                  "product_name": "Red Hat Enterprise Linux AI",
+                  "product_version": "1.5",
+                  "cpe": "cpe:/a:redhat:enterprise_linux_ai:1.5",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": [
+                      {
+                        "id": "RHELAI-12345",
+                        "source": "issues.example.com"
+                      }
+                    ]
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "rhel-ai-app",
+                "components": [
+                  {
+                    "name": "amd-azure-disk-image-1-5",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
+                    "tags": [
+                      "1.5",
+                      "latest"
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:ea7868ebdcc7a2116c620255034226611d837f42
+            workingDir: $(params.dataDir)
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # Check that artifacts were populated for marketplace disk image
+              ARTIFACTS_COUNT=$(jq '.releaseNotes.content.artifacts | length' "$DATA_FILE")
+              if [ "$ARTIFACTS_COUNT" -ne 1 ]; then
+                echo "Expected 1 artifact, got $ARTIFACTS_COUNT"
+                exit 1
+              fi
+
+              # Verify the PURL contains the version from staged.version, not "placeholder"
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              EXPECTED_PURL="pkg:generic/amd-azure-disk-image-1-5@1.5"
+
+              if [ "$PURL" != "$EXPECTED_PURL" ]; then
+                echo "Error: Expected PURL '$EXPECTED_PURL', got '$PURL'"
+                exit 1
+              fi
+
+              # Verify architecture was extracted correctly
+              ARCH=$(jq -r '.releaseNotes.content.artifacts[0].architecture' "$DATA_FILE")
+              if [ "$ARCH" != "x86_64" ]; then
+                echo "Error: Expected architecture 'x86_64', got '$ARCH'"
+                exit 1
+              fi
+
+              # Verify OS was set correctly
+              OS=$(jq -r '.releaseNotes.content.artifacts[0].os' "$DATA_FILE")
+              if [ "$OS" != "linux" ]; then
+                echo "Error: Expected OS 'linux', got '$OS'"
+                exit 1
+              fi
+
+              # Verify component name matches
+              COMPONENT=$(jq -r '.releaseNotes.content.artifacts[0].component' "$DATA_FILE")
+              if [ "$COMPONENT" != "amd-azure-disk-image-1-5" ]; then
+                echo "Error: Expected component 'amd-azure-disk-image-1-5', got '$COMPONENT'"
+                exit 1
+              fi
+
+              # Verify CVE information was properly attached
+              CVE_COUNT=$(jq '.releaseNotes.content.artifacts[0].cves.fixed | keys | length' "$DATA_FILE")
+              if [ "$CVE_COUNT" -ne 1 ]; then
+                echo "Error: Expected 1 CVE, got $CVE_COUNT"
+                exit 1
+              fi
+
+              CVE_KEY=$(jq -r '.releaseNotes.content.artifacts[0].cves.fixed | keys[0]' "$DATA_FILE")
+              if [ "$CVE_KEY" != "CVE-123" ]; then
+                echo "Error: Expected CVE-123, got '$CVE_KEY'"
+                exit 1
+              fi
+
+              echo "SUCCESS: Marketplace disk image PURL generated correctly with version: $PURL"


### PR DESCRIPTION
## Describe your changes
Adds the following tasks to the push-disk-images-to-marketplaces
pipeline:
- populate-release-notes
- check-data-keys
- embargo-check
- create-advisory
- close-advisory-issues
- update-cr-status

## Relevant Jira
CLDX-272

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
