### PR TITLE
fix: pyxis opt-in checks were failing

### DIFF
--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -58,10 +58,6 @@ spec:
           memory: 512Mi
           cpu: 200m
       env:
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-bundle.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
         - name: PYXIS_URL
           value: https://pyxis.engineering.redhat.com/v1
         - name: PYXIS_SERVER
@@ -89,6 +85,7 @@ spec:
         echo "${KRB5_CONF_CONTENT}" > "${KRB5_TEMP_CONF}"
         export KRB5_CONFIG="${KRB5_TEMP_CONF}"
         export KRB5_TRACE=/dev/stderr
+        export KRB5CCNAME=/tmp/krb5cc_0
 
         retry 5 kinit -V "${KRB5_PRINCIPAL}" -k -t "/tmp/keytab"
 


### PR DESCRIPTION
## Describe your changes

Removing unnecessary environment variables that were affecting the curl. These are not used in internal requests and they prevented us from being able to properly query pyxis.

Also reused a pattern of explicitly setting the KRB5CCNAME variable.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
