### PR TITLE
fix(RELEASE-1887): enable pipefail in apply-mapping task

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -149,7 +149,7 @@ spec:
           cpu: '1'
       script: |
         #!/usr/bin/env bash
-        set -eux
+        set -euxo pipefail
 
         SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
@@ -191,8 +191,8 @@ spec:
             tag_pattern="^${version_prefix}[0-9]+$"  # Build regex pattern dynamically
 
             # Extract the numeric part of existing tags and find the max increment
-            max_increment=$(echo "${existing_tags}" | grep -E "${tag_pattern}" | sed -E "s/${version_prefix}//" \
-            | sort -nr | head -n1)
+            max_increment=$(echo "${existing_tags}" | { grep -E "${tag_pattern}" || true; } \
+            | sed -E "s/${version_prefix}//" | sort -nr | head -n1)
 
             # Calculate the next increment (default to 1 if max_increment is empty or unset)
             increment=$((max_increment + 1))


### PR DESCRIPTION
## Describe your changes
Enabling pipefail ensures that a pipe fails when any of its commands fail. This ensures that skopeo errors are no longer masked.
    
One pipe in the incrementer logic had to be modified to account for the new behavior. In this pipeline, grep error is an acceptable state, so this modification ensures that the pipe continues even if grep fails.
## Relevant Jira
[RELEASE-1887](https://issues.redhat.com/browse/RELEASE-1887)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Cursor