### PR TITLE
fix(KONFLUX-11100): bug in push_image() in push-snapshot

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -153,7 +153,7 @@ spec:
             oras_args=(--platform "$6")
           fi
 
-          destination_digest=$(oras resolve --registry-config "$DEST_AUTH_FILE" "${oras_args[@]}" "$4:$5" || true)
+          destination_digest=$(oras resolve --registry-config "$DEST_AUTH_FILE" "$4:$5" || true)
 
           if [[ "$destination_digest" != "$1" || -z "$destination_digest" ]]; then
             printf '* Pushing component: %s to %s:%s\n' "$2" "$4" "$5"
@@ -206,7 +206,7 @@ spec:
                   && break
               else
                 # Fallback to classic image copy
-                cosign copy -f "$3" "$4:$5" && break
+                cosign copy -f --only=att,sbom "$3" "$4:$5" && break
               fi
               attempt=$((attempt+1))
             done
@@ -330,12 +330,12 @@ spec:
             fi
           fi
 
-          NUM_REPOS=$(jq -c '.repositories | length' <<< "$component")           
-          for ((j = 0; j < NUM_REPOS; j++)); do 
+          NUM_REPOS=$(jq -c '.repositories | length' <<< "$component")
+          for ((j = 0; j < NUM_REPOS; j++)); do
             repository=$(jq -c --argjson j "$j" '.repositories[$j]' <<< "$component")
             imageTags=$(jq '.tags' <<< "$repository")
             repository_url=$(jq -r '.url' <<< "$repository")
-          
+
             if [ -n "${source_container_digest-}" ] ; then
               # Push the source image with the source tag here. The source image will be
               # pushed with the provided tags below in the loop

--- a/tasks/managed/push-snapshot/tests/mocks.sh
+++ b/tasks/managed/push-snapshot/tests/mocks.sh
@@ -7,7 +7,7 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> "$(params.dataDir)/mock_cosign.txt"
 
-  if [[ "$*" == "copy -f registry.io/parallel-image:tag"*" "*":"* ]]
+  if [[ "$*" == "copy -f --only=att,sbom registry.io/parallel-image:tag"*" "*":"* ]]
   then
     LOCK_FILE="$(params.dataDir)/${RANDOM}.lock"
     touch $LOCK_FILE
@@ -20,14 +20,14 @@ function cosign() {
   fi
 
   # mock cosign failing for the no-permission test
-  if [[ "$*" == "copy -f registry.io/no-permmission:tag "*":"* ]]
+  if [[ "$*" == "copy -f --only=att,sbom registry.io/no-permmission:tag "*":"* ]]
   then
     echo Invalid credentials for registry.io/no-permmission:tag
     return 1
   fi
 
   # mock cosign failing the first 3x for the retry test
-  if [[ "$*" == "copy -f registry.io/retry-image:tag "*":"* ]]
+  if [[ "$*" == "copy -f --only=att,sbom registry.io/retry-image:tag "*":"* ]]
   then
     if [[ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" -le 3 ]]
     then
@@ -36,7 +36,7 @@ function cosign() {
     fi
   fi
 
-  if [[ "$*" == "copy -f private-registry.io/image:tag "*":"* ]]
+  if [[ "$*" == "copy -f --only=att,sbom private-registry.io/image:tag "*":"* ]]
   then
     if [[ $(cat /etc/ssl/certs/ca-custom-bundle.crt) != "mycert" ]]
     then
@@ -45,7 +45,7 @@ function cosign() {
     fi
   fi
 
-  if [[ "$*" != "copy -f "*":"*" "*":"* ]]
+  if [[ "$*" != "copy -f --only=att,sbom "*":"*" "*":"* ]]
   then
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -206,10 +206,10 @@ spec:
               # For hijklmn (no artifacts), it should fall back to cosign copy
               # Count cosign copy calls (tag1, tag2, tag3)
               COPIES=$(grep -c \
-                '^copy -f reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
+                '^copy -f --only=att,sbom reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
                 "$(params.dataDir)/mock_cosign.txt" || true)
               COPIES2=$(grep -c \
-                '^copy -f reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
+                '^copy -f --only=att,sbom reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
                 "$(params.dataDir)/mock_cosign.txt" || true)
               TOTAL=$((COPIES + COPIES2))
               # We expect 1 cosign copy (tag3) and 0 for tag1/tag2 (handled by oras cp -r)

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -206,20 +206,27 @@ spec:
               # The sha 4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03 is calculated
               # from the origin image pull spec - see oras() in mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF
 

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
@@ -171,10 +171,12 @@ spec:
               # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
               # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF
 

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -158,7 +158,7 @@ spec:
               set -eux
 
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
+              copy -f --only=att,sbom reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
               EOF
 
               if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls.txt")" \

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
@@ -163,10 +163,12 @@ spec:
               # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
               # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
+              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f --only=att,sbom\
+               registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF
 


### PR DESCRIPTION
## Describe your changes

The check if an image already exists in the target did not work, because oras resolve for origin_digest had no --platform, but oras resolve for destination_digest had --platform. So we would be comparing manifest list digest with specific platform image digest and it would never match.

Now we check the top level digest for both.

Also, we will no longer copy .sig artifacts as part of cosign copy - we now specify --only=att,sbom.

The concern here was that when a release is rerun
and the image is replaced (when the check didn't work), we will replace the cosign signature that we created in the previous release. And so until it is signed again later in the pipeline, there would be a short window when it's unsigned.

With the fix above, this shouldn't
really happen anymore, but we agreed that we still don't want to copy the build time signature over.

## Relevant Jira

KONFLUX-11100

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
