### PR TITLE
fix(RELEASE-1701): return latest advisory URL when all components already released

### DIFF
--- a/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -53,6 +53,10 @@ spec:
       value: $(tasks.filter-already-released-advisory-images-task.results.result)
     - name: unreleased_components
       value: $(tasks.filter-already-released-advisory-images-task.results.unreleased_components)
+    - name: advisory_url
+      value: $(tasks.filter-already-released-advisory-images-task.results.advisory_url)
+    - name: advisory_internal_url
+      value: $(tasks.filter-already-released-advisory-images-task.results.advisory_internal_url)
     - name: internalRequestPipelineRunName
       value: $(tasks.filter-already-released-advisory-images-task.results.internalRequestPipelineRunName)
     - name: internalRequestTaskRunName

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -187,15 +187,21 @@ spec:
               echo "No existing advisories found."
           fi
 
+          # Track the latest advisory that contains matching content
+          # EXISTING_ADVISORIES is sorted by modification time (newest first)
+          LATEST_ADVISORY_FILE=""
+
           EXISTING_CONTENT=/tmp/existing_content.json
           for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
               ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
               yq -o=json ".spec${spec_content_type} // []" "${ADVISORY_FILE}" > "$EXISTING_CONTENT"
-
               echo "Processing advisory: ${ADVISORY_FILE}"
               echo "Existing content in advisory: "
               cat "$EXISTING_CONTENT"
 
+              # Check if this advisory contains any matching content before filtering
+              CONTENT_BEFORE_FILTER=$(cat "$CONTENT_FILE")
+              
               # Update CONTENT by removing entries that already exist in the advisory
               if [ "$(params.contentType)" == "generic" ]; then
                 # Use purl as unique key for generic artifacts
@@ -221,15 +227,28 @@ spec:
               echo "Remaining entries after filtering:"
               cat "$CONTENT_FILE"
 
+              CONTENT_BEFORE_COUNT=$(jq 'length' <<< "$CONTENT_BEFORE_FILTER")
+              CONTENT_AFTER_COUNT=$(jq 'length' "$CONTENT_FILE")
+              if [[ $CONTENT_BEFORE_COUNT -gt $CONTENT_AFTER_COUNT ]]; then
+                if [[ -z "$LATEST_ADVISORY_FILE" ]]; then
+                  LATEST_ADVISORY_FILE="$ADVISORY_FILE"
+                  FILTERED_COUNT=$((CONTENT_BEFORE_COUNT - CONTENT_AFTER_COUNT))
+                  echo "Tracked latest advisory: $LATEST_ADVISORY_FILE (filtered $FILTERED_COUNT items)"
+                fi
+              fi
+
               # If after filtering, no entries are left, then we can exit early
               if jq -e 'length == 0' "$CONTENT_FILE" >/dev/null; then
-                  echo "Matching advisory exists: ${ADVISORY_FILE}. Skipping creation."
-                  ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${ADVISORY_FILE}"
-                  ADVISORY_TYPE=$(yq -r '.spec.type' "${ADVISORY_FILE}")
-                  ADVISORY_NAME=$(yq -r '.metadata.name' "${ADVISORY_FILE}")
+                  echo "All content found in existing advisories. Skipping creation."
+                  echo "Returning advisory: $LATEST_ADVISORY_FILE"
+                  
+                  ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${LATEST_ADVISORY_FILE}"
+                  ADVISORY_TYPE=$(yq -r '.spec.type' "${LATEST_ADVISORY_FILE}")
+                  ADVISORY_NAME=$(yq -r '.metadata.name' "${LATEST_ADVISORY_FILE}")
                   ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
                   echo -n "Success" > "$(results.result.path)"
                   echo -n "${ADVISORY_URL}" > "$(results.advisory_url.path)"
