### PR TITLE
fix(prepare-and-finalize-artifacts): replace oras pull with use

### DIFF
--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -469,6 +469,8 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
+        - name: orasOptions
+          value: "$(params.orasOptions)"
       runAfter:
         - sign-oot-kmods
         - build-oot-kmods-rpms

--- a/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
@@ -52,22 +52,25 @@ spec:
     - name: sourceDataArtifact
       type: string
       description: Produced trusted data artifact
+    - name: selectedArtifact
+      type: string
+      description: Selected input artifact to use
   volumes:
     - name: workdir
       emptyDir: {}
   stepTemplate:
+    securityContext:
+      runAsUser: 1001
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
     env:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.ociArtifactExpiresAfter)
-      - name: ORAS_OPTIONS
-        value: $(params.orasOptions)
       - name: DEBUG
         value: $(params.trustedArtifactsDebug)
   steps:
-    - name: select-and-download-artifact
+    - name: select-artifact
       image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
       computeResources:
         limits:
@@ -80,15 +83,51 @@ spec:
         set -euxo pipefail
 
         if [ -n "$(params.rpmDataArtifact)" ]; then
-          ARTIFACT_TO_PULL_WITH_PREFIX="$(params.rpmDataArtifact)"
+          ARTIFACT_TO_USE="$(params.rpmDataArtifact)"
+        elif [ -n "$(params.baseDataArtifact)" ]; then
+          ARTIFACT_TO_USE="$(params.baseDataArtifact)"
         else
-          ARTIFACT_TO_PULL_WITH_PREFIX="$(params.baseDataArtifact)"
+          echo "ERROR: Both rpmDataArtifact and baseDataArtifact are empty. At least one must be provided."
+          exit 1
         fi
-        ARTIFACT_TO_PULL="${ARTIFACT_TO_PULL_WITH_PREFIX#oci:}"
-        
-        mkdir -p "$(params.dataDir)"
-        oras pull -o "$(params.dataDir)" "${ARTIFACT_TO_PULL}"
 
+        echo "Selected artifact: ${ARTIFACT_TO_USE}"
+        echo -n "${ARTIFACT_TO_USE}" > "$(results.selectedArtifact.path)"
+    - name: use-selected-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: ORAS_OPTIONS
+          value: $(params.orasOptions)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Read the selected artifact from the result file
+        SELECTED_ARTIFACT=$(cat "$(results.selectedArtifact.path)")
+        echo "Using selected artifact: ${SELECTED_ARTIFACT}"
+        # Use the container entrypoint directly since the image is designed with entrypoint
+        if [ -x /usr/local/bin/entrypoint ]; then
+            exec /usr/local/bin/entrypoint use "${SELECTED_ARTIFACT}=$(params.dataDir)"
+        else
+            # Fallback to looking for build-trusted-artifacts command
+            if command -v build-trusted-artifacts >/dev/null 2>&1; then
+                exec build-trusted-artifacts use "${SELECTED_ARTIFACT}=$(params.dataDir)"
+            elif [ -x /usr/local/bin/build-trusted-artifacts ]; then
+                exec /usr/local/bin/build-trusted-artifacts use "${SELECTED_ARTIFACT}=$(params.dataDir)"
+            elif [ -x /usr/bin/build-trusted-artifacts ]; then
+                exec /usr/bin/build-trusted-artifacts use "${SELECTED_ARTIFACT}=$(params.dataDir)"
+            else
+                echo "ERROR: build-trusted-artifacts command not found"
+                exit 1
+            fi
+        fi
     - name: create-trusted-artifact
       computeResources:
         limits:
@@ -112,3 +151,5 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
+        - name: orasOptions
+          value: $(params.orasOptions)

--- a/tasks/managed/prepare-and-finalize-artifacts/tests/mocks.sh
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/mocks.sh
@@ -1,34 +1,46 @@
 #!/usr/bin/env sh
 set -eux
-
-echo "--- MOCK ORAS CALLED ---"
-echo "Arguments: $*"
-
+echo "--- MOCK ORAS CALLED ---" >&2
+echo "Arguments: $*" >&2
 COMMAND="$1"
-
 if [ "$COMMAND" = "pull" ]; then
     echo "Mock 'oras pull' called. Pretending to succeed."
     exit 0
-
 elif [ "$COMMAND" = "push" ]; then
     echo "Mock 'oras push' called. Validating arguments..."
-    
     EXPECTED_TARGET="mock.registry/test-repo/my-artifact"
-    
     if [ "$6" != "$EXPECTED_TARGET" ]; then
         echo "ERROR: Mock oras expected target '$EXPECTED_TARGET' (at \$6) but got '$6'"
         exit 1
     fi
-
     EXPECTED_SOURCE_NAME="sourceDataArtifact"
     if [ "$7" != "$EXPECTED_SOURCE_NAME" ]; then
         echo "ERROR: Mock oras expected source '$EXPECTED_SOURCE_NAME' (at \$7) but got '$7'"
         exit 1
     fi
-
     echo "SUCCESS: Mock oras push validated."
     exit 0
