### PR TITLE
fix(RELEASE-1972): filter env_variables and labels from CR status

### DIFF
--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-large-payload.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-large-payload.yaml
@@ -1,0 +1,237 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-large-payload
+spec:
+  description: |
+    Test update-cr-status task with a large number of components (800) containing
+    extensive metadata. Verifies that metadata filtering works correctly to ensure
+    payload size remains within etcd storage limits.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results/"
+              
+              # Generate a large JSON payload with multiple components containing metadata
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json" << 'EOF'
+              {
+                "components": [
+              EOF
+
+              # Generate 800 components with realistic metadata including env_variables and labels
+              for i in $(seq 1 800); do
+                if [ "$i" -gt 1 ]; then
+                  echo "," >> "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json"
+                fi
+
+                cat >> "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json" << COMPONENT
+                  {
+                    "name": "component-$i",
+                    "containerImage": "quay.io/example/app-$i@sha256:$(printf '%064d' "$i")",
+                    "metadata": {
+                      "env_variables": [
+                        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                        "container=oci",
+                        "GODEBUG=x509ignoreCN=0,madvdontneed=1",
+                        "HOME=/root",
+                        "USER=appuser",
+                        "WORKDIR=/app/component-$i",
+                        "CONFIG_PATH=/etc/config/component-$i",
+                        "DATA_PATH=/var/lib/component-$i/data",
+                        "LOG_PATH=/var/log/component-$i",
+                        "CACHE_PATH=/var/cache/component-$i",
+                        "TMP_PATH=/tmp/component-$i",
+                        "BUILD_ID=build-$(date +%s)-$i",
+                        "BUILD_NUMBER=$i",
+                        "BUILD_TAG=v1.2.3-build-$i",
+                        "BUILD_URL=https://build.example.com/job/$i",
+                        "GIT_COMMIT=$(printf '%040d' "$i")",
+                        "GIT_BRANCH=main",
+                        "GIT_URL=https://github.com/example/component-$i",
+                        "ARTIFACT_VERSION=1.2.3-$i",
+                        "LARGE_VAR_1=this-is-a-very-long-environment-variable-value-that-adds-significant-size-to-the-json-payload-$i",
+                        "LARGE_VAR_2=another-very-long-environment-variable-with-lots-of-data-that-bloats-the-payload-$i"
+                      ],
+                      "labels": [
+                        {"name": "build-date", "value": "2024-01-15T10:30:00"},
+                        {"name": "component", "value": "component-$i"},
+                        {
+                          "name": "description",
+                          "value": "Example component $i with metadata"
+                        },
+                        {"name": "version", "value": "1.2.3"},
+                        {"name": "release", "value": "20240115"},
+                        {"name": "architecture", "value": "x86_64"},
+                        {"name": "vendor", "value": "Example Vendor Corporation"},
+                        {"name": "maintainer", "value": "team-$i@example.com"},
+                        {"name": "documentation", "value": "https://docs.example.com/component-$i"},
+                        {"name": "source", "value": "https://github.com/example/component-$i"},
+                        {"name": "license", "value": "Apache-2.0"},
+                        {"name": "build-system", "value": "konflux"},
+                        {"name": "ci-pipeline", "value": "pipeline-$i"}
+                      ],
+                      "timestamp": "2024-01-15T10:30:00Z"
+                    }
+                  }
+              COMPONENT
+              done
+
+              cat >> "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json" << 'EOF'
+                ]
+              }
+              EOF
+
+              # Show the size of the payload
+              echo "Generated payload size:"
+              ls -lh "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json"
+              echo "Payload size in bytes:"
+              wc -c < "$(params.dataDir)/$(context.pipelineRun.uid)/results/large-payload.json"
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-large-payload
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-large-payload
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Test that the large payload was successfully stored"
+              components_count=$(kubectl get release release-large-payload -n default \
+                -o jsonpath='{.status.artifacts.components}' | jq '. | length')
+              
+              echo "Number of components in CR status: $components_count"
+              test "$components_count" == "800"
+
+              echo "Test that env_variables are filtered out (should be empty)"
+              env_vars=$(kubectl get release release-large-payload -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.env_variables}')
+              if [ -n "$env_vars" ]; then
+                echo "ERROR: env_variables should be filtered out but found: $env_vars"
+                exit 1
+              fi
+
+              echo "Test that labels are filtered out (should be empty)"
+              labels=$(kubectl get release release-large-payload -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.labels}')
+              if [ -n "$labels" ]; then
+                echo "ERROR: labels should be filtered out but found: $labels"
+                exit 1
+              fi
+
+              echo "Test that timestamp is preserved"
+              timestamp=$(kubectl get release release-large-payload -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.timestamp}')
+              test "$timestamp" == "2024-01-15T10:30:00Z"
+
+              # Show the final size stored in etcd
+              echo "Final size check:"
+              kubectl get release release-large-payload -n default -o json | \
+                jq '.status.artifacts' | wc -c | \
+                awk '{printf "CR status size: %d bytes (%.2f KB, %.2f MB)\n", $1, $1/1024, $1/1024/1024}'
+
+              echo "SUCCESS: Large payload handled correctly with filtering"
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-large-payload

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-with-metadata-filtering.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-with-metadata-filtering.yaml
@@ -1,0 +1,185 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-with-metadata-filtering
+spec:
+  description: |
+    Test update-cr-status task with component metadata including env_variables and labels.
+    Verifies that non-essential metadata fields are properly filtered from CR status.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results/"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/results/test.json" << EOF
+              {
+                  "components": [
+                      {
+                          "name": "example-application",
+                          "containerImage": "quay.io/example/my-app@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                          "metadata": {
+                              "env_variables": [
+                                  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                                  "container=oci",
+                                  "GODEBUG=x509ignoreCN=0,madvdontneed=1",
+                                  "HOME=/root",
+                                  "USER=appuser",
+                                  "WORKDIR=/app",
+                                  "CONFIG_PATH=/etc/config",
+                                  "LARGE_VAR=this-is-a-very-long-value-that-would-make-the-json-large-simulating-real-world-env-vars"
+                              ],
+                              "labels": [
+                                  {"name": "build-date", "value": "2024-01-15T10:30:00"},
+                                  {"name": "component", "value": "example-app"},
+                                  {
+                                    "name": "description",
+                                    "value": "Example application for testing metadata filtering"
+                                  },
+                                  {"name": "version", "value": "1.2.3"},
+                                  {"name": "release", "value": "20240115"},
+                                  {"name": "architecture", "value": "x86_64"}
+                              ],
+                              "timestamp": "2024-01-15T10:30:00Z"
+                          }
+                      }
+                  ]
+              }
+              EOF
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-filter
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status-filter
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Test that component metadata exists"
+              test "$(kubectl get release release-cr-status-filter -n default \
+                -o jsonpath='{.status.artifacts.components[0].name}')" == "example-application"
+
+              echo "Test that component metadata.timestamp is preserved (not filtered)"
+              test "$(kubectl get release release-cr-status-filter -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.timestamp}')" == "2024-01-15T10:30:00Z"
+
+              echo "Test that env_variables are filtered out (should be empty)"
+              env_vars=$(kubectl get release release-cr-status-filter -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.env_variables}')
+              if [ -n "$env_vars" ]; then
+                echo "ERROR: env_variables should be filtered out but found: $env_vars"
+                exit 1
+              fi
+
+              echo "Test that labels are filtered out (should be empty)"
+              labels=$(kubectl get release release-cr-status-filter -n default \
+                -o jsonpath='{.status.artifacts.components[0].metadata.labels}')
+              if [ -n "$labels" ]; then
+                echo "ERROR: labels should be filtered out but found: $labels"
+                exit 1
+              fi
+
+              echo "All checks passed - env_variables and labels were successfully filtered"
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-filter

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -136,10 +136,34 @@ spec:
             mv "$TEMP_FILE" "$RESULTS_JSON"
         done
 
