### PR TITLE
fix: update deprecated task path

### DIFF
--- a/integration-tests/pipelines/e2e-tests-kind-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-kind-pipeline.yaml
@@ -34,9 +34,6 @@ spec:
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/release-service-catalog'
       description: The ORAS container used to store all test artifacts.
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: component-image
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
@@ -60,7 +57,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -247,7 +244,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -273,34 +270,6 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.test-metadata.results.pull-request-author)"
-          operator: notin
-          values: ["red-hat-konflux[bot]"]
-        - input: "$(tasks.check-if-related-test.results.result)"
-          operator: in
-          values: ["true"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"

--- a/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
@@ -34,9 +34,6 @@ spec:
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/release-service-catalog'
       description: The ORAS container used to store all test artifacts.
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: component-image
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
@@ -60,7 +57,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -145,7 +142,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -171,34 +168,6 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.test-metadata.results.pull-request-author)"
-          operator: notin
-          values: ["red-hat-konflux[bot]"]
-        - input: "$(tasks.check-if-related-test.results.result)"
-          operator: in
-          values: ["true"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -35,9 +35,6 @@ spec:
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/release-service-catalog'
       description: The ORAS container used to store all test artifacts.
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: component-image
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
@@ -52,7 +49,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -203,7 +200,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -229,31 +226,6 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.test-metadata.results.pull-request-author)"
-          operator: notin
-          values: ["red-hat-konflux[bot]"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"


### PR DESCRIPTION
## Describe your changes

Updates the deprecated "common/tasks/" path to "tasks/". Path should be updated before 31/10/25 to avoid breaking changes. quality-dashboard is deprecated and should be removed.

## Relevant Jira

[KFLUXDP-464](https://issues.redhat.com/browse/KFLUXDP-464)
