### PR TITLE
fix: add missing rpmPath field in data schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -755,6 +755,10 @@
         "checksumKeytab": {
           "type": "string",
           "description": "Secret containing keytab file for the Kerberos user/server"
+        },
+        "rpmPath": {
+          "type": "string",
+          "description": "Directory where RPM packages will be pushed"
         }
       }
     },
@@ -1601,7 +1605,8 @@
               "signing-secret",
               "signingAuthor",
               "checksumFingerprint",
-              "checksumKeytab"
+              "checksumKeytab",
+              "rpmPath"
             ]
           }
         }


### PR DESCRIPTION
rpmPath used by push-oot-kmods pipeline is missing in data file

