### PR TITLE
feat(ROK-746): adds pulp_transfer to the push-rom-to-koji pipeline/task

### DIFF
--- a/pipelines/managed/push-artifacts-to-storage/README.md
+++ b/pipelines/managed/push-artifacts-to-storage/README.md
@@ -1,0 +1,22 @@
+# push-artifacts-to-storage pipeline
+
+Tekton pipeline to push rpms into the artifact storage instance.
+
+## Parameters
+
+| Name                            | Description                                                                                                                        | Optional | Default value                                             |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution                             | No       | -                                                         |
+| releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                                            | No       | -                                                         |
+| releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                                                   | No       | -                                                         |
+| releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                                                   | No       | -                                                         |
+| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                                               | No       | -                                                         |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | No       | -                                                         |
+| enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                                                | Yes      | brew-rhel-sst-prod                                        |
+| enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
+| verify_ec_task_git_revision     | The git revision to be used when consuming the verify-conforma task                                                                | No       | -                                                         |
+| ociStorage                      | The OCI repository where the Trusted Artifacts are stored                                                                          | Yes      | quay.io/konflux-ci/release-service-trusted-artifacts      |
+| orasOptions                     | oras options to pass to Trusted Artifacts calls                                                                                    | Yes      | ""                                                        |
+| trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
+| dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |

--- a/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -1,0 +1,433 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: push-artifacts-to-storage
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: push-artifact-storage
+spec:
+  description: |-
+    Tekton pipeline to push rpms into the artifact storage instance.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+      default: "brew-rhel-sst-prod"
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git revision to be used when consuming the verify-conforma task
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored
+      default: "quay.io/konflux-ci/release-service-trusted-artifacts"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      # to avoid tar extraction errors, we need to specify a subdirectory
+      # inside the volume.
+      default: "/var/workdir/release"
+  tasks:
+    - name: verify-access-to-resources
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - verify-access-to-resources
+    - name: collect-task-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-task-params/collect-task-params.yaml
+      params:
+        - name: dataDir
+          value: "$(params.dataDir)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: keysToExtract
+          value: |
+            [
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".conforma.timeout", "default": "8h0m0s"},
+              {"resultIndex": 2, "key": ".pushOptions.pushKeytab.secret"},
+              {"resultIndex": 3, "key": ".pushOptions.pushPipelineImage"},
+              {"resultIndex": 4, "key": ".pushOptions.pushType", "default": "import"}
+            ]
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+      runAfter:
+        - collect-data
+    - name: reduce-snapshot
+      timeout: "4h"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.dataDir)/$(tasks.collect-data.results.snapshotSpec)
+        - name: SINGLE_COMPONENT
+          value: $(tasks.collect-data.results.singleComponentMode)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/$(tasks.collect-data.results.snapshotName)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: $(tasks.collect-data.results.snapshotNamespace)
+        - name: SNAPSHOT_PATH
+          value: $(params.dataDir)/$(tasks.collect-data.results.snapshotSpec)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - collect-data
+    - name: verify-conforma
+      timeout: "4h00m0s"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/conforma/cli
+          - name: revision
+            value: "$(params.verify_ec_task_git_revision)"
+          - name: pathInRepo
+            value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
+      params:
+        - name: SNAPSHOT_FILENAME
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: TIMEOUT
+          value: "$(tasks.collect-task-params.results.extractedValues[1])"
+        - name: WORKERS
+          value: "$(tasks.collect-task-params.results.extractedValues[0])"
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: TRUSTED_ARTIFACTS_DEBUG
+          value: "$(params.trustedArtifactsDebug)"
+      runAfter:
+        - reduce-snapshot
+        - collect-task-params
+    - name: push-rpm-to-koji
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: pushSecret
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: pipelineImage
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - collect-task-params
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: notin
+          values: ["promote"]
+    - name: update-package-collection-after-push-rpm-process
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-package-collection/update-package-collection.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: pushSecret
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: pipelineImage
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: pushType
+          value: "$(tasks.collect-task-params.results.extractedValues[4])"
+      runAfter:
+        - push-rpm-to-koji
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: notin
+          values: ["promote"]
+    - name: promote-koji-draft-build
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: pushSecret
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: pipelineImage
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - collect-task-params
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: in
+          values: ["promote"]
+    - name: update-package-collection-after-promote-draft-build
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-package-collection/update-package-collection.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: pushSecret
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: pipelineImage
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: pushType
+          value: "$(tasks.collect-task-params.results.extractedValues[4])"
+      runAfter:
+        - promote-koji-draft-build
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: in
+          values: ["promote"]
+    - name: push-artifacts-to-storage
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: snapshotNamespace
+          value: "$(tasks.collect-data.results.snapshotNamespace)"
+        - name: snapshotBuildId
+          value: "$(tasks.collect-data.results.snapshotBuildId)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+      runAfter:
+        - collect-task-params
+      when:
+        - input: $(tasks.collect-task-params.results.extractedValues[4])
+          operator: notin
+          values: ["promote"]
+  finally:
+    - name: cleanup-internal-requests
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -108,6 +108,9 @@ spec:
     - name: snapshotNamespace
       type: string
       description: namespace where Snapshot is located
