### PR TITLE
feat(RELEASE-1793): add support for multiple repositories

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -237,17 +237,12 @@ spec:
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
-            deliveryRepo=$(jq -er '."rh-registry-repo"' <<< "$component")
-            tags=$(jq -c '.tags' <<< "$component")
             image=$(jq -r '.containerImage' <<< "$component")
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"
                 exit 1
             fi
-            sha=$(echo "${image}" | cut -d ':' -f 2)
-            # containerImage should be of the form registry.redhat.io/foo/bar@sha256:abcde
-            # This value will be used as the basis for the example values that follow
-            containerImage="${deliveryRepo}@sha256:${sha}"
+        
             # Construct CVE json
             CVEsJson='{"cves":{"fixed":{}}}'
             CVES=$(jq -c '[.releaseNotes.cves[]? | select(.component=="'"$name"'")]' "${DATA_FILE}")
@@ -260,46 +255,57 @@ spec:
                     '{($id): {"packages": $packages}}')
                 CVEsJson=$(jq --argjson cve "$cveJson" '.cves.fixed += $cve' <<< "$CVEsJson")
             done
-            # Add one entry per arch (amd64 for example)
-            get-image-architectures "${image}" | while IFS= read -r arch_json;
-            do
-                arch=$(jq -r .platform.architecture <<< "${arch_json}")
-                digest=$(jq -r .digest <<< "${arch_json}")
-                containerImage="${deliveryRepo}@${digest}"
-                # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
-                purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+        
+            arch_digests=$(get-image-architectures "${image}")
+        
+            # Iterate over repositories (new schema only)
+            NUM_REPOS=$(jq '.repositories | length' <<< "$component")
+            for ((r = 0; r < NUM_REPOS; r++)); do
+                repo=$(jq -c --argjson r "$r" '.repositories[$r]' <<< "$component")
+                deliveryRepo=$(jq -er '."rh-registry-repo"' <<< "$repo")
+                tags=$(jq -c '.tags' <<< "$repo")
 