+                  echo -n "$ADVISORY_INTERNAL_URL" > "$(results.advisory_internal_url.path)"
                   exit 0
               fi
           done

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -16,8 +16,8 @@ function git() {
     mkdir -p "$gitRepo"/data/advisories/dev-tenant/2024/1442
 
     touch -d "@1712012345" "$gitRepo"/data/advisories/dev-tenant/2025/1602
-    touch -d "@1712012344" "$gitRepo"/data/advisories/dev-tenant/2024/1452
-    touch -d "@1708012343" "$gitRepo"/data/advisories/dev-tenant/2025/1602
+    touch -d "@1712012344" "$gitRepo"/data/advisories/dev-tenant/2025/1601
+    touch -d "@1708012343" "$gitRepo"/data/advisories/dev-tenant/2024/1452
     touch -d "@1704012342" "$gitRepo"/data/advisories/dev-tenant/2024/1442
   elif [[ "$1" == "sparse-checkout" ]]; then
     : # no-op
@@ -51,7 +51,6 @@ function yq() {
   elif [[ "$2" == ".metadata.name" ]]; then
     echo "${advisory_year}:${advisory_num}"
   else
-
     echo "Returning advisory content for ${advisory_year}/${advisory_num}" >&2
 
     case "$advisory_num" in

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-all-images-found-latest
+spec:
+  description: |
+    Verifies that when all images are found in existing advisories,
+    the task returns the latest advisory URL (not just any matching advisory).
+    
+    Test scenario:
+    - Input contains 2 images: alpha123 and beta123
+    - Mock creates 4 advisories with timestamps (1602=newest, 1442=oldest)
+    - Advisory 1601 contains alpha123
+    - Advisory 1602 contains beta123 (newest with matching content)
+    - Since all images are found in existing advisories, no new advisory is created
+    - Task should return advisory 1602 (the latest one with matching content)
+    
+    This ensures retry scenarios return consistent, predictable results
+    (always the latest advisory, not the last one checked in the loop).
+  tasks:
+    - name: run-task
+      taskRef:
+        name: create-advisory-task
+      params:
+        - name: advisory_json
+          value: >-
+            H4sIACi17mgAA91RUWvbMBB+768Iek6s2u1CEYxljEH3NjroSynlIl9tUVnSpHNICPvvO8lOGtjT9jhjZN9339199+koQvTtqOnFtELVzc3yDDgYUCjxgO3iHmjxfYLFO2GHMRnvmFNXTXVzkUkUEQZOUKgZ1iE34lNJULiHIVhUM1ehvWMKHQrn4f7HZ47SwfmQTModMNHiHDPRB6NP+BQsRYtJRxNoUlNSlxA39Ha8zJ7jpYj4ihGdRp72JHqikJSUrdepmqVW2g/SeS4Uz7yMd4SOhDoKM0BXyo4FBeMwfssYj/k5wqEyXs49ZESLkHCTemg+rBXY0APbXQQEnwz5eOCymb6aHDxV5b2hKwJ3dXXNoYW8R9YDUfeGUNMY81wY2vVtvooxWg7DW3dyXPqALhHot01RsNUtfnof/sIFH/9Q3fsU6vUq9tM16V3e9yhezR7b/PPl8euquW6aFe9ym4HA/WdXyvDOW3CdnD6Vj53cS4cks9HNpq5qfsXzL36Wf+/iFunfTGyKiWzG1uJ/ZSIfV78BdpMq4dQDAAA=
+          # advisory_json string before `gzip -c|base64 -w 0` encoding:
+          # {"product_id":123,"product_name":"Red Hat Product","product_version":"1.2.3","product_stream":"tp1",
+          # "cpe":"cpe:/a:example:product:el8","type":"RHSA","synopsis":"test synopsis","topic":"test topic",
+          # "description":"test description","solution":"test solution","references":["https://docs.example.com/notes"],
+          # "content":{"images":[{"containerImage":"quay.io/example/release@sha256:alpha123",
+          # "repository":"example-stream/release","tags":["v1.0", "latest"],"architecture":"amd64",
+          # "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+          # "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}},{"containerImage":"quay.io/example/release@sha256:beta123",
+          # "repository":"example-stream/release","tags":["v2.0", "stable"],"architecture":"amd64",
+          # "purl":"pkg:example/openstack@256:abcde?repository_url=quay.io/example/rhosp16-rhel8","cves":{"fixed":{
+          # "CVE-2022-1234":{"packages":["pkg:golang/golang.org/x/net/http2@1.11.1"]}}}}]}}
+        - name: origin
+          value: dev-tenant
+        - name: application
+          value: "test-app"
+        - name: config_map_name
+          value: "create-advisory-test-cm"
+        - name: advisory_secret_name
+          value: "create-advisory-secret"
+        - name: errata_secret_name
+          value: "create-advisory-errata-secret"
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+    - name: check-result
+      params:
+        - name: advisory-url
+          value: $(tasks.run-task.results.advisory_url)
+        - name: result-status
+          value: $(tasks.run-task.results.result)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: advisory-url
+            type: string
+          - name: result-status
+            type: string
+        steps:
+          - name: verify-latest-advisory-returned
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              EXPECTED_URL="https://access.redhat.com/errata/RHSA-2025:1602"
+
+              if [[ "$(params.result-status)" != "Success" ]]; then
+                  echo "Task did not succeed. Status: $(params.result-status)"
+                  exit 1
+              fi
+
+              if [[ "$(params.advisory-url)" != "$EXPECTED_URL" ]]; then
+                  echo "Expected advisory URL: $EXPECTED_URL"
+                  echo "Got advisory URL: $(params.advisory-url)"
+                  exit 1
+              fi
+
+              echo "SUCCESS: Correctly returned latest advisory URL: $(params.advisory-url)"

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -33,6 +33,10 @@ spec:
       description: The name of the InternalRequest TaskRun
     - name: unreleased_components
       description: List of components that still need to be released encoded as a gzipped base64 string
+    - name: advisory_url
+      description: URL of the latest matching advisory when all components are already released
+    - name: advisory_internal_url
+      description: Internal URL of the latest matching advisory when all components are already released
   volumes:
     - name: advisory-secret
       secret:
@@ -119,9 +123,15 @@ spec:
             | gzip -c \
             | base64 -w 0)
           echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
+          echo -n "" > "$(results.advisory_url.path)"
+          echo -n "" > "$(results.advisory_internal_url.path)"
           echo -n "Success" > "$(results.result.path)"
           exit 0
         fi
+
+        # Track the latest advisory that contains matching content
+        # EXISTING_ADVISORIES is sorted by modification time (newest first)
+        LATEST_ADVISORY_FILE=""
 
         EXISTING_CONTENT=/tmp/existing_content.json
         # Use a mutable working set for progressive filtering across advisories
@@ -131,6 +141,9 @@ spec:
           yq -o=json '.spec.content.images // []' "$ADVISORY_FILE" > "$EXISTING_CONTENT"
 
           echo "Comparing against: $ADVISORY_FILE"
+
+          # Check if this advisory contains any matching content before filtering
+          ARCH_IMAGES_BEFORE_FILTER="$ARCH_IMAGES"
 
           # Filter arch-specific images using original triple-match logic
           ARCH_IMAGES=$(echo "$ARCH_IMAGES" | jq --slurpfile existing "$EXISTING_CONTENT" '
@@ -143,10 +156,36 @@ spec:
               )) | length == 0)
             ))')
 