+    - name: snapshotBuildId
+      type: string
+      description: Build Id where Snapshot originated
     - name: releasePipelineMetadata
       type: string
       description: json object containing git resolver metadata about the running release pipeline
@@ -201,6 +204,9 @@ spec:
         SNAPSHOTSPEC_PATH="$(params.subdirectory)/snapshot_spec.json"
         echo -n "$SNAPSHOTSPEC_PATH" > "$(results.snapshotSpec.path)"
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" | tee "$(params.dataDir)/$SNAPSHOTSPEC_PATH"
+        labels=$(get-resource "snapshot" "${SNAPSHOT}" "{.metadata.labels}")
+        BUILD_ID=$(jq -r '."appstudio.openshift.io/build-pipelinerun" // ""' <<< "${labels}")
+        echo -n "${BUILD_ID}" | tee "$(results.snapshotBuildId.path)"
 
         echo -e "\nGenerating collectors data"
         collectors_status=$(get-resource "release" "${RELEASE}" "{.status.collectors}")

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -116,6 +116,8 @@ spec:
               metadata:
                 name: snapshot-sample
                 namespace: default
+                labels:
+                  appstudio.openshift.io/build-pipelinerun: sample-build-id
               spec:
                 application: foo
                 components:
@@ -173,6 +175,8 @@ spec:
           value: $(tasks.run-task.results.snapshotName)
         - name: snapshotNamespace
           value: $(tasks.run-task.results.snapshotNamespace)
+        - name: snapshotBuildId
+          value: $(tasks.run-task.results.snapshotBuildId)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: subdirectory
@@ -200,6 +204,8 @@ spec:
           - name: snapshotName
             type: string
           - name: snapshotNamespace
+            type: string
+          - name: snapshotBuildId
             type: string
           - name: sourceDataArtifact
             type: string
@@ -261,6 +267,9 @@ spec:
 
               echo Test that the snapshotNamespace result was properly set
               test "$(params.snapshotNamespace)" == "default"
+
+              echo Test that the snapshotBuildId result was properly set
+              test "$(params.snapshotBuildId)" == "sample-build-id"
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/managed/push-artifacts-to-storage/README.md
+++ b/tasks/managed/push-artifacts-to-storage/README.md
@@ -1,0 +1,22 @@
+# push-artifacts-to-storage
+
+Tekton task to push konflux builds to artifact storage.
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath            | Path to the JSON file of the mapped Snapshot spec in the data workspace                                                    | No       | -                    |
+| snapshotNamespace       | Namespace that tha snapshot originated from                                                                                | No       | -                    |
+| snapshotBuildId         | Build Id that tha snapshot originated from                                                                                 | No       | -                    |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| dataPath                | Path to the JSON file of the merged data to use in the data workspace                                                      | No       | -                    |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |

