### PR TITLE
fix: creating secret failure for conflict

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -280,7 +280,9 @@ create_kubernetes_resources() {
 
     echo "Building and applying managed resources..."
     kustomize build "${SUITE_DIR}/resources/managed" | envsubst > "$tmpDir/managed-resources.yaml"
-    kubectl create -f "$tmpDir/managed-resources.yaml"
+    # use "kubectl apply" to avoid failure when a secret already exists 
+    # since some secret name is hardcoded in the task, it may conflict when several tests run in parellel. 
+    kubectl apply -f "$tmpDir/managed-resources.yaml"
 
     echo "Kubernetes resources applied."
 }


### PR DESCRIPTION
## Describe your changes
Since some secret name is hardcoded in the task, it may conflict when several tests run in parellel to create it.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
