### PR TITLE
feat(RELEASE-1540): add parallel osidb calls in get-advisory-severity

### DIFF
--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -102,6 +102,7 @@ spec:
 
           INCLUDE_FIELDS="cve_id,impact,affects.purl,affects.impact"
           ADVISORY_SEVERITY=""
+          CVE_CACHE_DIR=$(mktemp -d)
 
           get_higher_severity() { # Return higher sev of the two provided [current highest, new]
               if [ "$1" == "CRITICAL" ] || [ "$2" == "CRITICAL" ] ; then
@@ -119,6 +120,113 @@ spec:
               fi
           }
 
+          # Function to process a batch of CVEs with its own token
+          process_cve_batch() { # Expected arguments are [batch_id, batch_cves]
+              echo "Batch $1: Getting token..."
+              set +x
+              batch_token=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
+              if [[ -z "$batch_token" || "$batch_token" == "null" ]]; then
+                  echo "Batch $1: ERROR - Failed to obtain authentication token" | tee -a "$STDERR_FILE"
+                  exit 1
+              fi
+              set -x
+
+              echo "Batch $1: Processing CVEs..."
+
+              while read -r cve; do
+                  if [[ -n "$cve" ]]; then
+                      cache_file="$CVE_CACHE_DIR/${cve}.json"
+
+                      # Note: If we bypass this check in a race condition, the output from OSIDB will be
+                      # the same anyways so it is safe - multiple batches writing identical data is harmless
+                      if [[ -f "$cache_file" ]]; then
+                          continue  # Already processed
+                      fi
+
+                      echo "Batch $1: Processing CVE ${cve}"
+                      curl_url="${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}"
+                      set +x
+
+                      # Try API call with current token, refresh and retry if it fails
+                      if ! curl --retry 3 \
+                          -H 'Content-Type: application/json' \
+                          -H "Authorization: Bearer ${batch_token}" \
+                          "$curl_url" | jq '.results[0]' > "$cache_file"; then
+                          echo "Batch $1: API call failed, refreshing token and retrying..."
+                          batch_token=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
+                          if [[ -z "$batch_token" || "$batch_token" == "null" ]]; then
+                              echo "Batch $1: ERROR - Failed to obtain authentication token" | tee -a "$STDERR_FILE"
+                              exit 1
+                          fi
+                          curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${batch_token}" \
+                              "$curl_url" | jq '.results[0]' > "$cache_file"
+                          # Validate cache file was written with valid data
+                          if [[ ! -s "$cache_file" ]] || [[ "$(cat "$cache_file")" == "null" ]] ; then
+                              echo "Batch $1: ERROR - Querying OSIDB for CVE $cve failed" | tee -a "$STDERR_FILE"
+                              exit 1
+                          fi
+                      fi
+                      set -x
+                  fi
+              done <<< "$2"
+
+              echo "Batch $1: Completed"
+          }
+
+          ALL_CVES=$(jq -r '[.[] | select(.cves.fixed) | .cves.fixed | keys[]] | unique | .[]' <<< "${IMAGES}" \
+            | tr "\n" " ")
+
+          # Convert to array for batching
+          read -ra ALL_CVES_ARRAY <<< "$ALL_CVES"
+          TOTAL_CVES=${#ALL_CVES_ARRAY[@]}
+
+          BATCH_SIZE=30
+          NUM_BATCHES=$(( (TOTAL_CVES + BATCH_SIZE - 1) / BATCH_SIZE ))
+          MAX_PARALLEL_BATCHES=8
+          CURRENT_JOBS=0
+
+          echo "Processing $TOTAL_CVES unique CVEs in $NUM_BATCHES parallel batches of $BATCH_SIZE CVEs each"
+
+          for ((i = 0; i < NUM_BATCHES; i++)); do
+              START_IDX=$((i * BATCH_SIZE))
+              BATCH_LENGTH=$BATCH_SIZE
+
+              # Adjust batch length for last batch
+              if [[ $((START_IDX + BATCH_SIZE)) -gt $TOTAL_CVES ]]; then
+                  BATCH_LENGTH=$((TOTAL_CVES - START_IDX))
+              fi
+
+              if [[ $BATCH_LENGTH -gt 0 ]]; then
+                  # Create batch CVE string (simple bash array slice)
+                  BATCH_CVES=$(printf '%s\n' "${ALL_CVES_ARRAY[@]:$START_IDX:$BATCH_LENGTH}")
+
+                  # Start batch in background
+                  process_cve_batch "$i" "$BATCH_CVES" &
+                  CURRENT_JOBS=$((CURRENT_JOBS + 1))
+
+                  # If we've reached the limit, wait for any job to complete
+                  if [[ $CURRENT_JOBS -ge $MAX_PARALLEL_BATCHES ]]; then
+                      if ! wait -n; then
+                          echo "ERROR: Batch processing failed - stopping remaining jobs" | tee -a "$STDERR_FILE"
+                          exit 1
+                      fi
+                      CURRENT_JOBS=$((CURRENT_JOBS - 1))
+                  fi
+              fi
+          done
+
+          # Wait for all remaining batches to complete
+          while (( CURRENT_JOBS > 0 )); do
+              if ! wait -n; then
+                  echo "ERROR: Batch processing failed - stopping remaining jobs" | tee -a "$STDERR_FILE"
+                  exit 1
+              fi
+              CURRENT_JOBS=$((CURRENT_JOBS - 1))
+          done
+
+          echo "All CVE data retrieved"
+
+          # Now process images using cached CVE data
           NUM_IMAGES=$(jq 'length' <<< "${IMAGES}")
           for ((i = 0; i < NUM_IMAGES; i++)); do
               image=$(jq -c --argjson i "$i" '.[$i]' <<< "${IMAGES}")
@@ -127,16 +235,13 @@ spec:
               for ((j = 0; j < NUM_CVES; j++)); do
                   cve=$(jq -r --argjson j "$j" '.cves.fixed | to_entries[$j].key' <<< "${image}")
                   echo "Checking CVE ${cve} for component with repository ${repository}"
-                  # Get token. They are short lived, so get one for before each request
-                  set +x
-                  TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
-                  CURL_URL="${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}"
-                  echo "Calling OSIDB API: ${CURL_URL}"
-                  OUTPUT=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
-                      "$CURL_URL" \
-                      | jq '.results[0]')
-                  set -x
-                  echo "OSIDB API response: ${OUTPUT}"
+
+                  # Read saved CVE data
+                  if ! OUTPUT=$(cat "$CVE_CACHE_DIR/${cve}.json") ; then
+                      echo "ERROR: CVE ${cve} not found in cache - batch processing failed" | tee -a "$STDERR_FILE"
+                      exit 1
+                  fi
+
                   IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
                   # If there is a component specific impact, use that instead
                   # To check if it is the same component, we use the repository value and match it with the
