### PR TITLE
fix(RELEASE-2000): temporarily disable advisories

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -405,70 +405,72 @@ spec:
       runAfter:
         - verify-conforma
         - embargo-check
-    - name: create-advisory
-      params:
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: dataPath
-          value: "$(tasks.collect-data.results.data)"
-        - name: resultsDirPath
-          value: "$(tasks.collect-data.results.resultsDir)"
-        - name: pipelineRunUid
-          value: $(context.pipelineRun.uid)
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/create-advisory/create-advisory.yaml
-      runAfter:
-        - push-artifacts-to-cdn
-    - name: close-advisory-issues
-      params:
-        - name: dataPath
-          value: "$(tasks.collect-data.results.data)"
-        - name: advisoryUrl
-          value: "$(tasks.create-advisory.results.advisory_url)"
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.create-advisory.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
-      runAfter:
-        - create-advisory
+    # Advisory creation is temporarily disabled,
+    # see https://issues.redhat.com/browse/RELEASE-2000
+    # - name: create-advisory
+    #   params:
+    #     - name: releasePlanAdmissionPath
+    #       value: "$(tasks.collect-data.results.releasePlanAdmission)"
+    #     - name: snapshotPath
+    #       value: "$(tasks.collect-data.results.snapshotSpec)"
+    #     - name: dataPath
+    #       value: "$(tasks.collect-data.results.data)"
+    #     - name: resultsDirPath
+    #       value: "$(tasks.collect-data.results.resultsDir)"
+    #     - name: pipelineRunUid
+    #       value: $(context.pipelineRun.uid)
+    #     - name: ociStorage
+    #       value: $(params.ociStorage)
+    #     - name: sourceDataArtifact
+    #       value: "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)"
+    #     - name: dataDir
+    #       value: $(params.dataDir)
+    #     - name: trustedArtifactsDebug
+    #       value: "$(params.trustedArtifactsDebug)"
+    #     - name: taskGitUrl
+    #       value: "$(params.taskGitUrl)"
+    #     - name: taskGitRevision
+    #       value: "$(params.taskGitRevision)"
+    #   taskRef:
+    #     resolver: "git"
+    #     params:
+    #       - name: url
+    #         value: $(params.taskGitUrl)
+    #       - name: revision
+    #         value: $(params.taskGitRevision)
+    #       - name: pathInRepo
+    #         value: tasks/managed/create-advisory/create-advisory.yaml
+    #   runAfter:
+    #     - push-artifacts-to-cdn
+    # - name: close-advisory-issues
+    #   params:
+    #     - name: dataPath
+    #       value: "$(tasks.collect-data.results.data)"
+    #     - name: advisoryUrl
+    #       value: "$(tasks.create-advisory.results.advisory_url)"
+    #     - name: ociStorage
+    #       value: $(params.ociStorage)
+    #     - name: sourceDataArtifact
+    #       value: "$(tasks.create-advisory.results.sourceDataArtifact)"
+    #     - name: dataDir
+    #       value: $(params.dataDir)
+    #     - name: trustedArtifactsDebug
+    #       value: "$(params.trustedArtifactsDebug)"
+    #     - name: taskGitUrl
+    #       value: "$(params.taskGitUrl)"
+    #     - name: taskGitRevision
+    #       value: "$(params.taskGitRevision)"
+    #   taskRef:
+    #     resolver: "git"
+    #     params:
+    #       - name: url
+    #         value: $(params.taskGitUrl)
+    #       - name: revision
+    #         value: $(params.taskGitRevision)
+    #       - name: pathInRepo
+    #         value: tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+    #   runAfter:
+    #     - create-advisory
     - name: update-cr-status
       params:
         - name: resource
@@ -479,7 +481,9 @@ spec:
           value: $(params.ociStorage)
         - name: resultArtifacts
           value:
-            - "$(tasks.create-advisory.results.sourceDataArtifact)=$(params.dataDir)"
+            # Advisory creation is temporarily disabled,
+            # see https://issues.redhat.com/browse/RELEASE-2000
+            # - "$(tasks.create-advisory.results.sourceDataArtifact)=$(params.dataDir)"
             - "$(tasks.push-artifacts-to-cdn.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
@@ -499,7 +503,10 @@ spec:
           - name: pathInRepo
             value: tasks/managed/update-cr-status/update-cr-status.yaml
       runAfter:
-        - create-advisory
+        # Advisory creation is temporarily disabled,
+        # see https://issues.redhat.com/browse/RELEASE-2000
+        # - create-advisory
+        - push-artifacts-to-cdn
   finally:
     - name: cleanup-internal-requests
       taskRef:


### PR DESCRIPTION
## Describe your changes

Advisory creation in the push-artifacts-to-cdn pipeline has issues when forming the purl. See jira for more details.

So we will disable advisories for now.

## Relevant Jira

RELEASE-2000

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
