### PR TITLE
feat(RELEASE-1976): sign both identities in one cosign command

### DIFF
--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -137,7 +137,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+      image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
       computeResources:
         limits:
           memory: 2.5Gi
@@ -212,7 +212,7 @@ spec:
             backoff1=2
             backoff2=3
             until [ "$attempt" -gt "$(params.retries)" ] ; do # 3 retries by default
-                cosign "$@" && break
+                cosign3 "$@" && break
                 sleep $backoff2
 
                 # Fibbonaci backoff
@@ -226,10 +226,10 @@ spec:
               exit 1
             fi
         }
-        function check_existing_signatures() {
-          local identity=$1
-          local reference=$2
-          local digest=$3
+        function check_missing_signatures() {
+          local identities="$1"
+          local reference="$2"
+          local digest="$3"
           declare -a COSIGN_REKOR_ARGS=()
           if [ -v REKOR_URL ]; then
               COSIGN_REKOR_ARGS+=("--rekor-url=$REKOR_URL")
@@ -239,30 +239,45 @@ spec:
           else
               COSIGN_REKOR_ARGS+=("--insecure-ignore-tlog=true")
           fi
-          verify_output=$(run_cosign verify "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
+          found_sigs_file=$(mktemp --suffix sigs)
+          expected_sigs_file=$(mktemp --suffix sigs)
+          verify_output=$(run_cosign verify --new-bundle-format=false \
+                          "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
+          if [ -z "$verify_output" ]; then
+            verify_output="[]"
+          fi
+          found_sigs=$(echo "$verify_output" | jq --argjson identities "$identities" -j '['\
         '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
-        '|select(.critical.identity."docker-reference" == "'"$identity"'")'\
-        ']|length')
-          echo "$found_signatures"
+        '|select(.critical.identity."docker-reference" as $reference | $identities | index($reference))'\
+        ']|[.[]|{identity:.critical.identity."docker-reference",'\
+        'manifest_digest:.critical.image."docker-manifest-digest"}]')
+
+          echo "$found_sigs" > "$found_sigs_file"
+          expected_sigs=$(echo "$identities" |
+          jq --arg digest "$digest" -j '[.[]|'\
+        '{identity: ., manifest_digest: $digest}]')
+
+          echo "$expected_sigs" > "$expected_sigs_file"
+
+          missing_signatures=$(jq -s '.[0] - .[1]' "$expected_sigs_file" "$found_sigs_file")
+          echo "$missing_signatures"
         }
         function check_and_sign() {
-          local identity=$1
+          local identities=$1
           local reference=$2
           local digest=$3
+          local tag=$4
 
           # cosign has very limited support for selecting the right auth entry,
           # so create a custom auth file with just one entry.
           DOCKER_CONFIG="$(mktemp -d)"
           export DOCKER_CONFIG
           select-oci-auth "${reference}" > "${DOCKER_CONFIG}/config.json"
+          identities_with_tag=$(jq --arg tag "$tag" -R -s \
+                                '[gsub("\r?\n"; "")|split(",")|.[]|.+":"+$tag]' <<< "$identities")
 
           declare -a COSIGN_REKOR_ARGS=()
-          found_signatures=$(check_existing_signatures "$identity" "$reference@$digest" "$digest")
-          if [ -z "$found_signatures" ]; then
-            found_signatures=0
-          fi
-          echopid "FOUND SIGNATURES for ${identity} ${digest}: $found_signatures"
+          missing_signatures=$(check_missing_signatures "$identities_with_tag" "$reference@$digest" "$digest")
 
           if [ -v REKOR_URL ]; then
               COSIGN_REKOR_ARGS+=("-y" "--rekor-url=$REKOR_URL")
@@ -272,13 +287,17 @@ spec:
           else
               COSIGN_REKOR_ARGS+=("--tlog-upload=false")
           fi
-
-          if [ "$found_signatures" -eq 0 ]; then
-            run_cosign -t 3m0s sign "${COSIGN_REKOR_ARGS[@]}" \
+          identities_args=""
+          for missing in $(echo "$missing_signatures" | jq -rc '.[]|.identity'); do
+            identities_args="${missing},${identities_args}"
+          done
+          if [ "${identities_args}" != "" ]; then
+            run_cosign -t 3m0s sign --new-bundle-format=false "${COSIGN_REKOR_ARGS[@]}" \
               --key "$SIGN_KEY" \
-              --sign-container-identity "$identity" "$reference@$digest"
+              --sign-container-identity "${identities_args::-1}" \
+              "$reference@$digest"
           else
-            echopid "Skip signing ${identity} (${digest})"
+            echopid "Skip signing (${digest})"
           fi
         }
 
@@ -356,19 +375,25 @@ spec:
                 # Collect data for signing
                 # Sign each manifest in the manifest list
                 if [ $LIST -eq 1 ]; then
-                    for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                        for MDIGEST in $MANIFEST_DIGESTS; do
-                            for TAG in $REPO_TAGS; do
-                                to_sign+=("${REGISTRY_REF}:${TAG}@${MDIGEST}#${INTERNAL_CONTAINER_REF}")
+                    for MDIGEST in $MANIFEST_DIGESTS; do
+                        for TAG in $REPO_TAGS; do
+                            registry_refs=""
+                            for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                              registry_refs="${REGISTRY_REF},${registry_refs}"
                             done
+                            registry_refs="${registry_refs::-1}"
+                            to_sign+=("${registry_refs}#${MDIGEST}#${INTERNAL_CONTAINER_REF}#${TAG}")
                         done
                     done
                 fi
                 # Sign manifest list itself or manifest if it's not list
-                for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                    for TAG in $REPO_TAGS; do
-                        to_sign+=("${REGISTRY_REF}:${TAG}@${DIGEST}#${INTERNAL_CONTAINER_REF}")
+                for TAG in $REPO_TAGS; do
+                    registry_refs=""
+                    for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                      registry_refs="${REGISTRY_REF},${registry_refs}"
                     done
+                    registry_refs="${registry_refs::-1}"
+                    to_sign+=("${registry_refs}#${DIGEST}#${INTERNAL_CONTAINER_REF}#${TAG}")
                 done
             done
         done
@@ -381,11 +406,9 @@ spec:
         # Make groups based on reference + digest to avoid signing same digest in parallel
         # #
         for x in sys.stdin.read().strip().split(' '):
-          rest, internal_ref = x.split('#')
-          rest, digest = rest.split('@')
-          public_ref, tag = rest.split(':')
+          public_refs, digest, internal_ref, tag = x.split('#')
           digest_groups.setdefault(internal_ref+'@'+digest, []).append(
-            (internal_ref, public_ref, digest, tag)
+            (internal_ref, public_refs, digest, tag)
           )
         for to_yield in zip_longest(*digest_groups.values()):
           for entry in filter(None, to_yield):
@@ -404,7 +427,7 @@ spec:
               continue
             fi
             INTERNAL_REF=$(echo "$ENTRY" | cut -d' ' -f1)
-            PUBLIC_REF=$(echo "$ENTRY" | cut -d' ' -f2)
+            PUBLIC_REFS=$(echo "$ENTRY" | cut -d' ' -f2)
             DIGEST=$(echo "$ENTRY" | cut -d' ' -f3)
             TAG=$(echo "$ENTRY" | cut -d' ' -f4)
             # This function is stored in the utils/memory-throttle.sh file
@@ -413,7 +436,7 @@ spec:
             while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
               wait -n || SUCCESS=false
             done
-            check_and_sign "${PUBLIC_REF}:${TAG}" "${INTERNAL_REF}" "${DIGEST}" &
+            check_and_sign "${PUBLIC_REFS}" "${INTERNAL_REF}" "${DIGEST}" "${TAG}" &
             spawn_count=$((spawn_count + 1))
 
             # Allow memory usage to stabilize every BURST_SIZE spawns.

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -137,7 +137,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+      image: quay.io/konflux-ci/release-service-utils@sha256:15f326811b82b26e22780993b9879b106fbf0698a2d844bbe0e2fde9f5e4ca64
       computeResources:
         limits:
           memory: 2.5Gi
@@ -163,6 +163,9 @@ spec:
         fi
         PUBLIC_KEY="$(cat /etc/secrets/PUBLIC_KEY)"
         REKOR_PUBLIC_KEY="$(cat /etc/secrets/REKOR_PUBLIC_KEY)"
+        REKOR_PUBLIC_KEY_FILE=$(mktemp)
+        trap 'rm -f "$REKOR_PUBLIC_KEY_FILE"' EXIT
+        echo -n "$REKOR_PUBLIC_KEY" > "$REKOR_PUBLIC_KEY_FILE"
 
         set -x
 
@@ -212,7 +215,7 @@ spec:
             backoff1=2
             backoff2=3
             until [ "$attempt" -gt "$(params.retries)" ] ; do # 3 retries by default
-                cosign "$@" && break
+                cosign3 "$@" && break
                 sleep $backoff2
 
                 # Fibbonaci backoff
@@ -226,43 +229,59 @@ spec:
               exit 1
             fi
         }
-        function check_existing_signatures() {
-          local identity=$1
-          local reference=$2
-          local digest=$3
+        function check_missing_signatures() {
+          local identities="$1"
+          local reference="$2"
+          local digest="$3"
           declare -a COSIGN_REKOR_ARGS=()
           if [ -v REKOR_URL ]; then
               COSIGN_REKOR_ARGS+=("--rekor-url=$REKOR_URL")
-              REKOR_PUBLIC_KEY_FILE=$(mktemp)
-              echo -n "$REKOR_PUBLIC_KEY" > "$REKOR_PUBLIC_KEY_FILE"
               export SIGSTORE_REKOR_PUBLIC_KEY="$REKOR_PUBLIC_KEY_FILE"
           else
               COSIGN_REKOR_ARGS+=("--insecure-ignore-tlog=true")
           fi
-          verify_output=$(run_cosign verify "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
-        '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
-        '|select(.critical.identity."docker-reference" == "'"$identity"'")'\
-        ']|length')
-          echo "$found_signatures"
+          found_sigs_file=$(mktemp --suffix sigs)
+          expected_sigs_file=$(mktemp --suffix sigs)
+          # Ensure temp files are cleaned up on exit
+          trap 'rm -f "$found_sigs_file" "$expected_sigs_file"' RETURN
+          verify_output=$(run_cosign verify --new-bundle-format=false \
+                          "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
+          if [ -z "$verify_output" ]; then
+            verify_output="[]"
+          fi
+          found_sigs=$(echo "$verify_output" | jq --argjson identities "$identities" -j '['\
+        '.[]|select(.critical.image."docker-manifest-digest" == "'"$digest"'")'\
+        '|select(.critical.identity."docker-reference" as $reference | $identities | index($reference))'\
+        ']|[.[]|{identity:.critical.identity."docker-reference",'\
+        'manifest_digest:.critical.image."docker-manifest-digest"}]')
+
+          >&2 echo "FOUND SIGNATURES for ${digest}: $found_sigs"
+          echo "$found_sigs" > "$found_sigs_file"
+          expected_sigs=$(
+            echo "$identities" | jq --arg digest "$digest" -j '[.[]|{identity: ., manifest_digest: $digest}]'
+          )
+
+          echo "$expected_sigs" > "$expected_sigs_file"
+
+          missing_signatures=$(jq -s '.[0] - .[1]' "$expected_sigs_file" "$found_sigs_file")
+          echo "$missing_signatures"
         }
         function check_and_sign() {
-          local identity=$1
-          local reference=$2
-          local digest=$3
+          local identities="$1"
+          local reference="$2"
+          local digest="$3"
+          local tag="$4"
 
           # cosign has very limited support for selecting the right auth entry,
           # so create a custom auth file with just one entry.
           DOCKER_CONFIG="$(mktemp -d)"
           export DOCKER_CONFIG
           select-oci-auth "${reference}" > "${DOCKER_CONFIG}/config.json"
+          identities_with_tag=$(jq --arg tag "$tag" -R -s \
+                                '[gsub("\r?\n"; "")|split(",")|.[]|.+":"+$tag]' <<< "$identities")
 
           declare -a COSIGN_REKOR_ARGS=()
-          found_signatures=$(check_existing_signatures "$identity" "$reference@$digest" "$digest")
-          if [ -z "$found_signatures" ]; then
-            found_signatures=0
-          fi
-          echopid "FOUND SIGNATURES for ${identity} ${digest}: $found_signatures"
+          missing_signatures=$(check_missing_signatures "$identities_with_tag" "$reference@$digest" "$digest")
 
           if [ -v REKOR_URL ]; then
               COSIGN_REKOR_ARGS+=("-y" "--rekor-url=$REKOR_URL")
@@ -272,13 +291,14 @@ spec:
           else
               COSIGN_REKOR_ARGS+=("--tlog-upload=false")
           fi
-
-          if [ "$found_signatures" -eq 0 ]; then
-            run_cosign -t 3m0s sign "${COSIGN_REKOR_ARGS[@]}" \
+          identities_args=$(jq -rc '[.[]|.identity]|join(",")' <<< "$missing_signatures")
+          if [ -n "$identities_args" ]; then
+            run_cosign -t 3m0s sign --new-bundle-format=false "${COSIGN_REKOR_ARGS[@]}" \
               --key "$SIGN_KEY" \
-              --sign-container-identity "$identity" "$reference@$digest"
+              --sign-container-identity "${identities_args}" \
+              "$reference@$digest"
           else
-            echopid "Skip signing ${identity} (${digest})"
+            echopid "Skip signing (${digest})"
           fi
         }
 
@@ -356,19 +376,25 @@ spec:
                 # Collect data for signing
                 # Sign each manifest in the manifest list
                 if [ $LIST -eq 1 ]; then
-                    for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                        for MDIGEST in $MANIFEST_DIGESTS; do
-                            for TAG in $REPO_TAGS; do
-                                to_sign+=("${REGISTRY_REF}:${TAG}@${MDIGEST}#${INTERNAL_CONTAINER_REF}")
+                    for MDIGEST in $MANIFEST_DIGESTS; do
+                        for TAG in $REPO_TAGS; do
+                            registry_refs=""
+                            for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                              registry_refs="${REGISTRY_REF},${registry_refs}"
                             done
+                            registry_refs="${registry_refs::-1}"
+                            to_sign+=("${registry_refs}#${MDIGEST}#${INTERNAL_CONTAINER_REF}#${TAG}")
                         done
                     done
                 fi
                 # Sign manifest list itself or manifest if it's not list
-                for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
-                    for TAG in $REPO_TAGS; do
-                        to_sign+=("${REGISTRY_REF}:${TAG}@${DIGEST}#${INTERNAL_CONTAINER_REF}")
+                for TAG in $REPO_TAGS; do
+                    registry_refs=""
+                    for REGISTRY_REF in "${REGISTRY_REFERENCES[@]}"; do
+                      registry_refs="${REGISTRY_REF},${registry_refs}"
                     done
+                    registry_refs="${registry_refs::-1}"
+                    to_sign+=("${registry_refs}#${DIGEST}#${INTERNAL_CONTAINER_REF}#${TAG}")
                 done
             done
         done
@@ -381,11 +407,9 @@ spec:
         # Make groups based on reference + digest to avoid signing same digest in parallel
         # #
         for x in sys.stdin.read().strip().split(' '):
-          rest, internal_ref = x.split('#')
-          rest, digest = rest.split('@')
-          public_ref, tag = rest.split(':')
+          public_refs, digest, internal_ref, tag = x.split('#')
           digest_groups.setdefault(internal_ref+'@'+digest, []).append(
-            (internal_ref, public_ref, digest, tag)
+            (internal_ref, public_refs, digest, tag)
           )
         for to_yield in zip_longest(*digest_groups.values()):
           for entry in filter(None, to_yield):
@@ -404,7 +428,7 @@ spec:
               continue
             fi
             INTERNAL_REF=$(echo "$ENTRY" | cut -d' ' -f1)
-            PUBLIC_REF=$(echo "$ENTRY" | cut -d' ' -f2)
+            PUBLIC_REFS=$(echo "$ENTRY" | cut -d' ' -f2)
             DIGEST=$(echo "$ENTRY" | cut -d' ' -f3)
             TAG=$(echo "$ENTRY" | cut -d' ' -f4)
             # This function is stored in the utils/memory-throttle.sh file
@@ -413,7 +437,7 @@ spec:
             while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
               wait -n || SUCCESS=false
             done
-            check_and_sign "${PUBLIC_REF}:${TAG}" "${INTERNAL_REF}" "${DIGEST}" &
+            check_and_sign "${PUBLIC_REFS}" "${INTERNAL_REF}" "${DIGEST}" "${TAG}" &
             spawn_count=$((spawn_count + 1))
 
             # Allow memory usage to stabilize every BURST_SIZE spawns.

--- a/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
@@ -139,6 +139,8 @@ function skopeo() {
 function mktemp() {
   if [[ "${1:-}" == "-d" ]]; then
     /usr/bin/mktemp -d
+  elif [[ "${1:-}" == "--suffix" ]]; then
+    /usr/bin/mktemp "$@"
   else
     echo "temp_key_file"
   fi
@@ -148,7 +150,7 @@ function select-oci-auth() {
     echo "mock select-oci-auth called with: $*"
 }
 
-function cosign () {
+function cosign3 () {
   # check if call should end successfully
   # mock_cosign_success_calls file is expected to contain lines with "1" or "0" where
   # "1" means that the call should end successfully and "0" means that the call should end with an error

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-external-registry.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-external-registry.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:288a903105481b1ea11e558b179cf4010d66a3fa4f4ff22765a256668471554b
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:288a903105481b1ea11e558b179cf4010d66a3fa4f4ff22765a256668471554b
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -196,7 +196,8 @@ spec:
 
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               # For external registries, the identity and reference are the same (repository url)
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}:0.1 ${_TEST_REPO1}@sha256:2222
@@ -217,7 +218,8 @@ spec:
 
               # Verify calls are sorted because order may vary due to concurrent execution
               CALLS=$(sort "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false --insecure-ignore-tlog=true \
+              --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:2222
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:2222

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -99,7 +99,7 @@ spec:
                 touch "$(params.dataDir)/$(echo $REF | tr '/' '-')"
               done
               # setup cosign success calls - all calls should pass
-              for _ in $(seq 1 48); do
+              for _ in $(seq 1 32); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,33 +198,34 @@ spec:
               test "$CALLS" = "$EXPECTED"
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
               --sign-container-identity"
+              IDENTITY1="${_TEST_PUB_REPO1}:t1"
+              IDENTITY2="${_TEST_PUB_REPO2}:t1"
+              IDENTITY3="${_TEST_PUB_REPO3}:t1"
+
+              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+              IDENTITY22="${_TEST_PUB_REPO2}:t2"
+              IDENTITY32="${_TEST_PUB_REPO3}:t2"
+
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111
+              $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111
               EOF
               )
               echo "TESTING"
@@ -239,7 +240,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --rekor-url=https://fake-rekor-server --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false \
+              --rekor-url=https://fake-rekor-server --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
@@ -257,14 +259,6 @@ spec:
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111-2
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111-3
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
               EOF
               )
               echo "TESTING VERIFY CALLS"

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -99,7 +99,7 @@ spec:
                 touch "$(params.dataDir)/$(echo $REF | tr '/' '-')"
               done
               # setup cosign success calls - all calls should pass
-              for _ in $(seq 1 48); do
+              for _ in $(seq 1 32); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,33 +198,34 @@ spec:
               test "$CALLS" = "$EXPECTED"
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              -y --rekor-url=https://fake-rekor-server --key aws://arn:mykey \
               --sign-container-identity"
+              IDENTITY1="${_TEST_PUB_REPO1}:t1"
+              IDENTITY2="${_TEST_PUB_REPO2}:t1"
+              IDENTITY3="${_TEST_PUB_REPO3}:t1"
+
+              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+              IDENTITY22="${_TEST_PUB_REPO2}:t2"
+              IDENTITY32="${_TEST_PUB_REPO3}:t2"
+
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t1 ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:t2 ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${IDENTITY3} ${_TEST_REPO2}@sha256:1111
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-1
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-2
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111-3
+              $COSIGN_COMMON ${IDENTITY32} ${_TEST_REPO2}@sha256:1111
               EOF
               )
               echo "TESTING"
@@ -239,7 +240,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --rekor-url=https://fake-rekor-server --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false \
+              --rekor-url=https://fake-rekor-server --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
@@ -257,14 +259,6 @@ spec:
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111-2
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111-3
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:1111
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
               EOF
               )
               echo "TESTING VERIFY CALLS"

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories-existing.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories-existing.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-rh-sign-image-cosign-multiple-repositories
+  name: test-rh-sign-image-cosign-multiple-repositories-existing
 spec:
-  description: Test signing images with new multiple repositories schema
+  description: |
+    Test simulates signing multiple repositories in cosign when there are 
+    already existing signatures.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -86,13 +88,37 @@ spec:
                 touch "$(params.dataDir)/$(echo $REF1 | tr '/' '-')"
                 touch "$(params.dataDir)/$(echo $REF2 | tr '/' '-')"
               done
-
+              
+              cat > "$(params.dataDir)/$(echo "$REF1" | tr '/' '-')" << EOF
+              [
+              {
+                "critical": {
+                  "identity": {
+                    "docker-reference": "registry.stage.redhat.io/test-product/test-image0:t1"
+                  },
+                  "image": {
+                    "docker-manifest-digest": "sha256:0000-3"
+                  },
+                  "type": "cosign container image signature"
+                }
+              },
+              {
+                "critical": {
+                  "identity": {
+                    "docker-reference": "registry.access.stage.redhat.com/test-product/test-image0:t1"
+                  },
+                  "image": {
+                    "docker-manifest-digest": "sha256:0000"
+                  },
+                  "type": "cosign container image signature"
+                }
+              }
+              ]
+              EOF
               # Expected cosign calls:
-              # - 2 repos * (2+1) tags = 6 sign identities for main digest
-              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign identities for individual manifests
-              # - sign 2 identities at the same time
-              # - total sign calls = 12
-              # - 12 verify calls (1 per repo for all identities)
+              # - 2 repos * (2+1) tags = 6 sign calls for main digest
+              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign calls for individual manifests
+              # - 12 verify calls (1 per repo)
               # Total: 24 calls
               for _ in $(seq 1 24); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
@@ -193,7 +219,8 @@ spec:
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
               COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
-              --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              --tlog-upload=false --key aws://arn:mykey \
+              --sign-container-identity"
               IDENTITY4="${_TEST_PUB_REPO4}:latest"
               IDENTITY3="${_TEST_PUB_REPO3}:latest"
               IDENTITY2="${_TEST_PUB_REPO2}:t1"
@@ -202,6 +229,7 @@ spec:
               IDENTITY12="${_TEST_PUB_REPO1}:t2"
 
               EXPECTED=$(cat <<EOF
+              $COSIGN_COMMON ${IDENTITY2} ${_TEST_REPO1}@sha256:0000-3
               $COSIGN_COMMON ${IDENTITY3},${IDENTITY4} ${_TEST_REPO2}@sha256:0000
               $COSIGN_COMMON ${IDENTITY3},${IDENTITY4} ${_TEST_REPO2}@sha256:0000-1
               $COSIGN_COMMON ${IDENTITY3},${IDENTITY4} ${_TEST_REPO2}@sha256:0000-2
@@ -209,7 +237,6 @@ spec:
               $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000
               $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO1}@sha256:0000-3
               $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000
               $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO1}@sha256:0000-2
@@ -228,8 +255,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --new-bundle-format=false \
-              --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false --insecure-ignore-tlog=true \
+              --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories-existing.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories-existing.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-rh-sign-image-cosign-single-component
+  name: test-rh-sign-image-cosign-multiple-repositories-existing
 spec:
-  description: Test signing a single image by cosign
+  description: |
+    Test simulates signing multiple repositories in cosign when there are 
+    already existing signatures.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -59,13 +61,19 @@ spec:
                 "components": [
                   {
                     "name": "comp0",
-                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000",
                     "repositories": [
                       {
-                        "url": "quay.io/redhat-pending/test-product----test-image2",
-                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
-                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image2",
+                        "url": "quay.io/redhat-pending/test-product----test-image0",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0",
                         "tags": ["t1", "t2"]
+                      },
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image0-alt",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image0-alt",
+                        "registry-access-repo": "registry.access.stage.redhat.com/test-product/test-image0-alt",
+                        "tags": ["latest"]
                       }
                     ]
                   }
@@ -73,18 +81,52 @@ spec:
               }
               EOF
               # create empty cosign verify mock files
-              for D in sha256:0000 sha256:1111 sha256:2222 ; do
-                REF="quay.io/redhat-pending/test-product----test-image2@${D}"
-                touch "$(params.dataDir)/$(echo $REF | tr '/' '-')"
+              # Main digest and individual manifest digests from OCI manifest list
+              for D in sha256:0000 sha256:0000-1 sha256:0000-2 sha256:0000-3; do
+                REF1="quay.io/redhat-pending/test-product----test-image0@${D}"
+                REF2="quay.io/redhat-pending/test-product----test-image0-alt@${D}"
+                touch "$(params.dataDir)/$(echo $REF1 | tr '/' '-')"
+                touch "$(params.dataDir)/$(echo $REF2 | tr '/' '-')"
               done
-
-              # first 8 cosign calls should end with success
-              for _ in $(seq 1 4); do
+              
+              cat > "$(params.dataDir)/$(echo "$REF1" | tr '/' '-')" << EOF
+              [
+              {
+                "critical": {
+                  "identity": {
+                    "docker-reference": "registry.stage.redhat.io/test-product/test-image0:t1"
+                  },
+                  "image": {
+                    "docker-manifest-digest": "sha256:0000-3"
+                  },
+                  "type": "cosign container image signature"
+                }
+              },
+              {
+                "critical": {
+                  "identity": {
+                    "docker-reference": "registry.access.stage.redhat.com/test-product/test-image0:t1"
+                  },
+                  "image": {
+                    "docker-manifest-digest": "sha256:0000"
+                  },
+                  "type": "cosign container image signature"
+                }
+              }
+              ]
+              EOF
+              # Expected cosign calls:
+              # - 2 repos * (2+1) tags = 6 sign calls for main digest
+              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign calls for individual manifests
+              # - 12 verify calls (1 per repo)
+              # Total: 24 calls
+              for _ in $(seq 1 24); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
-              test-product/test-image2
+              test-product/test-image0
+              test-product/test-image0-alt
               EOF
           - name: create-trusted-artifact
             ref:
@@ -163,28 +205,45 @@ spec:
               #!/usr/bin/env bash
               set -eux
               echo "check results"
-              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image2"
-              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image2"
-              _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
+              _TEST_PUB_REPO1="registry.stage.redhat.io/test-product/test-image0"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image0"
+              _TEST_PUB_REPO3="registry.stage.redhat.io/test-product/test-image0-alt"
+              _TEST_PUB_REPO4="registry.access.stage.redhat.com/test-product/test-image0-alt"
+              _TEST_REPO1="quay.io/redhat-pending/test-product----test-image0"
+              _TEST_REPO2="quay.io/redhat-pending/test-product----test-image0-alt"
 
               CALLS=$(cat "$(params.dataDir)/mock_skopeo_calls")
-              EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222"
+              EXPECTED="inspect --raw docker://quay.io/redhat-user-workloads/test-product/test-image0@sha256:0000"
               test "$CALLS" = "$EXPECTED"
 
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false --tlog-upload=false \
-              --key aws://arn:mykey --sign-container-identity"
-              IDENTITY1="${_TEST_PUB_REPO1}:t1"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              --tlog-upload=false --key aws://arn:mykey \
+              --sign-container-identity"
+              IDENTITY4="${_TEST_PUB_REPO4}:latest"
+              IDENTITY3="${_TEST_PUB_REPO3}:latest"
               IDENTITY2="${_TEST_PUB_REPO2}:t1"
-              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+              IDENTITY1="${_TEST_PUB_REPO1}:t1"
               IDENTITY22="${_TEST_PUB_REPO2}:t2"
+              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY2} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-3
               EOF
               )