+          ARCH_IMAGES_BEFORE_COUNT=$(jq 'length' <<< "$ARCH_IMAGES_BEFORE_FILTER")
+          ARCH_IMAGES_AFTER_COUNT=$(jq 'length' <<< "$ARCH_IMAGES")
+          if [[ $ARCH_IMAGES_BEFORE_COUNT -gt $ARCH_IMAGES_AFTER_COUNT ]]; then
+            if [[ -z "$LATEST_ADVISORY_FILE" ]]; then
+              LATEST_ADVISORY_FILE="$ADVISORY_FILE"
+              FILTERED_COUNT=$((ARCH_IMAGES_BEFORE_COUNT - ARCH_IMAGES_AFTER_COUNT))
+              echo "Tracked latest advisory: $LATEST_ADVISORY_FILE (filtered $FILTERED_COUNT items)"
+            fi
+          fi
+
           # If no arch images remain, all components are released
           if jq -e 'length == 0' <<< "$ARCH_IMAGES" >/dev/null; then
             echo "All arch images in the snapshot have already been released in advisories. Stopping pipeline."
             echo -n "[]" | gzip -c | base64 -w 0 > "$(results.unreleased_components.path)"
+            
+            echo "Returning advisory: $LATEST_ADVISORY_FILE"
+            ADVISORY_TYPE=$(yq -r '.spec.type' "$LATEST_ADVISORY_FILE")
+            ADVISORY_NAME=$(yq -r '.metadata.name' "$LATEST_ADVISORY_FILE")
+            
+            if [[ "${GIT_REPO}" == *"/rhtap-release/"* ]]; then
+              ADVISORY_URL_PREFIX="https://access.stage.redhat.com/errata"
+            else
+              ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
+            fi
+            
+            LATEST_ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
+            LATEST_ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${LATEST_ADVISORY_FILE}"
+            
+            echo -n "$LATEST_ADVISORY_URL" > "$(results.advisory_url.path)"
+            echo -n "$LATEST_ADVISORY_INTERNAL_URL" > "$(results.advisory_internal_url.path)"
             echo -n "Success" > "$(results.result.path)"
             exit 0
           fi
@@ -161,4 +200,6 @@ spec:
         # Map back to original components and get unique names
         UNRELEASED_COMPONENTS=$(echo "$ARCH_IMAGES" | jq -c '[.[].name] | unique' | gzip -c | base64 -w 0)
         echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
+        echo -n "" > "$(results.advisory_url.path)"
+        echo -n "" > "$(results.advisory_internal_url.path)"
         echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
