### PR TITLE
fix: add retries for filter-already-released-advisory-images

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -274,6 +274,7 @@ spec:
       runAfter:
         - reduce-snapshot
     - name: filter-already-released-advisory-images
+      retries: 3
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
## Describe your changes

A user reported that this can fail sometimes, so a retry would help.

Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1757052884644949?thread_ts=1756371413.639589&cid=C04PZ7H0VA8

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
