### PR TITLE
fix: change type for buildRpm key at schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -761,7 +761,11 @@
           "description": "Directory where RPM packages will be pushed"
         },
         "buildRpm": {
-          "type": "boolean",
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ],
           "description": "Whether to build RPM packages from signed kernel modules. Default: true."
         }
       }


### PR DESCRIPTION
Boolean is causing issues so modified to 'string'