@@ -49,7 +49,12 @@ function yq() {
   advisory_path="$3"
   advisory_num=$(echo "$advisory_path" | awk -F'/' '{print $(NF-1)}')
 
-  if [[ "$2" == ".spec.content.images // []" ]]; then
+  if [[ "$2" == ".spec.type" ]]; then
+    echo "RHBA"
+  elif [[ "$2" == ".metadata.name" ]]; then
+    advisory_year=$(echo "$advisory_path" | awk -F'/' '{print $(NF-2)}')
+    echo "${advisory_year}:${advisory_num}"
+  elif [[ "$2" == ".spec.content.images // []" ]]; then
     case "$advisory_num" in
       1601)
         # Include entries that match our get-image-architectures mock digests

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-all-components-released.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-all-components-released.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-all-components-released
+spec:
+  description: |
+    Test the filter-already-released-advisory-images-task when all components
+    are already released. Should return latest advisory URL and empty unreleased components.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: transformedSnapshot
+          # Transformed snapshot with arch-specific images before `gzip -c|base64 -w 0` encoding:
+          # '[{"name":"released-component","containerImage":"registry.redhat.io/test@sha256:releasedarch123","tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test","originalComponent":"released-component","architecture":"amd64"}]'
+          value: 'H4sIAKei1mgAA32PsQ6CQBBEez9ja0BBpaAyofIbCMXm2Nxtwt2RvdWEGP9diMEO63nzMtO9IKAnaEBoJEw05Cb6KQYKChmYGBQ5kNw92i9lOanMhdDgUAuOR6Wkt+SwutbNJkExrqzOi0HRJmg6eJbFCfpsEUwxsUaZ921LTVy+hfla+QtHYcsBx/a3fOfOOouVjD5kPYN+qC/w7g8f+pQW4AYBAAA='
+        - name: origin
+          value: "test-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+        - name: unreleased_components
+          value: "$(tasks.run-filter-task.results.unreleased_components)"
+        - name: latest_advisory_url
+          value: "$(tasks.run-filter-task.results.advisory_url)"
+        - name: latest_advisory_internal_url
+          value: "$(tasks.run-filter-task.results.advisory_internal_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: unreleased_components
+            type: string
+          - name: latest_advisory_url
+            type: string
+          - name: latest_advisory_internal_url
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating filter task result for all components released scenario..."
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo "Task result was not Success: $(params.result)"
+                exit 1
+              fi
+
+              # Verify unreleased components list is empty
+              UNRELEASED_COMPONENTS=$(base64 -d <<< "$(params.unreleased_components)" | gunzip)
+              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED_COMPONENTS")
+              if [[ "$UNRELEASED_COUNT" -ne 0 ]]; then
+                echo "Expected 0 unreleased components, but found $UNRELEASED_COUNT"
+                exit 1
+              fi
+
+              # Verify latest advisory URLs are provided
+              if [[ -z "$(params.latest_advisory_url)" ]]; then
+                echo "Expected latest_advisory_url to be provided when all components are released"
+                exit 1
+              fi
+
+              if [[ -z "$(params.latest_advisory_internal_url)" ]]; then
+                echo "Expected latest_advisory_internal_url to be provided when all components are released"
+                exit 1
+              fi
+
+              echo "Latest advisory URL: $(params.latest_advisory_url)"
+              echo "Latest advisory internal URL: $(params.latest_advisory_internal_url)"
+
+              echo "Validation successful!"

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -82,6 +82,12 @@ spec:
     - name: environment
       type: string
       description: The environment for the advisory to be published. Options are stage and production
+    - name: latest_advisory_url
+      type: string
+      description: URL of the latest matching advisory when all components are already released
+    - name: latest_advisory_internal_url
+      type: string
+      description: Internal URL of the latest matching advisory when all components are already released
   volumes:
     - name: workdir
       emptyDir: {}
@@ -293,9 +299,13 @@ spec:
 
         internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
         internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
+        latestAdvisoryUrl="$(jq -jr '.advisory_url // ""' <<< "${results}")"
+        latestAdvisoryInternalUrl="$(jq -jr '.advisory_internal_url // ""' <<< "${results}")"
         echo "Internal request details:"
         echo "- Pipeline run: ${internalRequestPipelineRunName}"
         echo "- Task run: ${internalRequestTaskRunName}"
+        echo "- Latest advisory URL: ${latestAdvisoryUrl}"
+        echo "- Latest advisory internal URL: ${latestAdvisoryInternalUrl}"
 
         if [[ "$(jq -r '.result' <<< "$results")" == "Success" ]]; then
           echo "Image filtering successful"
@@ -330,13 +340,26 @@ spec:
             cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
             echo -n "Success" > "$(results.result.path)"
             echo -n "true" > "$(results.skip_release.path)"
