### PR TITLE
fix(RELEASE-2022): combine checksum fields to single credential

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -10,27 +10,24 @@ data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 
 ## Parameters
 
-| Name                  | Description                                                       | Optional | Default value                               |
-|-----------------------|-------------------------------------------------------------------|----------|---------------------------------------------|
-| snapshot_json         | String containing a JSON representation of the snapshot spec      | No       | -                                           |
-| concurrentLimit       | The maximum number of images to be pulled at once                 | Yes      | 3                                           |
-| author                | Author taken from Release to be used for checksum signing         | No       | -                                           |
-| signingKeyName        | Signing key name to be used for checksum signing                  | No       | -                                           |
-| quayURL               | Quay URL of the repo where content will be shared between tasks   | Yes      | quay.io/konflux-artifacts                   |
-| quaySecret            | Secret to interact with Quay                                      | Yes      | quay-credentials                            |
-| windowsCredentials    | Secret to interact with the Windows signing host                  | Yes      | windows-credentials                         |
-| windowsSSHKey         | Secret containing SSH private key for the Windows signing host    | Yes      | windows-ssh-key                             |
-| macHostCredentials    | Secret to interact with the Mac signing host                      | Yes      | mac-host-credentials                        |
-| macSigningCredentials | Secret to interact with the Mac signing utils                     | Yes      | mac-signing-credentials                     |
-| macSSHKey             | Secret containing SSH private key for the Mac signing host        | Yes      | mac-ssh-key                                 |
-| checksumUser          | User to interact with the checksum host                           | Yes      | konflux-release-signing-sa                  |
-| checksumHost          | Hostname of the checksum host                                     | Yes      | etera-worker.hosted.upshift.rdu2.redhat.com |
-| checksumFingerprint   | Secret containing the fingerprint for the checksum host           | Yes      | checksum-fingerprint                        |
-| checksumKeytab        | Secret containing the keytab for the checksum host                | Yes      | checksum-keytab                             |
-| kerberosRealm         | Kerberos realm for the checksum host                              | Yes      | IPA.REDHAT.COM                              |
-| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs         | No       | -                                           |
-| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre] | No       | -                                           |
-| pulpSecret            | Env specific secret containing the rhsm-pulp credentials          | No       | -                                           |
-| udcacheSecret         | Env specific secret containing the udcache credentials            | No       | -                                           |
-| cgwHostname           | Env specific hostname for content gateway                         | No       | -                                           |
-| cgwSecret             | Env specific secret containing the content gateway credentials    | No       | -                                           |
+| Name                  | Description                                                                     | Optional | Default value             |
+|-----------------------|---------------------------------------------------------------------------------|----------|---------------------------|
+| snapshot_json         | String containing a JSON representation of the snapshot spec                    | No       | -                         |
+| concurrentLimit       | The maximum number of images to be pulled at once                               | Yes      | 3                         |
+| author                | Author taken from Release to be used for checksum signing                       | No       | -                         |
+| signingKeyName        | Signing key name to be used for checksum signing                                | No       | -                         |
+| quayURL               | Quay URL of the repo where content will be shared between tasks                 | Yes      | quay.io/konflux-artifacts |
+| quaySecret            | Secret to interact with Quay                                                    | Yes      | quay-credentials          |
+| windowsCredentials    | Secret to interact with the Windows signing host                                | Yes      | windows-credentials       |
+| windowsSSHKey         | Secret containing SSH private key for the Windows signing host                  | Yes      | windows-ssh-key           |
+| macHostCredentials    | Secret to interact with the Mac signing host                                    | Yes      | mac-host-credentials      |
+| macSigningCredentials | Secret to interact with the Mac signing utils                                   | Yes      | mac-signing-credentials   |
+| macSSHKey             | Secret containing SSH private key for the Mac signing host                      | Yes      | mac-ssh-key               |
+| checksumCredentials   | Secret containing the keytab, user, host, and fingerprint for the checksum host | Yes      | checksum-credentials      |
+| kerberosRealm         | Kerberos realm for the checksum host                                            | Yes      | IPA.REDHAT.COM            |
+| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs                       | No       | -                         |
+| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre]               | No       | -                         |
+| pulpSecret            | Env specific secret containing the rhsm-pulp credentials                        | No       | -                         |
+| udcacheSecret         | Env specific secret containing the udcache credentials                          | No       | -                         |
+| cgwHostname           | Env specific hostname for content gateway                                       | No       | -                         |
+| cgwSecret             | Env specific secret containing the content gateway credentials                  | No       | -                         |

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -58,22 +58,10 @@ spec:
       type: string
       description: Secret containing SSH private key for the Mac signing host
       default: mac-ssh-key