-              echo "TESTING"
+              echo "TESTING SIGN CALLS"
               if [ "$CALLS" != "$EXPECTED" ]; then
                 echo "Diff:"
                 CALLS_FILE=$(mktemp XXXXX.calls)
@@ -199,8 +258,18 @@ spec:
               COSIGN_COMMON="verify --new-bundle-format=false --insecure-ignore-tlog=true \
               --key temp_key_file"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
               EOF
               )
               echo "TESTING VERIFY CALLS"

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -88,11 +88,13 @@ spec:
               done
 
               # Expected cosign calls:
-              # - 2 repos * (2+1) tags = 6 sign calls for main digest
-              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign calls for individual manifests
-              # - 24 verify calls (1 per sign call)
-              # Total: 48 calls
-              for _ in $(seq 1 48); do
+              # - 2 repos * (2+1) tags = 6 sign identities for main digest
+              # - 2 repos * 3 manifest digests * (2+1) tags = 18 sign identities for individual manifests
+              # - sign 2 identities at the same time
+              # - total sign calls = 12
+              # - 12 verify calls (1 per repo for all identities)
+              # Total: 24 calls
+              for _ in $(seq 1 24); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
@@ -172,7 +174,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -190,32 +192,28 @@ spec:
 
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              IDENTITY4="${_TEST_PUB_REPO4}:latest"
+              IDENTITY3="${_TEST_PUB_REPO3}:latest"
+              IDENTITY2="${_TEST_PUB_REPO2}:t1"
+              IDENTITY1="${_TEST_PUB_REPO1}:t1"
+              IDENTITY22="${_TEST_PUB_REPO2}:t2"
+              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO4}:latest ${_TEST_REPO2}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO3}:latest ${_TEST_REPO2}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY4},${IDENTITY3} ${_TEST_REPO2}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY2},${IDENTITY1} ${_TEST_REPO1}@sha256:0000-3
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-1
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-2
+              $COSIGN_COMMON ${IDENTITY22},${IDENTITY12} ${_TEST_REPO1}@sha256:0000-3
               EOF
               )
               echo "TESTING SIGN CALLS"