--- a/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-artifacts-to-storage
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: push-rok-storage
+spec:
+  description: |-
+    Tekton task to push konflux builds to artifact storage.
+  params:
+    - name: snapshotPath
+      type: string
+      description: |
+        Path to the JSON file of the mapped Snapshot spec in the data workspace
+    - name: snapshotNamespace
+      type: string
+      description: |
+        Namespace that tha snapshot originated from
+    - name: snapshotBuildId
+      type: string
+      description: |
+        Build Id that tha snapshot originated from
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: dataPath
+      type: string
+      description: |
+        Path to the JSON file of the merged data to use in the data workspace
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: rok-access
+      secret:
+        optional: true
+        secretName: rok-storage
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: push-build-to-artifact-storage
+      # The pipelineImage will be fetching from get-secrets task with koji installed there
+      image: quay.io/redhat-user-workloads/rpm-build-pipeline-tenant/environment:latest@sha256:90b1289849de3fb8b6435225f4409d2ae288acdcc0e38a5ff5fb563fef35c620
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 250m
+      env:
+        - name: SNAPSHOT_SPEC_FILE
+          value: $(params.dataDir)/$(params.snapshotPath)
+        - name: DATA_FILE
+          value: $(params.dataDir)/$(params.dataPath)
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "No valid snapshot file was provided."
+            exit 1
+        fi
+
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No data JSON was provided."
+            exit 1
+        fi
+
+        if [ ! -f /etc/rok-access/cli.toml ] ; then
+            echo "No rok-access provided."
+            exit 0
+        fi
+
+        KOJI_IMPORT_DRAFT=$(jq -r '.pushOptions.koji_import_draft' "${DATA_FILE}")
+
+        if [[ "$KOJI_IMPORT_DRAFT" == "false" ]]; then
+            echo "Draft build skipping Artifact Storage"
+            exit 0
+        fi
+
+        APPLICATION=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
+
+        pulp_transfer.py \
+        --config /etc/rok-access/cli.toml \
+        --build_id "$(params.snapshotNamespace)" \
+        --namespace "$(params.snapshotBuildId)" \
+        --cert_path /etc/rok-access/tls.crt \
+        --key_path /etc/rok-access/tls.key
+
+        printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$APPLICATION"
+      volumeMounts:
+        - mountPath: /etc/rok-access
+          name: rok-access
+          readOnly: true
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/push-artifacts-to-storage/tests/mocks.sh
+++ b/tasks/managed/push-artifacts-to-storage/tests/mocks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+function kinit() {
+    echo "kinit $*" >> "$(params.dataDir)/kinit_calls.txt"
+    call_count=$(wc -l < "$(params.dataDir)/kinit_calls.txt")
+    # Simulate kinit failures on first two calls
+    if [[ "$call_count" -lt 3 ]]; then
+        echo "kinit failed"
+        return 1
+    fi
+}
+
+function select-oci-auth() {
+    echo "select-oci-auth $*" >> "$(params.dataDir)/select_oci_auth_calls.txt"
+    # This usually includes some auth details, but we're not really going to use it
+    echo "{}"
+}
+
+function oras() {
+    echo "oras $*" >> "$(params.dataDir)/oras_calls.txt"
+    if [[ "$1" == "manifest" && "$2" == "fetch" ]]; then
+        if [[ "$3" == *test-bar* ]]; then
+            echo '{"annotations": {"koji.build-target": "mock-target-sidetag"}}'
+        else
+            echo '{"annotations": {"koji.build-target": "mock-target-candidate"}}'
+        fi
+    elif [[ "$1" == "pull" ]]; then
+        build_name=$(sed -e 's_.*\/__' -e 's_@.*__' <<< "$*")
+        cat > "cg_import.json" <<EOF
+        {
+            "metadata_version": 0,
+            "build": {
+                "name": "$build_name",
+                "version": "16.1",
+                "release": "10.el10_0",
+                "epoch": null
+            }
+        }
+EOF
+        touch "test.src.rpm"
+    fi
+}
+
+function mktemp() {
+    echo /tmp/foobar
+}

--- a/tasks/managed/push-artifacts-to-storage/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-artifacts-to-storage/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/push-artifacts-to-storage/tests/test-push-artifacts-to-storage.yaml
+++ b/tasks/managed/push-artifacts-to-storage/tests/test-push-artifacts-to-storage.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-storage
+spec:
+  description: |
+    Test the push-artifacts-to-storage task.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "test-foo",
+                      "pushSourceContainer": false,
+                      "repository": "quay.io/test/test-foo"
+                    },
+                    {
+                      "name": "test-bar",
+                      "pushSourceContainer": false,
+                      "repository": "quay.io/test/test-bar"
+                    }
+                  ]
+                },
+                "pushOptions": {
+                  "koji_profile": "koji",
+                  "koji_import_draft": true,
+                  "koji_tags": [
+                    "test-rpm"
+                  ],
+                  "pushKeytab": {
+                    "name": "test.keytab",
+                    "principal": "test@test.com",
+                    "secret": "test-secrets"
+                  },
+                  "pushPipelineImage": "test-image"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/test-foo@sha256:111",
+                    "name": "test-foo",
+                    "source": {
+                      "git": {
+                        "revision": "32c8f78c26e5831a87aa865ea80452fadbb3a95e",
+                        "url": "https://gitlab.example.com/rpms/test"
+                      }
+                    }
+                  },
+                  {
+                    "containerImage": "quay.io/test/test-bar@sha256:222",
+                    "name": "test-bar",
+                    "source": {
+                      "git": {
+                        "context": "./",
+                        "dockerfileUrl": "Containerfile",
+                        "revision": "222",
+                        "url": "https://gitlab.example.com/rpms/test-bar"
+                      }
+                    }
+                  },
+                  {
+                    "containerImage": "quay.io/test/test-baz@sha256:333",
+                    "name": "test-baz",
+                    "source": {
+                      "git": {
+                        "context": "./",
+                        "dockerfileUrl": "Containerfile",
+                        "revision": "333",
+                        "url": "https://gitlab.example.com/rpms/test-baz"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-storage
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: snapshotNamespace
+          value: "default-namespace"
+        - name: snapshotBuildId
+          value: "default-buildid"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # Use the same security context as the main task to avoid permission issues
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              exit_code=0
+              exit $exit_code


### PR DESCRIPTION
## Describe your changes

Adds transfering files from one pulp domain to another within the push-rpm-to-koji pipeline/task. This allows transfer files from a developer namespace to the canonical pulp namespace.

## Relevant Jira

https://issues.redhat.com/browse/ROK-746
