### PR TITLE
fix(KONFLUX-10283): run fbc opt-in on bundle images

### DIFF
--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -197,12 +197,98 @@ spec:
             exit 1
         fi
 
-        # Extract container images for opt-in checking
-        container_images=$(jq -c '[.components[].containerImage]' "${SNAPSHOT_PATH}")
-        echo "INFO: Container images to check:"
-        echo "${container_images}" | jq .
+        # Initialize result tracking arrays for comprehensive validation
+        validation_failed=false
+        package_validation_results='[]'
+        target_versions='[]'
 
-        # === IIB SERVICE ACCOUNT SELECTION ===
+        echo "INFO: Processing all ${component_count} components for validation..."
+
+        RENDERED_CATALOG=/tmp/catalog.json
+        bundle_images='[]'
+        for ((i=0; i<component_count; i++)); do
+            fbc_fragment=$(jq -cr --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
+            echo "INFO: Processing component $((i+1))/${component_count}: ${fbc_fragment}"
+
+            # === PACKAGE VALIDATION ===
+            # Validate that all packages in this fragment are in the allowedPackages list
+            # and extract all bundle images while we are at it.
+            echo "  INFO: Validating packages in fragment..."
+            rm -f "${RENDERED_CATALOG}"
+            opm render "${fbc_fragment}" > "${RENDERED_CATALOG}"
+            actual_packages=$(jq -r 'select(.schema=="olm.package") | .name' < "${RENDERED_CATALOG}" | uniq)
+            component_bundle_images=$(jq -r \
+              'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' \
+              < "${RENDERED_CATALOG}" | uniq | jq -R . | jq -s .)
+            bundle_images=$(jq --argjson component_bundle_images \
+              "$component_bundle_images" '. += $component_bundle_images' <<< "$bundle_images")
+
+            component_package_valid=true
+            disallowed_packages='[]'
+
+            for package in ${actual_packages}; do
+              if jq -e --arg pkg "$package" '.fbc.allowedPackages | index($pkg)' "${DATA_FILE}" > /dev/null
+              then
+                echo "    SUCCESS: ${package} is allowed"
+              else
+                echo "    ERROR: ${package} is NOT in allowedPackages list"
+                disallowed_packages=$(jq --arg pkg "$package" '. += [$pkg]' <<< "$disallowed_packages")
+                component_package_valid=false
+                validation_failed=true
+              fi
+            done
+
+            # Record package validation result for this component
+            package_result=$(jq -n \
+              --arg fragment "$fbc_fragment" \
+              --argjson valid "$component_package_valid" \
+              --argjson disallowed "$disallowed_packages" \
+              '{
+                "fragment": $fragment,
+                "packageValidationPassed": $valid,
+                "disallowedPackages": $disallowed
+              }')
+            package_validation_results=$(jq '. += [$result]' \
+              --argjson result "$package_result" <<< "$package_validation_results")
+
+            # === OCP VERSION VALIDATION ===
+            # Extract OCP target version from fragment base image per ADR-0026
+            echo "  INFO: Extracting OCP target version from fragment base image annotation..."
+
+            # Get image metadata
+            image_metadata=$(skopeo inspect --retry-times 3 --raw "docker://${fbc_fragment}")
+            media_type=$(jq -r .mediaType <<< "${image_metadata}")
+            ocp_version=$(jq -r '.annotations."org.opencontainers.image.base.name"' <<< "${image_metadata}" \
+              | cut -d: -f2 | sed 's/"//g')
+
+            # Handle multiplatform images
+            if [[ "$media_type" == "application/vnd.oci.image.index.v1+json" ]] || \
+               [[ "$media_type" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+                echo "    INFO: Multiplatform image detected, extracting manifest"
+                arch_json=$(get-image-architectures "${fbc_fragment}")
+                manifest_image_sha="$(jq -rs 'map(.digest)[0]'  <<< "$arch_json")"
+                single_arch_fragment="${fbc_fragment%@*}@${manifest_image_sha}"
+
+                ocp_version=$(skopeo inspect --retry-times 3 --raw "docker://${single_arch_fragment}" \
+                 | jq -r '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed 's/"//g')
+            fi
+
+            # Validate OCP version format
+            ocp_version_pattern="^v[0-9]\.[0-9]+$"
+            if ! echo "${ocp_version}" | grep -Eq "${ocp_version_pattern}"; then
+                echo "    ERROR: Invalid OCP version format: '${ocp_version}'"
+                echo "    Expected format: vX.Y (e.g., v4.12)"
+                validation_failed=true
+                ocp_version="invalid"
+            else
+                echo "    SUCCESS: Found valid OCP version: ${ocp_version}"
+                target_versions=$(jq --arg version "$ocp_version" '. += [$version]' <<< "$target_versions")
+            fi
+        done
+        # Ensure all bundle images are unique across fragments
+        bundle_images=$(jq -c 'unique' <<< "$bundle_images")
+
+        # === CHECK ALL BUNDLE IMAGES FOR OPT-IN ===
         # Select appropriate IIB service account based on environment (moved here to fix unbound variable)
         echo "INFO: Selecting IIB service account based on environment..."
         if [ "${staged_index}" = "true" ]; then
@@ -226,9 +312,16 @@ spec:
         for attempt in $(seq 1 "$max_retries"); do
             echo "Validation attempt ${attempt}/${max_retries}..."
 
+            echo "DEBUG: About to create internal request with parameters:"
+            echo "DEBUG:   - containerImages=${bundle_images}"
+            echo "DEBUG:   - iibServiceAccountSecret=${iib_service_account_secret}"
+            echo "DEBUG:   - pyxisServer=$(params.pyxisServer)"
+            echo "DEBUG:   - taskGitUrl=$(params.taskGitUrl)"
+            echo "DEBUG:   - taskGitRevision=$(params.taskGitRevision)"
+
             # Create internal request with proper error handling
             if ! internal-request --pipeline "check-fbc-opt-in" \
-                                 -p containerImages="${container_images}" \
+                                 -p containerImages="${bundle_images}" \
                                  -p iibServiceAccountSecret="${iib_service_account_secret}" \
                                  -p pyxisServer="$(params.pyxisServer)" \
                                  -p taskGitUrl="$(params.taskGitUrl)" \
@@ -308,51 +401,6 @@ spec:
         echo "INFO: FBC opt-in check completed successfully"
         echo "Opt-in results:"
         echo "${opt_in_results}" | jq .
-
-        # Initialize result tracking arrays for comprehensive validation
-        validation_failed=false
-        package_validation_results='[]'
-        
-        echo "INFO: Processing all ${component_count} components for validation..."
-        
-        for ((i=0; i<component_count; i++)); do
-            fbc_fragment=$(jq -cr --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
-            echo "INFO: Processing component $((i+1))/${component_count}: ${fbc_fragment}"
-            
-            # === PACKAGE VALIDATION ===
-            # Validate that all packages in this fragment are in the allowedPackages list
-            echo "  INFO: Validating packages in fragment..."
-            actual_packages=$(opm render "${fbc_fragment}" | jq -r 'select(.schema=="olm.package") | .name')
-            
-            component_package_valid=true
-            disallowed_packages='[]'
-            
-            for package in ${actual_packages}; do
-              if jq -e --arg pkg "$package" '.fbc.allowedPackages | index($pkg)' "${DATA_FILE}" > /dev/null
-              then
-                echo "    SUCCESS: ${package} is allowed"
-              else
-                echo "    ERROR: ${package} is NOT in allowedPackages list"
-                disallowed_packages=$(jq --arg pkg "$package" '. += [$pkg]' <<< "$disallowed_packages")
-                component_package_valid=false
-                validation_failed=true
-              fi
-            done
-            
-            # Record package validation result for this component
-            package_result=$(jq -n \
-              --arg fragment "$fbc_fragment" \
-              --argjson valid "$component_package_valid" \
-              --argjson disallowed "$disallowed_packages" \
-              '{
-                "fragment": $fragment,
-                "packageValidationPassed": $valid,
-                "disallowedPackages": $disallowed
-              }')
-            package_validation_results=$(jq '. += [$result]' \
-              --argjson result "$package_result" <<< "$package_validation_results")
-            
-        done
 
         # === VALIDATION SUMMARY ===
         echo "INFO: Summarizing validation results..."

--- a/tasks/managed/prepare-fbc-parameters/tests/mocks.sh
+++ b/tasks/managed/prepare-fbc-parameters/tests/mocks.sh
@@ -18,10 +18,10 @@ function kubectl() {
     # Check if this is the failure propagation test based on the allowedPackages in data.json
     if [ -f "$(params.dataDir)/data.json" ] && grep -q "non-matching-package" "$(params.dataDir)/data.json"; then
       # Return mock opt-in results for failure propagation test (all opted in, but packages will fail validation)
-      echo '{"optInResults": [{"containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297", "fbcOptIn": true}]}'
+      echo '{"optInResults": [{"containerImage": "quay.io/joelanford/example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/joelanford/example-operator-bundle:0.2.0", "fbcOptIn": true}]}'
     else
-      # Return mock opt-in results for successful integration test
-      echo '{"optInResults": [{"containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297", "fbcOptIn": true}, {"containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297", "fbcOptIn": true}]}'
+      # Return mock opt-in results for successful integration test - bundle images from the FBC fragment
+      echo '{"optInResults": [{"containerImage": "quay.io/joelanford/example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/joelanford/example-operator-bundle:0.2.0", "fbcOptIn": true}]}'
     fi
   else
     # Forward other kubectl calls to the real command


### PR DESCRIPTION
When changing the location of the FBC opt-in check, I erroneously was just submitting the FBC fragments instead of extracting the bundle images. With this change, we extract the bundle images at the same time that we are rendering the catalogs to check for package name validation. We then merge all bundle images across the fragments and submit all unique bundles to the internal request to check for opt-in status.

Resolves: KONFLUX-10283

Signed-off-by: arewm <arewm@users.noreply.github.com>

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