-        IFS='/' read -r namespace name <<< "$(params.resource)"
-
         # Read the final JSON from the file
         FINAL_JSON=$(cat "$RESULTS_JSON")
+
+        # Filter out large metadata fields to prevent exceeding etcd size limits
+        # Remove env_variables and labels from component metadata as they are stored in Pyxis
+        # and do not need to be duplicated in the CR status, which is subject to etcd's 1.5MB limit
+        echo "Reducing data size by filtering large metadata fields (env_variables, labels)..."
+        REDUCED_JSON=$(echo "$FINAL_JSON" | jq '
+          # Remove env_variables and labels from metadata objects throughout the JSON structure
+          walk(
+            if type == "object" and has("metadata") then
+              .metadata |= del(.env_variables, .labels)
+            else
+              .
+            end
+          )
+        ')
+
+        # Check the size of the reduced JSON (in bytes)
+        REDUCED_SIZE=$(echo -n "$REDUCED_JSON" | wc -c)
+        ORIGINAL_SIZE=$(echo -n "$FINAL_JSON" | wc -c)
+        echo "Original JSON size: $ORIGINAL_SIZE bytes"
+        echo "Reduced JSON size: $REDUCED_SIZE bytes (reduced by $((ORIGINAL_SIZE - REDUCED_SIZE)) bytes)"
+
+        # Use the reduced JSON going forward
+        FINAL_JSON="$REDUCED_JSON"
+        
+        IFS='/' read -r namespace name <<< "$(params.resource)"
 
         # Create patch file to avoid "Argument list too long" error
         PATCH_FILE="/tmp/patch-$(date +%s).json"


### PR DESCRIPTION
## Describe your changes
Fixes "etcdserver: request is too large" error by filtering out env_variables and labels metadata from component data before updating the Release CR status.

For releases with hundreds of components (e.g., OpenShift with 752 components), this reduces the JSON payload size by ~70%, bringing it well below the etcd 1.5MB limit.

Changes:
- Add jq filter using walk() to remove env_variables and labels from all metadata objects recursively
- Add logging to show size reduction (original vs reduced)
- Add test to verify filtering works while preserving other metadata fields like timestamp
## Relevant Jira

RELEASE-1972

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
