### PR TITLE
fix: support merge_group context in tektor validation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -190,7 +190,13 @@ jobs:
           verbose: true
           task-dir: ./tasks
           params: |
-            taskGitRevision=${{ github.event.pull_request.head.ref }}
-            taskGitUrl=${{ github.event.pull_request.head.repo.html_url }}
+            taskGitRevision=${{ 
+              github.event.pull_request.head.ref || 
+              github.event.merge_group.head_ref 
+            }}
+            taskGitUrl=${{ 
+              github.event.pull_request.head.repo.html_url || 
+              github.event.merge_group.head_repo.html_url 
+            }}
             verify_ec_task_git_revision=main
             mobster_tasks_git_revision=main


### PR DESCRIPTION
## Describe your changes
### Summary
- Fix tektor validation failures in GitHub merge queues
- Add fallback to merge_group context when pull_request unavailable

### Problem
The `check-resources-with-tektor` workflow fails when run in merge
queues because `github.event.pull_request` context is not available
in `merge_group` events. This causes `taskGitRevision` and
`taskGitUrl` parameters to be empty, resulting in tektor validation
errors: "must specify one of 'url' or 'repo'".

### Solution
Use conditional expressions (`||`) to fall back to `merge_group`
context values when `pull_request` context is unavailable:
- `github.event.pull_request.head.ref || github.event.merge_group.head_ref`
- `github.event.pull_request.head.repo.html_url || github.event.merge_group.head_repo.html_url`

## Relevant Jira
N/A

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`