### PR TITLE
feat(RELEASE-1925): reapply container metadata change from RELEASE-1771

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -384,6 +384,7 @@ spec:
                 raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${IMAGE_REF}" | jq -c)"
                 oci_version_raw="$(jq -r '.annotations."org.opencontainers.image.version" // ""' <<< "$raw_manifest")"
                 build_date="$(jq -r '.annotations."org.opencontainers.image.created" // ""' <<< "$raw_manifest")"
+                env_variables="[]"
                 labels="{}"
             else
                 # This is a regular container image - use standard skopeo inspect
@@ -395,7 +396,28 @@ spec:
                 oci_version_raw="$(jq -r \
                   '.Labels."org.opencontainers.image.version" // ""'\
                   <<< "$image_metadata")"
-                labels="$(jq -c '.Labels' <<< "${image_metadata}")"
+                env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
+                labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+            fi
+
+            # Add image env_variables metadata to component
+            if [ "$(jq 'length' <<< "$env_variables")" -ne 0 ] ; then
+              env_file=$(mktemp)
+              echo "$env_variables" > "$env_file"
+              jq --argjson i "$i" --slurpfile env "$env_file" \
+                '.components[$i].metadata = (.components[$i].metadata // {}) * {env_variables: $env[0]}' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            fi
+
+            # Add image labels metadata to component
+            if [ "$(jq 'length' <<< "$labels")" -ne 0 ] ; then
+              labels_file=$(mktemp)
+              # Convert labels from {key: value} to [{name: key, value: value}]
+              jq -c 'if . then to_entries | map({name: .key, value: .value}) else [] end' \
+               <<< "$labels" > "$labels_file"
+              jq --argjson i "$i" --slurpfile labels "$labels_file" \
+                '.components[$i].metadata = (.components[$i].metadata // {}) * {labels: $labels[0]}' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 
             # Transform version to OCI tag format: replace + with _ (convention for OCI compliance)

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -62,6 +62,11 @@ function skopeo() {
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}, "annotations": {"org.opencontainers.image.version": "1.2.3-beta"}}'
     return
+  elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://registry.io/metadata"* ]]
+  then
+    echo '{"Labels": {"build-date": "2024-07-29T02:17:29", "com.redhat.component": "app01", "description": "it is some app"}, 
+      "Env": ["container=oci", "PATH=usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]}'
+    return
   elif [[ "$*" == "inspect --retry-times 3 --no-tags --override-os linux --override-arch amd64 docker://quay.io/myorg/api-service"* ]]
   then
     echo '{"Labels": {"build-date": "2024-07-29T02:17:29"}}'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -2,13 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-with-gzipped-layers
+  name: test-apply-mapping-metadata
 spec:
   description: |
-    Run the create-pyxis-image task with an image that has gzipped layers, to
-    see that we reported the uncompressed digests correctly. The data file
-    also has .pyxis.includeLayers set to true, otherwise the layers would be
-    deleted and not processed.
+      Run the apply-mapping task with a snapshot JSON and verify that the resulting
+      snapshot contains the metadata extracted from docker://registry.io/metadata. 
+      This includes the labels and environment variables.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -51,37 +50,44 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
-              #!/usr/bin/env bash
+              #!/usr/bin/env sh
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mapped_snapshot.json << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "app01",
+                      "repositories": [
+                        {
+                          "url": "repo1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comp",
-                    "containerImage": "source@sha256:mydigest",
-                    "repositories": [
-                      {
-                        "url": "registry.io/image-with-gzipped-layers",
-                        "tags": [
-                          "testtag"
-                        ]
+                    "name": "app01",
+                    "containerImage": "registry.io/metadata@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
                       }
-                    ]
+                    }
                   }
                 ]
-              }
-              EOF
-
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
-              {
-                "pyxis": {
-                  "includeLayers": true
-                }
               }
               EOF
           - name: create-trusted-artifact
@@ -96,16 +102,12 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: create-pyxis-image
+        name: apply-mapping
       params:
-        - name: pyxisSecret
-          value: test-create-pyxis-image-cert
-        - name: server
-          value: stage
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/mydata.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -124,16 +126,14 @@ spec:
         - setup
     - name: check-result
       params:
-        - name: pyxisDataPath
-          value: $(tasks.run-task.results.pyxisDataPath)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
+      runAfter:
+        - run-task
       taskSpec:
         params:
-          - name: pyxisDataPath
-            type: string
           - name: sourceDataArtifact
             type: string
           - name: dataDir
@@ -162,32 +162,21 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < \
-                "$(params.dataDir)/mock_create_container_image.txt")" != 1 ]; then
-                echo Error: create_container_image was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_create_container_image.txt"
-                exit 1
-              fi
+              TEST_SNAPSHOT="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+            
+              echo "Test that component 0 has the correct environment variables"
+              test "$(
+                jq -c '.components[0] | .metadata.env_variables // []' < "$TEST_SNAPSHOT"
+              )" == '["container=oci","PATH=usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]'
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 4 ]; then
-                echo Error: oras was expected to be called 4 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
-
-              [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
-
-              # check that the size of the decompressed layers is as expected
-              jq -e '.uncompressed_layers[0].size == 21' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-              jq -e '.uncompressed_layers[1].size == 9' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-
-      runAfter:
-        - run-task
+              echo "Test that component 0 has the correct labels"
+              test "$(
+                jq -c '.components[0] | .metadata.labels // []' < "$TEST_SNAPSHOT"
+              )" == '[{"name":"build-date","value":"2024-07-29T02:17:29"},'\
+              '{"name":"com.redhat.component","value":"app01"},'\
+              '{"name":"description","value":"it is some app"}]'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -2,13 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-with-gzipped-layers
+  name: test-apply-mapping-no-metadata
 spec:
   description: |
-    Run the create-pyxis-image task with an image that has gzipped layers, to
-    see that we reported the uncompressed digests correctly. The data file
-    also has .pyxis.includeLayers set to true, otherwise the layers would be
-    deleted and not processed.
+    Run the apply-mapping task with a snapshot containing a helm chart component
+    and verify that the resulting snapshot contains no metadata.
+  workspaces:
+    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -31,10 +31,15 @@ spec:
       type: string
   tasks:
     - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
+        workspaces:
+          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -51,37 +56,43 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
             script: |
-              #!/usr/bin/env bash
+              #!/usr/bin/env sh
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mapped_snapshot.json << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
               {
-                "application": "myapp",
-                "components": [
-                  {
-                    "name": "comp",
-                    "containerImage": "source@sha256:mydigest",
-                    "repositories": [
-                      {
-                        "url": "registry.io/image-with-gzipped-layers",
-                        "tags": [
-                          "testtag"
-                        ]
-                      }
-                    ]
-                  }
-                ]
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "helm-chart",
+                      "repository": "registry.redhat.io/myorg/helm-chart",
+                      "tags": [
+                        "default"
+                      ]
+                    }
+                  ]
+                }
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
               {
-                "pyxis": {
-                  "includeLayers": true
-                }
+                "application": "some-app",
+                "components": [
+                  {
+                    "name": "helm-chart",
+                    "containerImage": "quay.io/myorg/helm-chart@sha256:789abcdef123456",
+                    "source": {
+                      "git": {
+                        "revision": "commit789xyz",
+                        "url": "https://github.com/myorg/helm-chart.git"
+                      }
+                    }
+                  }
+                ]
               }
               EOF
           - name: create-trusted-artifact
@@ -96,16 +107,12 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: create-pyxis-image
+        name: apply-mapping
       params:
-        - name: pyxisSecret
-          value: test-create-pyxis-image-cert
-        - name: server
-          value: stage
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/mydata.json
+          value: $(context.pipelineRun.uid)/test_data.json
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -123,17 +130,20 @@ spec:
       runAfter:
         - setup
     - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       params:
-        - name: pyxisDataPath
-          value: $(tasks.run-task.results.pyxisDataPath)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
+      runAfter:
+        - run-task
       taskSpec:
+        workspaces:
+          - name: data
         params:
-          - name: pyxisDataPath
-            type: string
           - name: sourceDataArtifact
             type: string
           - name: dataDir
@@ -162,32 +172,19 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < \
-                "$(params.dataDir)/mock_create_container_image.txt")" != 1 ]; then
-                echo Error: create_container_image was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_create_container_image.txt"
-                exit 1
-              fi
+              TEST_SNAPSHOT="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 4 ]; then
-                echo Error: oras was expected to be called 4 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
+              echo "Test that COMPONENT 0 has no environment variables metadata"
+              test "$(
+                jq '.components[0] | .metadata.env_variables // [] | length' < "$TEST_SNAPSHOT"
+              )" -eq 0
 