-
+elif [ "$COMMAND" = "blob" ]; then
+    SUBCOMMAND="$2"
+    echo "Mock 'oras blob $SUBCOMMAND' called." >&2
+    if [ "$SUBCOMMAND" = "fetch" ]; then
+        # Create a mock tar.gz stream for blob fetch
+        # This simulates fetching an artifact and outputting it as a compressed tarball
+        echo "Mock fetching blob..." >&2
+        # Create a temporary directory with mock content
+        TEMP_DIR=$(mktemp -d)
+        echo "mock extracted content from trusted artifact" > "$TEMP_DIR/artifact-file.txt"
+        echo "mock metadata" > "$TEMP_DIR/metadata.json"
+        # Create a gzipped tar and output to stdout (this is what the caller expects)
+        tar -C "$TEMP_DIR" -czf - .
+        # Clean up
+        rm -rf "$TEMP_DIR"
+        echo "Mock blob fetch completed." >&2
+        exit 0
+    else
+        echo "ERROR: Mock oras blob doesn't support subcommand: '$SUBCOMMAND'"
+        exit 1
+    fi
 else
     echo "ERROR: Mock oras script doesn't know how to handle command: '$COMMAND'"
     exit 1

--- a/tasks/managed/prepare-and-finalize-artifacts/tests/test-base-artifact-only.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/test-base-artifact-only.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-and-finalize-artifacts-base-only
+spec:
+  description: |
+    Test the prepare-and-finalize-artifacts task when only the base artifact is provided.
+    Should select and use the base artifact.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+    - name: taskGitUrl
+      type: string
+      default: "https://github.com/konflux-ci/release-service-catalog.git"
+    - name: taskGitRevision
+      type: string
+      default: "main"
+  tasks:
+    - name: run-task
+      taskRef:
+        name: prepare-and-finalize-artifacts
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: "mock.registry/test-repo/my-artifact"
+        - name: ociArtifactExpiresAfter
+          value: "1d"
+        - name: orasOptions
+          value: "--insecure"
+        - name: baseDataArtifact
+          value: "oci:mock.registry/test-repo/base-artifact@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        - name: rpmDataArtifact
+          value: ""
+        - name: trustedArtifactsDebug
+          value: ""
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+          

--- a/tasks/managed/prepare-and-finalize-artifacts/tests/test-no-artifacts.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/test-no-artifacts.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-and-finalize-artifacts-no-artifacts
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test the prepare-and-finalize-artifacts task when no artifacts are provided.
+    This should fail during the use step.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+    - name: taskGitUrl
+      type: string
+      default: "https://github.com/konflux-ci/release-service-catalog.git"
+    - name: taskGitRevision
+      type: string
+      default: "main"
+  tasks:
+    - name: run-task
+      taskRef:
+        name: prepare-and-finalize-artifacts
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: "mock.registry/test-repo/my-artifact"
+        - name: ociArtifactExpiresAfter
+          value: "1d"
+        - name: orasOptions
+          value: "--insecure"
+        - name: baseDataArtifact
+          value: ""
+        - name: rpmDataArtifact
+          value: ""
+        - name: trustedArtifactsDebug
+          value: ""
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+          

--- a/tasks/managed/prepare-and-finalize-artifacts/tests/test-rpm-artifact-only.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/test-rpm-artifact-only.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-prepare-and-finalize-artifacts
+  name: test-prepare-and-finalize-artifacts-rpm-only
 spec:
   description: |
-    Run the prepare-and-finalize-artifacts task and verify its steps are mocked.
+    Test the prepare-and-finalize-artifacts task when only the RPM artifact is provided.
+    Should select and use the RPM artifact.
   params:
     - name: dataDir
       description: The location where data will be stored
@@ -31,9 +32,9 @@ spec:
         - name: orasOptions
           value: "--insecure"
         - name: baseDataArtifact
-          value: "test-base-artifact"
+          value: ""
         - name: rpmDataArtifact
-          value: "test-rpm-artifact"
+          value: "oci:mock.registry/test-repo/rpm-artifact@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
         - name: trustedArtifactsDebug
           value: ""
         - name: taskGitUrl

--- a/tasks/managed/prepare-and-finalize-artifacts/tests/test-rpm-artifact.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/test-rpm-artifact.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-and-finalize-artifacts-rpm-priority
+spec:
+  description: |
+    Test the prepare-and-finalize-artifacts task when both base and RPM artifacts are provided.
+    Should prioritize and select the RPM artifact over the base artifact.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+    - name: taskGitUrl
+      type: string
+      default: "https://github.com/konflux-ci/release-service-catalog.git"
+    - name: taskGitRevision
+      type: string
+      default: "main"
+  tasks:
+    - name: run-task
+      taskRef:
+        name: prepare-and-finalize-artifacts
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: "mock.registry/test-repo/my-artifact"
+        - name: ociArtifactExpiresAfter
+          value: "1d"
+        - name: orasOptions
+          value: "--insecure"
+        - name: baseDataArtifact
+          value: "oci:mock.registry/test-repo/base-artifact@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        - name: rpmDataArtifact
+          value: "oci:mock.registry/test-repo/rpm-artifact@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        - name: trustedArtifactsDebug
+          value: ""
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+          


### PR DESCRIPTION
Select artifact at runtime and persist choice to a file, then invoke `build-trusted-artifacts use` to pull instead of `oras pull`. This restores support for sha256-only inputs and fixes the "failed to resolve sha256:..." error without changing pipeline behavior.

Signed-off-by: Harel Erlich herlich@redhat.com

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
