### PR TITLE
fix: update resources for push-oot-kmods-to-git task

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -87,9 +87,9 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 1Gi
         requests:
-          memory: 512Mi
+          memory: 1Gi
           cpu: 250m
       volumeMounts:
         - name: git-token-secret-vol


### PR DESCRIPTION
Update memory to 1Gi to avoid OOM errors when pushing