-    - name: checksumUser
+    - name: checksumCredentials
       type: string
-      description: User to interact with the checksum host
-      default: konflux-release-signing-sa
-    - name: checksumHost
-      type: string
-      description: Hostname of the checksum host
-      default: etera-worker.hosted.upshift.rdu2.redhat.com
-    - name: checksumFingerprint
-      type: string
-      description: Secret containing the fingerprint for the checksum host
-      default: checksum-fingerprint
-    - name: checksumKeytab
-      type: string
-      description: Secret containing the keytab for the checksum host
-      default: checksum-keytab
+      description: Secret containing the keytab, user, host, and fingerprint for the checksum host
+      default: checksum-credentials
     - name: kerberosRealm
       type: string
       description: Kerberos realm for the checksum host
@@ -121,13 +109,9 @@ spec:
       secret:
         secretName: windows-ssh-key
         defaultMode: 0444
-    - name: checksum-fingerprint-vol
+    - name: checksum-credentials-vol
       secret:
-        secretName: checksum-fingerprint
-        defaultMode: 0444
-    - name: checksum-keytab-vol
-      secret:
-        secretName: checksum-keytab
+        secretName: $(params.checksumCredentials)
         defaultMode: 0444
     - name: redhat-workloads-token
       secret:
@@ -720,10 +704,8 @@ spec:
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
-        - name: checksum-fingerprint-vol
-          mountPath: /mnt/secrets_fingerprint
-        - name: checksum-keytab-vol
-          mountPath: /mnt/secrets_keytab
+        - name: checksum-credentials-vol
+          mountPath: /mnt/checksum_credentials
         - name: quay-secret
           mountPath: /mnt/quaySecret
       env:
@@ -788,10 +770,12 @@ spec:
                     -o GSSAPIDelegateCredentials=yes \
                     -o IdentitiesOnly=yes"
 
