### PR TITLE
Fix finding Koji builds for promotion

### DIFF
--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -201,7 +201,6 @@ spec:
           builds=$(
             koji-cmd call --json-output listBuilds \
               userID="$USER_NAME" \
-              packageID="$componentName" \
               state=1 \
               source="$commitUrl" \
               draft=True

--- a/tasks/managed/promote-koji-draft-build/tests/mocks.sh
+++ b/tasks/managed/promote-koji-draft-build/tests/mocks.sh
@@ -44,9 +44,9 @@ EOF
 
 function koji() {
     echo "koji $@" >> "$(params.dataDir)/koji_calls.txt"
-    if [[ "$*" == *listBuilds*packageID=test-foo* ]]; then
+    if [[ "$*" == *listBuilds*source=git+https://gitlab.example.com/rpms/test-foo* ]]; then
         echo '[{"build_id": 1001, "creation_time": "2025-01-01 00:00:00.000000"}, {"build_id": 1002, "creation_time": "2025-01-01 01:00:00.000000"}]'
-    elif [[ "$*" == *listBuilds*packageID=test-bar* ]]; then
+    elif [[ "$*" == *listBuilds*source=git+https://gitlab.example.com/rpms/test-bar* ]]; then
         echo '[{"build_id": 2001, "creation_time": "2025-01-01 00:00:00.000000"}]'
     fi
 }

--- a/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
@@ -242,17 +242,16 @@ spec:
               }
 
               function test_list_builds() {
-                  packageID=$1
+                  url=$1
                   if assert_cmd_called_with koji --profile=koji call --json-output listBuilds \
                       userID=test \
-                      packageID="$packageID" \
                       state=1 \
-                      source="git+https://gitlab.example.com/rpms/$packageID#12345" \
+                      source="$url" \
                       draft=True
                   then
-                      echo "TEST PASSED: Koji build for $packageID was listed."
+                      echo "TEST PASSED: Koji build for source $url was listed."
                   else
-                      echo "TEST FAILED: Koji build for $packageID was not listed."
+                      echo "TEST FAILED: Koji build for source $url was not listed."
                       exit_code=1
                   fi
               }
@@ -290,8 +289,8 @@ spec:
 
               test_promote 1002
               test_promote 2001
-              test_list_builds test-foo
-              test_list_builds test-bar
+              test_list_builds 'git+https://gitlab.example.com/rpms/test-foo#12345'
+              test_list_builds 'git+https://gitlab.example.com/rpms/test-bar#12345'
               test_cmd_count 2 koji --profile=koji call promoteBuild
               test_cmd_count 3 kinit -kt
               test_kinit


### PR DESCRIPTION
The `packageID` attribute for finding builds for promotion is incorrectly set to the component name (which is slightly different than the package name).

To solve this, we can drop `packageID` from the search and use only the git URL to identify given component - this assumes that multiple components in a single release cannot share same git URL.

JIRA: RHELWF-13415

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
