### PR TITLE
fix: add push rpms to the push-oot-kmods pipeline

### DIFF
--- a/pipelines/managed/push-oot-kmods/README.md
+++ b/pipelines/managed/push-oot-kmods/README.md
@@ -1,6 +1,6 @@
 # push-oot-kmods pipeline
 
-Tekton pipeline to sign out-of-tree kernel modules and upload them to an internal Gitlab repository. Optionally builds RPM packages from signed modules when buildRpm parameter is set to "yes".
+Tekton pipeline to sign out-of-tree kernel modules and upload them to an internal Gitlab repository.
 
 ## Parameters
 
@@ -20,4 +20,3 @@ Tekton pipeline to sign out-of-tree kernel modules and upload them to an interna
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 | taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | Yes      | main                                                      |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| buildRpm                        | Whether to build RPM packages from signed kernel modules (yes/no)                                                                  | Yes      | yes                                                       |

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   description: >-
     Tekton pipeline to sign out-of-tree kernel modules and upload them to an internal Gitlab repository.
-    Optionally builds RPM packages from signed modules when buildRpm parameter is set to "yes".
   params:
     - name: release
       type: string
@@ -64,10 +63,6 @@ spec:
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
       default: https://github.com/konflux-ci/release-service-catalog.git
-    - name: buildRpm
-      type: string
-      description: Whether to build RPM packages from signed kernel modules (yes/no)
-      default: "yes"
   tasks:
     - name: verify-access-to-resources
       taskRef:
@@ -157,7 +152,8 @@ spec:
               {"resultIndex": 9, "key": ".ootsign.artifact-repo-url"},
               {"resultIndex": 10, "key": ".ootsign.artifact-branch"},
               {"resultIndex": 11, "key": ".ootsign.artifact-repo-token"},
-              {"resultIndex": 12, "key": ".ootsign.rpmPath"}
+              {"resultIndex": 12, "key": ".ootsign.rpmPath"},
+              {"resultIndex": 13, "key": ".ootsign.buildRpm"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -409,9 +405,9 @@ spec:
         - collect-task-params
     - name: build-oot-kmods-rpms
       when:
-        - input: "$(params.buildRpm)"
+        - input: "$(tasks.collect-task-params.results.extractedValues[13])"
           operator: in
-          values: ["yes", "true", "1"]
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -441,6 +437,10 @@ spec:
       runAfter:
         - sign-oot-kmods
     - name: push-oot-kmods
+      when:
+        - input: "$(tasks.collect-task-params.results.extractedValues[13])"
+          operator: notin
+          values: ["true"]
       taskRef:
         resolver: "git"
         params:
@@ -478,3 +478,44 @@ spec:
       runAfter:
         - sign-oot-kmods
         - collect-task-params
+    - name: push-oot-kmods-with-rpms
+      when:
+        - input: "$(tasks.collect-task-params.results.extractedValues[13])"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/push-oot-kmods/push-oot-kmods.yaml
+      params:
+        - name: signedKmodsPath
+          value: $(tasks.collect-task-params.results.extractedValues[7])
+        - name: rpmPath
+          value: $(tasks.collect-task-params.results.extractedValues[12])
+        - name: vendor
+          value: $(tasks.collect-task-params.results.extractedValues[8])
+        - name: artifactRepoUrl
+          value: $(tasks.collect-task-params.results.extractedValues[9])
+        - name: artifactBranch
+          value: $(tasks.collect-task-params.results.extractedValues[10])
+        - name: artifactRepoToken
+          value: $(tasks.collect-task-params.results.extractedValues[11])
+        - name: sourceDataArtifact
+          value: "$(tasks.build-oot-kmods-rpms.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - build-oot-kmods-rpms

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -759,6 +759,10 @@
         "rpmPath": {
           "type": "string",
           "description": "Directory where RPM packages will be pushed"
+        },
+        "buildRpm": {
+          "type": "boolean",
+          "description": "Whether to build RPM packages from signed kernel modules. Default: true."
         }
       }
     },
@@ -1606,7 +1610,8 @@
               "signingAuthor",
               "checksumFingerprint",
               "checksumKeytab",
-              "rpmPath"
+              "rpmPath",
+              "buildRpm"
             ]
           }
         }


### PR DESCRIPTION
Pushing the built rpms from signed kmods was missing

