### PR TITLE
fix(RELEASE-1979): idempotency check in publish_to_cgw_wrapper

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -167,7 +167,7 @@ spec:
         defaultMode: 0400
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi
@@ -329,7 +329,7 @@ spec:
             wait -n
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi
@@ -436,7 +436,7 @@ spec:
         echo "Digest for windows content: $windows_digest"
         echo -n "$windows_digest" > "$(results.unsignedWindowsDigest.path)"
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi
@@ -582,7 +582,7 @@ spec:
         # shellcheck disable=SC2029
         ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi
@@ -707,7 +707,7 @@ spec:
         ssh "${SSH_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}" "Remove-Item -LiteralPath \
         C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi
@@ -867,7 +867,7 @@ spec:
         mv "$SHA_SUM_PATH" "${SIGNED_DIR}/sha256sum.txt"
 
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 256Mi
@@ -959,7 +959,7 @@ spec:
         done
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+      image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -72,7 +72,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -70,7 +70,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filesfilename.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-push-artifacts-to-cdn-fail-skopeo-copy
 spec:
   description: |
-    Run the push-artifacts task with skopeo copy failing during image extraction. The containerImage 
+    Run the push-artifacts task with skopeo copy failing during image extraction. The containerImage
     value (nonexistent-disk-image) is set up to fail in mocks.sh to simulate extraction failures.
   tasks:
     - name: run-task
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
@@ -34,7 +34,7 @@ spec:
                         "source": "/releases/testproduct-binary-windows-amd64.tar.gz"
                       },
                       {
-                        "filename": "testproduct-staged-darwin-amd64.tar.gz", 
+                        "filename": "testproduct-staged-darwin-amd64.tar.gz",
                         "source": "/releases/testproduct-binary-darwin-amd64.tar.gz"
                       }
                     ]
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:91c030b48f7f1f88b32fba336fa5c2725a0f0bfd
+            image: quay.io/konflux-ci/release-service-utils:de01eb742f1fabeaefd1aabce1b24061b3fe72e1
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
## Describe your changes

Update the utils image used in push-artifacts-to-cdn-task .

The new image contains a fix for idempotency check in publish_to_cgw_wrapper.

Related PR:
https://github.com/konflux-ci/release-service-utils/pull/559

## Relevant Jira

RELEASE-1979

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
