### PR TITLE
fix(RELEASE-1757): utils image tag updated to the latest available

### DIFF
--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -35,7 +35,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory-oci-artifact
-      image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+      image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            image: quay.io/konflux-ci/release-service-utils:201dfdd7e0ee9c3639d6c0b856439874da975452
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -251,45 +251,66 @@ spec:
             COMPONENT_NAME=$(jq -r ".components[${COMPONENTS_INDEX}].name" "${SNAPSHOT_PATH}")
             echo "Processing component ${COMPONENT_NAME}"
 
-            # Get public image references
-            INTERNAL_CONTAINER_REF=$(jq -r ".components[${COMPONENTS_INDEX}].repository" "${SNAPSHOT_PATH}")
-            rh_registry_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"rh-registry-repo\"]" "${SNAPSHOT_PATH}")
-            registry_access_repo=$(jq -r ".components[${COMPONENTS_INDEX}][\"registry-access-repo\"]" \
-              "${SNAPSHOT_PATH}")
-            repository="${rh_registry_repo#*/}"
-
-            # Sign rh-registry-repo references (always) and registry-access-repo references
-            # (only if signatures for this registry are required)
-            REGISTRY_REFERENCES=("${rh_registry_repo}")
-            if grep -q "^${repository}$" "${SIGN_REGISTRY_ACCESS_FILE}"; then
-              REGISTRY_REFERENCES+=("${registry_access_repo}")
-            fi
+            COMPONENT=$(jq -c ".components[${COMPONENTS_INDEX}]" "${SNAPSHOT_PATH}")
 
             # Check if image is manifest list
             BUILD_CONTAINER_IMAGE=$(jq -r ".components[${COMPONENTS_INDEX}].containerImage" "${SNAPSHOT_PATH}")
             DIGEST="${BUILD_CONTAINER_IMAGE/*@}"
             IMAGE=$(skopeo inspect --raw "docker://${BUILD_CONTAINER_IMAGE}")
             MEDIA_TYPE=$(echo "$IMAGE" | jq -r '.mediaType')
-            TAGS=$(jq -r ".components[${COMPONENTS_INDEX}].tags|.[]" "${SNAPSHOT_PATH}")
             LIST=0
             if [ "$MEDIA_TYPE" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then LIST=1; fi
             if [ "$MEDIA_TYPE" = "application/vnd.oci.image.index.v1+json" ]; then LIST=1; fi
 
-            # Collect data for signing
-            # Sign each manifest in the manifest list
-            if [ $LIST -eq 1 ]; then
-                for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                    for MDIGEST in $(echo "$IMAGE" | jq -r '.manifests[]|.digest'); do
-                        for TAG in $TAGS; do
-                            to_sign+=("${REGISTRY_REF}:${TAG}@${MDIGEST}#${INTERNAL_CONTAINER_REF}")
+            # Process repositories array (apply-mapping guarantees this exists)
+            NUM_REPOSITORIES=$(jq '.repositories | length' <<< "$COMPONENT")
+            for (( i = 0; i < NUM_REPOSITORIES; i++ )); do
+                REPOSITORY_OBJECT=$(jq -c ".repositories[${i}]" <<< "$COMPONENT")
+
+                # Get repository URL and use it as INTERNAL_CONTAINER_REF
+                INTERNAL_CONTAINER_REF=$(jq -r '.url' <<< "$REPOSITORY_OBJECT")
+                rh_registry_repo=$(jq -r '."rh-registry-repo" // empty' <<< "$REPOSITORY_OBJECT")
+                registry_access_repo=$(jq -r '."registry-access-repo" // empty' <<< "$REPOSITORY_OBJECT")
+
+                # Skip if no rh-registry-repo (not applicable for signing)
+                if [ "$rh_registry_repo" = "" ] || [ "$rh_registry_repo" = "null" ]; then
+                    echo "No rh-registry-repo found for repository ${INTERNAL_CONTAINER_REF}, skipping signing"
+                    continue
+                fi
+
+                repository="${rh_registry_repo#*/}"
+
+                # Get tags from repository object
+                REPO_TAGS=$(jq -r '.tags[]? // empty' <<< "$REPOSITORY_OBJECT")
+                if [ -z "$REPO_TAGS" ]; then
+                    echo "No tags found for repository ${INTERNAL_CONTAINER_REF}, skipping signing"
+                    continue
+                fi
+
+                # Sign rh-registry-repo references (always) and registry-access-repo references
+                # (only if signatures for this registry are required)
+                REGISTRY_REFERENCES=("${rh_registry_repo}")
+                if [ "$registry_access_repo" != "" ] && [ "$registry_access_repo" != "null" ] && \
+                   grep -q "^${repository}$" "${SIGN_REGISTRY_ACCESS_FILE}"; then
+                    REGISTRY_REFERENCES+=("${registry_access_repo}")
+                fi
+
+                # Collect data for signing
+                # Sign each manifest in the manifest list
+                if [ $LIST -eq 1 ]; then
+                    for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                        for MDIGEST in $(jq -r '.manifests[]|.digest' <<< "$IMAGE"); do
+                            for TAG in $REPO_TAGS; do
+                                to_sign+=("${REGISTRY_REF}:${TAG}@${MDIGEST}#${INTERNAL_CONTAINER_REF}")
+                            done
                         done
                     done
-                done
-            fi
-            # Sign manifest list itself or manifest if it's not list
-            for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                for TAG in $TAGS; do
-                    to_sign+=("${REGISTRY_REF}:${TAG}@${DIGEST}#${INTERNAL_CONTAINER_REF}")
+                fi
+                # Sign manifest list itself or manifest if it's not list
+                for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                    for TAG in $REPO_TAGS; do
+                        to_sign+=("${REGISTRY_REF}:${TAG}@${DIGEST}#${INTERNAL_CONTAINER_REF}")
+                    done
                 done
             done
         done

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -63,18 +63,26 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000",
-                    "repository": "quay.io/redhat-pending/test-product----test-image0",
-                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0",
-                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0",
-                    "tags": ["t1", "t2"]
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image0",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0",
+                        "tags": ["t1", "t2"]
+                      }
+                    ]
                   },
                   {
                     "name": "comp1",
                     "containerImage": "quay.io/redhat-user-workloads/test-product/test-image1@sha256:1111",
-                    "repository": "quay.io/redhat-pending/test-product----test-image1",
-                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image1",
-                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image1",
-                    "tags": ["t1", "t2"]
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image1",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image1",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image1",
+                        "tags": ["t1", "t2"]
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
@@ -2,9 +2,9 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-rh-sign-image-cosign-single-component
+  name: test-rh-sign-image-cosign-multiple-repositories
 spec:
-  description: Test signing a single image by cosign
+  description: Test signing images with new multiple repositories schema
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -59,13 +59,19 @@ spec:
                 "components": [
                   {
                     "name": "comp0",
-                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000",
                     "repositories": [
                       {
-                        "url": "quay.io/redhat-pending/test-product----test-image2",
-                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
-                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
+                        "url": "quay.io/redhat-pending/test-product----test-image0",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0",
                         "tags": ["t1", "t2"]
+                      },
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image0-alt",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0-alt",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0-alt",
+                        "tags": ["latest"]
                       }
                     ]
                   }
@@ -73,18 +79,26 @@ spec:
               }
               EOF
               # create empty cosign verify mock files
