### PR TITLE
feat(RPRM-44): support for pushing rpms

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/README.md
+++ b/tasks/managed/push-rpms-to-pulp/README.md
@@ -1,0 +1,21 @@
+# push-rpms-to-pulp
+
+A task to push rpm packages from an OCI artifact to a Pulp repository.
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value              |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------------|
+| SNAPSHOT_PATH           | Path to the snapshot spec file containing image information                                                                | No       | -                          |
+| PULP_DOMAIN             | The domain to use for Pulp operations                                                                                      | No       | -                          |
+| PULP_SECRET_NAME        | The name of the secret containing the Pulp cli.toml file. It must have the cli.toml key                                    | No       | -                          |
+| DEFAULT_EXCLUDES        | comma-delimited list of file patterns to exclude from the upload                                                           | Yes      | -debuginfo-, -debugsource- |
+| resultsDirPath          | Path to the results directory in the data workspace                                                                        | No       | -                          |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                      |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                         |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                         |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                         |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                         |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release       |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                          |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                          |

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -1,0 +1,314 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-rpms-to-pulp
+spec:
+  description: |
+    A task to push rpm packages from an OCI artifact to a Pulp repository.
+  params:
+    - name: SNAPSHOT_PATH
+      type: string
+      description: Path to the snapshot spec file containing image information
+    - name: PULP_DOMAIN
+      type: string
+      description: The domain to use for Pulp operations
+    - name: PULP_SECRET_NAME
+      type: string
+      description: >-
+        The name of the secret containing the Pulp cli.toml file. It must have the cli.toml key
+    - name: DEFAULT_EXCLUDES
+      type: string
+      description: comma-delimited list of file patterns to exclude from the upload
+      default: "-debuginfo-, -debugsource-"
+    - name: resultsDirPath
+      description: Path to the results directory in the data workspace
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  results:
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: SNAPSHOT_PATH
+        value: $(params.dataDir)/$(params.SNAPSHOT_PATH)
+      - name: DEFAULT_EXCLUDES
+        value: $(params.DEFAULT_EXCLUDES)
+      - name: DATA_DIR
+        value: $(params.dataDir)
+      - name: PULP_DOMAIN
+        value: $(params.PULP_DOMAIN)
+      - name: PULP_SECRET_NAME
+        value: $(params.PULP_SECRET_NAME)
+      - name: RESULTS_DIR_PATH
+        value: $(params.resultsDirPath)
+      - name: ociStorage
+        value: $(params.ociStorage)
+      - name: ociArtifactExpiresAfter
+        value: $(params.ociArtifactExpiresAfter)
+      - name: trustedArtifactsDebug
+        value: $(params.trustedArtifactsDebug)
+      - name: IMAGES_TXT
+        value: $(params.dataDir)/images.txt
+      - name: FILES_DIR
+        value: $(params.dataDir)/files
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: ORAS_OPTIONS
+        value: $(params.orasOptions)
+      - name: DEBUG
+        value: $(params.trustedArtifactsDebug)
+    volumeMounts:
+      - name: workdir
+        mountPath: "/var/workdir"
+    workingDir: "/var/workdir"
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: push-rpms-to-pulp
+      image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 250m
+      env:
+        - name: CONFIG_FILE_CONTENT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.PULP_SECRET_NAME)
+              key: cli.toml
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        set +x
+        echo "${CONFIG_FILE_CONTENT:?}" > "/tmp/cli.toml"
+        export PULP_CONFIG_FILE="/tmp/cli.toml"
+        set -x
+
+        DOMAIN_EXISTS=$(pulp --config "$PULP_CONFIG_FILE" domain show --name "${PULP_DOMAIN}" \
+          | jq -r ".name // \"\"" || echo "")
+        if [[ "$DOMAIN_EXISTS" == "$PULP_DOMAIN" ]]; then
+            echo "Domain '${PULP_DOMAIN}' exists"
+        else
+            echo "Domain '${PULP_DOMAIN}' not found."
+            exit 1
+        fi
+
+        RESULTS_FILE="${DATA_DIR}/${RESULTS_DIR_PATH}/push-rpms-to-pulp-results.json"
+        mkdir -p "$(dirname "${RESULTS_FILE}")"
+
+        # Initialize results file with empty rpmfiles array
+        echo '{"rpmfiles": []}' > "$RESULTS_FILE"
+
+        < "${SNAPSHOT_PATH}" jq -r '.components[].containerImage' | tee "${IMAGES_TXT}"
+
+        AUTHFILE='/tmp/auth.json'
+        mkdir -p "${FILES_DIR}"
+        while read -r IMAGE; do
+          echo "Processing ${IMAGE}"
+          select-oci-auth "${IMAGE}" > "${AUTHFILE}"
+          oras pull --registry-config "${AUTHFILE}" "${IMAGE}" -o "${FILES_DIR}"
+        done < "${IMAGES_TXT}"
+
+        cd "${FILES_DIR}"
+
+        # Create filtered list of files to upload
+        FILES_TO_UPLOAD=()
+
+        # Convert comma-delimited exclude patterns to array
+        IFS=',' read -ra EXCLUDE_PATTERNS <<< "${DEFAULT_EXCLUDES}"
+
+        # Get all files and filter out excluded patterns
+        for file in *; do
+          if [ -f "$file" ]; then
+            # Only process .rpm files
+            if [[ "$file" != *.rpm ]]; then
+              echo "Skipping $file (not an RPM file)"
+              continue
+            fi
+
+            should_exclude=false
+
+            # Check if file matches any exclude pattern
+            for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+              # Remove leading/trailing whitespace from pattern
+              pattern=$(echo "$pattern" | xargs)
+              if [[ "$file" == *"$pattern"* ]]; then
+                echo "Excluding $file (matches pattern: $pattern)"
+                should_exclude=true
+                break
+              fi
+            done
+
+            # Add to upload list if not excluded
+            if [ "$should_exclude" = false ]; then
+              FILES_TO_UPLOAD+=("$file")
+              echo "Including $file for upload"
+            fi
+          fi
+        done
+
+        # Extract architectures from RPM filenames
+        ARCHES=()
+        for file in "${FILES_TO_UPLOAD[@]}"; do
+          # Skip .src.rpm and .noarch.rpm files
+          if [[ "$file" == *.src.rpm ]] || [[ "$file" == *.noarch.rpm ]]; then
+            continue
+          fi
+
+          # Extract architecture from filename (e.g., package-1.0-1.x86_64.rpm -> x86_64)
+          if [[ "$file" =~ \.([^.]+)\.rpm$ ]]; then
+            arch="${BASH_REMATCH[1]}"
+
+            # Add to ARCHES array if not already present
+            if [[ ! " ${ARCHES[*]} " == *" ${arch} "* ]]; then
+              ARCHES+=("$arch")
+              echo "Found architecture: $arch"
+            fi
+          fi
+        done
+
+        echo "Detected architectures: ${ARCHES[*]}"
+
+        # Map to the specific arch: *.x86_64.rpm -> x86_64 repo
+        # Map noarch rpm: *.noarch.rpm -> every arch repo
+        # Map source rpms: *.src.rpm -> source rpm repo
+
+        # Upload files organized by architecture
+        for arch in "${ARCHES[@]}"; do
+          echo "Processing architecture: $arch"
+
+          REPO_EXISTS=$(pulp  --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" \
+            rpm repository list --field name | jq -r ".[] | \
+            select(.name == \"${arch}\") | .name")
+
+          if [[ "$REPO_EXISTS" == "${arch}" ]]; then
+              echo "Repository '${arch}' exists"
+          else
+              echo "Repository '${arch}' does not exist."
+              exit 1
+          fi
+
+          # Upload arch-specific RPMs
+          for pkg in "${FILES_TO_UPLOAD[@]}"; do
+            if [[ "$pkg" == *."$arch".rpm ]]; then
+              echo "Uploading $pkg to $arch repository..."
+              set +e
+              pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
+                --file "${pkg}" --relative-path "$(basename "${pkg}")" \
+                --repository "$arch"
+              set -e
+              jq --arg pkg "${pkg}" --arg arch "${arch}" --arg pulprepo "${PULP_DOMAIN}/${arch}" \
+                '.rpmfiles += [{rpm: $pkg, arch: $arch, pulprepo: $pulprepo}]' \
+                "$RESULTS_FILE" > tmp.json && mv tmp.json "$RESULTS_FILE"
+            fi
+            # Upload .noarch.rpm files to this arch repository
+            if [[ "$pkg" == *.noarch.rpm ]]; then
+              echo "Uploading noarch $pkg to $arch repository..."
+              set +e
+              pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
+                --file "${pkg}" --relative-path "$(basename "${pkg}")" \
+                --repository "$arch"
+              set -e
+              jq --arg pkg "${pkg}" --arg arch "noarch" --arg pulprepo "${PULP_DOMAIN}/${arch}" \
+                '.rpmfiles += [{rpm: $pkg, arch: $arch, pulprepo: $pulprepo}]' \
+                "$RESULTS_FILE" > tmp.json && mv tmp.json "$RESULTS_FILE"
+            fi
+          done
+        done
+
+        # Upload .src.rpm files to source repository
+        for pkg in "${FILES_TO_UPLOAD[@]}"; do
+          if [[ "$pkg" == *.src.rpm ]]; then
+            echo "Uploading source $pkg to source repository..."
+            set +e
+            pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
+              --file "${pkg}" --relative-path "$(basename "${pkg}")" \
+              --repository "source"
+            set -e
+            jq --arg pkg "${pkg}" --arg arch "source" --arg pulprepo "${PULP_DOMAIN}/source" \
+              '.rpmfiles += [{rpm: $pkg, arch: $arch, pulprepo: $pulprepo}]' \
+              "$RESULTS_FILE" > tmp.json && mv tmp.json "$RESULTS_FILE"
+          fi
+        done
+
+        echo "Results written to: $RESULTS_FILE"
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function pulp() {
+    echo $* >> $(params.dataDir)/mock_pulp.txt
+    if [[ "$*" == *"domain show"* ]]; then
+        echo "{ \"name\": \"mydomain\" }"
+    elif [[ "$*" == *"rpm repository list"* ]]; then
+        echo "[ {\"name\": \"x86_64\"}, {\"name\": \"ppc64le\"}, {\"name\": \"s390x\"}, {\"name\": \"aarch64\"}, {\"name\": \"source\"} ]"
+    elif [[ "$*" == *"rpm content upload"* ]]; then
+        echo "Uploaded"
+    else
+        echo Error: Unexpected call
+        exit 1
+    fi
+}
+
+function select-oci-auth() {
+    echo Mock select-oci-auth called with: $*
+}
+
+function oras() {
+    echo Mock oras called with: $*
+    echo $* >> $(params.dataDir)/mock_oras.txt
+    local args="$*"
+
+    if [[ "$*" == "pull --registry-config"* ]]; then
+        echo "Mocking pulling files"
+
+        # Initialize a variable to store the value of the -o flag.
+        output_file_dir=""
+
+        # Loop through all arguments passed to the script.
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -o|--output)
+                    # Check if there is a next argument to capture.
+                    if [[ -n "$2" ]]; then
+                        # Capture the value of the next argument and store it.
+                        output_file_dir="$2"
+                        # Shift twice to move past both the flag and its value.
+                        shift 2
+                    fi
+                    ;;
+                *)
+                    # For any other arguments, just shift past them.
+                    shift
+                    ;;
+            esac
+        done
+
+        # Check if the output_file variable was successfully populated.
+        if [[ -n "$output_file_dir" ]]; then
+            echo "The captured output file dir is: $output_file_dir"
+        fi
+
+        if [[ "$args" == *"quay.io/test/happypath"* ]]; then
+            touch $output_file_dir/hello-2.12.1-6.fc44.aarch64.rpm
+            touch $output_file_dir/hello-2.12.1-6.fc44.ppc64le.rpm
+            touch $output_file_dir/hello-2.12.1-6.fc44.s390x.rpm
+            touch $output_file_dir/hello-2.12.1-6.fc44.src.rpm
+            touch $output_file_dir/hello-2.12.1-6.fc44.x86_64.rpm
+            touch $output_file_dir/hello-docs-2.12.1-6.fc44.noarch.rpm
+            touch $output_file_dir/hello-debuginfo-2.12.1-6.fc44.aarch64.rpm
+            touch $output_file_dir/hello-debuginfo-2.12.1-6.fc44.ppc64le.rpm
+            touch $output_file_dir/hello-debuginfo-2.12.1-6.fc44.s390x.rpm
+            touch $output_file_dir/hello-debuginfo-2.12.1-6.fc44.x86_64.rpm
+            touch $output_file_dir/hello-debugsource-2.12.1-6.fc44.aarch64.rpm
+            touch $output_file_dir/hello-debugsource-2.12.1-6.fc44.ppc64le.rpm
+            touch $output_file_dir/hello-debugsource-2.12.1-6.fc44.s390x.rpm
+            touch $output_file_dir/hello-debugsource-2.12.1-6.fc44.x86_64.rpm
+            # mimic having logs from each rpm build
+            mkdir -p $output_file_dir/logs
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.aarch64.rpm.log
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.ppc64le.rpm.log
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.s390x.rpm.log
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.src.rpm.log
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.x86_64.rpm.log
+            touch $output_file_dir/logs/hello-debuginfo-2.12.1-6.fc44.aarch64.rpm.log
+        elif [[ "$args" == *"quay.io/test/onlyrpms"* ]]; then
+            touch $output_file_dir/hello-2.12.1-6.fc44.x86_64.rpm
+            touch $output_file_dir/hello-debuginfo-2.12.1-6.fc44.x86_64.rpm
+            touch $output_file_dir/hello-debugsource-2.12.1-6.fc44.x86_64.rpm
+            # mimic having logs from each rpm build
+            mkdir -p $output_file_dir/logs
+            touch $output_file_dir/logs/hello-2.12.1-6.fc44.x86_64.rpm.log
+            touch $output_file_dir/logs/hello-debuginfo-2.12.1-6.fc44.x86_64.rpm.log
+            touch $output_file_dir/logs/hello-debugsource-2.12.1-6.fc44.x86_64.rpm.log
+        else
+            echo Error: Unexpected call
+            exit 1
+        fi
+
+    fi
+}

