### PR TITLE
revert(STONEINTG-1266): add step make data-acceptable-bundles repos public

### DIFF
--- a/tasks/managed/update-trusted-tasks/README.md
+++ b/tasks/managed/update-trusted-tasks/README.md
@@ -20,6 +20,5 @@ else a new artifact will be created.
 | sourceDataArtifact      | The source data artifact to use for trusted artifacts                                                                      | Yes      | ""                   |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
-| registrySecret          | The name of the secret with the registry token for making repositories public                                              | Yes      | registry-token       |
 | caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
 | caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |

--- a/tasks/managed/update-trusted-tasks/tests/mocks.sh
+++ b/tasks/managed/update-trusted-tasks/tests/mocks.sh
@@ -33,17 +33,3 @@ function ec() {
   exit 1
 }
 
-function curl() {
-  echo Mock curl called with: $* >&2
-  echo $* >> "$(params.dataDir)/mock_curl.txt"
-
-  # Mock successful API call to make repository public
-  if [[ "$*" =~ "quay.io/api/v1/repository".*"changevisibility" ]]; then
-      echo '{"success": true}'
-      return 0
-  fi
-  
-  # Pass through other curl calls
-  command curl "$@"
-}
-

--- a/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
@@ -3,13 +3,4 @@
 TASK_PATH=$1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Create test registry token secret for the tests
-kubectl create secret generic test-registry-token \
-  --from-literal=token="fake-token-for-testing" \
-  --dry-run=client -o yaml | kubectl apply -f - || true
-
-# Inject mocks into the update-trusted-tasks step (step[1])
 yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $TASK_PATH
-
-# Inject mocks into the make-data-acceptable-bundles-public step (step[2])
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' $TASK_PATH

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -113,8 +113,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
   finally:

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -87,8 +87,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
   finally:

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -115,8 +115,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
     - name: check-result
@@ -184,18 +182,5 @@ spec:
               if ! grep -qF -- "$out" "$(params.dataDir)/mock_ec.txt"; then
                 echo "Error: $out was not found in the ec command"
                 cat "$(params.dataDir)/mock_ec.txt"
-                exit 1
-              fi
-
-                            if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                echo Error: curl was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
-
-              expected_url="quay.io/api/v1/repository/exists/data-acceptable-bundles/changevisibility"
-              if ! grep -qF "$expected_url" "$(params.dataDir)/mock_curl.txt"; then
-                echo "Error: expected curl call to changevisibility API was not found"
-                cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -149,8 +149,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
     - name: check-result
@@ -231,27 +229,5 @@ spec:
               done
               if ! $all_found; then
                 cat "$(params.dataDir)/mock_ec.txt"
-                exit 1
-              fi
-
-              # Check curl was called for making repositories public
-              # notexist and exists repos should both be made public (2 unique repos)
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 2 ]; then
-                echo Error: curl was expected to be called 2 times. Actual calls:
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
-
-              expected_url="quay.io/api/v1/repository/notexist/data-acceptable-bundles/changevisibility"
-              if ! grep -qF "$expected_url" "$(params.dataDir)/mock_curl.txt"; then
-                echo "Error: expected curl call to changevisibility API for notexist repo was not found"
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
-
-              expected_url="quay.io/api/v1/repository/exists/data-acceptable-bundles/changevisibility"
-              if ! grep -qF "$expected_url" "$(params.dataDir)/mock_curl.txt"; then
-                echo "Error: expected curl call to changevisibility API for exists repo was not found"
-                cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -113,8 +113,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
     - name: check-result
@@ -193,19 +191,5 @@ spec:
               done
               if ! $all_found; then
                 cat "$(params.dataDir)/mock_ec.txt"
-                exit 1
-              fi
-
-              # Check curl was called for making repositories public
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                echo Error: curl was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
-
-              expected_url="quay.io/api/v1/repository/notexist/data-acceptable-bundles/changevisibility"
-              if ! grep -qF "$expected_url" "$(params.dataDir)/mock_curl.txt"; then
-                echo "Error: expected curl call to changevisibility API was not found"
-                cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -112,8 +112,6 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: registrySecret
-          value: "test-registry-token"
       runAfter:
         - setup
     - name: check-result
@@ -178,19 +176,5 @@ spec:
               if ! grep -qF -- "$out" "$(params.dataDir)/mock_ec.txt"; then
                 echo "Error: $out was not found in the ec command"
                 cat "$(params.dataDir)/mock_ec.txt"
-                exit 1
-              fi
-
-              # Check curl was called for making repositories public
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                echo Error: curl was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
-
-              expected_url="quay.io/api/v1/repository/notexist/data-acceptable-bundles/changevisibility"
-              if ! grep -qF "$expected_url" "$(params.dataDir)/mock_curl.txt"; then
-                echo "Error: expected curl call to changevisibility API was not found"
-                cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -49,10 +49,6 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-    - name: registrySecret
-      type: string
-      description: The name of the secret with the registry token for making repositories public
-      default: "registry-token"
     - name: caTrustConfigMapName
       type: string
       description: The name of the ConfigMap to read CA bundle data from