-              for D in sha256:0000 sha256:1111 sha256:2222 ; do
-                REF="quay.io/redhat-pending/test-product----test-image2@${D}"
-                touch "$(params.dataDir)/$(echo $REF | tr '/' '-')"
+              # Main digest and individual manifest digests from OCI manifest list
+              for D in sha256:0000 sha256:0000-1 sha256:0000-2 sha256:0000-3; do
+                REF1="quay.io/redhat-pending/test-product----test-image0@${D}"
+                REF2="quay.io/redhat-pending/test-product----test-image0-alt@${D}"
+                touch "$(params.dataDir)/$(echo $REF1 | tr '/' '-')"
+                touch "$(params.dataDir)/$(echo $REF2 | tr '/' '-')"
               done
 
-              # first 8 cosign calls should end with success
-              for _ in $(seq 1 8); do
+              # Expected cosign calls:
+              # - 2 repos * (2+1) tags = 6 sign calls for main digest
+              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign calls for individual manifests
+              # - 24 verify calls (1 per sign call)
+              # Total: 48 calls
+              for _ in $(seq 1 48); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
-              test-product/test-image2
+              test-product/test-image0
+              test-product/test-image0-alt
               EOF
           - name: create-trusted-artifact
             ref:
@@ -163,25 +177,48 @@ spec:
               #!/usr/bin/env bash
               set -eux
               echo "check results"
-              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image2"
-              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image2"
-              _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
+              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
+              _TEST_PUB_REPO3="registry.stage.redhat.io/test-product/test-image0-alt"
+              _TEST_PUB_REPO4="registry.access.stage.redhat.com/test-product/test-image0-alt"
+              _TEST_REPO1="quay.io/redhat-pending/test-product----test-image0"
+              _TEST_REPO2="quay.io/redhat-pending/test-product----test-image0-alt"
 
               CALLS=$(cat "$(params.dataDir)/mock_skopeo_calls")
-              EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222"
+              EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000"
               test "$CALLS" = "$EXPECTED"
 
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
               COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-3
               EOF
               )
-              echo "TESTING"
+              echo "TESTING SIGN CALLS"
               if [ "$CALLS" != "$EXPECTED" ]; then
                 echo "Diff:"
                 CALLS_FILE=$(mktemp XXXXX.calls)
@@ -195,10 +232,30 @@ spec:
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
               COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
               EOF
               )
               echo "TESTING VERIFY CALLS"

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -60,10 +60,14 @@ spec:
                   {
                     "name": "comp0",
                     "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
-                    "repository": "quay.io/redhat-pending/test-product----test-image2",
-                    "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
-                    "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
-                    "tags": ["t1", "t2"]
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image2",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
+                        "tags": ["t1", "t2"]
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
## Describe your changes
Update quay.io/konflux-ci/release-service-utils version to the latest available for all tasks.
As part of the RELEASE-1757 fix, we must ensure that used by tasks [release-service-utils](quay.io/konflux-ci/release-service-utils) image already includes the fix for the empty releaseNotes.issues.fixed issue (https://github.com/konflux-ci/release-service-utils/pull/493).

## Relevant Jira
[RELEASE-1757](https://issues.redhat.com/browse/RELEASE-1757)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
