### PR TITLE
fix(KONFLUX-10472): add back the list of images to results

### DIFF
--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -112,11 +112,11 @@ spec:
 
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/extract-index-image-results.json"
 
-        indexImage="$(jq -r '.components[-1].index_image' \
+        indexImage="$(jq -r '.components[].index_image' \
                     "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         echo -n "$indexImage" | tee "$(results.indexImage.path)"
 
-        indexImageResolved="$(jq -r '.components[-1].index_image_resolved' \
+        indexImageResolved="$(jq -r '.components[].index_image_resolved' \
                             "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         echo -n "$indexImageResolved" | tee "$(results.indexImageResolved.path)"
 

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
@@ -217,30 +217,22 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # Verify single-line results (no newlines)
-              echo "Verifying single-line results..."
-              if [[ "$(params.indexImage)" =~ $'\n' ]]; then
-                echo "ERROR: indexImage result contains newlines"
-                exit 1
-              fi
-              
-              if [[ "$(params.indexImageResolved)" =~ $'\n' ]]; then
-                echo "ERROR: indexImageResolved result contains newlines"
-                exit 1
-              fi
+              # read the images into an array
+              read -r -a array_of_images <<< "$(tr -s "\n" <<< "$(params.indexImage)")"
+              read -r -a array_of_resolved_images <<< "$(tr -s "\n" <<< "$(params.indexImageResolved)")"
 
               # Verify we get the final component's result (last one in batching)
               expected_final_image="redhat.com/rh-stage/iib:02"
               expected_final_resolved="redhat.com/rh-stage/iib@sha256:1234567890"
               
               echo "Test the indexImage result is the final component"
-              if [ "$(params.indexImage)" != "$expected_final_image" ]; then
+              if [ "${array_of_images[1]}" != "$expected_final_image" ]; then
                 echo "ERROR: Expected final index image $expected_final_image, got: $(params.indexImage)"
                 exit 1
               fi
 
               echo "Test the indexImageResolved result is the final component"
-              if [ "$(params.indexImageResolved)" != "$expected_final_resolved" ]; then
+              if [ "${array_of_resolved_images[1]}" != "$expected_final_resolved" ]; then
                 echo "ERROR: Expected final resolved image $expected_final_resolved, got: $(params.indexImageResolved)"
                 exit 1
               fi


### PR DESCRIPTION
this PR add back to the extract-index-image the
list of index images generated by iib.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
