### PR TITLE
feat: enforce CVE key format for releaseNotes

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -205,7 +205,8 @@
             "properties": {
               "key": {
                 "type": "string",
-                "description": "The key of the CVE e.g. CVE-3414"
+                "description": "The key of the CVE (e.g. CVE-2025-1234); must not be a URL",
+                "pattern": "^CVE-[0-9]{4}-[0-9]{4,}$"
               },
               "component": {
                 "type": "string",

--- a/tasks/managed/check-data-keys/README.md
+++ b/tasks/managed/check-data-keys/README.md
@@ -8,7 +8,7 @@ meaning all the data keys must be allowed and formatted correctly.
 For example, if `releaseNotes` is passed as a system and the data file does not have all the required
 releaseNotes keys, the schema will give validation errors, and the task will fail.
 
-Currently, `releaseNotes`, and `cdn` are the only supported systems.
+The validation schema is defined in `schema/dataKeys.json` in this repository.
 
 ## Parameters
 

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -16,7 +16,7 @@ spec:
     For example, if `releaseNotes` is passed as a system and the data file does not have all the required
     releaseNotes keys, the schema will give validation errors, and the task will fail.
 
-    Currently, `releaseNotes`, and `cdn` are the only supported systems.
+    The validation schema is defined in `schema/dataKeys.json` in this repository.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use
@@ -103,7 +103,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/check-data-keys/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/check-data-keys/tests/pre-apply-task-hook.sh
@@ -5,3 +5,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Inject mocks.sh into the task's first step
 yq -i '.spec.steps[1].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Add RBAC so that the SA executing the tests can retrieve configMap
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# Create a configMap with the schema to be used by the task
+kubectl delete configmap check-data-keys-schema --ignore-not-found
+kubectl create configmap check-data-keys-schema --from-file=dataKeys="$SCRIPT_DIR/../../../../schema/dataKeys.json"

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,6 +85,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,6 +83,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": true}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -79,19 +79,17 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "components": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },
+                  "cves": [
+                    {
+                      "key": "CVE-2022-1234",
+                      "component": "comp-1",
+                      "packages": [ "pkg:golang/golang.org/x/net/http2@1.11.1" ]
+                    }
+                  ],
                   "synopsis": "test synopsis",
                   "topic": "test topic",
                   "description": "test description",
@@ -121,6 +119,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-malformed-cve-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-malformed-cve-key.yaml
@@ -2,13 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-check-data-keys-fail-unsupported-system
+  name: test-check-data-keys-fail-malformed-cve-key
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the check-data-keys task with a systems value including an unsupport system and verify that the
-    task fails as expected.
+    Run the check-data-keys task with a malformed CVE key in the releaseNotes
+    object cves.fixed.key and verify that the task fails as expected.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -61,25 +61,13 @@ spec:
               {
                 "releaseNotes": {
                   "product_name": "Red Hat Openstack Product",
-                  "product_stream": "rhtas-tp1",
                   "product_id": [
                     123
                   ],
                   "product_version": "1.2.3",
+                  "product_stream": "rhtas-tp1",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
-                  "issues": {
-                    "fixed": [
-                      {
-                        "id": "RHOSP-12345",
-                        "source": "issues.example.com"
-                      },
-                      {
-                        "id": "1234567",
-                        "source": "bugzilla.example.com"
-                      }
-                    ]
-                  },
                   "content": {
                     "images": [
                       {
@@ -94,6 +82,23 @@ spec:
                       }
                     ]
                   },
+                  "cves": [
+                    {
+                      "key": "https://example.com/security/cve/cve-2025-1234",
+                      "component": "comp-1",
+                      "packages": [ "pkg:golang/golang.org/x/net/http2@1.11.1" ]
+                    },
+                    {
+                      "key": "cve-2025-1234",
+                      "component": "comp-2",
+                      "packages": [ "pkg:golang/golang.org/x/net/http2@1.11.1" ]
+                    },
+                    {
+                      "key": "CVE-2025-123",
+                      "component": "comp-3",
+                      "packages": [ "pkg:golang/golang.org/x/net/http2@1.11.1" ]
+                    }
+                  ],
                   "synopsis": "test synopsis",
                   "topic": "test topic",
                   "description": "test description",
@@ -123,9 +128,7 @@ spec:
         - name: systems
           value: |
             [
-              {"systemName": "releaseNotes", "dynamic": false},
-              {"systemName": "unsupported", "dynamic": false},
-              {"systemName": "random", "dynamic": false}
+              {"systemName": "releaseNotes", "dynamic": false}
             ]
         - name: schema
           value: "https://get-local-schema.com"

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,6 +85,8 @@ spec:
             [
               {"systemName": "cdn", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-data.yaml
@@ -35,6 +35,8 @@ spec:
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/missing.json"
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -92,6 +92,8 @@ spec:
             [
               {"systemName": "intention", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -75,19 +75,16 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "components": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },
+                  "cves": [
+                    {
+                      "key": "CVE-2022-1234",
+                      "component": "comp-1"
+                    }
+                  ],
                   "synopsis": "test synopsis",
                   "topic": "test topic",
                   "description": "test description",
@@ -119,6 +116,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -77,16 +77,7 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "components": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -90,16 +90,7 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "components": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },
@@ -134,6 +125,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -70,18 +70,17 @@ spec:
                   "type": "RHSA",
                   "cves": [
                     {
-                      "key": "CVE-123",
+                      "key": "CVE-2025-1234",
                       "component": "my-component-1"
                     },
                     {
-                      "key": "CVE-456",
+                      "key": "CVE-2025-4567",
                       "component": "my-component-2",
                       "packages": ["my-package1", "my-package2"]
                     },
                     {
-                      "key": "CVE-789",
-                      "component": "my-component-3",
-                      "packages": []
+                      "key": "CVE-2025-7890",
+                      "component": "my-component-3"
                     }
                   ],
                   "issues": {
@@ -104,14 +103,7 @@ spec:
                         "tags": ["latest"],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "packages": ["pkg:golang/golang.org/x/net/http2@1.11.1"]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },
@@ -144,6 +136,8 @@ spec:
             [
               {"systemName": "releaseNotes", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -87,6 +87,8 @@ spec:
             [
               {"systemName": "cdn", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -68,11 +68,11 @@ spec:
                   "type": "RHSA",
                   "cves": [
                     {
-                      "key": "CVE-123",
+                      "key": "CVE-2025-1234",
                       "component": "my-component-1"
                     },
                     {
-                      "key": "CVE-456",
+                      "key": "CVE-2025-4567",
                       "component": "my-component-2",
                       "packages": [
                         "my-package1",
@@ -80,7 +80,7 @@ spec:
                       ]
                     },
                     {
-                      "key": "CVE-789",
+                      "key": "CVE-2025-7897",
                       "component": "my-component-3",
                       "packages": [
                       ]
@@ -108,16 +108,7 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "packages": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -65,26 +65,6 @@ spec:
                   "product_stream": "rhtas-tp1",
                   "cpe": "cpe:/a:example:openstack:el8",
                   "type": "RHSA",
-                  "cves": [
-                    {
-                      "key": "CVE-123",
-                      "component": "my-component-1"
-                    },
-                    {
-                      "key": "CVE-456",
-                      "component": "my-component-2",
-                      "packages": [
-                        "my-package1",
-                        "my-package2"
-                      ]
-                    },
-                    {
-                      "key": "CVE-789",
-                      "component": "my-component-3",
-                      "packages": [
-                      ]
-                    }
-                  ],
                   "issues": {
                     "fixed": [
                       {
@@ -108,19 +88,16 @@ spec:
                         ],
                         "architecture": "amd64",
                         "signingKey": "abcde",
-                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8",
-                        "cves": {
-                          "fixed": {
-                            "CVE-2022-1234": {
-                              "packages": [
-                                "pkg:golang/golang.org/x/net/http2@1.11.1"
-                              ]
-                            }
-                          }
-                        }
+                        "purl": "pkg:example/openstack@sha256:abcde?repository_url=quay.io/example/rhosp16-rhel8"
                       }
                     ]
                   },
+                  "cves": [
+                    {
+                      "key": "CVE-2025-12345",
+                      "component": "my-component-1"
+                    }
+                  ],
                   "synopsis": "test synopsis",
                   "topic": "test topic",
                   "description": "test description",
@@ -158,6 +135,8 @@ spec:
               {"systemName": "cdn", "dynamic": false},
               {"systemName": "intention", "dynamic": false}
             ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions


### PR DESCRIPTION
## Describe your changes
* add regex pattern for releaseNotes.cves[].key in dataKeys schema
* move old test data CVEs from content.images.cves to releaseNotes.cves.
* update check-data-keys tests to read schema from configmap.  We can now do local testing and don't need to create two PRs.
* update mock.sh and pre-apply-task-hook.sh to load local schema via configmap
* add a test that fails when CVE key does not match CVE-<4>-<4+>

Slack: https://redhat-internal.slack.com//archives/C04PZ7H0VA8/p1763033457076779thread_ts=1762979086.594839&cid=C04PZ7H0VA8
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
