### PR TITLE
feat(CLDX-450): make cgw credential optional

### DIFF
--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -97,6 +97,10 @@ spec:
   volumes:
     - name: workdir
       emptyDir: {}
+    - name: cgw-secret
+      secret:
+        secretName: $(params.cgwSecret)
+        optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -140,17 +144,11 @@ spec:
         requests:
           memory: 256Mi
           cpu: 100m
+      volumeMounts:
+        - name: cgw-secret
+          mountPath: /var/secrets/cgw
+          readOnly: true
       env:
-        - name: CGW_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: $(params.cgwSecret)
-              key: username
-        - name: CGW_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: $(params.cgwSecret)
-              key: token
         - name: CGW_HOST
           value: $(params.cgwHostname)
       script: |
@@ -182,6 +180,22 @@ spec:
             exit 0
           fi
           echo "content type is not a generic artifact, skipping update-purl"
+          exit 0
+        elif [ "$content_type" = "binary" ] || [ "$content_type" = "generic" ] || \
+             [ "$content_type" = "disk-image" ]; then
+          # These content types require CGW credentials
+          if [ -f "/var/secrets/cgw/username" ] && [ -f "/var/secrets/cgw/token" ]; then
+            echo "CGW credentials found, setting environment variables..."
+            CGW_USERNAME=$(cat /var/secrets/cgw/username)
+            CGW_TOKEN=$(cat /var/secrets/cgw/token)
+            export CGW_USERNAME
+            export CGW_TOKEN
+          else
+            echo "Error: CGW credentials not found but content type '$content_type' requires CGW access."
+            exit 1
+          fi
+        else
+          echo "Content type '$content_type'. Skipping update-purl."
           exit 0
         fi
 


### PR DESCRIPTION
The create-advisory task has a step that updates the PURL field for some advisories. The way the task step is configured, it requires the cgw credential to be present even for non-applicable releases. Therefore if a service-account doesn't have access to the cgw secret it would fail. Rather than unnecessarily adding this credential to all service accounts that may use this task, it is better to use a volumeMount so the credential is optional.

## Relevant Jira
CLDX-450

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
