### PR TITLE
feat(RELEASE-2038): add generic timeout configuration for fbc catalog builds

### DIFF
--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -19,6 +19,9 @@ at the end to allow for timed out requests to finish so that we can just get the
 result. This will slightly compress the time in which batches are entered into the IIB
 queue to reduce the effect of a full queue on a single release.
 
+Timeout values can be configured per OCP version using .fbc.timeoutOverrides in the data
+file to accommodate versions that require longer build times.
+
 ## Parameters
 
 | Name                        | Description                                                                                                                | Optional | Default value        |

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -26,6 +26,9 @@ spec:
     at the end to allow for timed out requests to finish so that we can just get the final
     result. This will slightly compress the time in which batches are entered into the IIB
     queue to reduce the effect of a full queue on a single release.
+
+    Timeout values can be configured per OCP version using .fbc.timeoutOverrides in the data
+    file to accommodate versions that require longer build times.
   params:
     - name: snapshotPath
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
@@ -204,13 +207,41 @@ spec:
         default_build_timeout_seconds="3600"
         default_request_timeout_seconds="3600"
 
-        build_timeout_seconds=$(jq -r --arg build_timeout_seconds "${default_build_timeout_seconds}" \
+        # Get base timeouts from data file
+        base_build_timeout_seconds=$(jq -r --arg build_timeout_seconds "${default_build_timeout_seconds}" \
             '.fbc.buildTimeoutSeconds // $build_timeout_seconds' "${DATA_FILE}")
-        request_timeout_seconds=$(jq -r --arg request_timeout_seconds "${default_request_timeout_seconds}" \
+        base_request_timeout_seconds=$(jq -r --arg request_timeout_seconds "${default_request_timeout_seconds}" \
             '.fbc.requestTimeoutSeconds // $request_timeout_seconds' "${DATA_FILE}")
+        
         internal_request_service_account=$(jq -r '.fbc.internalRequestServiceAccount // "release-service-account"' \
             "${DATA_FILE}")
         publishing_credentials=$(jq -r '.fbc.publishingCredentials // "catalog-publishing-secret"' "$DATA_FILE")
+        
+        # Function to get timeout for a specific OCP version
+        # Checks for OCP-version-specific overrides in data file, otherwise uses base timeout
+        # Format: .fbc.timeoutOverrides."v4.12".requestTimeoutSeconds
+        get_timeout_for_ocp_version() {
+            local ocp_version="$1"
+            local timeout_type="$2"  # "request" or "build"
+            local default_value="$3"
+            
+            # Check data file overrides
+            local override_value
+            if [ "${timeout_type}" = "request" ]; then
+                override_value=$(jq -r --arg ocp_version "${ocp_version}" \
+                    '.fbc.timeoutOverrides[$ocp_version].requestTimeoutSeconds // empty' "${DATA_FILE}")
+            else
+                override_value=$(jq -r --arg ocp_version "${ocp_version}" \
+                    '.fbc.timeoutOverrides[$ocp_version].buildTimeoutSeconds // empty' "${DATA_FILE}")
+            fi
+            
+            # Use override if present, otherwise use base timeout
+            if [ -n "${override_value}" ] && [ "${override_value}" != "null" ]; then
+                echo "${override_value}"
+            else
+                echo "${default_value}"
+            fi
+        }
 
         # Use pre-determined values from prepare-fbc-parameters
         iib_service_account_secret="$(params.iibServiceAccountSecret)"
@@ -277,10 +308,9 @@ spec:
         groups_dir="$(params.dataDir)/ocp-groups"
         mkdir -p "$groups_dir"
 
-        # Calculate timeout for batches
+        # Timeout calculation will be done per OCP version group
+        # This allows different OCP versions to have different timeout values
         finally_task_timeout=300
-        pipeline_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds + finally_task_timeout )))
-        task_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds )))
 
         # Group components by OCP version for isolated processing
         group_components_by_ocp_version() {
@@ -326,6 +356,27 @@ spec:
             local group_components="$2"
 
             echo "INFO: Processing OCP group $group_ocp_version"
+
+            # Get OCP-version-specific timeouts
+            local group_request_timeout_seconds
+            group_request_timeout_seconds=$(get_timeout_for_ocp_version \
+                "${group_ocp_version}" "request" "${base_request_timeout_seconds}")
+            local group_build_timeout_seconds
+            group_build_timeout_seconds=$(get_timeout_for_ocp_version \
+                "${group_ocp_version}" "build" "${base_build_timeout_seconds}")
+            
+            # Calculate timeouts for this OCP version group
+            local group_pipeline_timeout_seconds=$(( group_request_timeout_seconds + finally_task_timeout ))
+            local group_pipeline_timeout
+            group_pipeline_timeout=$(date -u "+%Hh%Mm%Ss" -d "@${group_pipeline_timeout_seconds}")
+            local group_task_timeout
+            group_task_timeout=$(date -u "+%Hh%Mm%Ss" -d "@${group_request_timeout_seconds}")
+            local group_script_timeout_seconds=${group_pipeline_timeout_seconds}
+            
+            if [ "${group_request_timeout_seconds}" != "${base_request_timeout_seconds}" ]; then
+                echo "INFO: Using custom timeout override for OCP ${group_ocp_version}:" \
+                  "request=${group_request_timeout_seconds}s, build=${group_build_timeout_seconds}s"
+            fi
 
             # Get group-specific parameters from first component (all should have same values within group)
             local first_component
@@ -425,7 +476,7 @@ spec:
                     -p fbcFragments="$(printf '%s' "${batch_fragments}" | jq -c .)" \
                     -p iibServiceAccountSecret="${iib_service_account_secret}" \
                     -p publishingCredentials="${publishing_credentials}" \
-                    -p buildTimeoutSeconds="${build_timeout_seconds}" \
+                    -p buildTimeoutSeconds="${group_build_timeout_seconds}" \
                     -p buildTags="$(jq -c . <<< "${group_build_tags}")" \
                     -p addArches="$(jq -c . <<< "${add_arches}")" \
                     -p mustPublishIndexImage="${mustPublishIndexImage}" \
@@ -435,15 +486,24 @@ spec:
                     --service-account "${internal_request_service_account}" \
                     -l ${TASK_LABEL}="${TASK_ID}" \
                     -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
-                    --pipeline-timeout "${pipeline_timeout}" \
-                    --task-timeout "${task_timeout}" \
-                    -t "${request_timeout_seconds}" \
+                    --pipeline-timeout "${group_pipeline_timeout}" \
+                    --task-timeout "${group_task_timeout}" \
+                    -t "${group_script_timeout_seconds}" \
                     | tee "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log"
 
                 # Extract request name
                 local internalRequest
                 internalRequest=$(awk -F"'" '/created/ { print $2 }' \
                     "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log")
+
+                if [ -z "${internalRequest}" ]; then
+                    echo "ERROR: Failed to extract InternalRequest name from output"
+                    echo "Output file contents:"
+                    cat "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log"
+                    return 1
+                fi
+
+                echo "INFO: InternalRequest '${internalRequest}' created for batch $((batch_num + 1))"
 
                 # Validate internal request succeeded
                 local request_status
@@ -460,6 +520,21 @@ spec:
                         -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].message}')
                     echo "Reason: ${request_reason}"
                     echo "Message: ${request_message}"
