### PR TITLE
fix: add securityContext to remaining tasks

### DIFF
--- a/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
@@ -71,6 +71,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: collect-collectors-resources
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -103,7 +105,7 @@ spec:
         else
           get-resource "release" "${PREVIOUS_RELEASE}" | tee "$(workspaces.data.path)/$PREVIOUS_RELEASE_PATH"
         fi
-        
+
         RELEASE_PATH="$(params.subdirectory)/release.json"
         echo -n "$RELEASE_PATH" > "$(results.release.path)"
         get-resource "release" "${RELEASE}" | tee "$(workspaces.data.path)/$RELEASE_PATH"

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -59,6 +59,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: run-collectors
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -105,10 +107,10 @@ spec:
         fi
 
         cd /tmp
-        
+
         git clone "${COLLECTORS_REPOSITORY}" --branch "${COLLECTORS_REPOSITORY_REVISION}" collectors
         pushd collectors
-        
+
         # Set COLLECTOR_TYPE based on the value of COLLECTORS_RESOURCE_TYPE
         if [[ "$COLLECTORS_RESOURCE_TYPE" == "releaseplan" ]]; then
           COLLECTOR_TYPE="tenant"

--- a/tasks/collectors/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/save-collectors-results.yaml
@@ -50,6 +50,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: save-collectors-results
       image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
@@ -64,16 +66,16 @@ spec:
                 echo "Ignoring not JSON file: ${resultsFile}."
                 continue
             fi
-        
+
             fileName=$(basename "$resultsFile")
-        
+
             # Check if the file name does NOT match the pattern
             if ! [[ "$fileName" =~ ^(managed|tenant)-([a-zA-Z0-9_-]+)\.json$ ]]; then
                 echo "Ignoring invalid file name: $fileName"
-            else    
+            else
                 prefix="${BASH_REMATCH[1]}"
                 collector="${BASH_REMATCH[2]}"