--- a/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+#
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Create a dummy pulp secret (and delete it first if it exists)
+kubectl delete secret pulp-task-pulp-secret --ignore-not-found
+kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml=abcdef123
+
+# Create a dummy pulp secret (and delete it first if it exists)
+kubectl delete secret pulp-task-pulp-secret-missing --ignore-not-found
+kubectl create secret generic pulp-task-pulp-secret-missing --from-literal=dummy=abcdef123

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpms-to-pulp-fail-missing-creds
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-rpms-to-pulp task with required parameters - but the pulp secret is missing.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/happypath@sha256:12345",
+                    "name": "test",
+                    "source": {
+                      "git": {
+                        "revision": "32c8f78c26e5831a87aa865ea80452fadbb3a95e",
+                        "url": "https://gitlab.example.com/rpms/test"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-rpms-to-pulp
+      params:
+        - name: SNAPSHOT_PATH
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: pulp-task-pulp-secret-missing
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
@@ -1,0 +1,196 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpms-to-pulp-only-x86-64-rpms
+spec:
+  description: |
+    Run the push-rpms-to-pulp task with required parameters - but only x86_64 rpms are expected.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/onlyrpms@sha256:12345",
+                    "name": "test",
+                    "source": {
+                      "git": {
+                        "revision": "32c8f78c26e5831a87aa865ea80452fadbb3a95e",
+                        "url": "https://gitlab.example.com/rpms/test"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-rpms-to-pulp
+      params:
+        - name: SNAPSHOT_PATH
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              ls -lR "$(params.dataDir)"
+
+              results=$(cat "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-rpms-to-pulp-results.json")
+              echo "$results"
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 1 ]; then
+                echo Error: oras was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 3   ]; then
+                echo Error: pulp was expected to be called 3 times. Actual calls:
+                cat "$(params.dataDir)/mock_pulp.txt"
+                exit 1
+              fi
+
+              # count how many rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | length')" != 1 ]; then
+                echo Error: there should be 1 rpmfile in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+              # count how x86_64 rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "x86_64")) | length')" != 1 ]; then
+                echo Error: there should be 1 x86_64 rpmfile in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+              # count how noarch rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "noarch")) | length')" != 0 ]; then
+                echo Error: there should be 0 noarch rpmfiles in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+              # count how source rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "source")) | length')" != 0 ]; then
+                echo Error: there should be 0 source rpmfiles in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
@@ -1,0 +1,199 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-rpms-to-pulp
+spec:
+  description: |
+    Run the push-rpms-to-pulp task with required parameters - a happy path scenario.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/happypath@sha256:12345",
+                    "name": "test",
+                    "source": {
+                      "git": {
+                        "revision": "32c8f78c26e5831a87aa865ea80452fadbb3a95e",
+                        "url": "https://gitlab.example.com/rpms/test"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-rpms-to-pulp
+      params:
+        - name: SNAPSHOT_PATH
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              ls -lR "$(params.dataDir)"
+
+              results=$(cat "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-rpms-to-pulp-results.json")
+              echo "$results"
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 1 ]; then
+                echo Error: oras was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 14   ]; then
+                echo Error: pulp was expected to be called 14 times. Actual calls:
+                cat "$(params.dataDir)/mock_pulp.txt"
+                exit 1
+              fi
+
+              # count how many rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | length')" != 9 ]; then
+                echo Error: there should be 9 rpmfiles in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+
+              # count how x86_64 rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "x86_64")) | length')" != 1 ]; then
+                echo Error: there should be 1 x86_64 rpmfile in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+
+              # count how noarch rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "noarch")) | length')" != 4 ]; then
+                echo Error: there should be 4 noarch rpmfiles in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+
+              # count how source rpmfiles are in the results
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "source")) | length')" != 1 ]; then
+                echo Error: there should be 1 source rpmfile in the results. Actual results:
+                echo "$results"
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
- simple tekton task that takes rpms from OCI images within a Snapshot and uploads to pulp repositories in a pulp domain.
- it assumes that pulp resources already exist.
- it also is opinionated towards which repositories are used.
- includes https://github.com/konflux-ci/release-service-utils/pull/527

Assisted-by: Cursor

## Relevant Jira
- RPRM-44

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
