### PR TITLE
feat(1522): add trusted CA configmap support (batch 1/8)

### DIFF
--- a/tasks/collectors/collect-collectors-resources/README.md
+++ b/tasks/collectors/collect-collectors-resources/README.md
@@ -10,10 +10,12 @@ A task result is returned for each resource with the relative path to the stored
 
 ## Parameters
 
-| Name                   | Description                                                      | Optional | Default value |
-|------------------------|------------------------------------------------------------------|----------|---------------|
-| previousRelease        | The namespaced name of the previous Release                      | No       | -             |
-| release                | The namespaced name of the Release                               | No       | -             |
-| collectorsResourceType | The type of resource that contains the collectors                | Yes      | releaseplan   |
-| collectorsResource     | The namespaced name of the resource that contains the collectors | No       | -             |
-| subdirectory           | Subdirectory inside the workspace to be used                     | Yes      | ""            |
+| Name                   | Description                                                           | Optional | Default value |
+|------------------------|-----------------------------------------------------------------------|----------|---------------|
+| previousRelease        | The namespaced name of the previous Release                           | No       | -             |
+| release                | The namespaced name of the Release                                    | No       | -             |
+| collectorsResourceType | The type of resource that contains the collectors                     | Yes      | releaseplan   |
+| collectorsResource     | The namespaced name of the resource that contains the collectors      | No       | -             |
+| subdirectory           | Subdirectory inside the workspace to be used                          | Yes      | ""            |
+| caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
+| caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |

--- a/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
@@ -34,6 +34,14 @@ spec:
       description: Subdirectory inside the workspace to be used
       type: string
       default: ""
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   workspaces:
     - name: data
       description: Workspace to save the CR jsons to
@@ -50,6 +58,19 @@ spec:
     - name: resultsDir
       type: string
       description: The relative path in the workspace to the results directory
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: collect-collectors-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f

--- a/tasks/collectors/run-collectors/README.md
+++ b/tasks/collectors/run-collectors/README.md
@@ -14,3 +14,5 @@ resultsDir, one file per collector.
 | collectorsRepositoryRevision | Git repository revision                                                                 | Yes      | main          |
 | releasePath                  | Path to the json data file of the current in-progress Release                           | No       | -             |
 | previousReleasePath          | Path to the json data file of the previous successful Release prior to the current one  | No       | -             |
+| caTrustConfigMapName         | The name of the ConfigMap to read CA bundle data from                                   | Yes      | trusted-ca    |
+| caTrustConfigMapKey          | The name of the key in the ConfigMap that contains the CA bundle data                   | Yes      | ca-bundle.crt |

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -35,9 +35,30 @@ spec:
       type: string
       description:  >-
         Path to the json data file of the previous successful Release prior to the current one
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   workspaces:
     - name: data
       description: Workspace where the CRs are stored
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: run-collectors
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f

--- a/tasks/collectors/save-collectors-results/README.md
+++ b/tasks/collectors/save-collectors-results/README.md
@@ -4,9 +4,11 @@ A tekton task that updates the passed CR status with the contents stored in the 
 
 ## Parameters
 
-| Name           | Description                                                                  | Optional | Default value |
-|----------------|------------------------------------------------------------------------------|----------|---------------|
-| resourceType   | The type of resource that is being patched                                   | Yes      | release       |
-| statusKey      | The top level key to overwrite in the resource status                        | Yes      | collectors    |
-| resource       | The namespaced name of the resource to be patched                            | No       | -             |
-| resultsDirPath | The relative path in the workspace where the collectors results are saved to | No       | -             |
+| Name                 | Description                                                                  | Optional | Default value |
+|----------------------|------------------------------------------------------------------------------|----------|---------------|
+| resourceType         | The type of resource that is being patched                                   | Yes      | release       |
+| statusKey            | The top level key to overwrite in the resource status                        | Yes      | collectors    |
+| resource             | The namespaced name of the resource to be patched                            | No       | -             |
+| resultsDirPath       | The relative path in the workspace where the collectors results are saved to | No       | -             |
+| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                        | Yes      | trusted-ca    |
+| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data        | Yes      | ca-bundle.crt |

