### PR TITLE
fix(RELEASE-1770): add back the list of images to results

### DIFF
--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   description: |-
     Extract the index image fields from the inputDataFile
-    
+
     The inputDataFile is a result from another task which includes the workspace name in it. Thus,
     the workspace name for this task *must* be input.
   params:
@@ -120,8 +120,23 @@ spec:
                             "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         echo -n "$indexImageResolved" | tee "$(results.indexImageResolved.path)"
 
-        jq -n --arg image "$indexImage" --arg resolved "$indexImageResolved" \
-          '{"index_image": {"index_image": $image, "index_image_resolved": $resolved}}' | tee "$RESULTS_FILE"
+        jq '
+          {
+            index_image: (
+              [.components[]] |
+              group_by(.ocp_version) |
+              map(.[-1]) |
+              map({
+                key: .ocp_version,
+                value: {
+                  index_image: .index_image,
+                  index_image_resolved: .index_image_resolved
+                }
+              }) |
+              from_entries
+            )
+          }
+        ' "$(params.dataDir)/$(params.internalRequestResultsFile)" | tee "$RESULTS_FILE"
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
@@ -217,52 +217,23 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # Verify single-line results (no newlines)
-              echo "Verifying single-line results..."
-              if [[ "$(params.indexImage)" =~ $'\n' ]]; then
-                echo "ERROR: indexImage result contains newlines"
-                exit 1
-              fi
-              
-              if [[ "$(params.indexImageResolved)" =~ $'\n' ]]; then
-                echo "ERROR: indexImageResolved result contains newlines"
+              resultsFile="$(params.dataDir)/$(context.pipelineRun.uid)/results/extract-index-image-results.json"
+
+              actualImage=$(jq -r '.index_image."v4.12".index_image' "$resultsFile")
+              if [ "$actualImage" != "redhat.com/rh-stage/iib:02" ]; then
+                echo "ERROR: Expected v4.12 index_image to be iib:02 (last component), got: $actualImage"
                 exit 1
               fi
 
-              # Verify we get the final component's result (last one in batching)
-              expected_final_image="redhat.com/rh-stage/iib:02"
-              expected_final_resolved="redhat.com/rh-stage/iib@sha256:1234567890"
-              
-              echo "Test the indexImage result is the final component"
-              if [ "$(params.indexImage)" != "$expected_final_image" ]; then
-                echo "ERROR: Expected final index image $expected_final_image, got: $(params.indexImage)"
+              actualResolved=$(jq -r '.index_image."v4.12".index_image_resolved' "$resultsFile")
+              if [ "$actualResolved" != "redhat.com/rh-stage/iib@sha256:1234567890" ]; then
+                echo "ERROR: Expected v4.12 index_image_resolved from last component, got: $actualResolved"
                 exit 1
               fi
 
-              echo "Test the indexImageResolved result is the final component"
-              if [ "$(params.indexImageResolved)" != "$expected_final_resolved" ]; then
-                echo "ERROR: Expected final resolved image $expected_final_resolved, got: $(params.indexImageResolved)"
-                exit 1
-              fi
-
-              # testing new format
-              resultsFile="$(params.dataDir)/$(params.internalRequestResultsFile)"
-              if [ "$(jq -r '.components[0].index_image' "$resultsFile")" != "redhat.com/rh-stage/iib:01" ]; then
-                echo "Index image #0 does not match"
-              fi
-              if [ "$(jq -r '.components[1].index_image' "$resultsFile")" != "redhat.com/rh-stage/iib:02" ]; then
-                echo "Index image #1 does not match"
-              fi
-
-              indexImageResolved="$(jq -r '.components[0].index_image_resolved' "$resultsFile")"
-              if [ "$indexImageResolved" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
-                echo "Index image resolved #1 does not match"
-                exit 1
-              fi
-
-              indexImageResolved="$(jq -r '.components[1].index_image_resolved' "$resultsFile")"
-              if [ "$indexImageResolved" != "redhat.com/rh-stage/iib@sha256:1234567890" ]; then
-                echo "Index image resolved #0 does not match"
+              versionCount=$(jq '.index_image | keys | length' "$resultsFile")
+              if [ "$versionCount" != "1" ]; then
+                echo "ERROR: Expected exactly 1 OCP version, got: $versionCount"
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
@@ -204,18 +204,24 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              echo Test the indexImage result was properly set
-              test "$(params.indexImage)" == "redhat.com/rh-stage/iib:01"
+              resultsFile="$(params.dataDir)/$(context.pipelineRun.uid)/results/extract-index-image-results.json"
 
-              echo Test the indexImageResolved result was properly set
-              test "$(params.indexImageResolved)" == "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+              actualImage=$(jq -r '.index_image."v4.12".index_image' "$resultsFile")
+              if [ "$actualImage" != "redhat.com/rh-stage/iib:01" ]; then
+                echo "ERROR: Expected v4.12 index_image to be iib:01, got: $actualImage"
+                exit 1
+              fi
 
-              echo Check the results file
-              test "$(jq -r '.index_image.index_image' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/results/extract-index-image-results.json")" == \
-                "redhat.com/rh-stage/iib:01"
-              test "$(jq -r '.index_image.index_image_resolved' \
-                "$(params.dataDir)/$(context.pipelineRun.uid)/results/extract-index-image-results.json")" == \
-                "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+              actualResolved=$(jq -r '.index_image."v4.12".index_image_resolved' "$resultsFile")
+              if [ "$actualResolved" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                echo "ERROR: Expected v4.12 index_image_resolved, got: $actualResolved"
+                exit 1
+              fi
+
+              versionCount=$(jq '.index_image | keys | length' "$resultsFile")
+              if [ "$versionCount" != "1" ]; then
+                echo "ERROR: Expected exactly 1 OCP version, got: $versionCount"
+                exit 1
+              fi
       runAfter:
         - run-task


### PR DESCRIPTION
## Describe your changes

Update extract-index-image task to return all index images instead of just the last one.

## Relevant Jira

https://issues.redhat.com/browse/RELEASE-1770

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