-              [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
-
-              # check that the size of the decompressed layers is as expected
-              jq -e '.uncompressed_layers[0].size == 21' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-              jq -e '.uncompressed_layers[1].size == 9' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-
-      runAfter:
-        - run-task
+              echo "Test that component has no labels metadata"
+              test "$(
+                jq '.components[0] | .metadata.labels // [] | length' < "$TEST_SNAPSHOT"
+              )" -eq 0

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+      image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
       computeResources:
         limits:
           memory: 3Gi
@@ -205,6 +205,11 @@ spec:
             CONTAINER_IMAGE=$(jq -r ".components[${component_index}].containerImage" "${SNAPSHOT_SPEC_FILE}")
             SOURCE_REPO=${CONTAINER_IMAGE%%@sha256:*}
             DIGEST="${CONTAINER_IMAGE##*@}"
+
+            # Create metadata file for the component to be passed to create_container_image
+            # this includes the labels and env_variables of the container image.
+            METADATA_FILE=$(mktemp)
+            jq -r ".components[${component_index}].metadata // {}" "${SNAPSHOT_SPEC_FILE}" > "$METADATA_FILE"
 
             # Create component-specific auth file to avoid conflicts
             local AUTH_FILE="/tmp/auth_${component_index}"
@@ -338,6 +343,7 @@ spec:
                       --pyxis-url $PYXIS_URL \
                       --certified "$(params.certified)" \
                       --tags "$TAGS" \
