### PR TITLE
feat(RELEASE-1843): enable skip_customer_notifications in advisories

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -314,6 +314,10 @@
         "allow_custom_live_id": {
           "type": "boolean",
           "description": "Whether to allow custom live id or not e.g. true"
+        },
+        "skip_customer_notifications": {
+          "type": "boolean",
+          "description": "Whether to skip customer notifications or not e.g. true"
         }
       }
     },

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+      image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:5946bb2a4c353004b05dd1edbecf79fbceadb69c
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

skip_customer_notifications is a new optional field in releaseNotes. It will always be included in advisories, set to false by default.

Changes:
- add the field in the schema file
- update utils image to populate the field in advisory template, setting it to false by default

Depends on https://github.com/konflux-ci/release-service-utils/pull/516 (merged)

## Relevant Jira

RELEASE-1843

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