+                    
+                    # Additional diagnostics
+                    echo "INFO: InternalRequest details:"
+                    kubectl get internalrequest "${internalRequest}" -o yaml | grep -A 20 "status:" || true
+                    
+                    # Check if there's a PipelineRun associated
+                    local pipeline_run
+                    pipeline_run=$(kubectl get internalrequest "${internalRequest}" \
+                        -o jsonpath='{.status.results}' | jq -r '.internalRequestPipelineRunName // empty')
+                    if [ -n "${pipeline_run}" ]; then
+                        echo "INFO: Associated PipelineRun: ${pipeline_run}"
+                        echo "INFO: PipelineRun status:"
+                        kubectl get pipelinerun "${pipeline_run}" -o jsonpath='{.status.conditions}' | jq . || true
+                    fi
+                    
                     return 1
                 fi
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout-overrides.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-timeout-overrides.yaml
@@ -1,0 +1,272 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-timeout-overrides
+spec:
+  description: |
+    Test that timeout overrides are correctly applied per OCP version.
+    This test verifies that OCP-version-specific timeout configuration works.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              # Create data.json with timeout overrides for v4.12
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "fbc": {
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "buildTimeoutSeconds": 3600,
+                  "requestTimeoutSeconds": 3600,
+                  "timeoutOverrides": {
+                    "v4.12": {
+                      "requestTimeoutSeconds": 7200,
+                      "buildTimeoutSeconds": 7200
+                    }
+                  }
+                }
+              }
+              EOF
+
+              # Create snapshot with multi-OCP components
+              # v4.12 should use override timeout (7200s)
+              # v4.14 should use base timeout (3600s)
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp-v4-12",
+                    "containerImage": "registry.io/image-v4-12@sha256:0012",
+                    "repository": "prod-registry.io/prod-location",
+                    "updatedFromIndex": "quay.io/test/fbc-index-testing:v4.12",
+                    "targetIndex": "quay.io/test/fbc-target-index:v4.12",
+                    "ocpVersion": "v4.12"
+                  },
+                  {
+                    "name": "comp-v4-14",
+                    "containerImage": "registry.io/image-v4-14@sha256:0014",
+                    "repository": "prod-registry.io/prod-location",
+                    "updatedFromIndex": "quay.io/test/fbc-index-testing:v4.14",
+                    "targetIndex": "quay.io/test/fbc-target-index:v4.14",
+                    "ocpVersion": "v4.14"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: mustPublishIndexImage
+          value: "true"
+        - name: mustOverwriteFromIndexImage
+          value: "true"
+        - name: iibServiceAccountSecret
+          value: "test-iib-secret"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: internalRequestResultsFile
+          value: $(tasks.run-task.results.internalRequestResultsFile)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: pipelineRunUid
+            type: string
+          - name: internalRequestResultsFile
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-timeout-overrides
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              PIPELINE_UID="$(params.pipelineRunUid)"
+              
+              # Find all InternalRequests for this pipeline
+              internalRequests=$(kubectl get internalrequest \
+                -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" \
+                --no-headers -o custom-columns=":metadata.name" \
+                --sort-by=.metadata.creationTimestamp)
+              
+              if [ -z "$internalRequests" ]; then
+                echo "ERROR: No InternalRequests found for pipeline ${PIPELINE_UID}"
+                exit 1
+              fi
+
+              echo "Found InternalRequests:"
+              echo "$internalRequests"
+
+              # We expect 2 InternalRequests (one for each OCP version)
+              request_count=$(echo "$internalRequests" | wc -l)
+              if [ "$request_count" -ne 2 ]; then
+                echo "ERROR: Expected 2 InternalRequests, found ${request_count}"
+                exit 1
+              fi
+
+              # Check each InternalRequest for correct timeout configuration
+              for ir in $internalRequests; do
+                echo "Checking InternalRequest: $ir"
+                
+                requestParams=$(kubectl get internalrequest "$ir" -o jsonpath="{.spec.params}")
+                buildTimeout=$(jq -r '.buildTimeoutSeconds' <<< "$requestParams")
+                fromIndex=$(jq -r '.fromIndex' <<< "$requestParams")
+                
+                echo "  fromIndex: $fromIndex"
+                echo "  buildTimeout: $buildTimeout"
+                
+                # Determine which OCP version this request is for based on fromIndex
+                if [[ "$fromIndex" == *"v4.12"* ]]; then
+                  echo "  This is v4.12 - should use override timeout (7200)"
+                  if [ "$buildTimeout" != "7200" ]; then
+                    echo "ERROR: v4.12 buildTimeout should be 7200, got: $buildTimeout"
+                    exit 1
+                  fi
+                  echo "  ✓ v4.12 timeout override correctly applied"
+                elif [[ "$fromIndex" == *"v4.14"* ]]; then
+                  echo "  This is v4.14 - should use base timeout (3600)"
+                  if [ "$buildTimeout" != "3600" ]; then
+                    echo "ERROR: v4.14 buildTimeout should be 3600, got: $buildTimeout"
+                    exit 1
+                  fi
+                  echo "  ✓ v4.14 base timeout correctly applied"
+                else
+                  echo "ERROR: Unexpected fromIndex: $fromIndex"
+                  exit 1
+                fi
+              done
+
+              # Verify results file has both components
+              RESULTS_FILE="$(params.dataDir)/$(params.internalRequestResultsFile)"
+              component_count=$(jq '.components | length' "$RESULTS_FILE")
+              if [ "$component_count" -ne 2 ]; then
+                echo "ERROR: Expected 2 components in results, found ${component_count}"
+                exit 1
+              fi
+
+              echo "SUCCESS: Timeout overrides correctly applied per OCP version"
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              
+              kubectl delete internalrequests -l \
+                "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)" || true


### PR DESCRIPTION
## Describe your changes
Implements a flexible, configuration-driven timeout mechanism for fbc catalog builds, allowing teams to optionally configure custom timeout values per OCP version through the data file.

## Relevant Jira
[RELEASE-2038](https://issues.redhat.com/browse/RELEASE-2038)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


Assisted-by: Cursor