--- a/tasks/collectors/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/save-collectors-results.yaml
@@ -26,9 +26,30 @@ spec:
         The relative path in the workspace where the collectors results
         are saved to
       type: string
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   workspaces:
     - name: data
       description: Workspace where the results directory is stored
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: save-collectors-results
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f

--- a/tasks/internal/check-embargoed-cves-task/README.md
+++ b/tasks/internal/check-embargoed-cves-task/README.md
@@ -8,6 +8,8 @@ request.
 
 ## Parameters
 
-| Name | Description                                                                                | Optional | Default value |
-|------|--------------------------------------------------------------------------------------------|----------|---------------|
-| cves | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |
+| Name                 | Description                                                                                | Optional | Default value |
+|----------------------|--------------------------------------------------------------------------------------------|----------|---------------|
+| cves                 | String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345') | No       | -             |
+| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                                      | Yes      | trusted-ca    |
+| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data                      | Yes      | ca-bundle.crt |

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -18,6 +18,14 @@ spec:
       type: string
       description: |
           String containing a space separated list of CVEs to check (e.g. 'CVE-123 CVE-234 CVE-345')
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -28,6 +36,18 @@ spec:
       secret:
         secretName: osidb-service-account
         defaultMode: 0400
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: check-embargoed-cves
       image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e

--- a/tasks/internal/check-fbc-opt-in/README.md
+++ b/tasks/internal/check-fbc-opt-in/README.md
@@ -10,3 +10,5 @@ Returns opt-in status for each provided container image.
 | containerImages         | JSON array of container images to check for FBC opt-in status                   | No       | -             |
 | iibServiceAccountSecret | Secret with IIB service account credentials to be used for Pyxis authentication | No       | -             |
 | pyxisServer             | Pyxis server to use                                                             | Yes      | production    |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                           | Yes      | trusted-ca    |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data           | Yes      | ca-bundle.crt |

--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -21,6 +21,14 @@ spec:
       description: Pyxis server to use
       type: string
       default: production
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: optInResults
       type: string
@@ -45,12 +53,24 @@ spec:
       secret:
         secretName: iib-services-config
         defaultMode: 0400
+        defaultMode:
+          0400
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
       - name: service-account-secret
         mountPath: /mnt/service-account-secret
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: check-opt-in
       image: quay.io/konflux-ci/release-service-utils:9c82b0f13e40e76150835b628c86ce05ae95a366

--- a/tasks/internal/collect-simple-signing-params/README.md
+++ b/tasks/internal/collect-simple-signing-params/README.md
@@ -4,6 +4,8 @@ Task to collect parameters for the simple signing pipeline
 
 ## Parameters
 
-| Name            | Description                                     | Optional | Default value |
-|-----------------|-------------------------------------------------|----------|---------------|
-| config_map_name | Name of a configmap with pipeline configuration | No       | -             |
+| Name                 | Description                                                           | Optional | Default value |
+|----------------------|-----------------------------------------------------------------------|----------|---------------|
+| config_map_name      | Name of a configmap with pipeline configuration                       | No       | -             |
+| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
+| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -11,6 +11,15 @@ spec:
   params:
     - name: config_map_name
       description: Name of a configmap with pipeline configuration
+      type: string
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: pyxis_url
       description: Container API URL based for selected environment
@@ -38,6 +47,19 @@ spec:
       description: UMB SSL certificate file name
     - name: umb_ssl_key_file_name
       description: UMB SSL key file name
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: collect-simple-signing-params
       image: quay.io/konflux-ci/release-service-utils:7d0135b80a47cdaa225010ea1e2dff78d057c922

--- a/tasks/internal/create-advisory-oci-artifact-task/README.md
+++ b/tasks/internal/create-advisory-oci-artifact-task/README.md
@@ -13,3 +13,5 @@ request.
 | advisory_url                                    | the url of the advisory                                                                          | No       | -                                                   |
 | internalRequestPipelineRunName                  | Name of the PipelineRun that called this task                                                    | No       | -                                                   |
 | trusted_artifacts_dockerconfig_json_secret_name | The name of the secret that contains to dockerconfig json to use for trusted artifact operations | Yes      | quay-token-konflux-release-trusted-artifacts-secret |
