### PR TITLE
fix: remove image SHAs concatenation

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -247,7 +247,10 @@ spec:
                 arch_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/$platform_arch"
 
                 # Extract for this specific architecture using manifest digest
-                arch_specific_image="$source_image@$arch_digest"
+                # Extract the registry and repository from source_image (remove existing digest)
+                source_base=$(echo "$source_image" | cut -d'@' -f1)
+                arch_specific_image="$source_base@$arch_digest"
+                echo "Using architecture-specific image: $arch_specific_image"
                 extract_single_arch "$arch_specific_image" "$arch_dir" "$platform_arch"
             done
 

--- a/tasks/managed/extract-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/extract-oot-kmods/tests/mocks.sh
@@ -257,6 +257,94 @@ EOF
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
       ;;
+    "copy docker://quay.io/mock/multiarch@sha256:amd64digest123 dir:"*)
+      # Handle multiarch amd64 case
+      cat > "$tmp_dir/manifest.json" << 'EOF'
+{
+  "layers": [
+    {"digest": "sha256:amd64layer123"}
+  ]
+}
+EOF
+
+      LAYER_BUILD_DIR=$(mktemp -d)
+      mkdir -p "$LAYER_BUILD_DIR/kmods"
+
+      echo "amd64-kmod1" > "$LAYER_BUILD_DIR/kmods/amd64-mod1.ko"
+      echo "amd64-kmod2" > "$LAYER_BUILD_DIR/kmods/amd64-mod2.ko"
+      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
+      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
+      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+
+      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
+      rm -rf "$LAYER_BUILD_DIR"
+      ;;
+    "copy docker://quay.io/mock/multiarch@sha256:arm64digest456 dir:"*)
+      # Handle multiarch arm64 case
+      cat > "$tmp_dir/manifest.json" << 'EOF'
+{
+  "layers": [
+    {"digest": "sha256:arm64layer456"}
+  ]
+}
+EOF
+
+      LAYER_BUILD_DIR=$(mktemp -d)
+      mkdir -p "$LAYER_BUILD_DIR/kmods"
+
+      echo "arm64-kmod1" > "$LAYER_BUILD_DIR/kmods/arm64-mod1.ko"
+      echo "arm64-kmod2" > "$LAYER_BUILD_DIR/kmods/arm64-mod2.ko"
+      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
+      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
+      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+
+      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
+      rm -rf "$LAYER_BUILD_DIR"
+      ;;
+    "copy docker://quay.io/mock/image@sha256:amd64digest123 dir:"*)
+      # Handle mock/image amd64 case (for multiarch test with different base image name)
+      cat > "$tmp_dir/manifest.json" << 'EOF'
+{
+  "layers": [
+    {"digest": "sha256:amd64layer123"}
+  ]
+}
+EOF
+
+      LAYER_BUILD_DIR=$(mktemp -d)
+      mkdir -p "$LAYER_BUILD_DIR/kmods"
+
+      echo "amd64-kmod1" > "$LAYER_BUILD_DIR/kmods/amd64-mod1.ko"
+      echo "amd64-kmod2" > "$LAYER_BUILD_DIR/kmods/amd64-mod2.ko"
+      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
+      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
+      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+
+      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
+      rm -rf "$LAYER_BUILD_DIR"
+      ;;
+    "copy docker://quay.io/mock/image@sha256:arm64digest456 dir:"*)
+      # Handle mock/image arm64 case (for multiarch test with different base image name)
+      cat > "$tmp_dir/manifest.json" << 'EOF'
+{
+  "layers": [
+    {"digest": "sha256:arm64layer456"}
+  ]
+}
+EOF
+
+      LAYER_BUILD_DIR=$(mktemp -d)
+      mkdir -p "$LAYER_BUILD_DIR/kmods"
+
+      echo "arm64-kmod1" > "$LAYER_BUILD_DIR/kmods/arm64-mod1.ko"
+      echo "arm64-kmod2" > "$LAYER_BUILD_DIR/kmods/arm64-mod2.ko"
+      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
+      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
+      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+
+      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
+      rm -rf "$LAYER_BUILD_DIR"
+      ;;
     *)
       echo "Error: Unexpected skopeo call: $*"
       exit 1

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
@@ -58,7 +58,7 @@ spec:
               {
                 "components": [
                   {
-                    "containerImage": "quay.io/mock/multiarch@sha256:multiarchdigest"
+                    "containerImage": "quay.io/mock/multiarch@sha256:dummy"
                   }
                 ]
               }


### PR DESCRIPTION
Specific arch images are wrongly formed adding the SHA for it without removing the previous one, so the resulting images have invalid reference format (two SHAs).


