### PR TITLE
fix(RELEASE-1767): keep newlines in advisory fields

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+      image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
+            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Bump the utils image in create-advisory-task to fix newlines handling in advisory jinja template.

Until now, we used `>-` for multiline strings for some of the fields in the advisory jinja template. That means that we were removing most newlines from the input string. We shouldn't do that. We should pass the string that the user provided on input unmodified.

With `|-`, all newlines will be preserved.

Utils PR: https://github.com/konflux-ci/release-service-utils/pull/520

## Relevant Jira

RELEASE-1767

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