+                      --metadata "$METADATA_FILE" \
                       --is-latest "$(params.isLatest)" \
                       --verbose \
                       --oras-manifest-fetch "${MANIFEST_FILE}" \

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -9,16 +9,23 @@ function create_container_image() {
   # Extract repository name from parameters to determine the line number
   # This allows us to have a thread-safe way to determine the image id without locking
   local repository=""
+  local metadata_file=""
   local args=("$@")
 
-  # Parse arguments to extract the --name parameter (repository)
+  # Parse arguments to extract the --name (repository) and --metadata parameters
   for ((i=0; i<${#args[@]}; i++)); do
     if [[ "${args[i]}" == "--name" && $((i+1)) -lt ${#args[@]} ]]; then
       repository="${args[i+1]}"
-      break
+    elif [[ "${args[i]}" == "--metadata" && $((i+1)) -lt ${#args[@]} ]]; then
+      metadata_file="${args[i+1]}"
     fi
   done
 
+  # Append metadata to mock_metadata_output.json
+  if [[ -n "$metadata_file" && -f "$metadata_file" ]]; then 
+    jq . "$metadata_file" >> "$(params.dataDir)/mock_metadata_output.json"
+  fi
+  
   # Find the line number where this repository appears in the file
   local matching_lines=$(grep -n -- "--name $repository" "$(params.dataDir)/mock_create_container_image.txt")
   local line_count=$(echo "$matching_lines" | wc -l)

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
@@ -2,13 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-with-gzipped-layers
+  name: test-create-pyxis-image-containerimage-metadata.yaml
 spec:
   description: |
-    Run the create-pyxis-image task with an image that has gzipped layers, to
-    see that we reported the uncompressed digests correctly. The data file
-    also has .pyxis.includeLayers set to true, otherwise the layers would be
-    deleted and not processed.
+    Run the create-pyxis-image task with two components in the snapshot
+    and metadata. This includes the labels and env_variables of the container image.
+    This test will verify that the metadata is passed to the create_container_image task.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -62,13 +61,47 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comp",
-                    "containerImage": "source@sha256:mydigest",
+                    "name": "comp1",
+                    "containerImage": "source1@sha256:mydigest1",
+                    "metadata": {
+                      "labels": [
+                        {
+                          "name": "testlabel1",
+                          "value": "mydigest1"
+                        }
+                      ],
+                      "env_variables": [
+                        "testenv1=mydigest1"
+                      ]
+                    },
                     "repositories": [
                       {
-                        "url": "registry.io/image-with-gzipped-layers",
+                        "url": "registry.io/another-image1",
                         "tags": [
-                          "testtag"
+                          "testtag1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "source2@sha256:mydigest2",
+                    "metadata": {
+                      "labels": [
+                        {
+                          "name": "testlabel2",
+                          "value": "mydigest2"
+                        }
+                      ],
+                      "env_variables": [
+                        "testenv2=mydigest2"
+                      ]
+                    },
+                    "repositories": [
+                      {
+                        "url": "registry.io/another-image2",
+                        "tags": [
+                          "testtag2"
                         ]
                       }
                     ]
@@ -79,9 +112,6 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
-                "pyxis": {
-                  "includeLayers": true
-                }
               }
               EOF
           - name: create-trusted-artifact
@@ -166,28 +196,25 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
-
-              if [ "$(wc -l < \
-                "$(params.dataDir)/mock_create_container_image.txt")" != 1 ]; then
-                echo Error: create_container_image was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_create_container_image.txt"
-                exit 1
-              fi
-
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 4 ]; then
-                echo Error: oras was expected to be called 4 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
-
-              [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
-
-              # check that the size of the decompressed layers is as expected
-              jq -e '.uncompressed_layers[0].size == 21' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-              jq -e '.uncompressed_layers[1].size == 9' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-
+            
+              metadata_mock="$(params.dataDir)/mock_metadata_output.json"
+              
+              echo "Test that there are 2 metadata objects"
+              test "$(jq -s 'length' "$metadata_mock")" -eq 2
+              
+              echo "Test that testlabel1 with value mydigest1 is present"
+              test "$(jq -s 'any(.[].labels[]; .name == "testlabel1" and .value == "mydigest1")' \
+                "$metadata_mock")" = "true"
+              
+              echo "Test that testlabel2 with value mydigest2 is present"
+              test "$(jq -s 'any(.[].labels[]; .name == "testlabel2" and .value == "mydigest2")' \
+                "$metadata_mock")" = "true"
+              
+              echo "Test that testenv1=mydigest1 is present"
+              test "$(jq -s 'any(.[].env_variables[]; . == "testenv1=mydigest1")' "$metadata_mock")" = "true"
+              
+              echo "Test that testenv2=mydigest2 is present"
+              test "$(jq -s 'any(.[].env_variables[]; . == "testenv2=mydigest2")' "$metadata_mock")" = "true"
+              
       runAfter:
         - run-task

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
@@ -2,13 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-with-gzipped-layers
+  name: test-create-pyxis-image-containerimage-no-metadata.yaml
 spec:
   description: |
-    Run the create-pyxis-image task with an image that has gzipped layers, to
-    see that we reported the uncompressed digests correctly. The data file
-    also has .pyxis.includeLayers set to true, otherwise the layers would be
-    deleted and not processed.
+    Run the create-pyxis-image task with one component in the snapshot
+    and no metadata. This test will verify that an empty object is passed to the 
+    create_container_image task.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -62,13 +61,13 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comp",
-                    "containerImage": "source@sha256:mydigest",
+                    "name": "comp1",
+                    "containerImage": "source1@sha256:mydigest1",
                     "repositories": [
                       {
-                        "url": "registry.io/image-with-gzipped-layers",
+                        "url": "registry.io/another-image1",
                         "tags": [
-                          "testtag"
+                          "testtag1"
                         ]
                       }
                     ]
@@ -79,9 +78,6 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
-                "pyxis": {
-                  "includeLayers": true
-                }
               }
               EOF
           - name: create-trusted-artifact
@@ -166,28 +162,11 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eux
+            
+              metadata_mock="$(params.dataDir)/mock_metadata_output.json"
 
-              if [ "$(wc -l < \
-                "$(params.dataDir)/mock_create_container_image.txt")" != 1 ]; then
-                echo Error: create_container_image was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_create_container_image.txt"
-                exit 1
-              fi
-
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 4 ]; then
-                echo Error: oras was expected to be called 4 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
-
-              [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
-                = "inspect --retry-times 3 --raw docker://registry.io/image-with-gzipped-layers@sha256:mydigest" ]
-
-              # check that the size of the decompressed layers is as expected
-              jq -e '.uncompressed_layers[0].size == 21' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-              jq -e '.uncompressed_layers[1].size == 9' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/oras-manifest-fetch-0-0.json"
-
+              echo "Test that metadata is empty object" 
+              test "$(jq -r '.' "$metadata_mock")" = "{}"
+              
       runAfter:
         - run-task

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -194,7 +194,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

This reverts the revert of RELEASE-1771 .

To recap, the change was causing issues with very large snapshots. The fix for that is merged now (see RELEASE-1919 ), so we are ready to reapply this again.

Original PR: https://github.com/konflux-ci/release-service-catalog/pull/1475

Revert PR: https://github.com/konflux-ci/release-service-catalog/pull/1530

## Relevant Jira

RELEASE-1925

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
