### PR TITLE
fix: collect-data task fix merge-json

### DIFF
--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -125,7 +125,7 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+      image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
       computeResources:
         limits:
           memory: 64Mi
@@ -282,7 +282,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+      image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -114,7 +114,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -104,7 +104,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -238,7 +238,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -231,7 +231,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -248,7 +248,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -262,7 +262,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -219,7 +219,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -240,7 +240,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -91,7 +91,7 @@ spec:
                   - foo
                 origin: foo
                 data:
-                  singleComponentMode: true
+                  singleComponentMode: false
                   one:
                     two: three
                     four:
@@ -211,7 +211,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -219,18 +219,18 @@ spec:
               echo Test that data result was set properly
               actual=$(jq -cS . "$(params.dataDir)/$(params.subdirectory)/data.json")
               expected=$(jq -cS . <<< \
-                '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"},"singleComponentMode":true}')
+                '{"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],"two":"three"},"singleComponentMode":false}')
               test "$actual" = "$expected"
 
               echo Test that the singleComponentMode result was properly set
-              test "$(params.singleComponentMode)" == "true"  
+              test "$(params.singleComponentMode)" == "false"  
 
   finally:
     - name: cleanup
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -212,7 +212,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -228,7 +228,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -229,7 +229,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -264,7 +264,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:8353253caa411bfce2e121d75127693785348f51
+            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
## Describe your changes
The merge-json script was using the jq // operator which treats boolean false as falsy, causing it to fall back to the first JSON value instead of preserving the false value from the second JSON.

Bumps collect-data to latest digest to get the script change and update the test to check that false is preserved.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
