### PR TITLE
feat: allow task dir option in tektor

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -186,6 +186,7 @@ jobs:
         with:
           fail-on-error: true
           verbose: true
+          task-dir: ./tasks
           params: |
             taskGitRevision=${{ github.event.pull_request.head.ref }}
             taskGitUrl=${{ github.event.pull_request.head.repo.html_url }}


### PR DESCRIPTION
## Describe your changes
- allow task dir option in tektor
- Uses https://github.com/konflux-ci/tektor/pull/7

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
