### PR TITLE
fix: skip repo translation on staged builds

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -565,8 +565,13 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
+      when:
+        - input: $(tasks.prepare-fbc-parameters.results.mustPublishIndexImage)
+          operator: in
+          values: ["true"]
       runAfter:
         - add-fbc-contribution-to-index-image
+        - prepare-fbc-parameters
     - name: create-pyxis-image
       retries: 5
       taskRef:


### PR DESCRIPTION
This PR fixes the case when the RPA is for a stage build and does not require targetIndex, by skiping the collect- index-image step, as the fbc fragment will not be signed or published.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
