### PR TITLE
feat(RELEASE-1253): sign-base64-blob task idempotency

### DIFF
--- a/tasks/managed/sign-base64-blob/README.md
+++ b/tasks/managed/sign-base64-blob/README.md
@@ -2,6 +2,15 @@
 
 Creates an InternalRequest to sign a base64 encoded blob
 
+## Idempotent Behavior
+
+This task is **idempotent**. If a valid signature file (`.sig`) already exists in the binaries directory:
+- The task will validate the existing signature
+- If valid, it will skip the signing operation and exit successfully
+- If invalid or corrupted, it will remove the file and re-sign
+
+This allows the task to be safely retried without creating duplicate signing requests or wasting resources.
+
 ## Signing data parameters
 
  The signing configuration should be set as `data.sign` in the _releasePlanAdmission_. The data should be set in the

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -10,6 +10,15 @@ spec:
   description: |-
     Creates an InternalRequest to sign a base64 encoded blob
     
+    ## Idempotent Behavior
+    
+    This task is **idempotent**. If a valid signature file (`.sig`) already exists in the binaries directory:
+    - The task will validate the existing signature
+    - If valid, it will skip the signing operation and exit successfully
+    - If invalid or corrupted, it will remove the file and re-sign
+    
+    This allows the task to be safely retried without creating duplicate signing requests or wasting resources.
+    
     ## Signing data parameters
     
      The signing configuration should be set as `data.sign` in the _releasePlanAdmission_. The data should be set in the
@@ -138,7 +147,30 @@ spec:
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' "${DATA_FILE}")
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
-        echo "Creating InternalRequest to sign blob:"
+        # Determine the signature file path
+        checksum_file_name=$(find "$(params.dataDir)/$(params.binariesPath)" \
+          -maxdepth 1 -name '*SHA256SUMS*' ! -name '*.sig' -printf '%f\n' | head -n1)
+        sig_file_path="$(params.dataDir)/$(params.binariesPath)/${checksum_file_name}.sig"
+
+        # Check if signature already exists (idempotent behavior)
+        # NOTE: Current implementation supports single-signature scenarios.
+        # For multi-signature support (e.g., PQC + traditional), enhancement needed
+        # to check signatures per signing key from the config map. See MULTI_SIGNATURE_CONSIDERATIONS.md
+        if [ -f "$sig_file_path" ] && [ -s "$sig_file_path" ]; then
+            echo "Signature file already exists: $sig_file_path"
+            echo "Validating existing signature..."
+            
+            # Validate the signature is a valid GPG file
+            if gpg --list-packets "$sig_file_path" &>/dev/null; then
+                echo "Existing signature is valid. Skipping signing operation (idempotent behavior)."
+                exit 0
+            else
+                echo "Existing signature file is invalid or corrupted. Will re-sign."
+                rm -f "$sig_file_path"
+            fi
+        fi
+
+        echo "No valid signature found. Creating InternalRequest to sign blob:"
         echo "- blob=$(params.blob)"
         echo "- requester=$(params.requester)"
 
@@ -162,11 +194,9 @@ spec:
         decoded_payload=$(echo -n "$payload" | base64 -d)
 
         # Build .sig file
-        checksum_file_name=$(find "$(params.dataDir)/$(params.binariesPath)" -maxdepth 1 -name '*SHA256SUMS*' \
-          -printf '%f\n')
         echo -n "$decoded_payload" \
         | gpg --dearmor \
