### PR TITLE
fix: fbc conditional structure in JSON schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -1161,19 +1161,19 @@
                   "const": "fbc"
                 }
               }
-            },
-            "fbc": {
-              "properties": {
-                "preGA": {
-                  "enum": [
-                    true
-                  ]
-                }
-              },
-              "required": [
-                "preGA"
-              ]
             }
+          },
+          "fbc": {
+            "properties": {
+              "preGA": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "preGA"
+            ]
           }
         }
       },
@@ -1203,19 +1203,19 @@
                   "const": "fbc"
                 }
               }
-            },
-            "fbc": {
-              "properties": {
-                "hotfix": {
-                  "enum": [
-                    true
-                  ]
-                }
-              },
-              "required": [
-                "hotfix"
-              ]
             }
+          },
+          "fbc": {
+            "properties": {
+              "hotfix": {
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "hotfix"
+            ]
           }
         }
       },
@@ -1244,15 +1244,15 @@
                   "const": "fbc"
                 }
               }
-            },
-            "fbc": {
-              "properties": {
-                "stagedIndex": {
-                  "not": {
-                    "enum": [
-                      true
-                    ]
-                  }
+            }
+          },
+          "fbc": {
+            "properties": {
+              "stagedIndex": {
+                "not": {
+                  "enum": [
+                    true
+                  ]
                 }
               }
             }


### PR DESCRIPTION
## Describe your changes
The fbc property was nested inside systems object
causing the schema to look for systems.fbc instead of the root level fbc object.

This fix moves the fbc property to be a sibling of systems.

Affected conditions:
* preGA
* hotfix
* stagedIndex

Broken Commit: 1523b68
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
