### PR TITLE
refactor(RELEASE-1238): push source container by default

### DIFF
--- a/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
@@ -28,6 +28,7 @@ spec:
             - url: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
               tags:
                 - '{{ git_short_sha }}'
+          pushSourceContainer: false
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
@@ -19,6 +19,7 @@ spec:
       defaults:
         tags:
           - latest
+        pushSourceContainer: false
       components:
         - name: ${component_name}
           repositories:

--- a/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
+++ b/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
@@ -16,6 +16,7 @@ spec:
             - url: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
               tags:
                 - '{{ git_short_sha }}'
+          pushSourceContainer: false
     targetGHRepo: 'hacbs-release/infra-deployments'
     githubAppID: 932323
     githubAppInstallationID: 52284535

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -199,7 +199,8 @@ spec:
         # Default to false
         skipRepoPublishing="$(jq -r ".pyxis.skipRepoPublishing // false" "${DATA_FILE}")"
 
-        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' "${DATA_FILE}" || echo false)
+        defaultPushSourceContainer=$(jq -r \
+          '.mapping.defaults.pushSourceContainer | if . == null then true else . end' "${DATA_FILE}")
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-omitted.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-omitted.yaml
@@ -2,10 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-pushsourcecontainer-defaults
+  name: test-publish-pyxis-repository-source-container-omitted
 spec:
   description: |
-    Run the push-snapshot task with pushSourceContainer enabled via the defaults
+    Run the publish-pyxis-repository task with a single component and pushSourceContainer
+    omitted in the data JSON. This should behave the same as it being set to true, so a curl
+    call should be executed to set the source_container_image_enabled to true for the component.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -54,37 +56,29 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
               {
-                "application": "myapp",
+                "application": "my-app",
                 "components": [
                   {
-                    "name": "comp",
-                    "containerImage": "registry.io/image@sha256:abcdefg",
                     "repositories": [
                       {
-                        "url": "prod-registry.io/prod-location",
-                        "tags": [
-                          "testtag"
-                        ]
+                        "url": "quay.io/redhat-prod/my-product----my-image1"
                       }
-                    ],
-                    "source": {
-                      "git": {
-                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
-                        "url": "https://github.com/abc/python-basic"
-                      }
-                    }
+                    ]
                   }
                 ]
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
                 "mapping": {
                   "defaults": {
-                    "pushSourceContainer": true
+                    "tags": [
+                      "foo"
+                    ]
                   }
                 }
               }
@@ -101,14 +95,14 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: push-snapshot
+        name: publish-pyxis-repository
       params:
+        - name: pyxisSecret
+          value: test-publish-pyxis-repository-cert
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/snapshot.json
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
         - name: dataPath
-          value: $(context.pipelineRun.uid)/data.json
-        - name: retries
-          value: 0
+          value: $(context.pipelineRun.uid)/mydata.json
         - name: resultsDirPath
           value: $(context.pipelineRun.uid)/results
         - name: ociStorage
@@ -168,42 +162,15 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
-              # from the origin image pull spec - see mocks.sh
-              cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:testtag-source
-              EOF
-
-              # Sort to ignore the cosign call orders as it differs from parallel execution.
-              sort "$(params.dataDir)/cosign_expected_calls.txt" > \
-              "$(params.dataDir)/cosign_expected_calls_sorted.txt"
-              sort "$(params.dataDir)/mock_cosign.txt" > \
-              "$(params.dataDir)/mock_cosign_sorted.txt"
-
-              if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls_sorted.txt")" \
-                != "$(md5sum < "$(params.dataDir)/mock_cosign_sorted.txt")" ]; then
-                echo "Error: Expected cosign calls do not match actual calls"
-                echo Actual calls:
-                cat "$(params.dataDir)/mock_cosign_sort.txt"
-                echo Expected calls:
-                cat "$(params.dataDir)/cosign_expected_calls_sort.txt"
-                exit 1
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
+                  echo Error: curl was expected to be called 2 times. Actual calls:
+                  cat "$(params.dataDir)/mock_curl.txt"
+                  exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
-                echo Error: skopeo was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_skopeo.txt"
-                exit 1
-              fi
-
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
-                echo Error: oras was expected to be called 5 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
+              [[ "$(head -n 1 "$(params.dataDir)/mock_curl.txt")" \
+                  == *"/my-product/my-image1 "* ]]
+              [[ "$(tail -n 1 "$(params.dataDir)/mock_curl.txt")" \
+                  == *'"source_container_image_enabled":true}' ]]
       runAfter:
         - run-task

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -261,7 +261,8 @@ spec:
         # Create a temporary directory to store the results of each push
         TMP_RESULTS_DIR=$(mktemp -d)
 