@@ -66,9 +62,6 @@ spec:
       type: string
       description: Produced trusted data artifact
   volumes:
-    - name: registry-secret-vol
-      secret:
-        secretName: $(params.registrySecret)
     - name: workdir
       emptyDir: {}
     - name: trusted-ca
@@ -201,92 +194,6 @@ spec:
                 done
             done
         done
-    - name: make-data-acceptable-bundles-public
-      image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
-      computeResources:
-        limits:
-          memory: 256Mi
-        requests:
-          memory: 256Mi
-          cpu: 150m
-      volumeMounts:
-        - name: registry-secret-vol
-          mountPath: "/etc/secrets"
-      script: |
-        #!/usr/bin/env bash
-        set -eu
-        REGISTRY_TOKEN="$(cat /etc/secrets/token)"
-        set -x
-        # Function to call quay.io to make a repository public
-        # Parameters:
-        # repository: full path to repo on quay.io, e.g. "myorg/myrepo"
-        function make_repo_public() {
-          set +x
-          if curl -X POST \
-            --fail-with-body --retry 3 \
-            --header "Authorization: Bearer ${REGISTRY_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data '{"visibility": "public"}' \
-            "https://quay.io/api/v1/repository/${1}/changevisibility"
-          then
-            echo "Successfully made quay.io/${1} public"
-          else
-            echo "Error: Failed to make repo quay.io/${1} public."\
-              "Make sure the secret $(params.registrySecret) contains"\
-              " the \"token\" key with token that has permission to"\
-              " Administer Repositories."
-            exit 1
-          fi
-          set -x
-        }
-        SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
-        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
-            echo "No valid snapshot file was provided."
-            exit 1
-        fi
-        # Extract the application from the snapshot
-        application=$(jq -r '.application' "${SNAPSHOT_SPEC_FILE}")
-        # Get the number of components
-        NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
-        printf 'Making data-acceptable-bundles repositories public for "%s"\n\n' "$application"
-        
-        # Track all data-acceptable-bundles repositories that were created/updated
-        declare -A processed_repos
-        
-        for ((i = 0; i < NUM_COMPONENTS; i++))
-        do
-            # Extract the component from the snapshot
-            component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
-            # Get the number of repositories from the component
-            NUM_REPOSITORIES=$(jq '.repositories | length' <<< "$component")
-            # Iterate through each repository in the component
-            for ((j = 0; j < NUM_REPOSITORIES; j++))
-            do
-                # Extract the repository URL from the snapshot
-                repository=$(jq -r --argjson j "$j" '.repositories[$j].url' <<< "$component")
-                # The data-acceptable-bundles repo should reside in the same org in the registry.
-                # Fetch the repository and replace the repo with data-acceptable-bundles
-                # for example: quay.io/myorg/myrepo -> quay.io/myorg/data-acceptable-bundles
-                ACCEPTABLE_BUNDLES=$(echo "${repository}" \
-                  | awk -F'/' '{$NF="data-acceptable-bundles"; print $0}' OFS='/')
-                # Only process quay.io repositories and avoid duplicates
-                if [[ "$ACCEPTABLE_BUNDLES" == quay.io/* ]] && \
-                   [[ -z "${processed_repos[$ACCEPTABLE_BUNDLES]:-}" ]]; then
-                    echo "Making data-acceptable-bundles repository $ACCEPTABLE_BUNDLES public..."
-                    
-                    # Remove quay.io/ prefix for the API call
-                    REPO_PATH=${ACCEPTABLE_BUNDLES#quay.io/}
-                    REPO_PATH=${REPO_PATH%/} # Remove trailing slash just in case
-                    
-                    make_repo_public "$REPO_PATH"
-                    
-                    # Mark this repo as processed to avoid duplicates
-                    processed_repos[$ACCEPTABLE_BUNDLES]=1
-                fi
-            done
-        done
-        
-        echo "Completed making all data-acceptable-bundles repositories public"
     - name: create-trusted-artifact
       computeResources:
         limits:


### PR DESCRIPTION
## Describe your changes

This reverts commit 67a3c03d6ff0f09c4395dcb4e02ab972d463ef2a.

This change broke users, because it now requires a secret called registry-token (the name is hardcoded which is not great either), but nobody set up such secret in the konflux-release-data.

Also, it seems to me that this change added functionality that is already included in the pipeline via the make-repo-public task.

Related discussion: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1763969086887279

## Relevant Jira

[STONEINTG-1266](https://issues.redhat.com/browse/STONEINTG-1266)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
