### PR TITLE
feat(RELEASE-1731): update release-service-utils refs

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -68,7 +68,7 @@ spec:
     - name: pyxis-secret-vol
       secret:
         secretName: $(params.pyxisSecret)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -106,7 +106,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi
@@ -278,7 +278,7 @@ spec:
         fi
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -223,7 +223,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34016ab5a3904257c198a12d1829b0093214b6ee
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:fe734aa04168690e96f0a729f93845e7c70b7934
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               set -eux
 
@@ -150,7 +150,7 @@ spec:
         - name: pushSecret
           value: "push-koji-test"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+          value: "quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -71,7 +71,7 @@ spec:
     - name: pulp-secret-name-vol
       secret:
         secretName: $(params.PULP_SECRET_NAME)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     env:
       - name: SNAPSHOT_PATH
@@ -131,7 +131,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-rpms-to-pulp
-      image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:d39d3af868c7136f7e4bffb32d1e625398d6264a
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -118,7 +118,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-copy-artifacts.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-copy-artifacts
+spec:
+  description: |
+    Run the push-snapshot task with copyAttachedArtifacts enabled to test artifact copying functionality.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "reg.io/test@sha256:abcdefg",
+                    "repositories": [
+                      {
+                        "url": "registry.com/repository",
+                        "tags": [ "tag1", "tag2" ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "reg.io/test@sha256:hijklmn",
+                    "repositories": [
+                      {
+                        "url": "registry.com/repository",
+                        "tags": [ "tag3" ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": false
+                  },
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repositories": [
+                        {
+                          "url": "registry.com/repository"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp2",
+                      "repositories": [
+                        {
+                          "url": "registry.com/repository"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: "0"
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: copyAttachedArtifacts
+          value: "true"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: ociStorage
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              # Verify oras discover was called on both source images
+              grep 'discover --registry-config .* reg.io/test@sha256:abcdefg --format json' \
+                "$(params.dataDir)/mock_oras.txt"
+              grep 'discover --registry-config .* reg.io/test@sha256:hijklmn --format json' \
+                "$(params.dataDir)/mock_oras.txt"
+              # Since mock returns 1 artifact for sha256:abcdefg, task should use oras cp -r for its tags
+              grep -E \
+                'cp -r( --from-registry-config [^ ]+ --to-registry-config [^ ]+)?' \
+                "$(params.dataDir)/mock_oras.txt" | \
+              grep -E 'reg.io/test@sha256:abcdefg'
+              # For hijklmn (no artifacts), it should fall back to cosign copy
+              # Count cosign copy calls (tag1, tag2, tag3)
+              COPIES=$(grep -c \
+                '^copy -f reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
+                "$(params.dataDir)/mock_cosign.txt" || true)
+              COPIES2=$(grep -c \
+                '^copy -f reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
+                "$(params.dataDir)/mock_cosign.txt" || true)
+              TOTAL=$((COPIES + COPIES2))
+              # We expect 1 cosign copy (tag3) and 0 for tag1/tag2 (handled by oras cp -r)
+              test "$TOTAL" -eq 1 || {
+                echo "Unexpected cosign copies: $TOTAL (expected 1 for tag3 only)"
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              }
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-digests-match.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-digests-match
+spec:
+  description: |
+    Run the push-snapshot task with the source digest matching the destination digest.
+    No push will happen in this scenario.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped_snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag",
+                    "repositories": [
+                      {
+                        "url": "registry.io/image",
+                        "tags": [
+                          "tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              echo '{}' > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ -f "$(params.dataDir)/mock_cosign.txt" ]; then
+                echo Error: cosign was not expected to be called. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 2 ]; then
+                echo Error: oras was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              echo Make sure the results file was still written even though no push happened
+              test "$(jq -r '.images[0].name' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == "comp"
+              test "$(jq -r '.images[0].shasum' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == \
+                "sha256:0b770b6ec5414e841167266c96af42404e9f7049f72c21d0ab312e07c9403197"
+              test "$(jq -r '.images[0].urls | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "1"
+              test "$(jq -r '.images[0].arches | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-credentials.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-fail-no-credentials
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot task and check that it fails when trying to access a container
+    image without credentials while continuing to push the remaining images.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/no-permmission:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2",
+                        "tags": [
+                          "latest"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location3",
+                        "tags": [
+                          "some-cool-tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-data-file.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-fail-no-data-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot task with the no data file present in the default filepath of
+    data.json. The task should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped_snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location",
+                        "tags": [
+                          "tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-fail-no-snapshot-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot task with the no snapshot file present in the default filepath
+    of mapped_snapshot.json. The task should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-fail-tagless-component.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-fail-tagless-component
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot task with a component that has no tags. The task
+    should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-mount-certs.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-mount-certs
+spec:
+  description: |
+    Run the push-snapshot task and verify custom certificate is mounted
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "private-registry.io/image:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2",
+                        "tags": [
+                          "some-cool-tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: caTrustConfigMapName
+          value: test-use-custom-ca-cert
+        - name: caTrustConfigMapKey
+          value: cert
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # 2 for comp1 (the 2 provided tags)
+              # 3 for comp2 (provided tag, once for image, once for source container, + once for source tag)
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 8 ]; then
+                echo Error: oras was expected to be called 8 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              test "$(jq -r '.images[0].name' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == "comp1"
+              test "$(jq -r '.images[0].shasum' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == \
+                "sha256:6ff029b0b6cf82e3df2a2360dc88cd527c51132b557207d64634d9c245e0d15e"
+              test "$(jq -r '.images[0].urls | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+              test "$(jq -r '.images[0].arches | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-multi-repos.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-multi-repos.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-multi-repos
+spec:
+  description: |
+    Run the push-snapshot task with a component that has multiple repositories.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      },
+                      {
+                        "url": "backup-registry.io/backup-location1",
+                        "tags": [
+                          "backup-tag1",
+                          "backup-tag2"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2",
+                        "tags": [
+                          "some-cool-tag"
+                        ]
+                      },
+                      {
+                        "url": "mirror-registry.io/mirror-location2",
+                        "tags": [
+                          "mirror-tag"
+                        ]
+                      },
+                      {
+                        "url": "dev-registry.io/dev-location2",
+                        "tags": [
+                          "dev-tag1",
+                          "dev-tag2",
+                          "dev-tag3"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 17 ]; then
+                echo Error: cosign was expected to be called 17 times. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" -lt 7 ]; then
+                echo Error: oras was expected to be called at least 7 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              test "$(jq -r '.images[0].name' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == "comp1"
+
+              test "$(jq -r '.images[0].shasum' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == \
+                "sha256:6ff029b0b6cf82e3df2a2360dc88cd527c51132b557207d64634d9c245e0d15e"
+
+              test "$(jq -r '.images[0].urls | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "4"
+              test "$(jq -r '.images[0].arches | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+
+              test "$(jq -r '.images[1].name' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == "comp2"
+
+              test "$(jq -r '.images[1].urls | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "11"
+              test "$(jq -r '.images[1].arches | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+
+              # Verify specific URLs are present
+              urls_comp1=$(jq -r '.images[0].urls[]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")
+              echo "$urls_comp1" | grep -q "prod-registry.io/prod-location1:tag1-12345"
+              echo "$urls_comp1" | grep -q "prod-registry.io/prod-location1:tag2-zyxw"
+              echo "$urls_comp1" | grep -q "backup-registry.io/backup-location1:backup-tag1"
+              echo "$urls_comp1" | grep -q "backup-registry.io/backup-location1:backup-tag2"
+
+              urls_comp2=$(jq -r '.images[1].urls[]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")
+              echo "$urls_comp2" | grep -q "prod-registry.io/prod-location2:some-cool-tag"
+              echo "$urls_comp2" | grep -q "mirror-registry.io/mirror-location2:mirror-tag"
+              echo "$urls_comp2" | grep -q "dev-registry.io/dev-location2:dev-tag1"
+              echo "$urls_comp2" | grep -q "dev-registry.io/dev-location2:dev-tag2"
+              echo "$urls_comp2" | grep -q "dev-registry.io/dev-location2:dev-tag3"
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-parallel.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-parallel
+spec:
+  description: |
+    Run the push-snapshot task with various components and tags with multiple images proccessed in parallel.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/parallel-image:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/parallel-image:tag2",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2",
+                        "tags": [
+                          "some-cool-tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Validate mock call counts first
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 5 ]; then
+                echo Error: cosign was expected to be called 5 times.
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times.
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 8 ]; then
+                echo Error: oras was expected to be called 8 times.
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              if ! grep -q '5' "$(params.dataDir)"/*.count; then
+                echo "Error: Expected to see 5 parallel runs of push_image at some point."
+                echo "Actual counts:"
+                cat "$(params.dataDir)"/*.count
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-component
+spec:
+  description: |
+    Run the push-snapshot task with pushSourceContainer enabled via the component
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:abcdefg",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
+                    ],
+                    "source": {
+                      "git": {
+                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
+                        "url": "https://github.com/abc/python-basic"
+                      }
+                    },
+                    "pushSourceContainer": true
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # The sha 4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03 is calculated
+              # from the origin image pull spec - see oras() in mocks.sh
+              cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
+              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+               prod-registry.io/prod-location:testtag-source
+              EOF
+
+              # Sort to ignore the cosign call orders as it differs from parallel execution.
+              sort "$(params.dataDir)/cosign_expected_calls.txt" > \
+              "$(params.dataDir)/cosign_expected_calls_sorted.txt"
+              sort "$(params.dataDir)/mock_cosign.txt" > \
+              "$(params.dataDir)/mock_cosign_sorted.txt"
+
+              if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls_sorted.txt")" \
+                != "$(md5sum < "$(params.dataDir)/mock_cosign_sorted.txt")" ]; then
+                echo "Error: Expected cosign calls do not match actual calls"
+                echo Actual calls:
+                cat "$(params.dataDir)/mock_cosign_sorted.txt"
+                echo Expected calls:
+                cat "$(params.dataDir)/cosign_expected_calls_sorted.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
+                echo Error: oras was expected to be called 5 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -1,0 +1,209 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-defaults
+spec:
+  description: |
+    Run the push-snapshot task with pushSourceContainer enabled via the defaults
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:abcdefg",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
+                    ],
+                    "source": {
+                      "git": {
+                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
+                        "url": "https://github.com/abc/python-basic"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
+              # from the origin image pull spec - see mocks.sh
+              cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
+              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+               prod-registry.io/prod-location:testtag-source
+              EOF
+
+              # Sort to ignore the cosign call orders as it differs from parallel execution.
+              sort "$(params.dataDir)/cosign_expected_calls.txt" > \
+              "$(params.dataDir)/cosign_expected_calls_sorted.txt"
+              sort "$(params.dataDir)/mock_cosign.txt" > \
+              "$(params.dataDir)/mock_cosign_sorted.txt"
+
+              if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls_sorted.txt")" \
+                != "$(md5sum < "$(params.dataDir)/mock_cosign_sorted.txt")" ]; then
+                echo "Error: Expected cosign calls do not match actual calls"
+                echo Actual calls:
+                cat "$(params.dataDir)/mock_cosign_sort.txt"
+                echo Expected calls:
+                cat "$(params.dataDir)/cosign_expected_calls_sort.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
+                echo Error: oras was expected to be called 5 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-multiarch
+spec:
+  description: |
+    Test push-snapshot with a multi-architecture main image and source container to ensure .src
+     resolves and pushes without platform args.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "multiarch-app",
+                "components": [
+                  {
+                    "name": "multi-comp",
+                    "containerImage": "reg.io/test@sha256:abcdefg",
+                    "repositories": [
+                      {
+                        "url": "prod.io/loc",
+                        "tags": ["multi-tag"]
+                      }
+                    ],
+                    "pushSourceContainer": true
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {}
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
+              copy -f reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
+              EOF
+
+              if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls.txt")" \
+                != "$(md5sum < "$(params.dataDir)/mock_cosign.txt")" ]; then
+                echo "Error: Expected cosign calls do not match actual calls"
+                cat "$(params.dataDir)/mock_cosign.txt"
+                echo "Expected:"
+                cat "$(params.dataDir)/cosign_expected_calls.txt"
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* reg.io/test:sha256-abcdefg.src$" \
+                "$(params.dataDir)/mock_oras.txt" || {
+                echo "Error: Source .src resolution call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* reg.io/test:sha256-abcdefg.src" \
+                "$(params.dataDir)/mock_oras.txt"; then
+                echo "Error: Source .src resolution should not use --platform"
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* prod.io/loc:sha256-abcdefg.src$" \
+                "$(params.dataDir)/mock_oras.txt" || {
+                echo "Error: Initial .src push call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* prod.io/loc:sha256-abcdefg.src" \
+                "$(params.dataDir)/mock_oras.txt"; then
+                echo "Error: Initial .src push should not use --platform"
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* prod.io/loc:multi-tag-source$" \
+                "$(params.dataDir)/mock_oras.txt" || {
+                echo "Error: Tagged .src push call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* prod.io/loc:multi-tag-source" \
+                "$(params.dataDir)/mock_oras.txt"; then
+                echo "Error: Tagged .src push should not use --platform"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-skip-existing
+spec:
+  description: |
+    Run the push-snapshot task including source container push.
+    Test the scenario where the destination image already exists (both binary and source).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/skip-image:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/skip-image",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ -f "$(params.dataDir)/mock_cosign.txt" ]; then
+                echo Error: cosign was not expected to be called. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
+                echo Error: oras was expected to be called 5 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot-retries.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-retries
+spec:
+  description: |
+    Run the push-snapshot task with retries.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/retry-image:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location",
+                        "tags": [
+                          "latest"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              echo '{}' > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/mydata.json
+        - name: retries
+          value: 3
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 4 ]; then
+                echo Error: cosign was expected to be called 4 times. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 2 ]; then
+                echo Error: oras was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/backup/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/backup/test-push-snapshot.yaml
@@ -1,0 +1,211 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot
+spec:
+  description: |
+    Run the push-snapshot task with various components and tags.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1:tag1",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location1",
+                        "tags": [
+                          "tag1-12345",
+                          "tag2-zyxw"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2:tag2",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location2",
+                        "tags": [
+                          "some-cool-tag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # 2 for comp1 (the 2 provided tags)
+              # 3 for comp2 (provided tag, once for image, once for source container, + once for source tag)
+              if [ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" != 5 ]; then
+                echo Error: cosign was expected to be called 5 times. Actual calls:
+                cat "$(params.dataDir)/mock_cosign.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 8 ]; then
+                echo Error: oras was expected to be called 8 times. Actual calls:
+                cat "$(params.dataDir)/mock_oras.txt"
+                exit 1
+              fi
+
+              test "$(jq -r '.images[0].name' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == "comp1"
+              test "$(jq -r '.images[0].shasum' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" == \
+                "sha256:6ff029b0b6cf82e3df2a2360dc88cd527c51132b557207d64634d9c245e0d15e"
+              test "$(jq -r '.images[0].urls | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+              test "$(jq -r '.images[0].arches | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json")" \
+                == "2"
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eu

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -161,7 +161,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -149,7 +149,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -51,13 +51,15 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               # Write to writable directory
-              cat > /var/workdir/snapshot << EOF
+              cat > snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
               metadata:
@@ -74,9 +76,8 @@ spec:
                   - name: tom
                     containerImage: newimage2
               EOF
-              kubectl apply -f /var/workdir/snapshot
+              kubectl apply -f snapshot
 
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               kubectl get snapshot/snapshot-sample -ojson | jq .spec | tee \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json"
               chmod 666 "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json"
@@ -157,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -173,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -170,7 +170,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -176,7 +176,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -48,11 +48,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > snapshot << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Snapshot
@@ -150,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +173,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -73,7 +73,7 @@ spec:
     - name: secret-vol
       secret:
         secretName: $(params.secretName)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -85,6 +85,9 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser:
+        1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -108,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 2.5Gi
@@ -153,7 +156,11 @@ spec:
             fi
         fi
         PUBLIC_KEY_FILE=$(mktemp)
+        id
+        pwd
+        ls -ld /tekton/home
         echo -n "${PUBLIC_KEY:?}" > "$PUBLIC_KEY_FILE"
+        ls -ld "$PUBLIC_KEY_FILE"
 
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
 

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -35,6 +35,8 @@ spec:
           - name: workdir
             emptyDir: {}
         stepTemplate:
+          securityContext:
+            runAsUser: 1001
           volumeMounts:
             - mountPath: /var/workdir
               name: workdir
@@ -47,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -176,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -166,7 +166,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -95,7 +95,7 @@ spec:
     - name: pyxis-secret-vol
       secret:
         secretName: $(params.pyxisSecret)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -293,7 +293,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -237,7 +237,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -312,7 +312,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -339,7 +339,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -236,7 +236,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-repos.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-repos.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -299,7 +299,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -221,7 +221,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -267,7 +267,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -280,7 +280,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -113,7 +113,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -120,8 +120,6 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
-        - name: dataPath
-          value: ""
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
         - name: ociStorage
@@ -174,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -ex
@@ -277,7 +275,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,8 +131,6 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
-        - name: dataPath
-          value: ""
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
         - name: ociStorage
@@ -170,7 +168,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -ex
@@ -204,7 +202,7 @@ spec:
               test "$MR" == ""
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -132,8 +132,6 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
-        - name: dataPath
-          value: ""
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
         - name: ociStorage
@@ -171,7 +169,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -ex
@@ -206,7 +204,7 @@ spec:
               test "$MR" == "https://g/r/-/merge_requests/18"
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -128,8 +128,6 @@ spec:
           value: $(context.pipelineRun.uid)
         - name: snapshotPath
           value: $(context.pipelineRun.uid)/snapshot_spec.json
-        - name: dataPath
-          value: ""
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
         - name: ociStorage
@@ -182,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -ex
@@ -283,7 +281,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -12,14 +12,18 @@ spec:
   params:
     - name: message
       description: Message to be sent
+      type: string
     - name: tasksStatus
       description: status of tasks execution
+      type: string
     - name: secretName
       description: |
         Name of secret which contains authentication token for app
+      type: string
     - name: secretKeyName
       description: |
         Name of key within secret which contains webhook URL
+      type: string
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored
       type: string
@@ -96,7 +100,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: send-message
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -95,7 +95,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: set-severity
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -129,8 +129,6 @@ spec:
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
@@ -159,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -103,8 +103,6 @@ spec:
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
@@ -133,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -130,8 +130,6 @@ spec:
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
@@ -160,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -115,7 +115,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: sign-base64-blob
       image:
-        quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -109,8 +109,6 @@ spec:
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-        - name: dataPath
-          value: $(context.pipelineRun.uid)/data.json
         - name: binariesPath
           value: $(context.pipelineRun.uid)/binaries
       taskSpec:
@@ -145,7 +143,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +197,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -105,7 +105,7 @@ spec:
     - name: pyxis-secret-vol
       secret:
         secretName: $(params.pyxisSecret)
-        defaultMode: 0400
+        defaultMode: 0444
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -140,7 +140,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-index-image
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -123,8 +123,6 @@ spec:
       params:
         - name: requester
           value: testuser
-        - name: referenceImage
-          value: quay.io/testrepo/testimage:tag
         - name: manifestListDigests
           value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
@@ -154,15 +152,10 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:
-        - name: sourceDataArtifact
-          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -225,7 +218,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -117,8 +117,6 @@ spec:
       params:
         - name: requester
           value: testuser
-        - name: referenceImage
-          value: quay.io/testrepo/testimage:tag
         - name: manifestListDigests
           value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
@@ -148,15 +146,10 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:
-        - name: sourceDataArtifact
-          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -223,7 +216,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -114,8 +114,6 @@ spec:
       params:
         - name: requester
           value: testuser
-        - name: referenceImage
-          value: quay.io/redhat/redhat----testimage:tag
         - name: manifestListDigests
           value: "sha256:6f9a420f660e73b"
         - name: pipelineRunUid
@@ -153,7 +151,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +195,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -115,8 +115,6 @@ spec:
       params:
         - name: requester
           value: testuser
-        - name: referenceImage
-          value: quay.io/testrepo/testimage:tag
         - name: manifestListDigests
           value: "sha256:6f9a420f660e73a sha256:6f9a420f660e73b"
         - name: pipelineRunUid
@@ -146,15 +144,10 @@ spec:
       runAfter:
         - setup
     - name: check-result
-      params:
-        - name: sourceDataArtifact
-          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
-        - name: dataDir
-          value: $(params.dataDir)
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -215,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -72,15 +72,15 @@ spec:
     - name: bs-keytab
       secret:
         secretName: $(params.checksumKeytab)    
-        defaultMode: 0400
+        defaultMode: 0444
     - name: checksum-fingerprint
       secret:
         secretName: $(params.checksumFingerprint)
-        defaultMode: 0400
+        defaultMode: 0444
     - name: signing-secret-vol
       secret:
         secretName: $(params.signing-secret)
-        defaultMode: 0400
+        defaultMode: 0444
     - name: workdir
       emptyDir: {}
   stepTemplate:
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-files
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -109,7 +109,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -77,7 +77,7 @@ spec:
               }
               EOF
 
-              cat > release << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -87,7 +87,7 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
           - name: create-trusted-artifact-array
             ref:
               name: create-trusted-artifact-array
@@ -106,8 +106,6 @@ spec:
           value: default/release-cr-status-union
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: ociStorage
@@ -130,7 +128,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +148,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -64,7 +64,7 @@ spec:
               }
               EOF
 
-              cat > releaseplan << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/releaseplan" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
               metadata:
@@ -74,7 +74,7 @@ spec:
                 application: foo
                 target: foo
               EOF
-              kubectl apply -f releaseplan
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/releaseplan"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -119,7 +119,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
               }
               EOF
 
-              cat > release << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -89,7 +89,7 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
           - name: create-trusted-artifact-array
             ref:
               name: create-trusted-artifact-array
@@ -108,8 +108,6 @@ spec:
           value: default/release-cr-status-multiple
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
         - name: dataDir
           value: $(params.dataDir)
         - name: ociStorage
@@ -132,7 +130,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +156,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -63,7 +63,7 @@ spec:
               }
               EOF
 
-              cat > release << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -73,7 +73,7 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
               kubectl patch release release-cr-status-overwrite -n default \
                 --type=merge --subresource status --patch "status: {automated: false}"
           - name: create-trusted-artifact
@@ -117,7 +117,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -49,12 +49,13 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              cat > release << EOF
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -64,9 +65,8 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
               
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -63,7 +63,7 @@ spec:
               }
               EOF
 
-              cat > release << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -73,7 +73,7 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -61,7 +61,7 @@ spec:
               }
               EOF
 
-              cat > release << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: Release
               metadata:
@@ -71,7 +71,7 @@ spec:
                 snapshot: foo
                 releasePlan: foo
               EOF
-              kubectl apply -f release
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -111,7 +111,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -125,7 +125,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -92,7 +92,7 @@ spec:
         - name: sourceDataArtifacts
           value: $(params.resultArtifacts)
     - name: update-cr-status
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -16,18 +16,24 @@ spec:
   params:
     - name: dataJsonPath
       description: path to data json file
+      type: string
     - name: snapshotPath
+      type: string
       description: path to snapshot json file
     - name: defaultTargetGHRepo
+      type: string
       description: GitHub repository of the infra-deployments code
       default: redhat-appstudio/infra-deployments
     - name: defaultGithubAppID
+      type: string
       description: Default ID of Github app used for updating PR
       default: "305606"
     - name: defaultGithubAppInstallationID
+      type: string
       description: Default Installation ID of Github app in the organization
       default: "35269675"
     - name: sharedSecret
+      type: string
       default: infra-deployments-pr-creator
       description: secret in the namespace which contains private key for the GitHub App
     - name: ociStorage
@@ -108,7 +114,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: git-clone-infra-deployments
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 256Mi
@@ -125,7 +131,7 @@ spec:
         echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi
@@ -170,7 +176,7 @@ spec:
         echo "$PATCHED_SCRIPT"
         echo "$PATCHED_SCRIPT" | sh
     - name: get-diff-files
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 128Mi
@@ -186,7 +192,7 @@ spec:
         git status -s --porcelain | cut -c4- > ../updated_files.txt
     # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-pr
-      image: quay.io/konflux-ci/release-service-utils:0077f4af29bb55cb80fcce770dd32f2e7bba97d7
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -126,7 +126,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -100,7 +100,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -87,7 +87,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-single-component
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -11,10 +11,12 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux
+              
+              cd /tmp
 
               cat > release << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
@@ -83,7 +85,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -34,7 +34,7 @@ spec:
       default: "false"
   steps:
     - name: verify-access-to-resources
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 100Mi


### PR DESCRIPTION
## Describe your changes
The PR is one the PRs which update the [release-service-utils](https://issues.redhat.com/browse/RELEASE-service-utils) image references for RELEASE-1731. It also changes the secrets defaultMode from 0400 to 0444 so user 1001 can read them.  Related to https://github.com/konflux-ci/release-service-utils/pull/552

This PR includes changes in below managed tasks and unit tests:
push-oot-kmods
push-rpm-data-to-pyxis
push-rpms-to-pulp
push-rpm-to-koji
push-snapshot
reduce-snapshot
rh-sign-image
rh-sign-image-cosign
run-file-updates
send-slack-notification
set-advisory-severity
sign-base64-blob
sign-index-image
sign-oot-kmods
update-cr-status
update-infra-deployments
update-trusted-tasks
validate-single-component
verify-access-to-resources

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