+| caTrustConfigMapName                            | The name of the ConfigMap to read CA bundle data from                                            | Yes      | trusted-ca                                          |
+| caTrustConfigMapKey                             | The name of the key in the ConfigMap that contains the CA bundle data                            | Yes      | ca-bundle.crt                                       |

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -24,6 +24,14 @@ spec:
       type: string
       description: The name of the secret that contains to dockerconfig json to use for trusted artifact operations
       default: quay-token-konflux-release-trusted-artifacts-secret
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -39,6 +47,18 @@ spec:
         optional: true
         secretName: $(params.trusted_artifacts_dockerconfig_json_secret_name)
         defaultMode: 0400
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: create-advisory-oci-artifact
       image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -18,3 +18,5 @@ request.
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
 | contentType                    | The contentType of the release artifact. One of [image|binary|generic]                                 | Yes      | image         |
+| caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                                                  | Yes      | trusted-ca    |
+| caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data                                  | Yes      | ca-bundle.crt |

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -42,6 +42,14 @@ spec:
       type: string
       description: The contentType of the release artifact. One of [image|binary|generic]
       default: "image"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -62,6 +70,18 @@ spec:
       secret:
         secretName: $(params.errata_secret_name)
         defaultMode: 0400
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: create-advisory
       image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -12,3 +12,5 @@ that still need to be released (i.e., not found in any advisory).
 | origin                         | The origin workspace for the release CR                                                    | No       | -             |
 | advisory_secret_name           | Name of the secret containing advisory metadata                                            | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that requested this task                                           | No       | -             |
+| caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                                      | Yes      | trusted-ca    |
+| caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data                      | Yes      | ca-bundle.crt |

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -24,6 +24,14 @@ spec:
     - name: internalRequestPipelineRunName
       description: Name of the PipelineRun that requested this task
       type: string
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: result
       description: Success or error message
@@ -42,6 +50,19 @@ spec:
       secret:
         secretName: $(params.advisory_secret_name)
         defaultMode: 0400
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: filter-images
       image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -50,7 +50,6 @@ spec:
       secret:
         secretName: $(params.advisory_secret_name)
         defaultMode: 0400
-  volumes:
     - name: trusted-ca
       configMap:
         name: $(params.caTrustConfigMapName)

--- a/tasks/internal/get-advisory-severity/README.md
+++ b/tasks/internal/get-advisory-severity/README.md
@@ -11,3 +11,5 @@ impact from all of the CVEs is returned as a task result.
 |--------------------------------|--------------------------------------------------------------------------------|----------|---------------|
 | releaseNotesImages             | Base64 string of gzipped JSON array of image specific details for the advisory | No       | -             |
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                  | No       | -             |
+| caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                          | Yes      | trusted-ca    |
+| caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data          | Yes      | ca-bundle.crt |

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -19,6 +19,14 @@ spec:
     - name: internalRequestPipelineRunName
       type: string
       description: name of the PipelineRun that called this task
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -33,6 +41,18 @@ spec:
       secret:
         secretName: osidb-service-account
         defaultMode: 0400
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
   steps:
     - name: get-advisory-severity
       image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e


### PR DESCRIPTION
## Summary
- Add caTrustConfigMapName and caTrustConfigMapKey parameters to 10 tasks
- Enable support for self-signed certificates in local testing environments
- Tasks trust cluster CA bundles by mounting a configmap to /mnt/trusted-ca

This is batch 1 of 8, containing 10 tasks to validate the CI workflow before proceeding with the remaining tasks from PR #1523.

## Tasks modified in this batch
- tasks/collectors/collect-collectors-resources
- tasks/collectors/run-collectors
- tasks/collectors/save-collectors-results
- tasks/internal/check-embargoed-cves-task
- tasks/internal/check-fbc-opt-in
- tasks/internal/collect-simple-signing-params
- tasks/internal/create-advisory-oci-artifact-task
- tasks/internal/create-advisory-task
- tasks/internal/filter-already-released-advisory-images-task
- tasks/internal/get-advisory-severity

## Test plan
- Wait for CI to pass
- If successful, proceed with remaining 7 batches (~9 tasks each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)