### PR TITLE
fix: apply-mapping permission issue

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -97,6 +97,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -120,7 +122,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
       Run the apply-mapping task with a snapshot JSON and verify that the resulting
-      snapshot contains the metadata extracted from docker://registry.io/metadata. 
+      snapshot contains the metadata extracted from docker://registry.io/metadata.
       This includes the labels and environment variables.
   params:
     - name: ociStorage
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -162,13 +162,13 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux
 
               TEST_SNAPSHOT="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
-            
+
               echo "Test that component 0 has the correct environment variables"
               test "$(
                 jq -c '.components[0] | .metadata.env_variables // []' < "$TEST_SNAPSHOT"

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

I was getting this error in apply-mapping:

`open /tekton/home/.docker/config.json: permission denied`

It seems to be related to this utils change which changed the container to run as user 1001:

https://github.com/konflux-ci/release-service-utils/pull/552

To fix this, the apply-mapping task needs to use that user.

Other tasks already have this and I am not really sure why nobody else is facing this issue, but I confirmed
that this fixes it for me.

This also updates the utils image in the task to the latest one.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
