### PR TITLE
fix(RELEASE-1930): mask portions of mac signing logs

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -488,13 +488,16 @@ spec:
         mkdir -p "$BINARY_PATH"
 
         cd "$TEMP_DIR"
+        set +x
         /usr/local/bin/oras login quay.io -u ${QUAY_USER} -p ${QUAY_PASS}
+        set -x
         /usr/local/bin/oras pull $(params.quayURL)/unsigned@$unsigned_digest -o "$BINARY_PATH"
         # This is the directory where the content was extracted
         CONTENT_DIR=\$(find "$BINARY_PATH" -maxdepth 1 -type d | tail -n 1)
 
+        set +x
         security unlock-keychain -p $KEYCHAIN_PASSWORD login.keychain
-
+        set -x
         echo "Signing files in the \$CONTENT_DIR directory..."
         find "\$CONTENT_DIR" -type f | while read file; do
             echo "Signing: \$file"
@@ -509,11 +512,14 @@ spec:
         NEW_CONTENT_DIR=\$(basename "\$CONTENT_DIR")
         zip -r "$ZIP_PATH" "\$NEW_CONTENT_DIR"
 
+        echo "Submitting ZIP file to Apple notary service..."
+        set +x
         xcrun notarytool submit "$ZIP_PATH" \
             --wait \
             --apple-id "$APPLE_ID" \
             --team-id "$TEAM_ID" \
             --password "$APP_SPECIFIC_PASSWORD"
+        set -x
 
         PUSH_OUTPUT=\$(/usr/local/bin/oras push "$QUAY_URL/signed:$(context.taskRun.uid)-mac" "\$NEW_CONTENT_DIR")
         SIGNED_DIGEST=\$(echo "\$PUSH_OUTPUT" | grep 'Digest:' | awk '{print \$2}')


### PR DESCRIPTION
This change will ensure that no sensitive data is written to the logs for the apple signing steps.

## Relevant Jira
RELEASE-1930

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
