### PR TITLE
fix(KFLUXSPRT-5809): fix update-fbc-catalog jq parsing

### DIFF
--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -10,6 +10,7 @@ items:
   distribution_scope: "stage"
   from_index: "quay.io/scoheb/fbc-index-testing:latest"
   fbc_fragments: ["registry.io/image0@sha256:0000"]
+  build_tags: ["v4.12", "hotfix"]
   internal_index_image_copy: "registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib:1"
   index_image_resolved: "registry-proxy-stage.engineering.redhat.com/rh-osbs-stage/iib@sha256:0000"
   index_image: "quay.io/scoheb/fbc-index-testing:latest"

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -18,7 +18,7 @@ spec:
         - name: fromIndex
           value: "quay.io/scoheb/fbc-index-testing:latest"
         - name: buildTags
-          value: "[]"
+          value: '["v4.12", "hotfix"]'
         - name: addArches
           value: "[]"
         - name: iibServiceAccountSecret
@@ -76,6 +76,22 @@ spec:
                 exit 1
               fi
 
-              echo "SUCCESS: Hotfix behavior correctly set"
+              # Verify buildTags were parsed correctly (tests bug fixes)
+              buildInfo=$(base64 -d <<< "${JSON_BUILDINFO}" | gunzip)
+              buildTags=$(jq -r '.build_tags' <<< "${buildInfo}")
+              if [ "$buildTags" = "null" ] || [ -z "$buildTags" ]; then
+                echo "ERROR: build_tags missing from build info - buildTags parameter not processed correctly"
+                exit 1
+              fi
+
+              # Verify the tags match what we passed in
+              expectedTags='["hotfix","v4.12"]'  # sorted alphabetically by IIB
+              actualTags=$(jq -c '.build_tags | sort' <<< "${buildInfo}")
+              if [ "$actualTags" != "$expectedTags" ]; then
+                echo "ERROR: build_tags mismatch. Expected: $expectedTags, Got: $actualTags"
+                exit 1
+              fi
+
+              echo "SUCCESS: Hotfix behavior correctly set and buildTags validated"
       runAfter:
         - run-task

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
@@ -64,10 +64,10 @@ spec:
 
               # Decompress jsonBuildInfo since task now uses compression
               decompressed_json="$(base64 -d <<< "${JSON_BUILDINFO}" | gunzip)"
-              
-              # the jsonBuild mocks has 12 keys on it
+
+              # the jsonBuild mocks has 13 keys on it (including build_tags)
               keyLength=$(jq '. | length' <<< "${decompressed_json}")
-              if [ "$keyLength" -ne 12 ]; then
+              if [ "$keyLength" -ne 13 ]; then
                 echo "The task did not save a valid json in jsonBuildInfo result"
                 exit 1
               fi

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -165,7 +165,7 @@ spec:
                   select((.fbc_fragments | sort) == $fbc_fragments) |
                   select(.distribution_scope == "prod" or .distribution_scope == null) |
                   select(.build_tags != null and ($current_tags | length > 0) and
-                         ($current_tags | map(. as $tag | . | IN(.build_tags[])) | any))
+                         (. as $build | $current_tags | map(. as $tag | $tag | IN($build.build_tags[])) | any))
                 ] | sort_by(.updated) | last // empty')
 
             if [ -n "${in_progress_build}" ] && [ "${in_progress_build}" != "null" ]; then
@@ -249,7 +249,8 @@ spec:
         # if it finds a build which is completed or in progress, it should exit this step and jump to
         # the next step `s-wait-for-build-state` which will watch the build until it is completed.
         # Pass build_tags to enable PLR filtering for in-progress builds
-        build_tags_param="$(params.buildTags)"
+        # shellcheck disable=SC2016 # Tekton substitutes params before bash runs; single quotes preserve JSON
+        build_tags_param='$(params.buildTags)'
         build=$(check_previous_build "${KRB5_PRINCIPAL}" "${FROM_INDEX}" \
                   "${sorted_fbc_fragments}" "${build_tags_param}")
         if [ -n "${build}" ]; then


### PR DESCRIPTION
When updating the fbc catalog, we were hitting a couple jq issues. The parsing the the tags passed in were not properly quoted, so the result was invalid jq. Additionally, when trying to parse the additional tags, we were not scoped properly.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
