### PR TITLE
fix: setup envfile path in extract-oot-kmods

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -129,9 +129,11 @@ spec:
                 cp -r "$tmp_dir$KMODS_PATH"/*.ko "$(params.dataDir)/$SIGNED_KMODS_PATH/"
                 echo "Copying envfile to get versions data..."
                 # Also extract envfile if it exists in this layer
-                if tar -tf "$tmp_dir/$LAYER" | grep -q "^envfile$"; then
-                   tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir" "envfile" --no-same-owner
-                    cp "$tmp_dir/envfile" "$(params.dataDir)/$SIGNED_KMODS_PATH/"
+                DRIVERS_DIR="$(dirname "${KMODS_PATH#/}")"
+                ENVFILE_PATH="${DRIVERS_DIR}/envfile"
+                if tar -tf "$tmp_dir/$LAYER" | grep -q "^${ENVFILE_PATH}$"; then
+                   tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir" "$ENVFILE_PATH" --no-same-owner
+                    cp "$tmp_dir/$ENVFILE_PATH" "$(params.dataDir)/$SIGNED_KMODS_PATH/"
                 fi
             else
                 echo "$KMODS_PATH not found in $LAYER so skipping layer..."


### PR DESCRIPTION
envfile should be extracted from the root path and not the drivers path

