### PR TITLE
fix(KONFLUX-1443): deduplicate FBC index images per target

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -594,6 +594,26 @@ spec:
         # Execute the multi-OCP processing
         process_all_ocp_groups
 
+        # Deduplicate results: keep only the last component per unique target_index (the last one)
+        # This ensures downstream tasks (collect-index-images, create-pyxis-image) use the correct digest
+        UNIQUE_TARGETS=$(jq -r '[.components[].target_index] | unique | length' "$RESULTS_FILE")
+        TOTAL_COMPONENTS=$(jq -r '.components | length' "$RESULTS_FILE")
+
+        if [[ "$TOTAL_COMPONENTS" -gt "$UNIQUE_TARGETS" ]]; then
+          echo "Found $TOTAL_COMPONENTS components for $UNIQUE_TARGETS unique targets"
+          echo "Keeping only the last (most recent) index for each OCP target"
+
+          RESULTS_TEMP_FILE="/tmp/results-temp.json"
+          jq '[.components | group_by(.target_index) | .[] | last] | {components: .}' \
+            "$RESULTS_FILE" > "$RESULTS_TEMP_FILE"
+          mv "$RESULTS_TEMP_FILE" "$RESULTS_FILE"
+
+          DEDUPLICATED_COUNT=$(jq -r '.components | length' "$RESULTS_FILE")
+          echo "Deduplicated from $TOTAL_COMPONENTS to $DEDUPLICATED_COUNT components"
+        else
+          echo "No deduplication needed ($TOTAL_COMPONENTS components, $UNIQUE_TARGETS unique targets)"
+        fi
+
         # Get the final batch result for legacy compatibility (use last successful batch from any group)
         # Find the most recent batch result file
         latest_result_file=$(find "$(params.dataDir)" -name "ir-*-batch-*-result.json" \

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -152,7 +152,7 @@ spec:
               echo "=== Creating internal request to publish image:"
               echo ""
               echo "- from: ${sourceIndex}"
-              echo "- to: ${publishingImages[$i]}"
+              echo "- to: ${publishingImages[$x]}"
 
               internal-request --pipeline "${request}" \
                   -p sourceIndex="${sourceIndex}" \


### PR DESCRIPTION
## Describe your changes

When processing multiple FBC fragments in batches, each batch creates a new index image with a different digest. Only the final batch's index image is published to the target registry.

This commit restores the deduplication logic that was removed during the multi-OCP refactor. After all batches complete, we now keep only the last component per target_index, ensuring downstream tasks use the correct published digest.

Without this fix, create-pyxis-image fails trying to pull intermediate batch digests that don't exist in the target registry.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
