### PR TITLE
chore(RELEASE-1837): migrate to OSIDB v2 api

### DIFF
--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -84,7 +84,7 @@ spec:
               # Get token. They are short lived, so get one for before each request
               TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
               EMBARGOED=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
-                  "${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${CVE}&include_fields=cve_id,embargoed" \
+                  "${OSIDB_URL}/osidb/api/v2/flaws?cve_id=${CVE}&include_fields=cve_id,embargoed" \
                   | jq .results[0].embargoed)
               # null would mean no access to the CVE, which may mean embargoed, and true means embargoed
               if [ "$EMBARGOED" != "false" ] ; then

--- a/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
@@ -13,13 +13,13 @@ function curl() {
   if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
   then
     echo '{"access": "dummy-token"}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-embargo"* ]]
+  elif [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-embargo"* ]]
   then
     echo '{"results": [{"embargoed": true}]}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-noaccess"* ]]
+  elif [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-noaccess"* ]]
   then
     echo '{}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id="* ]]
+  elif [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id="* ]]
   then
     echo '{"results": [{"embargoed": false}]}'
   else

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -144,7 +144,7 @@ spec:
                       fi
 
                       echo "Batch $1: Processing CVE ${cve}"
-                      curl_url="${OSIDB_URL}/osidb/api/v1/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}"
+                      curl_url="${OSIDB_URL}/osidb/api/v2/flaws?cve_id=${cve}&include_fields=${INCLUDE_FIELDS}"
                       set +x
 
                       # Try API call with current token, refresh and retry if it fails

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -18,7 +18,7 @@ function curl() {
   fi
 
   # Performance test CVE requests - simulate realistic API delay
-  if [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-"*[0-9]* ]]
+  if [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-"*[0-9]* ]]
   then
     sleep 0.2  # Simulate 200ms API response time
     
@@ -38,7 +38,7 @@ function curl() {
   fi
 
   # PURL performance test with many affected components
-  if [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-many-components"* ]]
+  if [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-many-components"* ]]
   then
     # General impact is MODERATE, but target-repo component should have CRITICAL impact
     # Generate 500 affected components to test performance optimization
@@ -65,10 +65,10 @@ function curl() {
     done
     
     echo ']}]}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-critical"* ]]
+  elif [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-critical"* ]]
   then
     echo '{"results": [{"impact":"CRITICAL","affects":[{"purl":"pkg:oci/kubernetes?repository_url=component&a=b","impact":""}]}]}'
-  elif [[ "$*" == *"myurl/osidb/api/v1/flaws?cve_id=CVE-moderate"* ]]
+  elif [[ "$*" == *"myurl/osidb/api/v2/flaws?cve_id=CVE-moderate"* ]]
   then
     echo '{"results": [{"impact":"MODERATE","affects":[{"purl":"pkg:oci/kubernetes?repository_url=foo&a=b","impact":"LOW"},{"purl":"pkg:oci/kubernetes?repository_url=component&a=b","impact":"IMPORTANT"},{"purl":"","impact":"LOW"}]}]}'
   else


### PR DESCRIPTION
This commit migrates us from v1 to v2 for the OSIDB API. The only two tasks using OSIDB are get-advisory-severity and check-embargoed-cves, both of which are internal tasks. The endpoints we use are unchanged from v1 to v2, so no other change is necessary.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
