### PR TITLE
fix: update request timeout for set-advisory-severity

### DIFF
--- a/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/pipelines/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -23,6 +23,7 @@ spec:
       description: The revision in the taskGitUrl repo to be used
   tasks:
     - name: get-advisory-severity
+      timeout: "1h57m0s"
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -443,6 +443,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       taskRef:
+        timeout: "2h0m0s"
         params:
           - name: url
             value: $(params.taskGitUrl)

--- a/tasks/managed/set-advisory-severity/README.md
+++ b/tasks/managed/set-advisory-severity/README.md
@@ -7,7 +7,7 @@ Tekton task to set the severity level in the releaseNotes key of the data.json. 
 | Name                    | Description                                                                                                                | Optional | Default value        |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
 | dataPath                | Path to the JSON string of the merged data to use in the data workspace                                                    | No       | -                    |
-| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 2700                 |
+| requestTimeout          | InternalRequest timeout                                                                                                    | Yes      | 7200                 |
 | pipelineRunUid          | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                    |
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -18,7 +18,7 @@ spec:
       type: string
     - name: requestTimeout
       type: string
-      default: "2700"
+      default: "7200"
       description: InternalRequest timeout
     - name: pipelineRunUid
       type: string


### PR DESCRIPTION
## Describe your changes
Updates the task request timeout to unblock a user

Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1761308043008289?thread_ts=1761242801.686919&cid=C04PZ7H0VA8
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