@@ -230,7 +228,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false \
+              --insecure-ignore-tlog=true --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
@@ -240,18 +239,6 @@ spec:
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-2
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-3
               $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
-              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO2}@sha256:0000
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3
-              $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-1
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-2
               $COSIGN_COMMON ${_TEST_REPO1}@sha256:0000-3

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -83,14 +83,14 @@ spec:
               for _ in $(seq 1 3); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
-              # simulate cosign failure on 6th call
+              # simulate cosign failure on 4th call
               echo "0" >> "$(params.dataDir)/mock_cosign_success_calls"
 
               # after retrying, it should pass
               echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
-              test-product/test-image0
+              test-product/test-image2
               EOF
           - name: create-trusted-artifact
             ref:
@@ -166,21 +166,23 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
               echo "check results"
               _TEST_PUB_REPO="registry.stage.redhat.io/test-product/test-image2"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image2"
               _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:t1,${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2,${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
               - SIMULATED ERROR -
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2,${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
               EOF
               )
               echo "TESTING"
@@ -195,7 +197,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false \
+              --insecure-ignore-tlog=true --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -83,14 +83,14 @@ spec:
               for _ in $(seq 1 3); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
-              # simulate cosign failure on 6th call
+              # simulate cosign failure on 4th call
               echo "0" >> "$(params.dataDir)/mock_cosign_success_calls"
 
               # after retrying, it should pass
               echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
-              test-product/test-image0
+              test-product/test-image2
               EOF
           - name: create-trusted-artifact
             ref:
@@ -166,21 +166,23 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
               echo "check results"
               _TEST_PUB_REPO="registry.stage.redhat.io/test-product/test-image2"
+              _TEST_PUB_REPO2="registry.access.stage.redhat.com/test-product/test-image2"
               _TEST_REPO="quay.io/redhat-pending/test-product----test-image2"
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false \
+              --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1,${_TEST_PUB_REPO}:t1 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2,${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
               - SIMULATED ERROR -
-              $COSIGN_COMMON ${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2,${_TEST_PUB_REPO}:t2 ${_TEST_REPO}@sha256:2222
               EOF
               )
               echo "TESTING"
@@ -195,7 +197,8 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false \
+              --insecure-ignore-tlog=true --key temp_key_file"
               EXPECTED=$(cat <<EOF
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -79,7 +79,7 @@ spec:
               done
 
               # first 8 cosign calls should end with success
-              for _ in $(seq 1 8); do
+              for _ in $(seq 1 4); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -173,12 +173,15 @@ spec:
 
               # call records need to be sorted as concurrentLimit is set to 2
               CALLS=$(sort "$(params.dataDir)/mock_cosign_sign_calls")
-              COSIGN_COMMON="-t 3m0s sign --tlog-upload=false --key aws://arn:mykey --sign-container-identity"
+              COSIGN_COMMON="-t 3m0s sign --new-bundle-format=false --tlog-upload=false \
+              --key aws://arn:mykey --sign-container-identity"
+              IDENTITY1="${_TEST_PUB_REPO1}:t1"
+              IDENTITY2="${_TEST_PUB_REPO2}:t1"
+              IDENTITY12="${_TEST_PUB_REPO1}:t2"
+              IDENTITY22="${_TEST_PUB_REPO2}:t2"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO2}:t2 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t1 ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_PUB_REPO1}:t2 ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${IDENTITY1},${IDENTITY2} ${_TEST_REPO}@sha256:2222
+              $COSIGN_COMMON ${IDENTITY12},${IDENTITY22} ${_TEST_REPO}@sha256:2222
               EOF
               )
               echo "TESTING"
@@ -193,10 +196,9 @@ spec:
               fi
 
               CALLS=$(cat "$(params.dataDir)/mock_cosign_verify_calls")
-              COSIGN_COMMON="verify --insecure-ignore-tlog=true --key temp_key_file"
+              COSIGN_COMMON="verify --new-bundle-format=false --insecure-ignore-tlog=true \
+              --key temp_key_file"
               EXPECTED=$(cat <<EOF
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
-              $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
               $COSIGN_COMMON ${_TEST_REPO}@sha256:2222
               EOF

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -85,7 +85,7 @@ spec:
               done
 
               # Setup cosign success calls (verify + sign for each operation)
-              for _ in $(seq 1 32); do
+              for _ in $(seq 1 16); do
                   echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
               done
 
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:67d9a69feba01d13c8c29bd71d6b70bb67c3b7fd97d9080d100476199b9f1f96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -173,7 +173,7 @@ spec:
               REMAINING_CALLS=$(wc -l < "$(params.dataDir)/mock_cosign_success_calls" || echo 0)
 
               if [ "$REMAINING_CALLS" -ne 0 ]; then
-                echo "Expected all cosign calls to be consumed, but $REMAINING_CALLS calls remain"
+                echo "Expected all (16) cosign calls to be consumed, but $REMAINING_CALLS calls remain"
                 exit 1
               fi
 


### PR DESCRIPTION
## Describe your changes
Cosign command now support multiple identities arguments for single                                                                                                                                                                           command run.

## Relevant Jira
https://issues.redhat.com/browse/RELEASE-1976

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
