### PR TITLE
fix(RELEASE-1919): arg list too long in filter task

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -113,9 +113,9 @@ spec:
 
         if [[ -z "$EXISTING_ADVISORIES" ]]; then
           echo "No existing advisories found. No components have been released yet."
-          # Extract unique original component names from transformed snapshot
+          # Extract unique component names from transformed snapshot
           UNRELEASED_COMPONENTS=$(echo "$TRANSFORMED_SNAPSHOT_JSON" \
-            | jq -c '[.[].originalComponent] | unique' \
+            | jq -c '[.[].name] | unique' \
             | gzip -c \
             | base64 -w 0)
           echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
@@ -152,13 +152,13 @@ spec:
           fi
         done
 
-        # Extract unique original component names from remaining arch images (Martin's approach)
+        # Extract unique component names from remaining arch images
         ORIGINAL_ARCH_COUNT=$(echo "$TRANSFORMED_SNAPSHOT_JSON" | jq 'length')
         REMAINING_ARCH_COUNT=$(echo "$ARCH_IMAGES" | jq 'length')
         echo "Filtered out $((ORIGINAL_ARCH_COUNT - REMAINING_ARCH_COUNT)) arch-specific image(s) already in advisories"
         echo "Remaining unpublished arch images: $ARCH_IMAGES"
 
-        # Map back to original components and get unique names (Martin's approach)
-        UNRELEASED_COMPONENTS=$(echo "$ARCH_IMAGES" | jq -c '[.[].originalComponent] | unique' | gzip -c | base64 -w 0)
+        # Map back to original components and get unique names
+        UNRELEASED_COMPONENTS=$(echo "$ARCH_IMAGES" | jq -c '[.[].name] | unique' | gzip -c | base64 -w 0)
         echo -n "$UNRELEASED_COMPONENTS" > "$(results.unreleased_components.path)"
         echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
@@ -6,29 +6,23 @@ metadata:
 spec:
   description: |
     Test the filter-already-released-advisory-images-task with a multi-arch Image Index.
-    Verify that the task resolves Image Index to architecture-specific digests and 
+    Verify that the task resolves Image Index to architecture-specific digests and
     correctly filters out components that are already in advisories.
   tasks:
     - name: run-filter-task
       taskRef:
         name: filter-already-released-advisory-images-task
       params:
-        - name: snapshot
-          # Snapshot with multi-arch image before `gzip -c|base64 -w 0` encoding:
-          # '{"components":[{"name":"multi-arch-component","version":"1.0.0","containerImage":"quay.io/test/multi-arch-image@sha256:indexdigest789","tags":["v1.0"],"repository":"quay.io/test","rh-registry-repo":"registry.redhat.io/test"}]}'
-          value: 'H4sIABaakWgAA13NzQ6CMAzA8buP0TMMNPGLk1efwXBYoNmauA27QiSEd3c7SIzHtb/+t0AX3BA8eonQPBbw2iE04ManUKm5s+UGoIAJOVLwCexVreo06YIXTR757rTJl69Rz4pCJRil+slQ3t+i1YfjqSHf47snk8z5ck0Z0Sb/D1PqQlsA4xAiSeD5L5ks25LRUBSey+yS+L4VY2+1bHht190HL/cbTeMAAAA='
         - name: transformedSnapshot
           # Transformed snapshot with multi-arch component resolved to
           # arch-specific images before `gzip -c|base64 -w 0` encoding:
           # '[
           #   {"name":"multi-arch-component","containerImage":"registry.redhat.io/test@sha256:amd64digest123",
-          #    "tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test",
-          #    "originalComponent":"multi-arch-component","architecture":"amd64"},
+          #    "tags":["v1.0"],"repository":"registry.redhat.io/test"},
           #   {"name":"multi-arch-component","containerImage":"registry.redhat.io/test@sha256:arm64digest456",
-          #    "tags":["v1.0"],"repository":"registry.redhat.io/test","rh-registry-repo":"registry.redhat.io/test",
-          #    "originalComponent":"multi-arch-component","architecture":"arm64"}
+          #    "tags":["v1.0"],"repository":"registry.redhat.io/test"}
           # ]'
-          value: 'H4sIAA1tk2gAA81Quw6CQBDs/YytORQECioTK7+BUGzgcmzC3Zm9xYQY/l3OBDusLGznlZlpnuDQaqjBTqOQQu4G1Xl79047gQQ67wTJab5ZNFHH2lAQnlPW/YCSkj+KDnIJA+ZlVaPtq6Ins0JZfl4DBE2AuoFHlp6gTVb/3QcSz/N+2GrjQW2kipavYs9kyOF4/RTf3RMBEt3JxHHNuy4syc9vYLvdUJTV/98Q68LSHl78/+B/EAIAAA=='
+          value: 'H4sIABLe8GgAA62OsQ7CIBRFdz/jzRRtbRmYXPsNTYcXIEAi0DyeJo3x38XB0cW43px7cpYHZEwONKTblWOHZEJnStpKdplBgCmZMWZHc0L/5sj5WJl2Sc4GZBnLkV3lSw04TEpjsmq00bepH85NwOgr6AXuvTzBKtp/KzVyof27DJ7i712UPl3jpH7uWg8vNOiqQDIBAAA='
         - name: origin
           value: "test-origin"
         - name: advisory_secret_name

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -135,11 +135,6 @@ spec:
             echo "No valid snapshot file was provided at $SNAPSHOT_FILE"
             exit 1
         fi
-        snapshot=$(jq -c '.' "$SNAPSHOT_FILE" | gzip -c | base64 -w 0)
-        if [ -z "$snapshot" ]; then
-            echo "Failed to read snapshot file"
-            exit 1
-        fi
 
         # Transform snapshot components to architecture-specific images
         echo "Transforming snapshot components using get-image-architectures..."
