### PR TITLE
fix: use nonroot user in sign-oot-kmods task

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -154,7 +154,7 @@ spec:
         echo "Signing OOT modules from $(params.dataDir)/$signedKmodsPath.."
         SIGNED_KMODS_PATH="$(params.dataDir)/$signedKmodsPath"
         SSH_OPTS=(
-          -o UserKnownHostsFile=/root/.ssh/known_hosts
+          -o UserKnownHostsFile=~/.ssh/known_hosts
           -o GSSAPIAuthentication=yes
           -o GSSAPIDelegateCredentials=yes
         )
@@ -184,10 +184,10 @@ spec:
         export KRB5CCNAME
         kinit -kt /etc/sec-keytab/keytab-build-and-sign.keytab "${signUser}@$(params.kerberosRealm)"
 
-        mkdir -p /root/.ssh
-        chmod 700 /root/.ssh
-        cp /etc/sec-checksum/checksumFingerprint /root/.ssh/known_hosts
-        chmod 600 root/.ssh/known_hosts
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        cp /etc/sec-checksum/checksumFingerprint ~/.ssh/known_hosts
+        chmod 600 ~/.ssh/known_hosts
 
         cd "$SIGNED_KMODS_PATH" || exit 1
         # Copy unsigned kmods to signing server

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -24,7 +24,7 @@ function ssh() {
   echo "$*" >> "$(params.dataDir)/mock_ssh.txt"
 
   case "$*" in
-    "-o UserKnownHostsFile=/root/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
+    "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
       ;;
     *)
       echo "Error: Incorrect ssh parameters"
@@ -39,7 +39,7 @@ function scp() {
   echo "$*" >> "$(params.dataDir)/mock_scp.txt"
 
   case "$*" in
-    "-o UserKnownHostsFile=/root/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
+    "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
       ;;
     *)
       echo "Error: Incorrect scp parameters"


### PR DESCRIPTION
Using root user is not allowed in task so changing to regular user

