### PR TITLE
fix: set resultArtifacts to src=dest for pushDiskImg

### DIFF
--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -340,7 +340,7 @@ spec:
           value: $(params.ociStorage)
         - name: resultArtifacts
           value:
-            - "$(tasks.push-disk-images.results.sourceDataArtifact)"
+            - "$(tasks.push-disk-images.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug


### PR DESCRIPTION
## Describe your changes
The task `update-cr-status` was passing only the source path: "$(tasks.push-disk-images.results.sourceDataArtifact)"

It must be "source=destination" like other pipelines, using params.dataDir: "$(tasks.push-disk images.results.sourceDataArtifact) =$(params.dataDir)"
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
