### PR TITLE
fix: move timeout from taskRef in set-advisory-severity

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -421,6 +421,7 @@ spec:
         - check-data-keys
         - populate-release-notes
     - name: set-advisory-severity
+      timeout: "2h0m0s"
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
           operator: in
@@ -443,7 +444,6 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       taskRef:
-        timeout: "2h0m0s"
         params:
           - name: url
             value: $(params.taskGitUrl)


### PR DESCRIPTION
## Describe your changes
Tekton requires timeout on the Pipeline Task, not under taskRef.

This breaking change come from #1555
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
