### PR TITLE
chore: update internal tasks image to latest

### DIFF
--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -25,7 +25,7 @@ spec:
       description: Space separated string of embargoed CVEs if any are found, empty string otherwise
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -34,7 +34,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e56dd7c1875e352677af23c3d63ee5fb266c8a63
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -30,7 +30,7 @@ spec:
       description: Name of this Task Run to be made available to caller
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -37,7 +37,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -127,7 +127,7 @@ spec:
         secretName: checksum-keytab
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi
@@ -246,7 +246,7 @@ spec:
             wait -n
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi
@@ -359,7 +359,7 @@ spec:
         echo "Digest for windows content: $windows_digest"
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi
@@ -527,7 +527,7 @@ spec:
         # shellcheck disable=SC2029
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi
@@ -665,7 +665,7 @@ spec:
         ssh $SSH_OPTS "Remove-Item -LiteralPath \
         C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi
@@ -829,7 +829,7 @@ spec:
         mv "$SHA_SUM_PATH" "${SIGNED_DIR}/sha256sum.txt"
 
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 256Mi
@@ -914,7 +914,7 @@ spec:
         done
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -72,7 +72,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-gzip.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -70,7 +70,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-oras-pull.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-same-filename.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7a1d88df0e5aa21f6219db2a8732af87eed7ed73
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
## Describe your changes
We are still receiving CVE alerts in `stonesoup-int-srvc`; some tasks are running on old images.

This pr updates affected task digests from:
e56dd7c1875e352677af23c3d63ee5fb266c8a63 and 7a1d88df0e5aa21f6219db2a8732af87eed7ed73
to 002e438fd71196a7b4613308025358476acc1f8e
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
