### PR TITLE
fix: ensure signed .ko files replace unsigned ones in trusted artifacts

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -198,6 +198,8 @@ spec:
         # Sign kmods
         sign_kmods
         # Copy back signed kmods to workspace
+        # Remove unsigned files first to ensure complete replacement
+        rm -f "${SIGNED_KMODS_PATH}"/*.ko
         scp "${SSH_OPTS[@]}" "${signUser}@${signHost}:~/kmods/*.ko" "${SIGNED_KMODS_PATH}"/
 
         # Restore envfile after signing process

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -33,13 +33,45 @@ function ssh() {
   esac
 }
 
+function rm() {
+  echo "Mock rm called with: $*"
+
+  echo "$*" >> "$(params.dataDir)/mock_rm.txt"
+
+  case "$*" in
+    "-f "*"/*.ko")
+      ;;
+    "-f "*signed-kmods*)
+      ;;
+    *)
+      echo "Error: Unexpected rm parameters: $*"
+      exit 1
+      ;;
+  esac
+}
+
 function scp() {
   echo "Mock scp called with: $*"
-  
+
   echo "$*" >> "$(params.dataDir)/mock_scp.txt"
 
   case "$*" in
     "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
+      # Check if this is the download command (contains *.ko in remote path)
+      if [[ "$*" == *"~/kmods/*.ko"* ]]; then
+        # This is the download command - extract destination directory (last argument)
+        local args=($*)
+        local dest_path="${args[-1]}"
+        echo "Mock scp: Creating signed files in destination: $dest_path"
+        if [ -d "$dest_path" ]; then
+          echo "SIGNED_MODULE1" > "$dest_path/mod1.ko"
+          echo "SIGNED_MODULE2" > "$dest_path/mod2.ko"
+          echo "Mock scp: Created signed files in $dest_path"
+        else
+          echo "Mock scp: Warning - destination directory $dest_path does not exist"
+        fi
+      fi
+      # For upload command, we don't need to do anything special
       ;;
     *)
       echo "Error: Incorrect scp parameters"

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -116,8 +116,9 @@ spec:
 
               # Check for mocked signing operations in different locations depending on trusted artifacts mode
               echo "INFO: ociStorage provided, checking dataDir for mock files"
-              FILE="$(params.dataDir)/mock_scp.txt"
-              
+              SCP_FILE="$(params.dataDir)/mock_scp.txt"
+              RM_FILE="$(params.dataDir)/mock_rm.txt"
+
               # Also verify that the signed kmods exist in the dataDir
               if [ -d "$(params.dataDir)/$(params.signedKmodsPath)" ]; then
                 echo "SUCCESS: signed-kmods directory found in dataDir"
@@ -127,20 +128,53 @@ spec:
                 echo "Available directories in dataDir:"
                 ls -la "$(params.dataDir)" || echo "dataDir does not exist"
               fi
-              
-              if [ -f "$FILE" ]; then
-                echo "Mock scp file found: $FILE"
+
+              # Check that rm command was called to remove unsigned .ko files
+              if [ -f "$RM_FILE" ]; then
+                echo "Mock rm file found: $RM_FILE"
                 echo "Contents:"
-                cat "$FILE"
-                
-                if grep -q 'mod1.ko' "$FILE" && grep -q 'mod2.ko' "$FILE"; then
-                  echo "SUCCESS: Found both mod1.ko and mod2.ko in $FILE"
+                cat "$RM_FILE"
+
+                if grep -q '\.ko' "$RM_FILE"; then
+                  echo "SUCCESS: Found rm command with .ko files in $RM_FILE"
                 else
-                  echo "ERROR: One or both .ko files not found in $FILE"
+                  echo "ERROR: rm command with .ko files not found in $RM_FILE"
                   exit 1
                 fi
               else
-                echo "SUCCESS: Test passed - mock scp file not found, which indicates mocking worked correctly"
+                echo "ERROR: Mock rm file not found - rm command was not called"
+                exit 1
+              fi
+
+              # Check that scp command was called to copy signed files
+              if [ -f "$SCP_FILE" ]; then
+                echo "Mock scp file found: $SCP_FILE"
+                echo "Contents:"
+                cat "$SCP_FILE"
+
+                if grep -q 'mod1.ko' "$SCP_FILE" && grep -q 'mod2.ko' "$SCP_FILE"; then
+                  echo "SUCCESS: Found both mod1.ko and mod2.ko in $SCP_FILE"
+                else
+                  echo "ERROR: One or both .ko files not found in $SCP_FILE"
+                  exit 1
+                fi
+              else
+                echo "ERROR: Mock scp file not found - scp command was not called"
+                exit 1
+              fi
+
+              # Verify that the signed files now contain "SIGNED" content to confirm replacement
+              if [ -f "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko" ]; then
+                content=$(cat "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko")
+                if [[ "$content" == "SIGNED_MODULE1" ]]; then
+                  echo "SUCCESS: mod1.ko contains signed content"
+                else
+                  echo "ERROR: mod1.ko does not contain expected signed content, found: $content"
+                  exit 1
+                fi
+              else
+                echo "ERROR: mod1.ko not found after signing process"
+                exit 1
               fi
       params:
         - name: signedKmodsPath


### PR DESCRIPTION
Remove unsigned .ko files before copying
signed ones back from signing server to prevent
build-oot-kmods-rpms task from receiving unsigned files when buildRpm=true.