-                uniqueTag=""
-                NUM_TAGS=$(jq length <<< "$tags")
-                for ((j = 0; j < NUM_TAGS; j++)) ; do
-                    tag=$(jq -r --argjson j "$j" '.[$j]' <<< "$tags")
-                    if [[ $tag =~ $UNIQUE_TAG_REGEX ]] && [[ ${#tag} > ${#uniqueTag} ]] ; then
-                        uniqueTag="${tag}"
+                # Add one entry per arch (amd64 for example)
+                while IFS= read -r arch_json;
+                do
+                    arch=$(jq -r .platform.architecture <<< "${arch_json}")
+                    digest=$(jq -r .digest <<< "${arch_json}")
+                    containerImage="${deliveryRepo}@${digest}"
+                    # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
+                    purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+    
+                    uniqueTag=""
+                    NUM_TAGS=$(jq length <<< "$tags")
+                    for ((j = 0; j < NUM_TAGS; j++)) ; do
+                        tag=$(jq -r --argjson j "$j" '.[$j]' <<< "$tags")
+                        if [[ $tag =~ $UNIQUE_TAG_REGEX ]] && [[ ${#tag} > ${#uniqueTag} ]] ; then
+                            uniqueTag="${tag}"
+                        fi
+                    done
+    
+                    # if a unique tag is found, then purl will become:
+                    # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo&tag=0.1-12345678
+                    if [[ -n $uniqueTag ]] ; then
+                        purl="${purl}&tag=${uniqueTag}"
                     fi
-                done
-
-                # if a unique tag is found, then purl will become:
-                # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo&tag=0.1-12345678
-                if [[ -n $uniqueTag ]] ; then
-                    purl="${purl}&tag=${uniqueTag}"
-                fi
-
-                jsonString=$(jq -cn \
-                    --arg component "$name" \
-                    --arg arch "$arch" \
-                    --arg containerImage "$containerImage" \
-                    --arg purl "$purl" \
-                    --arg repository "$deliveryRepo" \
-                    --argjson tags "$tags" \
-                    '{"architecture": $arch, "containerImage": $containerImage, "purl": $purl,
-                    "repository": $repository, "tags": $tags, "component": $component}')
-                if [ "$(jq '.cves.fixed | length' <<< "$CVEsJson")" -gt 0 ]; then
-                    jsonString=$(jq --argjson cves "$CVEsJson" '. += $cves' <<< "$jsonString")
-                fi
-
-                # Inject JSON into data.json
-                jq --argjson image "$jsonString" '.releaseNotes.content.images += [$image]' "${DATA_FILE}" > \
-                    /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+    
+                    jsonString=$(jq -cn \
+                        --arg component "$name" \
+                        --arg arch "$arch" \
+                        --arg containerImage "$containerImage" \
+                        --arg purl "$purl" \
+                        --arg repository "$deliveryRepo" \
+                        --argjson tags "$tags" \
+                        '{"architecture": $arch, "containerImage": $containerImage, "purl": $purl,
+                        "repository": $repository, "tags": $tags, "component": $component}')
+                    if [ "$(jq '.cves.fixed | length' <<< "$CVEsJson")" -gt 0 ]; then
+                        jsonString=$(jq --argjson cves "$CVEsJson" '. += $cves' <<< "$jsonString")
+                    fi
+    
+                    # Inject JSON into data.json
+                    jq --argjson image "$jsonString" '.releaseNotes.content.images += [$image]' "${DATA_FILE}" > \
+                        /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+                done <<< "$arch_digests"
             done
         done
     - name: populate-release-notes-artifacts

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
@@ -109,9 +109,16 @@ spec:
                     {
                       "name": "comp",
                       "containerImage": "registry.io/image@sha256:123456",
-                      "repository": {
-                        "url": "https://github.com/user/repo.git"
-                      }
+                      "repositories": [
+                        {
+                          "url": "quay.io/redhat-prod/product----repo",
+                          "rh-registry-repo": "registry.redhat.io/product/repo",
+                          "tags": [
+                            "foo",
+                            "bar"
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
@@ -99,9 +99,11 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.redhat.io/product/repo@sha256:abcdefg",
-                    "repository": {
-                      "url": "https://github.com/user/repo.git"
-                    }
+                    "repositories": [
+                      {
+                        "url": "https://github.com/user/repo.git"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -112,11 +112,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -125,11 +125,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -145,11 +145,15 @@ spec:
                   {
                     "name": "releng-test-product-binaries",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
@@ -162,19 +162,27 @@ spec:
                   {
                     "name": "amd-bootc-iso-disk-image-1-5",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
-                    "tags": [
-                      "1.5.3",
-                      "latest"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/rhel-ai----disk-image",
+                        "tags": [
+                          "1.5.3",
+                          "latest"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "amd-bootc-qcow2-disk-image-1-5",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
-                    "tags": [
-                      "1.5.3",
-                      "latest"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/rhel-ai----disk-image",
+                        "tags": [
+                          "1.5.3",
+                          "latest"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -156,11 +156,15 @@ spec:
                   {
                     "name": "releng-test-product-binaries",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -63,11 +63,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -95,23 +95,31 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "9.4-1723436855",
-                      "9.4.0-1723436855",
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "9.4-1723436855",
+                          "9.4.0-1723436855",
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   },
                   {
                     "name": "comp2",
                     "containerImage": "registry.io/image2@sha256:abcde",
-                    "repository": "quay.io/redhat-pending/product2----repo2",
-                    "rh-registry-repo": "registry.stage.redhat.io/product2/repo2",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/product2----repo2",
+                        "rh-registry-repo": "registry.stage.redhat.io/product2/repo2",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-populate-release-notes-rhsa-references
+  name: test-populate-release-notes-multiple-repositories
 spec:
   description: |
-    Run the populate-release-notes task with a RHSA type. Ensure that references are added for each
-    CVE, existing ones are maintained, and there are no duplicates.
+    Run the populate-release-notes task with multiple repositories in the snapshot JSON and verify
+    the data JSON has the proper content
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -58,36 +58,6 @@ spec:
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "releaseNotes": {
-                  "cves": [
-                    {
-                      "component": "comp",
-                      "packages": [
-                        "pkg1",
-                        "pkg2"
-                      ],
-                      "key": "CVE-123",
-                      "summary": "",
-                      "uploadDate": "01-01-1980",
-                      "url": ""
-                    },
-                    {
-                      "component": "comp",
-                      "key": "CVE-123",
-                      "summary": "",
-                      "uploadDate": "01-01-1980",
-                      "url": ""
-                    },
-                    {
-                      "component": "comp",
-                      "packages": [
-                        "pkg3"
-                      ],
-                      "key": "CVE-456",
-                      "summary": "",
-                      "uploadDate": "01-01-1980",
-                      "url": ""
-                    }
-                  ],
                   "product_id": [
                     123
                   ],
@@ -112,7 +82,6 @@ spec:
                   "description": "test description",
                   "solution": "test solution",
                   "references": [
-                    "https://docs.example.com/some/example/release-notes",
                     "https://docs.example.com/some/example/release-notes"
                   ]
                 }
@@ -130,6 +99,16 @@ spec:
                       {
                         "url": "quay.io/redhat-prod/product----repo",
                         "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "9.4-1723436855",
+                          "9.4.0-1723436855",
+                          "foo",
+                          "bar"
+                        ]
+                      },
+                      {
+                        "url": "quay.io/redhat-prod/product----repo2",
+                        "rh-registry-repo": "registry.redhat.io/product/repo2",
                         "tags": [
                           "foo",
                           "bar"
@@ -215,22 +194,48 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # There should be 4 references. The one provided (not duplicated), the generic classification one,
-              # and ones for CVE-123 and CVE-456
-              test "$(jq '.releaseNotes.references | length' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" \
-                == 4
-              test "$(jq -jr '.releaseNotes.references[0]' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == \
-                "https://access.redhat.com/security/cve/CVE-123"
-              test "$(jq -jr '.releaseNotes.references[1]' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == \
-                "https://access.redhat.com/security/cve/CVE-456"
-              test "$(jq -jr '.releaseNotes.references[2]' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == \
-                "https://access.redhat.com/security/updates/classification/"
-              test "$(jq -jr '.releaseNotes.references[3]' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == \
-                "https://docs.example.com/some/example/release-notes"
+              echo Checking image1repo1arch1...
+              image1repo1arch1=$(jq '.releaseNotes.content.images[0]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "$image1repo1arch1")" == "amd64"
+              test "$(jq -r '.containerImage' <<< "$image1repo1arch1")" == \
+                "registry.redhat.io/product/repo@sha256:abcdefg"
+              test "$(jq -r '.purl' <<< "$image1repo1arch1")" == \
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+              test "$(jq -r '.repository' <<< "$image1repo1arch1")" == "registry.redhat.io/product/repo"
+              test "$(jq -rc '.tags' <<< "$image1repo1arch1")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
+
+              echo Checking image1repo1arch2...
+              image1repo1arch2=$(jq '.releaseNotes.content.images[1]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "$image1repo1arch2")" == "s390x"
+              test "$(jq -r '.containerImage' <<< "$image1repo1arch2")" == \
+                "registry.redhat.io/product/repo@sha256:deadbeef"
+              test "$(jq -r '.purl' <<< "$image1repo1arch2")" == \
+               "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+              test "$(jq -r '.repository' <<< "$image1repo1arch2")" == "registry.redhat.io/product/repo"
+              test "$(jq -rc '.tags' <<< "$image1repo1arch2")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
+              
+              echo Checking image1repo2arch1...
+              image1repo2arch1=$(jq '.releaseNotes.content.images[2]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "$image1repo2arch1")" == "amd64"
+              test "$(jq -r '.containerImage' <<< "$image1repo2arch1")" == \
+                "registry.redhat.io/product/repo2@sha256:abcdefg"
+              test "$(jq -r '.purl' <<< "$image1repo2arch1")" == \
+                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+              test "$(jq -r '.repository' <<< "$image1repo2arch1")" == "registry.redhat.io/product/repo2"
+              test "$(jq -rc '.tags' <<< "$image1repo2arch1")" == '["foo","bar"]'
+
+              echo Checking image1repo2arch2...
+              image1repo2arch2=$(jq '.releaseNotes.content.images[3]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "$image1repo2arch2")" == "s390x"
+              test "$(jq -r '.containerImage' <<< "$image1repo2arch2")" == \
+                "registry.redhat.io/product/repo2@sha256:deadbeef"
+              test "$(jq -r '.purl' <<< "$image1repo2arch2")" == \
+               "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+              test "$(jq -r '.repository' <<< "$image1repo2arch2")" == "registry.redhat.io/product/repo2"
+              test "$(jq -rc '.tags' <<< "$image1repo2arch2")" == '["foo","bar"]'
       runAfter:
         - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -102,11 +102,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -91,11 +91,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -126,11 +126,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -95,11 +95,15 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/image@sha256:123456",
-                    "repository": "quay.io/redhat-prod/product----repo",
-                    "rh-registry-repo": "registry.redhat.io/product/repo",
-                    "tags": [
-                      "foo",
-                      "bar"
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
                     ]
                   }
                 ]


### PR DESCRIPTION
## Describe your changes

Rogue suggested to keep the same format for the advisory and just create new images for each repo.

This commit modifies the advisory information that create-advisory consumes, handling the new change that deprecates repository in favor of repositories.

## Relevant Jira
RELEASE-1793

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