@@ -165,26 +160,27 @@ spec:
                 while IFS= read -r arch_json; do
                     if [[ -n "$arch_json" ]]; then
                         arch_digest=$(jq -r '.digest' <<< "$arch_json")
-                        arch=$(jq -r '.platform.architecture' <<< "$arch_json")
                         containerImage="${repo_url}@${arch_digest}"
 
-                        jq \
+                        # Create minimal object with only the 4 fields needed by the consuming task
+                        jq -n \
+                            --arg name "$COMPONENT_NAME" \
                             --arg ci "$containerImage" \
+                            --argjson tags "$(jq '.tags' <<< "$component")" \
                             --arg repo "$repo_url" \
-                            --arg orig_name "$COMPONENT_NAME" \
-                            --arg arch "$arch" \
-                            '.containerImage = $ci
-                             | .repository = $repo
-                             | .originalComponent = $orig_name
-                             | .architecture = $arch' \
-                            <<< "$component"
+                            '{
+                              name: $name,
+                              containerImage: $ci,
+                              tags: $tags,
+                              repository: $repo
+                            }'
                     fi
                 done <<< "$digests"
             done
         done > "$TRANSFORMED_COMPONENTS"
 
         # Create transformed snapshot with arch-specific images
-        transformedSnapshot=$(jq -s '.' "$TRANSFORMED_COMPONENTS" | gzip -c | base64 -w 0)
+        transformedSnapshot=$(jq -sc '.' "$TRANSFORMED_COMPONENTS" | gzip -c | base64 -w 0)
         rm -f "$TRANSFORMED_COMPONENTS"
 
         if [ -z "$transformedSnapshot" ]; then

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
@@ -246,7 +246,7 @@ spec:
 
               # Validate multi-repo component entries
               multiRepoEntries=$(jq -c \
-                '.[] | select(.originalComponent=="multi-repo-component")' \
+                '.[] | select(.name=="multi-repo-component")' \
                 <<< "$transformedSnapshotJson")
               multiRepoCount=$(echo "$multiRepoEntries" | wc -l)
               if [ "$multiRepoCount" -ne 3 ]; then
@@ -264,11 +264,6 @@ spec:
                         "$repository"
                       exit 1
                     fi
-                    if [ "$(jq -r '.architecture' <<< "$entry")" != "amd64" ]; then
-                      echo "Unexpected architecture for multi-repo-component entry with repository" \
-                        "$repository"
-                      exit 1
-                    fi
                     ;;
                   *)
                     echo "Unexpected repository for multi-repo-component: $repository"
@@ -279,7 +274,7 @@ spec:
 
               # Validate single-repo component entry
               singleRepoEntry=$(jq -c \
-                '.[] | select(.originalComponent=="single-repo-component")' \
+                '.[] | select(.name=="single-repo-component")' \
                 <<< "$transformedSnapshotJson")
               if [ -z "$singleRepoEntry" ]; then
                 echo "Missing transformed entry for single-repo-component"
@@ -291,10 +286,6 @@ spec:
               fi
               if [[ "$(jq -r '.containerImage' <<< "$singleRepoEntry")" != *"@sha256:amd64digest_def456" ]]; then
                 echo "Unexpected digest for single-repo-component in transformedSnapshot"
-                exit 1
-              fi
-              if [ "$(jq -r '.architecture' <<< "$singleRepoEntry")" != "amd64" ]; then
-                echo "Unexpected architecture for single-repo-component in transformedSnapshot"
                 exit 1
               fi
 
@@ -370,4 +361,3 @@ spec:
               set -eux
 
               kubectl delete internalrequests --all
- 

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -233,7 +233,7 @@ spec:
                 exit 1
               fi
               # Validate per-component transformed entries
-              oldEntry=$(jq -c '.[] | select(.originalComponent=="old-component")' <<< "$transformedSnapshotJson")
+              oldEntry=$(jq -c '.[] | select(.name=="old-component")' <<< "$transformedSnapshotJson")
               if [ -z "$oldEntry" ]; then
                 echo "Missing transformed entry for old-component"
                 exit 1
@@ -246,12 +246,8 @@ spec:
                 echo "Unexpected digest for old-component in transformedSnapshot"
                 exit 1
               fi
-              if [ "$(jq -r '.architecture' <<< "$oldEntry")" != "amd64" ]; then
-                echo "Unexpected architecture for old-component in transformedSnapshot"
-                exit 1
-              fi
 
-              newEntry=$(jq -c '.[] | select(.originalComponent=="new-component")' <<< "$transformedSnapshotJson")
+              newEntry=$(jq -c '.[] | select(.name=="new-component")' <<< "$transformedSnapshotJson")
               if [ -z "$newEntry" ]; then
                 echo "Missing transformed entry for new-component"
                 exit 1
@@ -262,10 +258,6 @@ spec:
               fi
               if [[ "$(jq -r '.containerImage' <<< "$newEntry")" != *"@sha256:amd64digest_def456" ]]; then
                 echo "Unexpected digest for new-component in transformedSnapshot"
-                exit 1
-              fi
-              if [ "$(jq -r '.architecture' <<< "$newEntry")" != "amd64" ]; then
-                echo "Unexpected architecture for new-component in transformedSnapshot"
                 exit 1
               fi
 


### PR DESCRIPTION
## Describe your changes

Recently we started adding more metadata (env vars and labels) to the mapped snapshot, see RELEASE-1771 and #1475 .

This made the snapshot string that we pass to the internal filter task longer and in some cases we would hit the limit.

The filter task only needs a few fields for each component, so let's limit the json to the bare minimum.

## Relevant Jira

RELEASE-1919

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
