### PR TITLE
fix(KFLUXSPRT-6103): increase memory limits for push-rpm-data-to-pyxis

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -302,9 +302,9 @@ spec:
         quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 2Gi
         requests:
-          memory: 512Mi
+          memory: 2Gi
           cpu: '1'
       volumeMounts:
         - name: pyxis-secret-vol


### PR DESCRIPTION
## Describe your changes
The push-rpm-data-to-pyxis task was failing with OOMKilled errors when 
processing large workloads, causing release pipeline failures.

The push-rpm-data-to-pyxis step had insufficient memory allocation (512Mi) 
for handling parallel processing of multiple SBOM files and uploading RPM 
data to Pyxis. The task processes up to 20 images 
concurrently by default (configurable via concurrentLimit parameter), 
which requires significant memory and CPU for parallel operations.

Increased memory limits and requests from 512Mi to 1Gi (2x increase) for 
the push-rpm-data-to-pyxis step. This provides adequate headroom for 
parallel SBOM processing and RPM data uploads to Pyxis.

## Relevant Jira
[KFLUXSPRT-6103](https://issues.redhat.com/browse/KFLUXSPRT-6103)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
