### PR TITLE
refactor(RELEASE-1791): remove deprecated repository field from mapping

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -464,10 +464,6 @@
                 "type": "string",
                 "description": "Name to be used while comparing against the name label when multiple repositories are defined"
               },
-              "repository": {
-                "type": "string",
-                "description": "URL where you want to push the artifact e.g. quay.io/redhat/example-component"
-              },
               "repositories": {
                 "type": "array",
                 "items": {
@@ -1802,19 +1798,8 @@
                 "minItems": 1,
                 "items": {
                   "required": [
-                    "name"
-                  ],
-                  "anyOf": [
-                    {
-                      "required": [
-                        "repository"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "repositories"
-                      ]
-                    }
+                    "name",
+                    "repositories"
                   ]
                 }
               }


### PR DESCRIPTION
## Describe your changes

Remove support for the deprecated single 'repository' string field in mapping.components. All components must now use the 'repositories' array format.

## Relevant Jira

https://issues.redhat.com/browse/RELEASE-1791

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
