### PR TITLE
feat(RELEASE-1731): update release-service-utils reference

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -146,7 +146,7 @@ spec:
         - name: orasOptions
           value: $(params.orasOptions)
     - name: add-contribution
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
@@ -65,7 +65,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
             type: string
         steps:
           - name: check-sanitization
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -146,7 +146,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-basic.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-basic.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:9c82b0f13e40e76150835b628c86ce05ae95a366
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -133,7 +133,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:9c82b0f13e40e76150835b628c86ce05ae95a366
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:9c82b0f13e40e76150835b628c86ce05ae95a366
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-staged-processing
-            image: quay.io/konflux-ci/release-service-utils:9c82b0f13e40e76150835b628c86ce05ae95a366
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               #
@@ -266,7 +266,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -248,6 +248,6 @@ spec:
 
               echo Test that comp3 has the correct contentGateway defaults
               test "$(
-                jq -c '.components[] | select(.name=="comp3") | .contentGateway' \
+                jq -cS '.components[] | select(.name=="comp3") | .contentGateway' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
-              )" == '{"productName":"myapp","productCode":"MYAPP","productVersionName":"1.0","filePrefix":"myapp-1.3"}'
+              )" == '{"filePrefix":"myapp-1.3","productCode":"MYAPP","productName":"myapp","productVersionName":"1.0"}'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a58dc96cb28b54cdef2564a346d43a6d7bd4d656
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c11bda9ba25f1a2008dadac3d2f9925a8da3bac1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -89,7 +89,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: base64-encode-checksum
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -98,7 +98,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
@@ -93,7 +93,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: build-rpm-packages
-      image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-output-path.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-output-path.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +150,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-custom-path
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-incomplete-envfile.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-incomplete-envfile.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-missing-envfile.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-missing-envfile.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -109,7 +109,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-no-modules.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-no-modules.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,7 +108,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-source-integrity.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-source-integrity.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-integrity
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -151,7 +151,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:001c270152854f9184d29fb6ed2dfc93c8749930ed1cf87a01f0cf7b32c1c39c
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -103,7 +103,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -15,7 +15,7 @@ spec:
       description: The uid of the current pipelineRun. It is only available at the pipeline level
   steps:
     - name: cleanup-internal-requests
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
@@ -18,11 +18,11 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
-              
+
               cat > irs << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: InternalRequest
@@ -65,7 +65,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -27,7 +27,7 @@ spec:
       description: Workspace where the directory to cleanup exists
   steps:
     - name: cleanup
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -20,7 +20,7 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
@@ -19,7 +19,7 @@ spec:
           - name: input
         steps:
           - name: put-content-in-workspace
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -52,7 +52,7 @@ spec:
           - name: input
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -61,7 +61,7 @@ spec:
     - name: access-token-secret-vol
       secret:
         secretName: konflux-advisory-jira-secret
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -96,7 +96,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: close-issues
-      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -143,7 +143,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -108,7 +108,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-atlas-params
       image:
-        quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -98,11 +98,14 @@ spec:
       taskSpec:
         params:
           - name: secretName
+            type: string
           - name: ssoTokenUrl
+            type: string
           - name: atlasApiUrl
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,13 +108,18 @@ spec:
       taskSpec:
         params:
           - name: secretName
+            type: string
           - name: ssoTokenUrl
+            type: string
           - name: atlasApiUrl
+            type: string
           - name: retryAWSSecretName
+            type: string
           - name: retryS3Bucket
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -104,10 +104,12 @@ spec:
       taskSpec:
         params:
           - name: secretName
+            type: string
           - name: retryAWSSecretName
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,13 +108,18 @@ spec:
       taskSpec:
         params:
           - name: secretName
+            type: string
           - name: ssoTokenUrl
+            type: string
           - name: atlasApiUrl
+            type: string
           - name: retryAWSSecretName
+            type: string
           - name: retryS3Bucket
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d320c36f3d707cd5bfe55fe783f70236c06cc2e5
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -125,7 +125,7 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
   steps:
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 64Mi
@@ -282,7 +282,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -41,11 +41,13 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -162,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -41,11 +41,13 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -162,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -31,11 +31,13 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -114,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -31,11 +31,13 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -104,7 +106,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -46,11 +46,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -205,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -238,7 +240,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -45,11 +45,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -200,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -231,7 +233,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
@@ -45,11 +45,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -248,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -262,7 +264,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -45,11 +45,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -219,7 +221,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -240,7 +242,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
@@ -45,11 +45,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -211,7 +213,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -230,7 +232,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
@@ -46,11 +46,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -212,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -228,7 +230,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -45,11 +45,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
@@ -229,7 +231,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -264,7 +266,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:c896b10f793954cc27ff4b9e8df23563df64359f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -101,7 +101,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-gh-params
       image:
