### PR TITLE
feat(RELEASE-1457): branch promotion workflow supports hot fixes

### DIFF
--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -42,6 +42,14 @@ on:
         type: boolean
         required: true
         default: false
+      override-hotfix-check:
+        description: |
+          Override hotfix check: If true, do not fail when hotfix commits are found that are missing in the source
+          branch. Warning: If you select this, you risk reintroducing a bug that was hot fixed. Only use this option
+          if you know the bug is fixed in the source branch (just perhaps in a different way)
+        type: boolean
+        required: true
+        default: false
 jobs:
   promote-branch:
     name: Promote Branch
@@ -98,12 +106,13 @@ jobs:
         id: promote
         run: |
           .github/scripts/promote_branch.sh --promotion-type $PROMOTION_TYPE --force-to-staging $FORCE \
-            --override $OVERRIDE --dry-run $DRY
+            --override $OVERRIDE --dry-run $DRY --override-hotfix-check $OVERRIDE_HOTFIX
         env:
           PROMOTION_TYPE: ${{ inputs.promotion-type }}
           FORCE: ${{ inputs.force-to-staging }}
           OVERRIDE: ${{ inputs.override }}
           DRY: ${{ inputs.dry-run }}
+          OVERRIDE_HOTFIX: ${{ inputs.override-hotfix-check }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Update Jira ticket(s)


### PR DESCRIPTION
This commit updates the promote branch workflow to add support for hot fix commits. It will now force push when promoting so that hot fix commits do not have to be reverted beforehand. In addition, there is now a new check (which can be overridden) to ensure that the promotion will not wipe out the contents of a hot fix commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