-        | tee "$(params.dataDir)/$(params.binariesPath)/${checksum_file_name}.sig"
+        | tee "$sig_file_path"
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/sign-base64-blob/tests/mocks.sh
+++ b/tasks/managed/sign-base64-blob/tests/mocks.sh
@@ -25,5 +25,23 @@ function kubectl() {
 }
 
 function gpg() {
-  echo -n "dummy-payload"
+  # Handle --list-packets for signature validation (idempotent behavior)
+  if [[ "$*" == *"--list-packets"* ]]; then
+    # Extract the file path from the arguments (last argument)
+    local file_path="${@: -1}"
+    
+    # Check if the file contains "corrupted" text (invalid signature)
+    if [ -f "$file_path" ] && grep -q "corrupted" "$file_path" 2>/dev/null; then
+      # Invalid/corrupted signature
+      return 1
+    else
+      # Valid binary signature
+      return 0
+    fi
+  elif [[ "$*" == *"--dearmor"* ]]; then
+    # For signature creation, just pass through the input
+    echo -n "dummy-payload"
+  else
+    echo -n "dummy-payload"
+  fi
 }

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-corrupted.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-corrupted.yaml
@@ -1,0 +1,220 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sign-base64-blob-corrupted
+spec:
+  description: |
+    Test that sign-base64-blob task handles corrupted signature files.
+    When a corrupted/invalid signature exists, the task should re-sign.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "sign": {
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/binaries"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/binaries/foo_SHA256SUMS"
+              
+              # Create a corrupted/invalid signature file (plain text instead of GPG binary)
+              echo "This is corrupted signature data, not valid GPG" > \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/binaries/foo_SHA256SUMS.sig"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: sign-base64-blob
+      params:
+        - name: requester
+          value: testuser
+        - name: blob
+          value: test-blob
+        - name: binariesPath
+          value: $(context.pipelineRun.uid)/binaries
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: binariesPath
+          value: $(context.pipelineRun.uid)/binaries
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: binariesPath
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Verify an InternalRequest WAS created (since corrupted sig should trigger re-signing)
+              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+                -o custom-columns=":metadata.name")"
+              
+              if [ -z "$internalRequest" ]; then
+                echo "❌ Error: No InternalRequest was created!"
+                echo "Task should have detected corrupted signature and re-signed"
+                exit 1
+              fi
+              echo "✓ InternalRequest was created (corrupted signature detected and re-signed)"
+
+              # Verify parameters were passed correctly
+              params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+
+              if [ "$(jq -r '.blob' <<< "${params}")" != "test-blob" ]; then
+                echo "❌ blob parameter does not match"
+                exit 1
+              fi
+              echo "✓ Blob parameter correct"
+
+              # Verify new signature file was created
+              binaries_path="$(params.dataDir)/$(params.binariesPath)"
+              sig_file=$(find "$binaries_path" -maxdepth 1 -name '*SHA256SUMS.sig' -printf '%f\n')
+              
+              if [ -z "$sig_file" ]; then
+                echo "❌ Error: No signature file found!"
+                exit 1
+              fi
+              echo "✓ Signature file exists: $sig_file"
+
+              # Verify the signature was replaced (should be "dummy-payload", not corrupted text)
+              file_content=$(cat "$binaries_path/$sig_file")
+              if [ "$file_content" = "This is corrupted signature data, not valid GPG" ]; then
+                echo "❌ Error: Corrupted signature was not replaced!"
+                exit 1
+              fi
+              
+              if [ "$file_content" != "dummy-payload" ]; then
+                echo "❌ Error: New signature has unexpected content"
+                echo "Expected: dummy-payload"
+                echo "Got: $file_content"
+                exit 1
+              fi
+              echo "✓ Signature file was replaced with valid signature"
+
+              echo ""
+              echo "✅ All corrupted signature handling checks passed!"
+              echo "   - Task detected corrupted signature"
+              echo "   - Task removed corrupted file"
+              echo "   - Task created new InternalRequest"
+              echo "   - Task generated new valid signature"
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-idempotent.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-idempotent.yaml
@@ -1,0 +1,203 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sign-base64-blob-idempotent
+spec:
+  description: |
+    Test idempotent behavior of sign-base64-blob task.
+    When a valid signature file already exists, the task should skip signing.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "sign": {
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/binaries"
+              touch "$(params.dataDir)/$(context.pipelineRun.uid)/binaries/foo_SHA256SUMS"
+              
+              # Create a pre-existing valid signature file (mock binary signature)
+              # This simulates an existing valid signature that should be preserved
+              echo -n "existing-valid-signature-data" > \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/binaries/foo_SHA256SUMS.sig"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: sign-base64-blob
+      params:
+        - name: requester
+          value: testuser
+        - name: blob
+          value: test-blob
+        - name: binariesPath
+          value: $(context.pipelineRun.uid)/binaries
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: binariesPath
+          value: $(context.pipelineRun.uid)/binaries
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: binariesPath
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Verify no InternalRequest was created (idempotent behavior)
+              internalRequestCount=$(kubectl get internalrequest --no-headers \
+                2>/dev/null | wc -l || echo "0")
+              if [ "$internalRequestCount" != "0" ]; then
+                echo "❌ Error: InternalRequest was created when it should" \
+                  "have been skipped (found $internalRequestCount)"
+                echo "This violates idempotent behavior!"
+                exit 1
+              fi
+              echo "✓ No InternalRequest was created (idempotent behavior verified)"
+
+              # Verify the signature file still exists and is unchanged
+              binaries_path="$(params.dataDir)/$(params.binariesPath)"
+              sig_file=$(find "$binaries_path" -maxdepth 1 -name '*SHA256SUMS.sig' -printf '%f\n')
+              
+              if [ -z "$sig_file" ]; then
+                echo "❌ Error: Signature file was removed!"
+                exit 1
+              fi
+              echo "✓ Signature file exists: $sig_file"
+
+              # Verify signature file is not empty
+              if [ ! -s "$binaries_path/$sig_file" ]; then
+                echo "❌ Error: Signature file is empty!"
+                exit 1
+              fi
+              echo "✓ Signature file is not empty"
+
+              # Verify the content is the original signature (not replaced)
+              file_content=$(cat "$binaries_path/$sig_file")
+              expected_content="existing-valid-signature-data"
+              if [ "$file_content" != "$expected_content" ]; then
+                echo "❌ Error: Signature file content was modified!"
+                echo "Expected: $expected_content"
+                echo "Got: $file_content"
+                exit 1
+              fi
+              echo "✓ Signature file content is unchanged"
+
+              echo ""
+              echo "✅ All idempotency checks passed!"
+              echo "   - Task skipped signing when valid signature existed"
+              echo "   - No unnecessary InternalRequest was created"
+              echo "   - Existing signature file was preserved"
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
Implements idempotency for the `sign-base64-blob` task. The task now checks if a valid signature file already exists before creating a new signing request, ensuring pipeline retries don't create duplicate signing operations.

    - Modified `sign-base64-blob.yaml`: Added check for existing `.sig` file with GPG validation
    - Updated task README with idempotent behavior documentation
    - Created 2 new unit tests (idempotent behavior + corrupted signature handling)

[sign-base64-blob task idempotent solution doc](https://docs.google.com/document/d/1r9YwJxKwA7G4ao1-efImozJGIJecKFWZOmylo6HkpWs/edit?tab=t.0#heading=h.ak7getgb28f4)

## Relevant Jira
[RELEASE-1253](https://issues.redhat.com/browse/RELEASE-1253)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Copilot