+        # Read checksum configuration from secret
+        checksum_user=$(cat /mnt/checksum_credentials/user)
+        checksum_host=$(cat /mnt/checksum_credentials/host)
+
         sign_file() {
             sign_method=$1  # The signing method: --clearsign or --gpgsign
-            checksum_user=$(params.checksumUser)
-            checksum_host=$(params.checksumHost)
             pipeline_run_uid=$(context.taskRun.uid)
             output_path="/home/$checksum_user/$pipeline_run_uid/checksum/sha256sum.txt.$2"
             input_file="/home/$checksum_user/$pipeline_run_uid/checksum/sha256sum.txt"
@@ -808,12 +792,12 @@ spec:
         # so we use GSSAPI Delegate (in ssh opts) to transfer the ticket to the checksum host
         KRB5CCNAME=FILE:/tmp/krb5cc_$(id -u)
         export KRB5CCNAME
-        base64 -d /mnt/secrets_keytab/keytab > /tmp/sa.keytab
-        retry 5 kinit -kt /tmp/sa.keytab "$(params.checksumUser)@$(params.kerberosRealm)"
+        base64 -d /mnt/checksum_credentials/keytab > /tmp/sa.keytab
+        retry 5 kinit -kt /tmp/sa.keytab "${checksum_user}@$(params.kerberosRealm)"
 
         mkdir -p /tmp/.ssh
         chmod 700 /tmp/.ssh
-        cp "/mnt/secrets_fingerprint/fingerprint" /tmp/.ssh/known_hosts
+        cp "/mnt/checksum_credentials/fingerprint" /tmp/.ssh/known_hosts
         chmod 600 /tmp/.ssh/known_hosts
 
         # get all of the signed binaries into a common directory
@@ -850,21 +834,21 @@ spec:
         done
         # Send sha256sum.txt to the checksum host for signing
         # shellcheck disable=SC2029,SC2086
-        ssh $SSH_OPTS "$(params.checksumUser)@$(params.checksumHost)" "mkdir -p ~/$(context.taskRun.uid)/checksum"
+        ssh $SSH_OPTS "${checksum_user}@${checksum_host}" "mkdir -p ~/$(context.taskRun.uid)/checksum"
         # shellcheck disable=SC2086
         scp $SSH_OPTS "${SHA_SUM_PATH}" \
-        "$(params.checksumUser)@$(params.checksumHost):~/$(context.taskRun.uid)/checksum"
+        "${checksum_user}@${checksum_host}:~/$(context.taskRun.uid)/checksum"
 
         sign_file --clearsign sig
         sign_file --gpgsign gpg
 
         # scp the two files back to the content directory
         scp "$SSH_OPTS" \
-        "$(params.checksumUser)@$(params.checksumHost):~/$(context.taskRun.uid)/checksum/sha256sum.txt.sig" \
+        "${checksum_user}@${checksum_host}:~/$(context.taskRun.uid)/checksum/sha256sum.txt.sig" \
         "${SIGNED_DIR}/sha256sum.txt.sig"
 
         scp "$SSH_OPTS" \
-        "$(params.checksumUser)@$(params.checksumHost):~/$(context.taskRun.uid)/checksum/sha256sum.txt.gpg" \
+        "${checksum_user}@${checksum_host}:~/$(context.taskRun.uid)/checksum/sha256sum.txt.gpg" \
         "${SIGNED_DIR}/sha256sum.txt.gpg"
 
         mv "$SHA_SUM_PATH" "${SIGNED_DIR}/sha256sum.txt"

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -195,7 +195,8 @@ function scp() {
 
 function kinit() {
     echo Mocking kinit call with: $*
-    if [ "$*" == "-kt /etc/secrets_keytab/keytab konflux-release-signing-sa@IPA.REDHAT.COM" ] ; then
+    # Accept any kinit call with -kt flag as the user and host are now dynamic
+    if [[ "$*" == *"-kt"* ]] ; then
         echo initialized
     fi
 }

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
@@ -40,7 +40,7 @@ kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfi
 # create ssh secrets
 
 # cleaning up secrets first
-for secret in checksum-fingerprint checksum-keytab quay-credentials windows-credentials mac-host-credentials mac-signing-credentials; do
+for secret in checksum-credentials quay-credentials windows-credentials mac-host-credentials mac-signing-credentials; do
     kubectl delete secret "$secret" --ignore-not-found
 done
 
@@ -51,8 +51,11 @@ for OS in windows mac; do
     kubectl create secret generic "${OS}-ssh-key" --from-file="${OS}_id_rsa=${TMPDIR}/${OS}" --from-literal="${OS}"_fingerprint="$(ssh-keygen -lf "${TMPDIR}/${OS}.pub")"
 done
 ssh-keygen -f "${TMPDIR}/checksum" -N ""
-kubectl create secret generic "checksum-fingerprint" --from-literal=fingerprint="$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
-kubectl create secret generic "checksum-keytab" --from-literal=keytab=""
+kubectl create secret generic "checksum-credentials" \
+    --from-literal=keytab="" \
+    --from-literal=user="konflux-release-signing-sa" \
+    --from-literal=host="etera-worker.hosted.upshift.rdu2.redhat.com" \
+    --from-literal=fingerprint="$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
 
 # create quay, windows and mac secrets
 kubectl create secret generic quay-credentials --from-literal=username="testuser" --from-literal=password="testpass"


### PR DESCRIPTION
Replace checksum-keytab and checksum-fingerprint with checksum-credentials.

Example:

checksum-credentials:
  keytab: <base64-encoded-keytab>
  user: konflux-release-checksum-e2e-sa
  host: etera-worker.hosted.upshift.rdu2.redhat.com
  fingerprint: <ssh-fingerprint>

Will need to update vault when this is merged.

Code-assisted by Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
