### PR TITLE
fix(RELEASE-1908): Replace deprecated conforma URL

### DIFF
--- a/pipelines/managed/e2e/e2e.yaml
+++ b/pipelines/managed/e2e/e2e.yaml
@@ -107,7 +107,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -215,7 +215,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -236,7 +236,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -228,7 +228,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -233,7 +233,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -300,7 +300,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -201,7 +201,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -203,7 +203,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -262,7 +262,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -265,7 +265,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -262,7 +262,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -224,7 +224,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -196,7 +196,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -323,7 +323,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -269,7 +269,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -297,7 +297,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -189,6 +189,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       taskRef:
+        resolver: "git"
         params:
           - name: url
             value: $(params.taskGitUrl)
@@ -196,7 +197,6 @@ spec:
             value: $(params.taskGitRevision)
           - name: pathInRepo
             value: tasks/managed/check-data-keys/check-data-keys.yaml
-        resolver: git
       runAfter:
         - collect-data
     - name: reduce-snapshot
@@ -272,7 +272,7 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: https://github.com/enterprise-contract/ec-cli
+            value: https://github.com/conforma/cli
           - name: revision
             value: "$(params.verify_ec_task_git_revision)"
           - name: pathInRepo

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -78,6 +78,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:


### PR DESCRIPTION
## Describe your changes
Replaced https://github.com/enterprise-contract/ec-cli with the https://github.com/conforma/cli since it was "moved permanently" to the new location.

Note: 
This particular change has an indirect connection to the Conforma change. When the Conforma CLI URL was updated across multiple files, the CI validation script automatically ran on all changed files to check security compliance. It caught the missing security context, which was then fixed in the same commit to maintain compliance.

## Relevant Jira
[RELEASE-1908](https://issues.redhat.com/browse/RELEASE-1908)

Signed-off-by: elenagerman [elgerman@redhat.com](mailto:elgerman@redhat.com)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
