### PR TITLE
fix(RHELWF-13471): import draft builds with correct sidetags

### DIFF
--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -145,6 +145,13 @@ spec:
             koji --profile="$KOJI_PROFILE" "$@"
         }
 
+        is_sidetag() {
+            echo "Getting tag info and sidetag value for '$1':" > /dev/stderr
+            koji-cmd --noauth call --json-output getTag "$1" |
+              tee /dev/stderr |
+                jq -r '.extra.sidetag'
+        }
+
         # Fetch the component list from data.pushOptions.components by default, if there is no such list
         # fetch from data.mapping.components.
         RELEASE_COMPONENTS=$(jq -r '
@@ -233,12 +240,15 @@ spec:
               echo "ERROR: No Koji build target found in the container image annotations."
               exit 1
           fi
-          # For draft builds, remove "-candidate" tag suffix if present and
-          # append "-draft".
-          if [[ "$draft" == "true" && "$koji_target" != *-draft ]]; then
-              koji_tag=${koji_target%-candidate}-draft
-          else
-              koji_tag=${koji_target}
+
+          koji_tag=${koji_target}
+          # Make sure "-draft" suffix is added to the tag for draft imports,
+          # but avoid modifying sidetags.
+          if [[ "$draft" == "true" && "$koji_tag" != *-draft ]]; then
+            is_sidetag=$(is_sidetag "$koji_tag")
+            if [[ "$is_sidetag" == "false" ]]; then
+                koji_tag=${koji_tag%-candidate}-draft
+            fi
           fi
           KOJI_TAGS="$koji_tag $KOJI_TAGS"
 

--- a/tasks/managed/push-rpm-to-koji/tests/mocks.sh
+++ b/tasks/managed/push-rpm-to-koji/tests/mocks.sh
@@ -3,10 +3,10 @@ set -eux
 
 # mocks to be injected into task step scripts
 function kinit() {
-    echo "kinit $@" >> "$(params.dataDir)/kinit_calls.txt"
+    echo "kinit $*" >> "$(params.dataDir)/kinit_calls.txt"
     call_count=$(wc -l < "$(params.dataDir)/kinit_calls.txt")
     # Simulate kinit failures on first two calls
-    if [[ "$call_count" < 3 ]]; then
+    if [[ "$call_count" -lt 3 ]]; then
         echo "kinit failed"
         return 1
     fi
@@ -17,21 +17,26 @@ function mktemp() {
 }
 
 function select-oci-auth() {
-    echo "select-oci-auth $@" >> "$(params.dataDir)/select_oci_auth_calls.txt"
+    echo "select-oci-auth $*" >> "$(params.dataDir)/select_oci_auth_calls.txt"
     # This usually includes some auth details, but we're not really going to use it
     echo "{}"
 }
 
 function oras() {
-    echo "oras $@" >> "$(params.dataDir)/oras_calls.txt"
+    echo "oras $*" >> "$(params.dataDir)/oras_calls.txt"
     if [[ "$1" == "manifest" && "$2" == "fetch" ]]; then
-        echo '{"annotations": {"koji.build-target": "mock-target"}}'
+        if [[ "$3" == *test-bar* ]]; then
+            echo '{"annotations": {"koji.build-target": "mock-target-sidetag"}}'
+        else
+            echo '{"annotations": {"koji.build-target": "mock-target-candidate"}}'
+        fi
     elif [[ "$1" == "pull" ]]; then
+        build_name=$(sed -e 's_.*\/__' -e 's_@.*__' <<< "$*")
         cat > "cg_import.json" <<EOF
         {
             "metadata_version": 0,
             "build": {
-                "name": "libecpg",
+                "name": "$build_name",
                 "version": "16.1",
                 "release": "10.el10_0",
                 "epoch": null
@@ -43,8 +48,16 @@ EOF
 }
 
 function koji() {
-    echo "koji $@" >> "$(params.dataDir)/koji_calls.txt"
-    if [[ "$*" == *CGInitBuild* ]]; then
-        echo '{"build_id": 12345, "token": "mock-token"}'
+    echo "koji $*" >> "$(params.dataDir)/koji_calls.txt"
+    if [[ "$*" == *CGInitBuild*\"test-foo\"* ]]; then
+        echo '{"build_id": 111, "token": "mock-token"}'
+    elif [[ "$*" == *CGInitBuild*\"test-bar\"* ]]; then
+        echo '{"build_id": 222, "token": "mock-token"}'
+    elif [[ "$*" == *CGInitBuild*\"test-baz\"* ]]; then
+        echo '{"build_id": 333, "token": "mock-token"}'
+    elif [[ "$*" == *getTag*-sidetag* ]]; then
+        echo '{"extra": {"sidetag": true}}'
+    elif [[ "$*" == *getTag* ]]; then
+        echo '{"extra": {"sidetag": false}}'
     fi
 }

--- a/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
@@ -61,14 +61,14 @@ spec:
                 "mapping": {
                   "components": [
                     {
-                      "name": "test",
-                      "pushSourceContainer": false,
-                      "repository": "quay.io/test/test"
-                    },
-                    {
                       "name": "test-foo",
                       "pushSourceContainer": false,
                       "repository": "quay.io/test/test-foo"
+                    },
+                    {
+                      "name": "test-bar",
+                      "pushSourceContainer": false,
+                      "repository": "quay.io/test/test-bar"
                     }
                   ]
                 },
@@ -93,8 +93,8 @@ spec:
                 "artifacts": {},
                 "components": [
                   {
-                    "containerImage": "quay.io/test/test@sha256:12345",
-                    "name": "test",
+                    "containerImage": "quay.io/test/test-foo@sha256:111",
+                    "name": "test-foo",
                     "source": {
                       "git": {
                         "revision": "32c8f78c26e5831a87aa865ea80452fadbb3a95e",
@@ -103,26 +103,26 @@ spec:
                     }
                   },
                   {
-                    "containerImage": "quay.io/test/test-foo@sha256:12345",
-                    "name": "test-foo",
-                    "source": {
-                      "git": {
-                        "context": "./",
-                        "dockerfileUrl": "Containerfile",
-                        "revision": "12345",
-                        "url": "https://gitlab.example.com/rpms/test-foo"
-                      }
-                    }
-                  },
-                  {
-                    "containerImage": "quay.io/test/test-bar@sha256:12345",
+                    "containerImage": "quay.io/test/test-bar@sha256:222",
                     "name": "test-bar",
                     "source": {
                       "git": {
                         "context": "./",
                         "dockerfileUrl": "Containerfile",
-                        "revision": "12345",
+                        "revision": "222",
                         "url": "https://gitlab.example.com/rpms/test-bar"
+                      }
+                    }
+                  },
+                  {
+                    "containerImage": "quay.io/test/test-baz@sha256:333",
+                    "name": "test-baz",
+                    "source": {
+                      "git": {
+                        "context": "./",
+                        "dockerfileUrl": "Containerfile",
+                        "revision": "333",
+                        "url": "https://gitlab.example.com/rpms/test-baz"
                       }
                     }
                   }
@@ -242,9 +242,10 @@ spec:
               }
 
               function test_init_build() {
+                  build_name=$1
                   import_build_data=$(jq --compact-output <<EOD
                       {
-                        "name": "libecpg",
+                        "name": "$build_name",
                         "version": "16.1",
                         "release": "10.el10_0",
                         "epoch": null,
@@ -263,8 +264,9 @@ spec:
               }
 
               function test_import() {
+                  build=$1
                   if assert_cmd_called_with koji --profile=koji import-cg \
-                        --draft "cg_import\.json" --token=mock-token --build-id=12345 "\."
+                        --draft "cg_import\.json" --token=mock-token --build-id="$build" "\."
                   then
                       echo "TEST PASSED: Koji build was imported as draft."
                   else
@@ -275,7 +277,8 @@ spec:
 
               function test_tag() {
                   tag=$1
-                  if assert_cmd_called_with koji --profile=koji call tagBuild "$tag" 12345; then
+                  build_id=$2
+                  if assert_cmd_called_with koji --profile=koji call tagBuild "$tag" "$build_id"; then
                       echo "TEST PASSED: Koji build was tagged with $tag."
                   else
                       echo "TEST FAILED: Koji build was not tagged with $tag."
@@ -297,7 +300,7 @@ spec:
                   if assert_cmd_called_with kinit -kt "\./test.keytab" "test@test\.com"; then
                       echo "TEST PASSED: kinit was called."
                   else
-                      echo "TEST PASSED: kinit was not called."
+                      echo "TEST FAILED: kinit was not called."
                       exit_code=1
                   fi
               }
@@ -313,12 +316,17 @@ spec:
                   fi
               }
 
-              test_init_build
-              test_import
-              test_tag test-rpm
-              test_tag mock-target-draft
-              test_oras_pull quay.io/test/test@sha256:12345
-              test_oras_pull quay.io/test/test-foo@sha256:12345
+              test_init_build test-foo
+              test_init_build test-bar
+              test_import 111
+              test_import 222
+              test_tag test-rpm 111
+              test_tag test-rpm 222
+              test_tag mock-target-draft 111
+              test_tag mock-target-sidetag 222
+              test_oras_pull quay.io/test/test-foo@sha256:111
+              test_oras_pull quay.io/test/test-bar@sha256:222
+              test_cmd_count 2 koji --profile=koji call --json CGInitBuild
               test_cmd_count 2 oras pull
               test_cmd_count 3 kinit -kt
               test_kinit


### PR DESCRIPTION
## Describe your changes

Avoid attaching "-draft" to sidetag names for draft builds.

## Relevant Jira

RHELWF-13471

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
