### PR TITLE
fix: change source for kmods in rpm

### DIFF
--- a/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
@@ -194,7 +194,7 @@ spec:
         } > "${SPEC_FILE}"
 
         # Copy .ko files to SOURCES directory
-        cp -- *.ko "${RPM_BUILD_ROOT}/SOURCES/"
+        cp "${SIGNED_KMODS_PATH}"/*.ko "${RPM_BUILD_ROOT}/SOURCES/"
 
         # Build the RPM
         echo "Building RPM package..."


### PR DESCRIPTION
kmods in rpm were still unsigned.
This change includes the signed kmods in rpmbuild.

