### PR TITLE
fix: extract final component index image to avoid newlines

### DIFF
--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -112,11 +112,11 @@ spec:
 
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/extract-index-image-results.json"
 
-        indexImage="$(jq -r '.components[].index_image' \
+        indexImage="$(jq -r '.components[-1].index_image' \
                     "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         echo -n "$indexImage" | tee "$(results.indexImage.path)"
 
-        indexImageResolved="$(jq -r '.components[].index_image_resolved' \
+        indexImageResolved="$(jq -r '.components[-1].index_image_resolved' \
                             "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         echo -n "$indexImageResolved" | tee "$(results.indexImageResolved.path)"
 

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
@@ -217,23 +217,33 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # testing the compatibility
-              images=$(tr -s "\n" " " <<< "$(params.indexImage)")
-              resolvedImages=$(tr -s "\n" " " <<< "$(params.indexImageResolved)")
+              # Verify single-line results (no newlines)
+              echo "Verifying single-line results..."
+              if [[ "$(params.indexImage)" =~ $'\n' ]]; then
+                echo "ERROR: indexImage result contains newlines"
+                exit 1
+              fi
+              
+              if [[ "$(params.indexImageResolved)" =~ $'\n' ]]; then
+                echo "ERROR: indexImageResolved result contains newlines"
+                exit 1
+              fi
 
-              index_image1=$(awk '{print $1}' <<< "$images")
-              index_image2=$(awk '{print $2}' <<< "$images")
+              # Verify we get the final component's result (last one in batching)
+              expected_final_image="redhat.com/rh-stage/iib:02"
+              expected_final_resolved="redhat.com/rh-stage/iib@sha256:1234567890"
+              
+              echo "Test the indexImage result is the final component"
+              if [ "$(params.indexImage)" != "$expected_final_image" ]; then
+                echo "ERROR: Expected final index image $expected_final_image, got: $(params.indexImage)"
+                exit 1
+              fi
 
-              index_image_resolved1=$(awk '{print $1}' <<< "$resolvedImages")
-              index_image_resolved2=$(awk '{print $2}' <<< "$resolvedImages")
-
-              echo Test the indexImage result was properly set
-              test "$index_image1" == "redhat.com/rh-stage/iib:01"
-              test "$index_image2" == "redhat.com/rh-stage/iib:02"
-
-              echo Test the indexImageResolved result was properly set
-              test "$index_image_resolved1" == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
-              test "$index_image_resolved2" == "redhat.com/rh-stage/iib@sha256:1234567890"
+              echo "Test the indexImageResolved result is the final component"
+              if [ "$(params.indexImageResolved)" != "$expected_final_resolved" ]; then
+                echo "ERROR: Expected final resolved image $expected_final_resolved, got: $(params.indexImageResolved)"
+                exit 1
+              fi
 
               # testing new format
               resultsFile="$(params.dataDir)/$(params.internalRequestResultsFile)"


### PR DESCRIPTION
## Describe your changes

Fix FBC pipeline failures caused by multi-line results in extract-index-image task. Changed jq query from '.components[]' to '.components[-1]' to extract only the final component result, preventing Tekton pipeline result rejection.

Also updated test to validate single-line results instead of working around multi-line output with tr command.

Fixes #1423

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: arewm <arewm@users.noreply.github.com>

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
