### PR TITLE
feat(RELEASE-1540): less python subprocesses in get-advisory-severity

### DIFF
--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -35,12 +35,12 @@ spec:
         defaultMode: 0400
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+      image: quay.io/konflux-ci/release-service-utils:8151de6a3ec9143e0601166a85d12633a60d3c26
       computeResources:
         limits:
-          memory: 32Mi
+          memory: 128Mi
         requests:
-          memory: 32Mi
+          memory: 128Mi
           cpu: '1'  # 1 is the max allowed by at least the staging cluster
       volumeMounts:
         - name: osidb-service-account-vol
@@ -242,28 +242,26 @@ spec:
                       exit 1
                   fi
 
-                  IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
                   # If there is a component specific impact, use that instead
                   # To check if it is the same component, we use the repository value and match it with the
                   # repository_url field in the purl from OSIDB. Thus, we have to check each entry as
-                  # repository_url is not its own field
-                  NUM_AFFECTED_COMPONENTS=$(jq '.affects | length' <<< "$OUTPUT")
-                  for ((k = 0; k < NUM_AFFECTED_COMPONENTS; k++)); do
-                      AFFECTED_COMPONENT=$(jq --argjson k "$k" '.affects[$k]' <<< "$OUTPUT")
-                      PURL=$(jq -r '.purl // ""' <<< "$AFFECTED_COMPONENT")
-                      # .purl can be empty, so we direct stderr and just have it return empty string if purl was empty
-                      AFFECTED_REPOSITORY=$(python3 -c "from packageurl import PackageURL; \
-                        print(PackageURL.from_string('$PURL').to_dict()['qualifiers']['repository_url'])" \
-                        2> /dev/null || true)
-                      if [ "$AFFECTED_REPOSITORY" == "$repository" ] ; then
-                          COMPONENT_IMPACT=$(jq -r '.impact // ""' <<< "$AFFECTED_COMPONENT")
-                          # If we found a component specific impact, use that
-                          if [ -n "$COMPONENT_IMPACT" ] ; then
-                              IMPACT="$COMPONENT_IMPACT"
-                          fi
-                          break
+                  # repository_url is not its own field. Default to general impact first.
+                  IMPACT=$(jq -r '.impact' <<< "$OUTPUT")
+                  PURLS_JSON=$(jq -c '
+                      [.affects[] |
+                       select(.purl and (.purl | length > 0)) |
+                       {purl: .purl, impact: (.impact // "")}]
+                  ' <<< "$OUTPUT")
+
+                  if [[ "$PURLS_JSON" != "[]" ]]; then
+                      # Process all purls at once in Python and find matching repository
+                      COMPONENT_IMPACT=$(echo "$PURLS_JSON" | python3 /home/utils/find_matching_purl.py "$repository")
+
+                      # Use component-specific impact if found
+                      if [[ -n "$COMPONENT_IMPACT" ]]; then
+                          IMPACT="$COMPONENT_IMPACT"
                       fi
-                  done
+                  fi
                   ADVISORY_SEVERITY=$(get_higher_severity "$ADVISORY_SEVERITY" "$IMPACT")
               done
           done

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-advisory-severity-purl-processing-performance
+spec:
+  description: |
+    Test that optimized purl processing (single Python call) completes within reasonable time limits.
+    Uses CVE with 250 affected components. The max duration is 12 seconds - with the old approach
+    (one Python subprocess per component), this would take ~30s due to subprocess overhead.
+    Thus, it ensures the purl processing optimization is working.
+  tasks:
+    - name: record-start-time
+      taskSpec:
+        results:
+          - name: startTime
+            type: string
+        steps:
+          - name: record-time
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Record start timestamp
+              date +%s > "$(results.startTime.path)"
+              echo "Purl processing performance test started at: $(date)"
+    - name: run-task
+      taskRef:
+        name: get-advisory-severity
+      params:
+        - name: releaseNotesImages
+          value: >-
+            H4sIAAAAAAAAA4uuVipKLcgvzizJL6pUslIqSSxKTy3RBYkp6Sgll6UWK1lVK6VlVqSmgBjOYa66uYl5lbrJ+bkF+XmpeSVgeWRedGwtEMRyAQCrS1UEWgAAAA==
+          # value before `gzip -c|base64 -w 0` encoding:
+          # [{"repository":"target-repo","cves":{"fixed":{"CVE-many-components":{"components":[]}}}}]
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+      runAfter:
+        - record-start-time
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: startTime
+          value: $(tasks.record-start-time.results.startTime)
+        - name: severity
+          value: $(tasks.run-task.results.severity)
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: startTime
+            type: string
+          - name: severity
+            type: string  
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:002e438fd71196a7b4613308025358476acc1f8e
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              START_TIME="$(params.startTime)"
+              END_TIME=$(date +%s)
+              DURATION=$((END_TIME - START_TIME))
+
+              echo "Purl processing performance test results:"
+              echo "Start time: $(date -d @"$START_TIME")"
+              echo "End time: $(date -d @"$END_TIME")"
+              echo "Total duration: ${DURATION} seconds"
+
+              # With 500 affected components and one python process, it should complete in under 12 seconds
+              MAX_DURATION=12
+              if [ "$DURATION" -gt "$MAX_DURATION" ]; then
+                echo "Error: Task took ${DURATION}s, expected under ${MAX_DURATION}s"
+                echo "This suggests purl processing optimization may not be working correctly"
+                exit 1
+              fi
+
+              if [ "$(params.result)" != Success ]; then
+                echo "Error: result task result is not correct"
+                exit 1
+              fi
+
+              # Should find the component-specific CRITICAL impact for target-repo (component #249)
+              if [ "$(params.severity)" != "Critical" ]; then
+                echo "Error: Expected Critical severity from component-specific impact, got $(params.severity)"
+                exit 1
+              fi


### PR DESCRIPTION
This commit updates the get-advisory-severity internal task to use one python subprocess to check the component specific impacts, instead of one per affected component. The use of less python subprocesses should give us a large performance improvement.

Due to the increase in paralellization, the commit also ups the memory limits of the task.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
