### PR TITLE
fix(release-2004): allow for parallel CDN task runs

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -513,7 +513,7 @@ spec:
         # shell check complains about the variable (unsigned_digest) not being used but it is used in the script
         # shellcheck disable=SC2034
         unsigned_digest=$(cat "$(results.unsignedMacDigest.path)")
-        mac_signing_script="/tmp/mac_signing_script.sh"
+        mac_signing_script="/tmp/mac_signing_script_$(context.taskRun.uid).sh"
 
         TEMP_DIR="/tmp/$(context.taskRun.uid)"
         BINARY_PATH="$TEMP_DIR/unsigned/macos"
@@ -568,10 +568,11 @@ spec:
         EOF
 
         # Copy the script to the Mac host
-        scp "${SSH_OPTS[@]}" "$mac_signing_script" "${MAC_USER}@${MAC_HOST}:/tmp/mac_signing_script.sh"
+        scp "${SSH_OPTS[@]}" "$mac_signing_script" "${MAC_USER}@${MAC_HOST}:${mac_signing_script}"
 
         # Execute the script on the Mac host
-        ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" bash /tmp/mac_signing_script.sh
+        # shellcheck disable=SC2029
+        ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" bash "${mac_signing_script}"
 
         # Copy the signed digest back to the pipeline
         scp "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}:/tmp/$(context.taskRun.uid)/push_digest.txt" \
@@ -580,7 +581,7 @@ spec:
         # Clean up the Mac host now that we are done
         # shell check complains about the variable $(context.taskRun.uid) being evaluated on the client side
         # shellcheck disable=SC2029
-        ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid)"
+        ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf /tmp/$(context.taskRun.uid) ${mac_signing_script}"
     - name: sign-windows-binaries
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
       computeResources:
@@ -650,7 +651,8 @@ spec:
 
         unsigned_digest=$(cat "$(results.unsignedWindowsDigest.path)")
         # Create the batch script
-        windows_signing_script_file="/tmp/windows_signing_script_file.bat"
+        windows_signing_script_file="/tmp/windows_signing_script_file_$(context.taskRun.uid).bat"
+        WINDOWS_SIGNING_SCRIPT_PATH="C:/Users/${WINDOWS_USER}/AppData/Local/Temp/windows_signing_script_file_$(context.taskRun.uid).bat"
         set +x
         cat << EOF > "$windows_signing_script_file"
 
@@ -685,12 +687,12 @@ spec:
         set -x
         # shellcheck disable=SC2086
         scp "${SCP_OPTS[@]}" "$windows_signing_script_file" \
-        "${WINDOWS_USER}@${WINDOWS_HOST}:C:/Users/${WINDOWS_USER}/AppData/Local/Temp/windows_signing_script_file.bat"
+        "${WINDOWS_USER}@${WINDOWS_HOST}:${WINDOWS_SIGNING_SCRIPT_PATH}"
 
         # Execute the script on the Windows host
         # shellcheck disable=SC2029,SC2086
         ssh "${SSH_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}" \
-          "C:/Users/${WINDOWS_USER}/AppData/Local/Temp/windows_signing_script_file.bat"
+          "${WINDOWS_SIGNING_SCRIPT_PATH}"
 
         # disable shellcheck for escaping the taskRun.uid as we want that evaluated on client side
         # shellcheck disable=SC2029,SC2086
@@ -705,7 +707,8 @@ spec:
         # disable shellcheck for escaping the taskRun.uid as we want that evaluated on client side
         # shellcheck disable=SC2029,SC2086
         ssh "${SSH_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}" "Remove-Item -LiteralPath \
-        C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse"
+        C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\$(context.taskRun.uid) -Force -Recurse; \
+        Remove-Item -LiteralPath ${WINDOWS_SIGNING_SCRIPT_PATH} -Force"
     - name: generate-checksums
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
       computeResources:


### PR DESCRIPTION
Parallel push-artifacts-to-cdn tasks will fail on the signing steps if we don't use unique paths.

This adds the pipeline run id to the signing script files.

Code-assisted with Cursor AI

## Relevant Jira
RELEASE-2004

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
