### PR TITLE
feat: protect e2e-base from deletion

### DIFF
--- a/integration-tests/collectors/test.env
+++ b/integration-tests/collectors/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=collectors-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_collector_sa_name=collector-sa-${uuid}

--- a/integration-tests/e2e/test.env
+++ b/integration-tests/e2e/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=${component_type}-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_sa_name=${component_type}-sa-${uuid}

--- a/integration-tests/fbc-release/test.env
+++ b/integration-tests/fbc-release/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=fbc-release-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 # Component 2 configuration (for multi-component tests)

--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -26,6 +26,14 @@ spec:
     - name: KUBECONFIG_SECRET_NAME
       default: 'kubeconfig-secret'
       type: string
+    - name: component_github_org
+      default: 'hacbs-release-tests'
+      type: string
+      description: 'GitHub organization for test repositories'
+    - name: component_base_repo_name
+      default: 'hacbs-release-tests/e2e-base'
+      type: string
+      description: 'Base repository name that should be protected from deletion'
   tasks:
     - name: get-snapshot-data
       params:
@@ -73,6 +81,10 @@ spec:
           value: $(params.GITHUB_TOKEN_SECRET_NAME)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
+        - name: component_github_org
+          value: $(params.component_github_org)
+        - name: component_base_repo_name
+          value: $(params.component_base_repo_name)
 
       taskSpec:
         params:
@@ -84,6 +96,8 @@ spec:
           - name: VAULT_PASSWORD_SECRET_NAME
           - name: GITHUB_TOKEN_SECRET_NAME
           - name: KUBECONFIG_SECRET_NAME
+          - name: component_github_org
+          - name: component_base_repo_name
         results:
           - name: TEST_OUTPUT
             description: Test output
@@ -118,6 +132,10 @@ spec:
                     fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/branch']
               - name: uuid
                 value: $(context.pipelineRun.uid)
+              - name: component_github_org
+                value: $(params.component_github_org)
+              - name: component_base_repo_name
+                value: $(params.component_base_repo_name)
             script: |
               #!/usr/bin/env bash
 
@@ -247,12 +265,18 @@ spec:
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: VAULT_PASSWORD_SECRET_NAME
           value: $(params.VAULT_PASSWORD_SECRET_NAME)
+        - name: component_github_org
+          value: $(params.component_github_org)
+        - name: component_base_repo_name
+          value: $(params.component_base_repo_name)
       taskSpec:
         params:
           - name: STEP_IMAGE
           - name: GITHUB_TOKEN_SECRET_NAME
           - name: KUBECONFIG_SECRET_NAME
           - name: VAULT_PASSWORD_SECRET_NAME
+          - name: component_github_org
+          - name: component_base_repo_name
         steps:
           - name: cleanup-resources
             image: $(params.STEP_IMAGE)
@@ -274,6 +298,10 @@ spec:
                   secretKeyRef:
                     name: $(params.VAULT_PASSWORD_SECRET_NAME)
                     key: password
+              - name: component_github_org
+                value: $(params.component_github_org)
+              - name: component_base_repo_name
+                value: $(params.component_base_repo_name)
             script: |
               #
               # Why are we doing this?

--- a/integration-tests/push-to-addons-registry/test.env
+++ b/integration-tests/push-to-addons-registry/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=push-to-addons-registry-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_sa_name=push-to-addons-registry-sa-${uuid}

--- a/integration-tests/push-to-external-registry/test.env
+++ b/integration-tests/push-to-external-registry/test.env
@@ -15,10 +15,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=push-to-external-registry-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_sa_name=push-to-external-registry-sa-${uuid}

--- a/integration-tests/release-to-github/test.env
+++ b/integration-tests/release-to-github/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=release-to-github-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 export component_version=v1.0.0
 

--- a/integration-tests/rh-push-to-external-registry/test.env
+++ b/integration-tests/rh-push-to-external-registry/test.env
@@ -17,10 +17,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=rh-push-to-external-registry-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_sa_name=rh-push-to-external-registry-sa-${uuid}

--- a/integration-tests/rh-push-to-registry-redhat-io/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=rh-push-to-registry-redhat-io-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export release_plan_name=rh-push-to-registry-redhat-io-rp-${uuid}

--- a/integration-tests/rhtap-service-push/test.env
+++ b/integration-tests/rhtap-service-push/test.env
@@ -19,10 +19,8 @@ export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
 export appstudio_component_branch="appstudio-${component_name}"
 
-export component_github_org=hacbs-release-tests
 export component_base_branch=rhtap-service-push-base
 export component_repo_name=${component_github_org}/${component_name}
-export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 export tenant_sa_name=rhtap-service-push-sa-${uuid}

--- a/integration-tests/scripts/delete-repository.sh
+++ b/integration-tests/scripts/delete-repository.sh
@@ -29,6 +29,19 @@ if [ -z "$repo_name" ] ; then
   exit 1
 fi
 
+# Check if component_base_repo_name is set for protection
+if [ -z "${component_base_repo_name}" ]; then
+  echo "🔴 error: component_base_repo_name environment variable not set"
+  echo "   This variable is required to protect base repositories from deletion"
+  exit 1
+fi
+
+# Protect the base repository from deletion
+if [[ "$repo_name" == "${component_base_repo_name}" ]]; then
+  echo "🔴 error: cannot delete protected base repository: ${component_base_repo_name}"
+  exit 1
+fi
+
 # Verify repository exists before attempting deletion
 echo "Verifying repository ${repo_name} exists..."
 REPO_RESPONSE=$(curl -L \


### PR DESCRIPTION
## Describe your changes

The variables in the integration tests' `test.env` can be easily confused. We should protect against accidental misconfiguration resulting in deletion of the `e2e-base` repo. 

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
