### PR TITLE
fix(RELEASE-1866): use proper list of cves to populate references

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -583,18 +583,26 @@ spec:
             exit 1
         fi
 
-        NUM_CVES=$(jq '.releaseNotes.cves | length' "${DATA_FILE}")
-
-        # Set type to RHSA if there are fixed CVEs
-        if [[ "$NUM_CVES" -gt 0 ]] ; then
-            jq '.releaseNotes.type = "RHSA"' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+        if jq -e '.releaseNotes.content.images' "$DATA_FILE" > /dev/null; then
+            CONTENT_TYPE=".releaseNotes.content.images"
+        elif jq -e '.releaseNotes.content.artifacts' "$DATA_FILE" > /dev/null; then
+            CONTENT_TYPE=".releaseNotes.content.artifacts"
+        else
+            echo "No content found under releaseNotes.content.images or .artifacts;"
+            exit 0
         fi
 
-        if [ "$(jq -r '.releaseNotes.type' "${DATA_FILE}")" != "RHSA" ] ; then
-            echo "Type is not RHSA. Ensuring references key exists, but not adding any"
+        CVES=$(jq -r "$CONTENT_TYPE"'[] | select(.cves.fixed) | .cves.fixed' "${DATA_FILE}")
+        NUM_CVES=$(jq 'length' <<< "$CVES" | jq -s 'add')
+
+        if [[ "$NUM_CVES" -eq 0 ]] ; then
+            echo "No CVEs found. Ensuring references key exists, but not adding anything to it"
             jq '.releaseNotes.references += []' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
             exit 0
         fi
+
+        # Set type to RHSA as there are CVEs fixed
+        jq '.releaseNotes.type = "RHSA"' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
 
         # Inject classification link into data.json references
         jq '.releaseNotes.references += ["https://access.redhat.com/security/updates/classification/"]' \
@@ -602,7 +610,7 @@ spec:
 
         for ((i = 0; i < NUM_CVES; i++))
         do
-            cve=$(jq -r --argjson i "$i" '.releaseNotes.cves[$i].key' "${DATA_FILE}")
+            cve=$(jq -rs --argjson i "$i" 'map(keys[]) | .[$i]' <<< "${CVES}")
             # Inject cve link into data.json references
             jq --arg cve "$cve" '.releaseNotes.references += ["https://access.redhat.com/security/cve/\($cve)"]' \
                 "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Run the populate-release-notes task with a RHSA type. Ensure that references are added for each
-    CVE, existing ones are maintained, and there are no duplicates.
+    CVE, existing ones are maintained, there are no duplicates, and the CVEs for non existent components
+    are not added.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -83,6 +84,13 @@ spec:
                         "pkg3"
                       ],
                       "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "non-existent",
+                      "key": "CVE-999",
                       "summary": "",
                       "uploadDate": "01-01-1980",
                       "url": ""
@@ -216,7 +224,8 @@ spec:
               set -eux
 
               # There should be 4 references. The one provided (not duplicated), the generic classification one,
-              # and ones for CVE-123 and CVE-456
+              # and ones for CVE-123 and CVE-456. CVE-999 should not be added as non-existent component isn't
+              # in the snapshot
               test "$(jq '.releaseNotes.references | length' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" \
                 == 4


### PR DESCRIPTION
This commit updates the step of populate-release-notes that adds the references when the type is RHSA. It fixes the step to now only add CVEs for components that are mapped, instead of adding all CVEs listed in releaseNotes.cves, regardless if their component is included or not.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