-        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' "$DATA_FILE")
+        defaultPushSourceContainer=$(jq -r \
+          '.mapping.defaults.pushSourceContainer | if . == null then true else . end' "$DATA_FILE")
         COPY_ATTACHED_ARTIFACTS="$(params.copyAttachedArtifacts)"
 
         application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
@@ -308,7 +309,7 @@ spec:
 
           # Push source container if the component has pushSourceContainer: true or if the
           # pushSourceContainer key is missing from the component and the defaults has
-          # pushSourceContainer: true
+          # pushSourceContainer: true or omitted (defaultPushSourceContainer defaults to true)
           pushSourceContainer=$(jq -r '.pushSourceContainer' <<< "$component")
           hasPushSourceContainer=$(jq 'has("pushSourceContainer")' <<< "$component")
 

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -75,7 +75,15 @@ spec:
               }
               EOF
 
-              echo '{}' > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": false
+                  }
+                }
+              }
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-pushsourcecontainer-component
+  name: test-push-snapshot-pushsourcecontainer-defaults-true
 spec:
   description: |
-    Run the push-snapshot task with pushSourceContainer set in the component
+    Run the push-snapshot task with pushSourceContainer enabled via the defaults
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -59,45 +59,7 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comptrue",
-                    "containerImage": "registry.io/image@sha256:abcdefg",
-                    "repositories": [
-                      {
-                        "url": "prod-registry.io/prod-location",
-                        "tags": [
-                          "testtag"
-                        ]
-                      }
-                    ],
-                    "source": {
-                      "git": {
-                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
-                        "url": "https://github.com/abc/python-basic"
-                      }
-                    },
-                    "pushSourceContainer": true
-                  },
-                  {
-                    "name": "compfalse",
-                    "containerImage": "registry.io/image@sha256:abcdefg",
-                    "repositories": [
-                      {
-                        "url": "prod-registry.io/prod-location",
-                        "tags": [
-                          "testtag"
-                        ]
-                      }
-                    ],
-                    "source": {
-                      "git": {
-                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
-                        "url": "https://github.com/abc/python-basic"
-                      }
-                    },
-                    "pushSourceContainer": false
-                  },
-                  {
-                    "name": "compomitted",
+                    "name": "comp",
                     "containerImage": "registry.io/image@sha256:abcdefg",
                     "repositories": [
                       {
@@ -121,6 +83,9 @@ spec:
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": true
+                  }
                 }
               }
               EOF
@@ -203,19 +168,9 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # The sha 4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03 is calculated
-              # from the origin image pull spec - see oras() in mocks.sh
+              # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
+              # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:testtag-source
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:testtag-source
               copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
               copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
@@ -233,22 +188,20 @@ spec:
                 != "$(md5sum < "$(params.dataDir)/mock_cosign_sorted.txt")" ]; then
                 echo "Error: Expected cosign calls do not match actual calls"
                 echo Actual calls:
-                cat "$(params.dataDir)/mock_cosign_sorted.txt"
+                cat "$(params.dataDir)/mock_cosign_sort.txt"
                 echo Expected calls:
-                cat "$(params.dataDir)/cosign_expected_calls_sorted.txt"
+                cat "$(params.dataDir)/cosign_expected_calls_sort.txt"
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 3 ]; then
-                echo Error: skopeo was expected to be called 3 time. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
 
-              # It is 4 oras calls per component + 1 if source container push is enabled
-              # comptrue and compomitted have it enabled, so 4+4+4+1+1=14
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 14 ]; then
-                echo Error: oras was expected to be called 14 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
+                echo Error: oras was expected to be called 5 times. Actual calls:
                 cat "$(params.dataDir)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-pushsourcecontainer-component
+  name: test-push-snapshot-pushsourcecontainer-omitted
 spec:
   description: |
