### PR TITLE
fix(RELEASE-2055): remove filtered_snapshot from results

### DIFF
--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -360,11 +360,11 @@ spec:
             cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
             echo -n "Success" > "$(results.result.path)"
             echo -n "true" > "$(results.skip_release.path)"
-            
+
             # Write the latest advisory URLs to results
             echo -n "$latestAdvisoryUrl" > "$(results.latest_advisory_url.path)"
             echo -n "$latestAdvisoryInternalUrl" > "$(results.latest_advisory_internal_url.path)"
-            
+
             # Create results file with advisory information (same format as create-advisory)
             jq -n --arg url "$latestAdvisoryUrl" --arg internal_url "$latestAdvisoryInternalUrl" \
               '{"advisory": {"url": $url, "internal_url": $internal_url}}' | tee "$RESULTS_FILE"
@@ -374,13 +374,10 @@ spec:
           cat "$FILTERED_SNAPSHOT" > "$SNAPSHOT_FILE"
           echo -n "Success" > "$(results.result.path)"
           echo -n "false" > "$(results.skip_release.path)"
-          
+
           # Set advisory URL results to empty when components need release
           echo -n "" > "$(results.latest_advisory_url.path)"
           echo -n "" > "$(results.latest_advisory_internal_url.path)"
-          
-          # Create results file with filtered snapshot data only
-          jq -n --rawfile snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
         else
           echo "Filtering failed. Results:"
           echo "$results"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
@@ -315,19 +315,17 @@ spec:
               fi
 
               # Check that the filtered snapshot contains both components
-              base_dir="$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              results_file="$base_dir/filter-already-released-advisory-images-results.json"
-              filteredSnapshot=$(jq -r '.filtered_snapshot' "$results_file")
-              if [ "$(jq -r '.components | length' <<< "$filteredSnapshot")" != "2" ]; then
+              snapshot_file="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              if [ "$(jq -r '.components | length' "$snapshot_file")" != "2" ]; then
                 echo "Filtered snapshot should contain both components"
                 exit 1
               fi
 
               # Verify both components are present in filtered snapshot
               multiRepoInFiltered=$(jq -r \
-                '.components[] | select(.name=="multi-repo-component") | .name' <<< "$filteredSnapshot")
+                '.components[] | select(.name=="multi-repo-component") | .name' "$snapshot_file")
               singleRepoInFiltered=$(jq -r \
-                '.components[] | select(.name=="single-repo-component") | .name' <<< "$filteredSnapshot")
+                '.components[] | select(.name=="single-repo-component") | .name' "$snapshot_file")
               if [ -z "$multiRepoInFiltered" ] || [ -z "$singleRepoInFiltered" ]; then
                 echo "Both components should be present in filtered snapshot"
                 exit 1

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -287,14 +287,12 @@ spec:
               fi
 
               # Check that the filtered snapshot contains only the new component
-              base_dir="$(params.dataDir)/$(context.pipelineRun.uid)/results"
-              results_file="$base_dir/filter-already-released-advisory-images-results.json"
-              filteredSnapshot=$(jq -r '.filtered_snapshot' "$results_file")
-              if [ "$(jq -r '.components | length' <<< "$filteredSnapshot")" != "1" ]; then
+              snapshot_file="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              if [ "$(jq -r '.components | length' "$snapshot_file")" != "1" ]; then
                 echo "Filtered snapshot should contain only one component"
                 exit 1
               fi
-              if [ "$(jq -r '.components[0].name' <<< "$filteredSnapshot")" != "new-component" ]; then
+              if [ "$(jq -r '.components[0].name' "$snapshot_file")" != "new-component" ]; then
                 echo "Filtered snapshot should contain only the new component"
                 exit 1
               fi


### PR DESCRIPTION
## Describe your changes

With large snapshots, users are hitting kubectl error in update-cr-status. This is because one of the saved results contained the full filtered snapshot, including metadata (env vars, labels).

This result was saved in the filter task. Upon discussion in the team, it seems we never intended to have this result and it was there by mistake. So let's remove it.

The filter task only needs to save the advisory details if all images are already released, but if not, no results are needed.

BTW, this was supposed to be fixed in RELEASE-1972 but it turns out that fix never really worked. We may want to remove that code later.

## Relevant Jira

RELEASE-2055

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