-        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -92,7 +92,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-index-images
       image:
-        quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -107,6 +107,9 @@ spec:
       taskSpec:
         params:
           - name: indexImageSnapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
         volumes:
           - name: workdir
             emptyDir: {}
@@ -131,7 +134,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -111,6 +111,9 @@ spec:
       taskSpec:
         params:
           - name: indexImageSnapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
         volumes:
           - name: workdir
             emptyDir: {}
@@ -135,7 +138,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -107,6 +107,9 @@ spec:
       taskSpec:
         params:
           - name: indexImageSnapshot
+            type: string
+          - name: sourceDataArtifact
+            type: string
         volumes:
           - name: workdir
             emptyDir: {}
@@ -131,7 +134,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
@@ -104,7 +104,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-mrrc-params
-      image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:28fca729e118024bd0f1bd8db4f2651a130ef152
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -147,13 +147,17 @@ spec:
       taskSpec:
         params:
           - name: mrrcParamFilePath
+            type: string
           - name: charonConfigFilePath
+            type: string
           - name: charonAWSSecret
+            type: string
           - name: sourceDataArtifact
             type: string
           - name: dataDir
             type: string
           - name: charonSignCASecret
+            type: string
         volumes:
           - name: workdir
             emptyDir: {}
@@ -178,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -86,7 +86,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-secret
       image:
-        quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -87,8 +87,6 @@ spec:
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,8 +83,6 @@ spec:
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -108,9 +106,10 @@ spec:
       taskSpec:
         params:
           - name: secret
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -89,8 +89,6 @@ spec:
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -114,9 +112,10 @@ spec:
       taskSpec:
         params:
           - name: secret
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -107,7 +107,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -145,9 +145,10 @@ spec:
       taskSpec:
         params:
           - name: message
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -153,11 +153,14 @@ spec:
       taskSpec:
         params:
           - name: message
+            type: string
           - name: slack-notification-secret
+            type: string
           - name: slack-notification-secret-keyname
+            type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -98,7 +98,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-task-params
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-empty-keys.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-empty-keys.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-invalid-index.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-invalid-index.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-missing-resultindex.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-missing-resultindex.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-data.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-default.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-default.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-non-integer-index.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-non-integer-index.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-array.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-array.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-json.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-json.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -126,14 +126,20 @@ spec:
       taskSpec:
         params:
           - name: arrayValue
+            type: string
           - name: bar
+            type: string
           - name: simpleValue
+            type: string
           - name: defaultStringValue
+            type: string
           - name: defaultNumberValue
+            type: string
           - name: emptyDefaultValue
+            type: string
         steps:
           - name: verify-results
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -306,7 +306,7 @@ spec:
           .releaseNotes.content.artifacts = $updated
         ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -255,7 +255,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -234,7 +234,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -269,7 +269,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -269,7 +269,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -302,7 +302,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -278,7 +278,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -295,7 +295,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -263,7 +263,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -306,7 +306,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -237,8 +237,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: "contentType"
-          value: "binary"
       runAfter:
         - setup
     - name: check-result
@@ -281,7 +279,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -362,7 +360,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -72,7 +72,7 @@ spec:
     - name: gh-token-secret-vol
       secret:
         secretName: $(params.githubSecret)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -107,7 +107,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-release-from-binaries
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -138,7 +138,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-release.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -137,7 +137,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -97,7 +97,7 @@ spec:
     - name: pyxis-secret-vol
       secret:
         secretName: $(params.pyxisSecret)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -194,7 +194,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:4579b8d372e034d788129fa16185c1278faecd09
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes
The PR is one the PRs which update the [release-service-utils](https://issues.redhat.com/browse/RELEASE-service-utils) image references for [RELEASE-1731](https://issues.redhat.com/browse/RELEASE-1731). It also changes the secrets defaultMode from 0400 to 0444 so user 1001 can read them. Related to https://github.com/konflux-ci/release-service-utils/pull/552

This PR includes changes in below managed tasks and unit tests:
add-fbc-contribution
apply-mapping
base64-encode-checksum
build-oot-kmods-rpms
check-data-keys
cleanup-internal-requests
cleanup-workspace
close-advisory-issues
collect-atlas-params
collect-data
collect-gh-params
collect-index-images
collect-mrrc-params
collect-registry-token-secret
collect-slack-notification-params
collect-task-params
create-advisory
create-advisory.yaml
create-github-release

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
