### PR TITLE
fix: Preserve envfile during signing process

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -190,6 +190,12 @@ spec:
         chmod 600 ~/.ssh/known_hosts
 
         cd "$SIGNED_KMODS_PATH" || exit 1
+
+        # Backup envfile before signing process
+        if [ -f "envfile" ]; then
+            cp envfile /tmp/envfile.backup
+        fi
+
         # Copy unsigned kmods to signing server
         ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/kmods"
         scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/kmods/"
@@ -197,6 +203,11 @@ spec:
         sign_kmods
         # Copy back signed kmods to workspace
         scp "${SSH_OPTS[@]}" "${signUser}@${signHost}:~/kmods/*.ko" "${SIGNED_KMODS_PATH}"/
+
+        # Restore envfile after signing process
+        if [ -f "/tmp/envfile.backup" ]; then
+            cp /tmp/envfile.backup envfile
+        fi
     - name: create-trusted-artifact
       computeResources:
         limits:


### PR DESCRIPTION
envfile from previous task is lost because of scp command.
It makes push-oot-kmods task fail.
This commit saves it to /tmp before scp command to copy it back afterwards.

