### PR TITLE
fix: wrong image in create-advisory

### DIFF
--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -155,7 +155,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-purl
-      image: quay.io/distribution_relengs/publish-to-dev-portal-test-image:purl
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
       computeResources:
         limits:
           memory: 256Mi


### PR DESCRIPTION
## Describe your changes

The update-purl step in create-advisory was using
a custom image. This image was used for testing
(before the new get_cgw_download_urls.py script
was added to the utils image) and the catalog
PR was accidentally merged with it.

Here's the PR that added it to the utils image:
https://github.com/konflux-ci/release-service-utils/pull/435

The PR where this was originally added:
https://github.com/konflux-ci/release-service-catalog/pull/971

Cc: @swickersh 

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
