### PR TITLE
fix(push-oot-kmods): pass rpmPath to push-to-git task

### DIFF
--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -493,6 +493,8 @@ spec:
           value: "$(tasks.prepare-and-finalize-artifacts.results.sourceDataArtifact)"
         - name: signedKmodsPath
           value: $(tasks.collect-task-params.results.extractedValues[17])
+        - name: rpmPath
+          value: $(tasks.collect-task-params.results.extractedValues[22])
         - name: dataDir
           value: $(params.dataDir)
         - name: gitRepoUrl


### PR DESCRIPTION
The `rpmPath` parameter was correctly collected but was not being passed to the `push-to-git` task params. This caused the task to use the default empty value, resulting in RPMs not being uploaded to the git repository.

This commit adds the missing parameter mapping to ensure RPMs are processed correctly.

Signed-off-by: Harel Erlich herlich@redhat.com

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