-        
+
                 # Update RESULTS_JSON with the content of the current file under the correct key
                 RESULTS_JSON=$(jq --arg prefix "$prefix" --arg collector "$collector" \
                     --slurpfile content "$resultsFile" \

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -48,6 +48,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: check-embargoed-cves
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
+++ b/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
@@ -39,6 +39,9 @@ spec:
       description: UMB SSL certificate file name
     - name: umb_ssl_key_file_name
       description: UMB SSL key file name
+  stepTemplate:
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: collect-blob-signing-params
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -64,6 +64,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: collect-simple-signing-params
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -82,7 +82,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
-
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: create-advisory
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
@@ -118,7 +119,7 @@ spec:
           SERVICE_ACCOUNT_NAME="$(cat /mnt/errata_secret/name)"
           SERVICE_ACCOUNT_KEYTAB="$(cat /mnt/errata_secret/base64_keytab)"
 
-          # export variables required by the called script "gitlab-functions" in release-service-utils 
+          # export variables required by the called script "gitlab-functions" in release-service-utils
           export GITLAB_HOST ACCESS_TOKEN GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL
 
           STDERR_FILE=/tmp/stderr.txt
@@ -222,7 +223,7 @@ spec:
 
               # Check if this advisory contains any matching content before filtering
               CONTENT_BEFORE_FILTER=$(cat "$CONTENT_FILE")
-              
+
               # Update CONTENT by removing entries that already exist in the advisory
               if [ "$(params.contentType)" == "generic" ]; then
                 # Use purl as unique key for generic artifacts
@@ -262,7 +263,7 @@ spec:
               if jq -e 'length == 0' "$CONTENT_FILE" >/dev/null; then
                   echo "All content found in existing advisories. Skipping creation."
                   echo "Returning advisory: $LATEST_ADVISORY_FILE"
-                  
+
                   ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${LATEST_ADVISORY_FILE}"
                   ADVISORY_TYPE=$(yq -r '.spec.type' "${LATEST_ADVISORY_FILE}")
                   ADVISORY_NAME=$(yq -r '.metadata.name' "${LATEST_ADVISORY_FILE}")

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -62,7 +62,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
-
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: filter-images
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
@@ -191,20 +192,20 @@ spec:
           if jq -e 'length == 0' <<< "$ARCH_IMAGES" >/dev/null; then
             echo "All arch images in the snapshot have already been released in advisories. Stopping pipeline."
             echo -n "[]" | gzip -c | base64 -w 0 > "$(results.unreleased_components.path)"
-            
+
             echo "Returning advisory: $LATEST_ADVISORY_FILE"
             ADVISORY_TYPE=$(yq -r '.spec.type' "$LATEST_ADVISORY_FILE")
             ADVISORY_NAME=$(yq -r '.metadata.name' "$LATEST_ADVISORY_FILE")
-            
+
             if [[ "${GIT_REPO}" == *"/rhtap-release/"* ]]; then
               ADVISORY_URL_PREFIX="https://access.stage.redhat.com/errata"
             else
               ADVISORY_URL_PREFIX="https://access.redhat.com/errata"
             fi
-            
+
             LATEST_ADVISORY_URL="${ADVISORY_URL_PREFIX}/${ADVISORY_TYPE}-${ADVISORY_NAME}"
             LATEST_ADVISORY_INTERNAL_URL="${GIT_REPO//\.git/}/-/raw/main/${LATEST_ADVISORY_FILE}"
-            
+
             echo -n "$LATEST_ADVISORY_URL" > "$(results.advisory_url.path)"
             echo -n "$LATEST_ADVISORY_INTERNAL_URL" > "$(results.advisory_internal_url.path)"
             echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -53,7 +53,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
-
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: get-advisory-severity
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -58,6 +58,8 @@ spec:
     env:
       - name: "HOME"
         value: "/tekton/home"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: request-advisory-oci-artifact
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   description: |-
     Task to encode the Terraform Checksum file.
-    
+
     It returns as a result the blob to sign, that is the result of the base64 encoded checksum
   params:
     - name: binaries_dir
@@ -83,6 +83,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -34,6 +34,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: cleanup-internal-requests
       image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -46,6 +46,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: cleanup
       image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -92,6 +92,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -102,6 +102,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -9,17 +9,17 @@ metadata:
 spec:
   description: |-
     Tekton task to collect the information added to the data field of the release resources.
-    
+
     The purpose of this task is to collect all the data and supply it to the other task in the pipeline by creating
     a json file called `data.json` in the workspace.
-    
+
     This task also stores the passed resources as json files in a workspace.
-    
+
     The parameters to this task are lowercase instead of camelCase because they are passed from the operator, and the
     operator passes them as lowercase.
-    
+
     A task result is returned for each resource with the relative path to the stored JSON for it in the workspace.
-    
+
     Finally, the task checks that the keys from the correct resource (a key that should come from the
     ReleasePlanAdmission should not be present in the Release data section).
   params:
@@ -141,6 +141,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: collect-data
       image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -95,6 +95,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -86,6 +86,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -80,6 +80,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -102,6 +102,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -93,6 +93,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -161,7 +163,7 @@ spec:
             RESULT_INDEX=$(jq -r ".[$i].resultIndex" <<< "$KEYS_JSON")
             KEY=$(jq -r ".[$i].key" <<< "$KEYS_JSON")
             DEFAULT_VALUE=$(jq -r ".[$i].default // null" <<< "$KEYS_JSON")
-            
+
             if [ "$RESULT_INDEX" = "null" ] || [ "$KEY" = "null" ]; then
                 echo "Invalid key extraction specification at index $i: missing resultIndex or key"
                 exit 1

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -100,6 +100,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/enforce-labels/enforce-labels.yaml
+++ b/tasks/managed/enforce-labels/enforce-labels.yaml
@@ -58,6 +58,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -91,13 +93,13 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -ex
-        
+
         SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
         if [ ! -f "${SNAPSHOT_FILE}" ] ; then
             echo "No valid snapshot file was provided."
             exit 1
         fi
-        
+
         # derive namespace/repo from a container image URL
         derive_name_from_url() {
             local url="$1"
@@ -105,27 +107,27 @@ spec:
             # remove tag or digest (anything after : or @), strip leading slashes
             sed -E 's~^[^/]+://~~; s~^[^/]+/~~; s~[:@].*$~~' <<< "$url" | sed 's#^/*##'
         }
-        
+
         num_components=$(jq '.components | length' "${SNAPSHOT_FILE}")
         for ((i = 0; i < num_components; i++))
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
-        
+
             # Fetch the value of the 'name' label from the container's metadata
             name_label=$(jq -r '.metadata.labels? | .[] | select(.name == "name") | .value' <<< "$component" || true)
-        
+
             # Check if the label was found. It is always required.
             if [[ -z "$name_label" || "$name_label" == "null" ]]; then
               echo "Error: Component '$name' is missing the required container label 'name' in its metadata."
               exit 1
             fi
-        
+
             # Fetch canonicalName from the component root
             canonical_name=$(jq -r ".canonicalName // empty" <<< "$component")
-        
+
             num_repos=$(jq '.repositories | length' <<< "$component")
-        
+
             if [[ "$num_repos" -eq 1 ]]; then
                 # --- SINGLE REPOSITORY LOGIC ---
                 # Must match the derived URL name. Component-level canonicalName is ignored.
@@ -134,9 +136,9 @@ spec:
                     echo "Error: Component '$name' repositories[0].url is missing" >&2
                     exit 1
                 fi
-        
+
                 derived_name=$(derive_name_from_url "$url")
-        
+
                 if [[ "$name_label" != "$derived_name" ]]; then
                     echo "Error: Component '$name' name label ('$name_label') does not match" \
                       "derived name from URL ('$derived_name')" >&2
@@ -150,7 +152,7 @@ spec:
                       "component-level 'canonicalName'." >&2
                     exit 1
                 fi
-        
+
                 if [[ "$name_label" != "$canonical_name" ]]; then
                     echo "Error: Component '$name' name label ('$name_label') does not match" \
                       "component-level canonicalName ('$canonical_name')" >&2

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -93,6 +93,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -91,6 +91,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -176,9 +178,9 @@ spec:
             repositories=$(jq -c '.repositories' <<< "$COMPONENT")
             NUM_REPOS=$(jq 'length' <<< "$repositories")
 
-            for ((j = 0; j < NUM_REPOS; j++)); do 
+            for ((j = 0; j < NUM_REPOS; j++)); do
               REPO=$(jq -r --argjson j "$j" '.[$j]."url"' <<< "$repositories")
-            
+
               echo "Making repository $REPO public..."
 
               if [[ "$REPO" != quay.io/* ]]; then

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   description: |-
     Tekton Task to publish VM disk images into various cloud marketplaces using `pubtools-marketplacesvm`.
-    
+
     It currently supports images in `raw` and `vhd` formats for `AWS` and `Azure` respectively.
   params:
     - name: snapshotPath
@@ -147,9 +147,9 @@ spec:
         set -eu
 
         CLOUD_CREDENTIALS="$(cat /etc/secrets/key)"
-        
-        # export variables required by the script "marketplacesvm_push_wrapper" in release-service-utils 
-        export CLOUD_CREDENTIALS 
+
+        # export variables required by the script "marketplacesvm_push_wrapper" in release-service-utils
+        export CLOUD_CREDENTIALS
 
         set -x
 

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   description: |-
     Tekton task to extract a pull spec from a Snapshot.
-    
+
     The purpose of this task is to extract just a single component's pullSpec from a passed Snapshot.
   params:
     - name: snapshot
@@ -41,6 +41,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: prepare-validation
       image:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -105,8 +105,7 @@ spec:
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
     securityContext:
-      runAsUser:
-        1001
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -108,6 +108,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -79,7 +79,7 @@ spec:
   volumes:
     - name: bs-keytab
       secret:
-        secretName: $(params.checksumKeytab)    
+        secretName: $(params.checksumKeytab)
         defaultMode: 0444
     - name: checksum-fingerprint
       secret:
@@ -112,6 +112,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:
@@ -141,7 +143,7 @@ spec:
           memory: 512Mi
         requests:
           memory: 512Mi
-          cpu: 250m 
+          cpu: 250m
       volumeMounts:
         - name: checksum-fingerprint
           mountPath: "/etc/sec-checksum"
@@ -161,10 +163,10 @@ spec:
 
         signedKmodsPath="$(params.signedKmodsPath)"
         signingAuthor="$(params.signingAuthor)"
-        # Remove newline in signing variables 
+        # Remove newline in signing variables
         signUser="${signUser//$'\n'/}"
         signHost="${signHost//$'\n'/}"
-         
+
         echo "Signing OOT modules from $(params.dataDir)/$signedKmodsPath.."
         SIGNED_KMODS_PATH="$(params.dataDir)/$signedKmodsPath"
         SSH_OPTS=(

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -89,6 +89,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact-array
       computeResources:
@@ -131,17 +133,17 @@ spec:
                 echo "Passed results JSON file ${resultsFile} in results directory was not proper JSON."
                 exit 1
             fi
-            
+
             # Merge with array concatenation for array fields and object merging
             jq --slurpfile new "${resultsFile}" '
               # Store current values as $base and get all unique keys from both objects
-              . as $base | ($base | keys + ($new[0] | keys)) | unique | 
+              . as $base | ($base | keys + ($new[0] | keys)) | unique |
               # Process each key and build the merged result
               reduce .[] as $key ({}; . + {($key): (
                 # Case 1: Both values are arrays - concatenate them
                 if ($new[0][$key] | type == "array") and ($base[$key] | type == "array")
                 then $base[$key] + $new[0][$key]
-                else 
+                else
                   # Case 2: Both values are objects - merge them recursively
                   if ($new[0][$key] | type == "object") and ($base[$key] | type == "object")
                   then $base[$key] * $new[0][$key]
@@ -180,7 +182,7 @@ spec:
 
         # Use the reduced JSON going forward
         FINAL_JSON="$REDUCED_JSON"
-        
+
         IFS='/' read -r namespace name <<< "$(params.resource)"
 
         # Create patch file to avoid "Argument list too long" error

--- a/tasks/managed/validate-single-component/README.md
+++ b/tasks/managed/validate-single-component/README.md
@@ -1,6 +1,6 @@
 # validate-single-component
 
-A tekton task that validates the snapshot only contains a 
+A tekton task that validates the snapshot only contains a
 single component. The task will fail otherwise.
 
 ## Parameters

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    A tekton task that validates the snapshot only contains a 
+    A tekton task that validates the snapshot only contains a
     single component. The task will fail otherwise.
   params:
     - name: snapshotPath
@@ -82,6 +82,8 @@ spec:
         value: "$(params.orasOptions)"
       - name: "DEBUG"
         value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: use-trusted-artifact
       computeResources:

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -53,6 +53,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+    securityContext:
+      runAsUser: 1001
   steps:
     - name: verify-access-to-resources
       image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162


### PR DESCRIPTION
## Describe your changes

This is related to an incident from last week
where after the latest promotion to production,
things started to fail.

This is because the utils image was changed
to use a non-root user:
https://github.com/konflux-ci/release-service-utils/pull/567

It now relies on user with UID 1001 and we need to use the same in the tasks otherwise the tasks
fail to create files under /tekton/home .

This is a follow up of
https://github.com/konflux-ci/release-service-catalog/pull/1651 which fixed some tasks, but not all.

Assisted-by: Cursor

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
