### PR TITLE
fix: set IR timeouts for get-advisory-severity

### DIFF
--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -152,6 +152,8 @@ spec:
         mkdir -p "$(dirname "$IR_FILE")"
 
         internal-request --pipeline "get-advisory-severity" \
+            --pipeline-timeout "2h0m0s" \
+            --task-timeout "1h55m0s" \
             -p releaseNotesImages="${RELEASENOTESIMAGES}" \
             -p taskGitUrl="$(params.taskGitUrl)" \
             -p taskGitRevision="$(params.taskGitRevision)" \


### PR DESCRIPTION
## Describe your changes
IR defaulted to 1h and caused early timeouts despite 2h pipeline config. We now pass timeouts to
internal-request for the get-advisory-severity

Linked PRs:
#1556
#1555

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
