### PR TITLE
fix: remove the key if issues.fixed has no value

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -292,7 +292,15 @@ spec:
 
           # Prepare variables for the advisory template
           # Write to file to avoid argument length limits
-          jq -c '{"advisory":{"spec":.}}' /tmp/advisory_with_key.json > /tmp/template_data.json
+          # Remove releaseNotes.issues.fixed key if it's an empty array to prevent null values in YAML
+          jq -c '
+            if (.releaseNotes.issues.fixed // [] | length) == 0 then
+              del(.releaseNotes.issues.fixed)
+            else
+              .
+            end |
+            {"advisory":{"spec":.}}
+          ' /tmp/advisory_with_key.json > /tmp/template_data.json
           jq -c --arg advisory_name "$ADVISORY_NAME" --arg advisory_ship_date "$SHIP_DATE" \
             '$ARGS.named + .' /tmp/template_data.json > /tmp/template_data_final.json
 


### PR DESCRIPTION
## Describe your changes
Users providing YAML with an empty fixed: field (no value) caused 'fixed: null' in generated advisories, breaking template processing and causing advisory generation failures.

To fix this issue, a jq transformation was added (for the relevant part of the code - lines 295-303) that removes the releaseNotes.issues.fixed key entirely when empty/null, preventing null values in final YAML output.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
