### PR TITLE
fix: fetch back labels properly

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -21,8 +21,9 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ digest_sha }}" -> The image digest of the respective component
 * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
   repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
-* "{{ oci_version }}" -> The version from OCI image annotations
-  (extracts org.opencontainers.image.version annotation and converts + to _ for tag compliance)
+* "{{ oci_version }}" -> The version from OCI image annotations for Helm charts as media type, and from OCI image
+  labels for the other supported media types (extracts org.opencontainers.image.version and converts + to _ for
+  tag compliance)
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -29,8 +29,9 @@ spec:
     * "{{ digest_sha }}" -> The image digest of the respective component
     * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
       repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
-    * "{{ oci_version }}" -> The version from OCI image annotations
-      (extracts org.opencontainers.image.version annotation and converts + to _ for tag compliance)
+    * "{{ oci_version }}" -> The version from OCI image annotations for Helm charts as media type, and from OCI image
+      labels for the other supported media types (extracts org.opencontainers.image.version and converts + to _ for
+      tag compliance)
 
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
   params:
@@ -370,7 +371,8 @@ spec:
             arch_json="$(get-image-architectures "${IMAGE_REF}")"
             # The build-date label and Created values are not the same per architecture, but we don't support separate
             # tags per arch. So, we just use the first digest listed.
-            digest="$(jq -rs 'map(.digest) | .[0]' <<< "$arch_json")"
+            arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
+            os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
 
             # Get configMediaType from architecture info to determine artifact type
             config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
@@ -385,14 +387,13 @@ spec:
                 labels="{}"
             else
                 # This is a regular container image - use standard skopeo inspect
-                # use --raw option to get annotations c.f https://github.com/containers/skopeo/issues/1583
                 image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
-                  --raw docker://"${IMAGE_REF/@*}@${digest}" | jq -c)"
+                  --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
                 # For timestamp, use Labels.build-date and fallback to Created
                 build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
                 # Get org.opencontainers.image.version from annotations, and fallback to Labels if not.
                 oci_version_raw="$(jq -r \
-                  '.annotations."org.opencontainers.image.version" // .Labels."org.opencontainers.image.version" // ""'\
+                  '.Labels."org.opencontainers.image.version" // ""'\
                   <<< "$image_metadata")"
                 labels="$(jq -c '.Labels' <<< "${image_metadata}")"
             fi

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -46,27 +46,27 @@ function skopeo() {
       return
   fi
 
-  if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/badimage"* ]]
+  if [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/badimage"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/labels"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/labels"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "Goodlabel": "labelvalue", "Goodlabel.with-dash": "labelvalue-with-dash", "Badlabel": "label with space"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/onlycreated"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/onlycreated"* ]]
   then
     echo '{"Labels": {"not-a-build-date": "2024-07-29T02:17:29"}, "Created": "2024-07-29T02:17:29"}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/web-app"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/web-app"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}, "annotations": {"org.opencontainers.image.version": "1.2.3-beta"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/api-service"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/api-service"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags docker://quay.io/myorg/helm-chart"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/helm-chart"* ]]
   then
     # Helm chart should fail normal inspect and fall back to raw manifest
     return 1
@@ -74,9 +74,9 @@ function skopeo() {
   then
     echo '{"annotations": {"org.opencontainers.image.version": "2.0.1+alpha", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
     return
-  elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://"* ]]
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://"* ]]
   then
-    echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}, "annotations": {"org.opencontainers.image.version": "2.0.1+alpha"}}'
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "org.opencontainers.image.version": "2.0.1+alpha"}}'
     return
   fi
 


### PR DESCRIPTION
As a follow-up of [1] who broke the ability to get the labels properly.

[1] https://github.com/konflux-ci/release-service-catalog/pull/1456