-    Run the push-snapshot task with pushSourceContainer set in the component
+    Run the push-snapshot task with pushSourceContainer enabled via being omitted
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -59,45 +59,7 @@ spec:
                 "application": "myapp",
                 "components": [
                   {
-                    "name": "comptrue",
-                    "containerImage": "registry.io/image@sha256:abcdefg",
-                    "repositories": [
-                      {
-                        "url": "prod-registry.io/prod-location",
-                        "tags": [
-                          "testtag"
-                        ]
-                      }
-                    ],
-                    "source": {
-                      "git": {
-                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
-                        "url": "https://github.com/abc/python-basic"
-                      }
-                    },
-                    "pushSourceContainer": true
-                  },
-                  {
-                    "name": "compfalse",
-                    "containerImage": "registry.io/image@sha256:abcdefg",
-                    "repositories": [
-                      {
-                        "url": "prod-registry.io/prod-location",
-                        "tags": [
-                          "testtag"
-                        ]
-                      }
-                    ],
-                    "source": {
-                      "git": {
-                        "revision": "a51005b614c359b17a24317fdb264d76b2706a5a",
-                        "url": "https://github.com/abc/python-basic"
-                      }
-                    },
-                    "pushSourceContainer": false
-                  },
-                  {
-                    "name": "compomitted",
+                    "name": "comp",
                     "containerImage": "registry.io/image@sha256:abcdefg",
                     "repositories": [
                       {
@@ -118,12 +80,7 @@ spec:
               }
               EOF
 
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
-              {
-                "mapping": {
-                }
-              }
-              EOF
+              echo '{}' > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -203,19 +160,9 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # The sha 4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03 is calculated
-              # from the origin image pull spec - see oras() in mocks.sh
+              # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
+              # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:testtag-source
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
-               prod-registry.io/prod-location:testtag-source
               copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
               copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
@@ -233,22 +180,20 @@ spec:
                 != "$(md5sum < "$(params.dataDir)/mock_cosign_sorted.txt")" ]; then
                 echo "Error: Expected cosign calls do not match actual calls"
                 echo Actual calls:
-                cat "$(params.dataDir)/mock_cosign_sorted.txt"
+                cat "$(params.dataDir)/mock_cosign_sort.txt"
                 echo Expected calls:
-                cat "$(params.dataDir)/cosign_expected_calls_sorted.txt"
+                cat "$(params.dataDir)/cosign_expected_calls_sort.txt"
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 3 ]; then
-                echo Error: skopeo was expected to be called 3 time. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
 
-              # It is 4 oras calls per component + 1 if source container push is enabled
-              # comptrue and compomitted have it enabled, so 4+4+4+1+1=14
-              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 14 ]; then
-                echo Error: oras was expected to be called 14 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_oras.txt")" != 5 ]; then
+                echo Error: oras was expected to be called 5 times. Actual calls:
                 cat "$(params.dataDir)/mock_oras.txt"
                 exit 1
               fi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -61,6 +61,7 @@ spec:
                   {
                     "name": "comp",
                     "containerImage": "registry.io/retry-image:tag",
+                    "pushSourceContainer": false,
                     "repositories": [
                       {
                         "url": "prod-registry.io/prod-location",

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -196,7 +196,8 @@ spec:
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' "${DATA_FILE}")
-        defaultPushSourceContainer=$(jq -r '.mapping.defaults.pushSourceContainer' "${DATA_FILE}")
+        defaultPushSourceContainer=$(jq -r \
+          '.mapping.defaults.pushSourceContainer | if . == null then true else . end' "${DATA_FILE}")
 
         if [[ "$(params.pyxisServer)" == "production" ]]
         then
@@ -252,7 +253,7 @@ spec:
             sourceContainerDigest=
             # Push source container if the component has pushSourceContainer: true or if the
             # pushSourceContainer key is missing from the component and the defaults has
-            # pushSourceContainer: true
+            # pushSourceContainer: true or omitted (defaultPushSourceContainer defaults to true)
             if [[ $(jq -r '.pushSourceContainer' <<< "$component") == "true" ]] || \
                [[ $(jq 'has("pushSourceContainer")' <<< "$component") == "false" \
                 && ${defaultPushSourceContainer} == "true" ]] ; then

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
@@ -236,9 +236,13 @@ spec:
               expectedDigests=()
               for((i=0; i<3; i++)); do
                 expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix-12345")
+                expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix-12345-source")
                 expectedReferences+=("registry.access.stage.redhat.com/prod/repo${i}:some-prefix-12345")
+                expectedReferences+=("registry.access.stage.redhat.com/prod/repo${i}:some-prefix-12345-source")
                 expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix")
+                expectedReferences+=("registry.stage.redhat.io/prod/repo${i}:some-prefix-source")
                 expectedReferences+=("registry.access.stage.redhat.com/prod/repo${i}:some-prefix")
+                expectedReferences+=("registry.access.stage.redhat.com/prod/repo${i}:some-prefix-source")
                 expectedDigests+=("sha256:000${i}")
               done
 

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -125,6 +125,11 @@ spec:
               {
                 "sign": {
                   "configMapName": "signing-config-map"
+                },
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": false
+                  }
                 }
               }
               EOF


### PR DESCRIPTION
This commit updates the tasks that use the pushSourceContainer key for components. Previously, omitting it would result in no source container being pushed. With this commit, that behavior is reversed - the source container will be pushed if the key is omitted.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
