### PR TITLE
feat(RELEASE-2014): remove filename from push-artifact schema

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -535,10 +535,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "filename": {
-                      "type": "string",
-                      "description": "file basename"
-                    },
                     "source": {
                       "type": "string",
                       "description": "full path to the file within image"


### PR DESCRIPTION
Filename is derived from the source field for push-artifacts-to-cdn. 
Disk-image pipeline still uses it which is why you'll still see filename under staged.destination.files.filename

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
