### PR TITLE
fix(RELEASE-1911): adds requester to signing task

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -85,7 +85,32 @@ spec:
     - name: pyxis-ssl-cert-secret
       secret:
         secretName: $(params.pyxis_ssl_cert_secret_name)
+  results:
+    - name: certificate-issuer
+      description: issuer uid extracted from the certificate
   steps:
+    - name: get-certificate-issuer
+      image: "$(params.pipeline_image)"
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 100m
+      workingDir: "$(workspaces.data.path)"
+      volumeMounts:
+        - name: umb-ssl-cert-secret
+          mountPath: /mnt/umb_ssl_cert_secret
+          readOnly: true
+      script: |
+        #!/usr/bin/env bash
+        set -x
+        umb_cert="$(cat "/mnt/umb_ssl_cert_secret/$(params.umb_ssl_cert_file_name)")"
+        issuer="$(openssl x509 -noout -subject <<< "$umb_cert" \
+          | awk '{print substr($0, index($0, "UID=")+4)}')"
+
+        echo -n "${issuer}" | tee "$(results.certificate-issuer.path)"
+
     - name: build-pubtools-sign-config
       image: "$(params.pipeline_image)"
       securityContext:
@@ -121,6 +146,11 @@ spec:
       script: |
         #!/usr/bin/env /bin/bash
         set -x
+        creator=$(cat $(results.certificate-issuer.path))
+        if [ -z "$creator" ]; then
+          creator="{creator}"
+        fi
+
         cat <<EOF > "$(workspaces.data.path)/pubtools-sign-config.yaml"
         msg_signer:
           messaging_brokers:
@@ -128,7 +158,7 @@ spec:
           messaging_cert_key: /tmp/umb.pem
           messaging_ca_cert: ${CA_BUNDLE}
           topic_send_to: topic://${umb_publish_topic}
-          topic_listen_to: queue://Consumer.{creator}.${requester}-{task_id}.${umb_listen_topic}
+          topic_listen_to: queue://Consumer.${creator}.${requester}-{task_id}.${umb_listen_topic}
           environment: prod
           service: ${umb_client_name}
           timeout: 60
@@ -170,6 +200,7 @@ spec:
                         -key "/tmp/umb.key"\
                         -servername "$umb_url"\
                         -CAfile "${CA_BUNDLE}" < /dev/null
+
     - name: request-signature
       image: "$(params.pipeline_image)"
       computeResources:
@@ -192,6 +223,8 @@ spec:
           value: "$(params.sig_key_names)"
         - name: signature_data_file
           value: "$(params.signature_data_file)"
+        - name: requester
+          value: "$(params.requester)"
       script: |
         #!/usr/bin/env /bin/bash
         
@@ -224,6 +257,7 @@ spec:
         echo " ${reference_args[@]} ${digest_args[@]} --task-id $task_id"
 
         pubtools-sign-msg-container-sign \
+          --requester "${requester}" \
           --signing-key-name "${sig_key_names}" \
           --signing-key "${sig_key_names}" \
           --config-file "$(workspaces.data.path)/pubtools-sign-config.yaml" "${reference_args[@]}" "${digest_args[@]}" \

