### PR TITLE
refactor(RELEASE-1983): use external script for check-embargoed-cves

### DIFF
--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -52,7 +52,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
       computeResources:
         limits:
           memory: 32Mi
@@ -62,57 +62,12 @@ spec:
       volumeMounts:
         - name: osidb-service-account-vol
           mountPath: /mnt/osidb-service-account
-      script: |
-          #!/usr/bin/env bash
-          set -eo pipefail
-
-          SERVICE_ACCOUNT_NAME="$(cat /mnt/osidb-service-account/name)"
-          SERVICE_ACCOUNT_KEYTAB="$(cat /mnt/osidb-service-account/base64_keytab)"
-          OSIDB_URL="$(cat /mnt/osidb-service-account/osidb_url)"
-
-          # shellcheck disable=SC2317 # shellcheck calls all the commands in exitfunc unreachable because it is called
-          # via trap
-          exitfunc() {
-              local err="$1"
-              local line="$2"
-              local command="$3"
-              if [ "$err" -eq 0 ] ; then
-                  echo -n "Success" > "$(results.result.path)"
-              else
-                  echo -n \
-                    "$0: ERROR '$command' failed at line $line - exited with status $err" > "$(results.result.path)"
-              fi
-              exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
-          }
-          # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
-          trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
-
-          echo -n "" > "$(results.embargoed_cves.path)"
-
-          # write keytab to file
-          echo -n "${SERVICE_ACCOUNT_KEYTAB}" | base64 --decode > /tmp/keytab
-          # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
-          KRB5CCNAME=$(mktemp)
-          export KRB5CCNAME
-          KRB5_CONFIG=$(mktemp)
-          export KRB5_CONFIG
-          export KRB5_TRACE=/dev/stderr
-          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
-          retry 5 kinit "${SERVICE_ACCOUNT_NAME}" -k -t /tmp/keytab
-
-          RC=0
-          for CVE in $(params.cves); do
-              echo "Checking CVE ${CVE}"
-              # Get token. They are short lived, so get one for before each request
-              TOKEN=$(curl --retry 3 --negotiate -u : "${OSIDB_URL}"/auth/token | jq -r '.access')
-              EMBARGOED=$(curl --retry 3 -H 'Content-Type: application/json' -H "Authorization: Bearer ${TOKEN}" \
-                  "${OSIDB_URL}/osidb/api/v2/flaws?cve_id=${CVE}&include_fields=cve_id,embargoed" \
-                  | jq .results[0].embargoed)
-              # null would mean no access to the CVE, which may mean embargoed, and true means embargoed
-              if [ "$EMBARGOED" != "false" ] ; then
-                  echo "CVE ${CVE} is embargoed"
-                  echo -n "${CVE} " >> "$(results.embargoed_cves.path)"
-                  RC=1
-              fi
-          done
-          exit $RC
+      env:
+        - name: RESULT_RESULT
+          value: $(results.result.path)
+        - name: RESULT_EMBARGOED_CVES
+          value: $(results.embargoed_cves.path)
+      command: ["/home/scripts/bash/tasks/internal/check-embargoed-cves.sh"]
+      args:
+        - --cves
+        - $(params.cves)

--- a/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
 # mocks to be injected into task step scripts
@@ -28,5 +28,6 @@ function curl() {
   fi
 }
 
-# The retry script won't see the kinit function unless we export it
+# The external script won't see these functions unless we export them
 export -f kinit
+export -f curl

--- a/tasks/internal/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
@@ -3,8 +3,28 @@
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+# The task uses command/args instead of script, so we need to convert it to a script
+# that includes our mocks and then calls the original command.
+
+# Create a wrapper script that includes mocks and calls the original command
+cat > /tmp/wrapped-script.sh <<'EOF'
+#!/usr/bin/env bash
+set -eux
+EOF
+
+# Append the mocks
+cat "$SCRIPT_DIR/mocks.sh" >> /tmp/wrapped-script.sh
+
+# Add the original command call with its args
+cat >> /tmp/wrapped-script.sh <<'EOF'
+
+/home/scripts/bash/tasks/internal/check-embargoed-cves.sh --cves "$(params.cves)"
+EOF
+
+# Replace command/args with script in the task
+yq -i '.spec.steps[0].script = load_str("/tmp/wrapped-script.sh")' "$TASK_PATH"
+yq -i 'del(.spec.steps[0].command)' "$TASK_PATH"
+yq -i 'del(.spec.steps[0].args)' "$TASK_PATH"
 
 # Create a dummy osidb secret (and delete it first if it exists)
 # The secret name is hardcoded in the task so the mock secret name can't have the task name in it

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
This commit refactors the check-embargoed-cves internal task to use a script from the utils image for its execution instead of inline bash. The script is the same as what the bash was. This is a first step towards moving the task bash scripts to their own standalone ones so that unit tests are easier to write for them.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
