### PR TITLE
fix: add securityContext in push-rpm-data-to-pyxis

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -82,6 +82,8 @@ spec:
         value: "$(params.trustedArtifactsDebug)"
       - name: RETRIES
         value: "3"  # Default number of retries for cosign download
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:


### PR DESCRIPTION
## Describe your changes
The error open /tekton/home/.docker/config.json: permission denied is met in push-rpm-data-to-pyxis
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