--- a/tasks/internal/request-and-upload-signature/tests/mocks.sh
+++ b/tasks/internal/request-and-upload-signature/tests/mocks.sh
@@ -29,6 +29,9 @@ function pubtools-pyxis-upload-signatures() {
 function openssl() {
   >&2 echo "Mock openssl called with: $*"
   echo "$*" >> "$(workspaces.data.path)/mock_openssl.txt"
+  if [[ "$*" =~ "x509 -noout -subject" ]]; then
+    echo "UID=test-mock"
+  fi
 }
 
 export CUSTOM_TASK_ID="1234"

--- a/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
@@ -3,11 +3,9 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
-yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
-yq -i '.spec.steps[4].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[4].script' "$TASK_PATH"
+for i in `seq 0 5`; do
+  yq -i '.spec.steps['$i'].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps['$i'].script' "$TASK_PATH"
+done
 
 # Create a dummy secret for ssl cert for pyxis interactions (and delete it first if it exists)
 kubectl delete secret pyxis-ssl-cert --ignore-not-found

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -106,7 +106,7 @@ spec:
         - name: references
           value: "registry.redhat.io/myproduct/myrepo:abc registry.redhat.io/myproduct/myrepo:def"
         - name: requester
-          value: tom
+          value: test-user
         - value: 4096R/55A34A82 SHA-256
           name: sig_key_id
         - value: containerisvsign
@@ -155,7 +155,7 @@ spec:
               set -eux
               umb_publish_topic=VirtualTopic.eng.operatorpipelines.isv.sign
               umb_listen_topic=VirtualTopic.eng.robosignatory.isv.sign
-              requester=tom
+              requester=test-user
               umb_client_name=operatorpipelines
 
               cat <<EOF > "/tmp/expected_config.yaml"
@@ -165,7 +165,7 @@ spec:
                 messaging_cert_key: /tmp/umb.pem
                 messaging_ca_cert: /etc/pki/tls/certs/ca-bundle.crt
                 topic_send_to: topic://${umb_publish_topic}
-                topic_listen_to: queue://Consumer.{creator}.${requester}-{task_id}.${umb_listen_topic}
+                topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
                 timeout: 60
@@ -176,8 +176,8 @@ spec:
               EOF
               diff -Naur "/tmp/expected_config.yaml" "$(workspaces.data.path)/pubtools-sign-config.yaml"
 
-              expected="--signing-key-name containerisvsign --signing-key containerisvsign --config-file \
-              "$(workspaces.data.path)/pubtools-sign-config.yaml" \
+              expected="--requester ${requester} --signing-key-name containerisvsign --signing-key containerisvsign \
+              --config-file "$(workspaces.data.path)/pubtools-sign-config.yaml" \
               --reference registry.redhat.io/myproduct/myrepo:abc \
               --reference registry.redhat.io/myproduct/myrepo:def \
               --digest sha256:0000 --digest sha256:1111 --task-id 1234"

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
@@ -77,7 +77,7 @@ spec:
         - name: references
           value: "registry.redhat.io/myproduct/myrepo:abc"
         - name: requester
-          value: tom
+          value: test-user
         - value: 4096R/55A34A82 SHA-256
           name: sig_key_id
         - value: containerisvsign
@@ -126,7 +126,7 @@ spec:
               set -eux
               umb_publish_topic=VirtualTopic.eng.operatorpipelines.isv.sign
               umb_listen_topic=VirtualTopic.eng.robosignatory.isv.sign
-              requester=tom
+              requester=test-user
               umb_client_name=operatorpipelines
 
               cat <<EOF > "/tmp/expected_config.yaml"
@@ -136,7 +136,7 @@ spec:
                 messaging_cert_key: /tmp/umb.pem
                 messaging_ca_cert: /etc/pki/tls/certs/ca-bundle.crt
                 topic_send_to: topic://${umb_publish_topic}
-                topic_listen_to: queue://Consumer.{creator}.${requester}-{task_id}.${umb_listen_topic}
+                topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
                 timeout: 60
@@ -147,8 +147,8 @@ spec:
               EOF
               diff -Naur "/tmp/expected_config.yaml" "$(workspaces.data.path)/pubtools-sign-config.yaml"
 
-              expected="--signing-key-name containerisvsign --signing-key containerisvsign --config-file \
-              "$(workspaces.data.path)/pubtools-sign-config.yaml" \
+              expected="--requester ${requester} --signing-key-name containerisvsign --signing-key containerisvsign \
+              --config-file "$(workspaces.data.path)/pubtools-sign-config.yaml" \
               --reference registry.redhat.io/myproduct/myrepo:abc --digest sha256:0000 --task-id 1234"
               echo "$expected" > "/tmp/expected"
               cat "$(workspaces.data.path)/mock_pubtools-sign.txt"


### PR DESCRIPTION
this PR adds the requester to request-and-upload signature task which is missing.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
