### PR TITLE
fix(RELEASE-1571): file uncompression in push-artifacts-to-cdn

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -387,8 +387,24 @@ spec:
         mkdir -p "$MAC_CONTENT" "$WINDOWS_CONTENT" "$LINUX_CONTENT"
         cd "$CONTENT_DIR"
 
-        # Loop through each gz file and move them to the appropriate directory
+        # First unpack all archives in place (removing the archives)
         find "$CONTENT_DIR" -type f -iregex ".*\.zip\|.*\.gz" 2>/dev/null | while read -r file; do
+          dir=$(dirname "$file")
+          case "$file" in
+            (*.tar.gz)
+              tar -xzf "$file" -C "$dir" && rm "$file"
+              ;;
+            (*.gz)
+              gzip -d "$file"
+              ;;
+            (*.zip)
+              unzip "$file" -d "$dir" && rm "$file"
+              ;;
+          esac
+        done
+
+        # Then move unpacked files to appropriate directories based on architecture
+        find "$CONTENT_DIR" -type f 2>/dev/null | while read -r file; do
           case "$file" in
             (*darwin*)
               mv "$file" unsigned/macos/
@@ -400,24 +416,6 @@ spec:
               mv "$file" linux/
               ;;
           esac
-        done
-
-        # Unzip files in each directory
-        for dir in unsigned/macos unsigned/windows linux; do
-          find "$dir"/*.{zip,gz} 2>/dev/null | while read -r file; do
-            ext="${file#*.}"
-            case "$ext" in
-              tar.gz)
-                tar -xf "$file"
-              ;;
-              gz)
-                gzip -d "$file"
-              ;;
-              zip)
-                zip -X "$file"
-              ;;
-            esac
-          done
         done
 
         cd "$UNSIGNED_DIR"


### PR DESCRIPTION
## Describe your changes

There was an issue with the workflow where the windows tgz stayed
compressed.

Let's uncompress everything first and then move to the right folder.

We already confirmed this works in a test pipeline.

## Relevant Jira

RELEASE-1571

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
