### PR TITLE
fix(RELEASE-2032): add security context for SCC compliance

### DIFF
--- a/.tekton/release-service-catalog-pull-request.yaml
+++ b/.tekton/release-service-catalog-pull-request.yaml
@@ -118,6 +118,7 @@ spec:
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -499,6 +500,10 @@ spec:
       optional: true
   taskRunTemplate:
     serviceAccountName: build-pipeline-release-service-catalog
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 1001
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/release-service-catalog-staging-pull-request.yaml
+++ b/.tekton/release-service-catalog-staging-pull-request.yaml
@@ -96,6 +96,7 @@ spec:
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -554,6 +555,10 @@ spec:
       optional: true
   taskRunTemplate:
     serviceAccountName: build-pipeline-release-service-catalog-staging
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 1001
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/release-service-catalog-staging-push.yaml
+++ b/.tekton/release-service-catalog-staging-push.yaml
@@ -83,6 +83,7 @@ spec:
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "false"
       description: Build a source image.
       name: build-source-image
@@ -541,6 +542,10 @@ spec:
       optional: true
   taskRunTemplate:
     serviceAccountName: build-pipeline-release-service-catalog-staging
+    podTemplate:
+      spec:
+        securityContext:
+          runAsUser: 1001
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Describe your changes
Added securityContext with runAsUser: 1001 to taskRunTemplate.podTemplate in all three 
pipeline files to fix SCC validation errors on the clone-repository task.

The bundled git-clone task runs as root by default, which violates the restrictive SCC 
policies enforced by the build-pipeline service account. Setting runAsUser: 1001 ensures 
all tasks run as a non-root user, satisfying SCC requirements.

## Relevant Jira
[RELEASE-2032](https://issues.redhat.com/browse/RELEASE-2032)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