@@ -164,7 +269,7 @@ spec:
           done
 
           if [ -z "$ADVISORY_SEVERITY" ] ; then
-              echo "Unable to find severity on any cve listed in the releaseNotes" | tee "$STDERR_FILE"
+              echo "Unable to find severity on any cve listed in the releaseNotes" | tee -a "$STDERR_FILE"
               exit 1
           fi
 

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -12,8 +12,33 @@ function curl() {
 
   if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
   then
-    echo '{"access": "dummy-token"}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-critical"* ]]
+    sleep 0.1  # Small delay to simulate network
+    echo '{"access": "batch-token-'${RANDOM}'"}'
+    return
+  fi
+
+  # Performance test CVE requests - simulate realistic API delay
+  if [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-"*[0-9]* ]]
+  then
+    sleep 0.2  # Simulate 200ms API response time
+    
+    # Extract CVE number for response variety
+    cve_id=$(echo "$*" | grep -o 'CVE-[0-9]*')
+    if [[ "$cve_id" =~ CVE-([0-9]+) ]]; then
+      cve_num="${BASH_REMATCH[1]}"
+      
+      # Make every 10th CVE critical, rest moderate
+      if [[ $((cve_num % 10)) -eq 0 ]]; then
+        echo '{"results": [{"impact":"CRITICAL","affects":[]}]}'
+      else
+        echo '{"results": [{"impact":"MODERATE","affects":[]}]}'
+      fi
+    fi
+    return
+  fi
+
+  # Non numerical CVEs aren't part of performance tests, so do not include a sleep
+  if [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-critical"* ]]
   then
     echo '{"results": [{"impact":"CRITICAL","affects":[{"purl":"pkg:oci/kubernetes?repository_url=component&a=b","impact":""}]}]}'
   elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-moderate"* ]]

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity-osidb-calls-parallel
+spec:
+  description: |
+    Test that batched CVE processing completes within reasonable time limits. The max
+    duration is 20 seconds, so with the sleeps in the mock curl command, this would not
+    pass if the CVEs were checked serially. Thus, it ensures parallel processing is working.
+  tasks:
+    - name: record-start-time
+      taskSpec:
+        results:
+          - name: startTime
+            type: string
+        steps:
+          - name: record-time
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Record start timestamp
+              date +%s > "$(results.startTime.path)"
+              echo "Test started at: $(date)"
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: >-
+            H4sIAMpXA2kC/+3XwWoCQQzG8XeZ8xaaZDKT8Vr6Cr2IJ7sFD3VFRVrEd1eL9NT/QG8tuKeBby/7SyZk58e0HTfTbrWftp9plpbT+2Zaj+u9pCEtD+MuzY7pbfUxvl4PTy/PD3I9fL92yeeL0/CVKCaGScbEMSmYVEwCk4aJPHLECsIMwg7CEMISwhTCFsIYwhrKGtrpCdZQ1lDWUNZQ1lDWUNZQ1jDWMNawzhVhDWMNYw1jDWMNYw1jjcwamTUya+TOxGCNzBqZNTJrZNbIrOE/aVyegWat0qy9N/u92f9js98i1nDWcNbwzrbAGs4azhrOGs4ahTUKaxTWKKxRWKN0lifWKKxRWKOwRmWNyhqVNSprVNao/st5bDSP//IH3aLOcszlrVzeyuUN1gjWCNYI1gjWCNYI1ojOvwJrBGs01mis0VijsUZjjQbNvjgDulqbTeoNAAA=
+          # value before `gzip -c|base64 -w 0` encoding:
+          # 95 unique CVEs (CVE-1 through CVE-95) across 3 repositories with overlapping CVEs 
+          # to test both parallel batch processing and CVE deduplication
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+      runAfter:
+        - record-start-time
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: startTime
+          value: $(tasks.record-start-time.results.startTime)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: startTime
+            type: string
+          - name: severity
+            type: string  
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              START_TIME="$(params.startTime)"
+              END_TIME=$(date +%s)
+              DURATION=$((END_TIME - START_TIME))
+
+              echo "Performance test results:"
+              echo "Start time: $(date -d @"$START_TIME")"
+              echo "End time: $(date -d @"$END_TIME")"
+              echo "Total duration: ${DURATION} seconds"
+
+              # With 95 CVEs and parallel processing, should complete in under 20 seconds
+              # Serial processing would take ~28s, parallel should take ~6s
+              MAX_DURATION=20
+              if [ "$DURATION" -gt "$MAX_DURATION" ]; then
+                echo "Error: Task took ${DURATION}s, expected under ${MAX_DURATION}s"
+                echo "This suggests parallel processing may not be working correctly"
+                exit 1
+              fi
+
+              if [ "$(params.result)" != Success ]; then
+                echo "Error: result task result is not correct"
+                exit 1
+              fi
+
+              if [ "$(params.severity)" != "Critical" ]; then
+                echo "Error: severity task result is not correct"
+                exit 1
+              fi


### PR DESCRIPTION
This commit updates the get-advisory-severity internal task to use parallel batches when fetching CVE data from OSIDB. It will now reuse the same OSIDB token for each batch, since the token is supposed to be good for 5 minutes and we do 30 calls per batch. As long as it does not take over 10 seconds per batch, reusing it should be fine. It also ensures that if we have duplicate CVEs, we only query for it once. A new test is added to check this functionality is working.

This does not resolve RELEASE-1540, it is just the first step. A second commit will be added to address the part about checking component specific impacts.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
