### PR TITLE
feat(RELEASE-1854): add new data keys

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "enforceContainerFirstSecurityLabels": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, name and cpe label values will be enforced"
+    },
     "systems": {
       "type": "array",
       "items": {
@@ -453,6 +458,10 @@
               "name": {
                 "type": "string",
                 "description": "The component name found in the snapshot e.g. example-component"
+              },
+              "canonicalName": {
+                "type": "string",
+                "description": "Name to be used while comparing against the name label when multiple repositories are defined"
               },
               "repository": {
                 "type": "string",


### PR DESCRIPTION
## Describe your changes

This commit adds the enforceContainerFirstSecurityLabels data key. This key will be used to control the enforcement of name and cpe labels.

In addition, the canonicalName key is added under components to be able to define a canonical name when pushing to multiple repositories.

## Relevant Jira

RELEASE-1854

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [X] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