-            jq -n --rawfile snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+            
+            # Write the latest advisory URLs to results
+            echo -n "$latestAdvisoryUrl" > "$(results.latest_advisory_url.path)"
+            echo -n "$latestAdvisoryInternalUrl" > "$(results.latest_advisory_internal_url.path)"
+            
+            # Create results file with advisory information (same format as create-advisory)
+            jq -n --arg url "$latestAdvisoryUrl" --arg internal_url "$latestAdvisoryInternalUrl" \
+              '{"advisory": {"url": $url, "internal_url": $internal_url}}' | tee "$RESULTS_FILE"
             exit 0
           fi
 
           cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
           echo -n "Success" > "$(results.result.path)"
           echo -n "false" > "$(results.skip_release.path)"
+          
+          # Set advisory URL results to empty when components need release
+          echo -n "" > "$(results.latest_advisory_url.path)"
+          echo -n "" > "$(results.latest_advisory_internal_url.path)"
+          
+          # Create results file with filtered snapshot data only
           jq -n --rawfile snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
         else
           echo "Filtering failed. Results:"

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -19,14 +19,16 @@ function get-image-architectures() {
 
 function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
-  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  if [[ "$*" == *"get internalrequest"*"-o=jsonpath={.status.results}"* ]]
   then
     UNRELEASED=$(echo -n '["new-component", "multi-repo-component", "single-repo-component"]' | gzip -c | base64 -w 0)
     echo '{
       "result": "Success",
       "unreleased_components": "'"$UNRELEASED"'",
       "internalRequestPipelineRunName": "test-pipeline-run",
-      "internalRequestTaskRunName": "test-task-run"
+      "internalRequestTaskRunName": "test-task-run",
+      "advisory_url": "https://access.redhat.com/errata/RHBA-2024:1234",
+      "advisory_internal_url": "https://gitlab.example.com/repo/-/raw/main/data/advisories/dev/2024/1234/advisory.yaml"
     }'
   else
     /usr/bin/kubectl "$@"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-all-components-released
+spec:
+  description: |
+    Test the filter-already-released-advisory-images managed task when all components
+    are already released. Should return latest advisory URL and skip_release=true.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "already-released-component",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/repo",
+                        "rh-registry-repo": "quay.io/redhat-pending/repo"
+                      }
+                    ],
+                    "containerImage": "quay.io/redhat-pending/repo@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: skip_release
+            type: string
+          - name: latest_advisory_url
+            type: string
+          - name: latest_advisory_internal_url
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Check that skip_release is set to true (pipeline should be skipped)
+              if [ "$(params.skip_release)" != "true" ]; then
+                echo "skip_release should be true when all components are already released"
+                exit 1
+              fi
+
+              # Check that the result was properly set to Success
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+
+              # Check that latest advisory URLs are provided
+              if [ -z "$(params.latest_advisory_url)" ]; then
+                echo "Expected latest_advisory_url to be provided when all components are released"
+                exit 1
+              fi
+
+              if [ -z "$(params.latest_advisory_internal_url)" ]; then
+                echo "Expected latest_advisory_internal_url to be provided when all components are released"
+                exit 1
+              fi
+
+              echo "Latest advisory URL: $(params.latest_advisory_url)"
+              echo "Latest advisory internal URL: $(params.latest_advisory_internal_url)"
+
+              # Check that results file contains advisory information
+              base_dir="$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              results_file="$base_dir/filter-already-released-advisory-images-results.json"
+              if [ ! -f "$results_file" ]; then
+                echo "Results file not found: $results_file"
+                exit 1
+              fi
+
+              # Verify the results file contains advisory information
+              if ! jq -e '.advisory.url' "$results_file" >/dev/null; then
+                echo "Results file should contain advisory.url"
+                exit 1
+              fi
+
+              if ! jq -e '.advisory.internal_url' "$results_file" >/dev/null; then
+                echo "Results file should contain advisory.internal_url"
+                exit 1
+              fi
+
+              echo "All assertions passed: all components released correctly handled"
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: latest_advisory_url
+          value: $(tasks.run-task.results.latest_advisory_url)
+        - name: latest_advisory_internal_url
+          value: $(tasks.run-task.results.latest_advisory_internal_url)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
When all images in a snapshot are already released in advisories, the filter task now returns the URL of the latest matching advisory instead of no URL. This addresses user confusion during retries where they received older advisory URLs.

- Add latest_advisory_url and latest_advisory_internal_url results
- Write results file with advisory info for update-cr-status
- Update pipeline to include filter task results
- Add comprehensive tests for new functionality

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
