### PR TITLE
feat(RELEASE-924): Migrate test RPAs to repositories format

### DIFF
--- a/integration-tests/collectors/resources/managed/rpa.yaml
+++ b/integration-tests/collectors/resources/managed/rpa.yaml
@@ -26,7 +26,8 @@ spec:
         pushSourceContainer: true
       components:
         - name: ${component_name}
-          repository: quay.io/redhat-pending/rhtap----rh-advisories-component
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
     releaseNotes:
       product_id:
         - 999

--- a/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
@@ -24,9 +24,10 @@ spec:
     mapping:
       components:
         - name: ${component_name}
-          repository: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
-          tags:
-            - '{{ git_short_sha }}'
+          repositories:
+            - url: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
+              tags:
+                - '{{ git_short_sha }}'
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
@@ -19,7 +19,8 @@ spec:
         pushSourceContainer: false
       components:
         - name: ${component_name}
-          repository: quay.io/redhat-pending/rhtap----rh-advisories-component
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
@@ -21,7 +21,8 @@ spec:
           - latest
       components:
         - name: ${component_name}
-          repository: quay.io/redhat-pending/rhtap----rh-advisories-component
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
     fileUpdates:
       - paths:
           - path: data/teams/stonesoup/users/shebert.yml

--- a/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
+++ b/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
@@ -12,9 +12,10 @@ spec:
     mapping:
       components:
         - name: ${component_name}
-          repository: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
-          tags:
-            - '{{ git_short_sha }}'
+          repositories:
+            - url: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
+              tags:
+                - '{{ git_short_sha }}'
     targetGHRepo: 'hacbs-release/infra-deployments'
     githubAppID: 932323
     githubAppInstallationID: 52284535


### PR DESCRIPTION
 Migrate ReleasePlanAdmission test files to use the new 'repositories'
 array format instead of the deprecated 'repository' field.

 This migration updates all integration test RPAs to use the new schema,
 ensuring the test suite validates the new format before production rollout.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
