### PR TITLE
revert(RELEASE-1918): remove cosign signing from fbc pipeline

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -427,46 +427,6 @@ spec:
         - extract-requester-from-release
         - add-fbc-contribution-to-index-image
         - collect-task-params
-    - name: rh-sign-index-image-cosign
-      timeout: "6h00m0s"
-      retries: 3
-      when:
-        - input: "$(tasks.prepare-fbc-parameters.results.mustSignIndexImage)"
-          operator: in
-          values: ["true"]
-        - input: $(tasks.collect-task-params.results.extractedValues[4])
-          operator: notin
-          values: [""]
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
-      params:
-        - name: snapshotPath
-          value: "$(tasks.collect-index-images.results.indexImageSnapshot)"
-        - name: secretName
-          value: "$(tasks.collect-task-params.results.extractedValues[4])"
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.collect-index-images.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      runAfter:
-        - collect-index-images
-        - collect-task-params
-        - prepare-fbc-parameters
     - name: extract-index-image
       taskRef:
         resolver: "git"
@@ -537,7 +497,6 @@ spec:
           values: ["true"]
       runAfter:
         - sign-index-image
-        - rh-sign-index-image-cosign
     - name: collect-index-images
       taskRef:
         resolver: "git"


### PR DESCRIPTION
https://github.com/konflux-ci/release-service-catalog/pull/1535 added rh-sign-image-cosign to the fbc-release pipeline. It just hit production and is failing for users, so this commit reverts the addition of the task to the pipeline to unblock them while a fix is worked on.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
