### PR TITLE
fix: get annotations for oci_version

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -370,8 +370,7 @@ spec:
             arch_json="$(get-image-architectures "${IMAGE_REF}")"
             # The build-date label and Created values are not the same per architecture, but we don't support separate
             # tags per arch. So, we just use the first digest listed.
-            arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
-            os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
+            digest="$(jq -rs 'map(.digest) | .[0]' <<< "$arch_json")"
 
             # Get configMediaType from architecture info to determine artifact type
             config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
@@ -386,11 +385,15 @@ spec:
                 labels="{}"
             else
                 # This is a regular container image - use standard skopeo inspect
+                # use --raw option to get annotations c.f https://github.com/containers/skopeo/issues/1583
                 image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
-                  --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
+                  --raw docker://"${IMAGE_REF/@*}@${digest}" | jq -c)"
                 # For timestamp, use Labels.build-date and fallback to Created
                 build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
-                oci_version_raw="$(jq -r '.annotations."org.opencontainers.image.version" // ""' <<< "$image_metadata")"
+                # Get org.opencontainers.image.version from annotations, and fallback to Labels if not.
+                oci_version_raw="$(jq -r \
+                  '.annotations."org.opencontainers.image.version" // .Labels."org.opencontainers.image.version" // ""'\
+                  <<< "$image_metadata")"
                 labels="$(jq -c '.Labels' <<< "${image_metadata}")"
             fi
 

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -46,27 +46,27 @@ function skopeo() {
       return
   fi
 
-  if [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
+  if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/badimage"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/labels"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Goodlabel.with-dash": "labelvalue-with-dash", "Badlabel": "label with space"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/onlycreated"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}, "Created": "2024-07-29T02:17:29"}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/web-app"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/web-app"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}, "annotations": {"org.opencontainers.image.version": "1.2.3-beta"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/api-service"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/api-service"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/helm-chart"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags docker://quay.io/myorg/helm-chart"* ]]
   then
     # Helm chart should fail normal inspect and fall back to raw manifest
     return 1
@@ -74,9 +74,9 @@ function skopeo() {
   then
     echo '{"annotations": {"org.opencontainers.image.version": "2.0.1+alpha", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://"* ]]
   then
-    echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}, "annotations": {"org.opencontainers.image.version": "2.0.1+alpha"}}'
     return
   fi
 


### PR DESCRIPTION
We add '--raw' option to the skopeo command to get the annotations, see
[1] for more details. Also, to not rely on the machine which runs the
inspection, we inspect the first entry of the manifest list, assuming
that all manifests have the same annotations.
Finally, we fallback to the Labels in case
`org.opencontainers.image.version` is not in annotations list.

closes https://github.com/konflux-ci/release-service-catalog/issues/1455

[1] https://github.com/containers/skopeo/issues/1583