### PR TITLE
fix(RELEASE-1923): libcrypto error when connecting via ssh

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -468,7 +468,7 @@ spec:
         cp "/mnt/secrets/mac_fingerprint" /tmp/.ssh/known_hosts
         chmod 600 /tmp/.ssh/id_rsa /tmp/.ssh/known_hosts
 
-        SSH_OPTS=(-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts)
+        SSH_OPTS=(-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -o IdentitiesOnly=yes)
 
         # shell check complains about the variable (unsigned_digest) not being used but it is used in the script
         # shellcheck disable=SC2034
@@ -598,8 +598,9 @@ spec:
         chmod 600 /tmp/.ssh/known_hosts /tmp/.ssh/id_rsa
 
         SSH_OPTS="-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -p ${WINDOWS_PORT} \
-        ${WINDOWS_USER}@${WINDOWS_HOST}"
-        SCP_OPTS="-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -P ${WINDOWS_PORT}"
+        ${WINDOWS_USER}@${WINDOWS_HOST} -o IdentitiesOnly=yes"
+        SCP_OPTS="-i /tmp/.ssh/id_rsa -o UserKnownHostsFile=/tmp/.ssh/known_hosts -P ${WINDOWS_PORT} \
+        -o IdentitiesOnly=yes"
 
         unsigned_digest=$(cat "$(results.unsignedWindowsDigest.path)")
         # Create the batch script
@@ -734,7 +735,8 @@ spec:
 
         SSH_OPTS="-o UserKnownHostsFile=/tmp/.ssh/known_hosts \
                     -o GSSAPIAuthentication=yes \
-                    -o GSSAPIDelegateCredentials=yes"
+                    -o GSSAPIDelegateCredentials=yes \
+                    -o IdentitiesOnly=yes"
 
         sign_file() {
             sign_method=$1  # The signing method: --clearsign or --gpgsign


### PR DESCRIPTION
## Describe your changes

We were getting a weird libcrypto error when trying to connect to the mac signing host via ssh. The reason seems to be because the tekton user has nologin in /etc/passwd and this can limit the use of some crypto functions. This option makes the problem disappear.

## Relevant Jira

RELEASE-1923

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
