### PR TITLE
feat(RELEASE-1963): add cert expiration check to internal tasks

### DIFF
--- a/pipelines/internal/simple-signing-pipeline/README.md
+++ b/pipelines/internal/simple-signing-pipeline/README.md
@@ -5,14 +5,15 @@ pipeline.
 
 ## Parameters
 
-| Name             | Description                                                                                                           | Optional | Default value                                             |
-|------------------|-----------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| pipeline_image   | An image with CLI tools needed for the signing                                                                        | Yes      | quay.io/redhat-isv/operator-pipelines-images:released     |
-| manifest_digests | Space separated manifest digest for the signed content, usually in the format sha256:xxx                              | No       | -                                                         |
-| references       | Space separated docker reference for the signed content, e.g. registry.redhat.io/redhat/community-operator-index:v4.9 | No       | -                                                         |
-| repositories     | Space separated list of repository names where the signed content is located, e.g. redhat-community-operator-index    | No       | -                                                         |
-| requester        | Name of the user that requested the signing, for auditing purposes                                                    | No       | -                                                         |
-| config_map_name  | A config map name with configuration                                                                                  | Yes      | hacbs-signing-pipeline-config                             |
-| taskGitUrl       | The url to the git repo where the release-service-catalog tasks to be used are stored                                 | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| taskGitRevision  | The revision in the taskGitUrl repo to be used                                                                        | No       | -                                                         |
-| pyxisServer      | The server type to use. Options are 'production' and 'stage'                                                          | Yes      | production                                                |
+| Name                   | Description                                                                                                           | Optional | Default value                                             |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| pipeline_image         | An image with CLI tools needed for the signing                                                                        | Yes      | quay.io/redhat-isv/operator-pipelines-images:released     |
+| manifest_digests       | Space separated manifest digest for the signed content, usually in the format sha256:xxx                              | No       | -                                                         |
+| references             | Space separated docker reference for the signed content, e.g. registry.redhat.io/redhat/community-operator-index:v4.9 | No       | -                                                         |
+| repositories           | Space separated list of repository names where the signed content is located, e.g. redhat-community-operator-index    | No       | -                                                         |
+| requester              | Name of the user that requested the signing, for auditing purposes                                                    | No       | -                                                         |
+| config_map_name        | A config map name with configuration                                                                                  | Yes      | hacbs-signing-pipeline-config                             |
+| taskGitUrl             | The url to the git repo where the release-service-catalog tasks to be used are stored                                 | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision        | The revision in the taskGitUrl repo to be used                                                                        | No       | -                                                         |
+| pyxisServer            | The server type to use. Options are 'production' and 'stage'                                                          | Yes      | production                                                |
+| certExpirationWarnDays | Number of days before expiration to warn about certificate expiration                                                 | Yes      | 7                                                         |

--- a/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -46,6 +46,10 @@ spec:
       type: string
       description: The server type to use. Options are 'production' and 'stage'
       default: production
+    - name: certExpirationWarnDays
+      type: string
+      description: Number of days before expiration to warn about certificate expiration
+      default: "7"
   workspaces:
     - name: pipeline
   tasks:
@@ -63,6 +67,30 @@ spec:
       params:
         - name: config_map_name
           value: $(params.config_map_name)
+    - name: check-signing-certificates
+      retries: 3
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/check-signing-certificates/check-signing-certificates.yaml
+      params:
+        - name: umb_ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_secret_name)
+        - name: umb_ssl_cert_file_name
+          value: $(tasks.collect-simple-signing-params.results.umb_ssl_cert_file_name)
+        - name: pyxis_ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_cert_secret_name)
+        - name: pyxis_ssl_cert_file_name
+          value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_cert_file_name)
+        - name: certExpirationWarnDays
+          value: $(params.certExpirationWarnDays)
+      runAfter:
+        - collect-simple-signing-params
     - name: request-and-upload-signature
       retries: 5
       taskRef:
@@ -120,4 +148,4 @@ spec:
           workspace: pipeline
           subPath: signing
       runAfter:
-        - collect-simple-signing-params
+        - check-signing-certificates

--- a/tasks/internal/check-signing-certificates/README.md
+++ b/tasks/internal/check-signing-certificates/README.md
@@ -1,0 +1,13 @@
+# check-signing-certificates
+
+Tekton task to verify the expiration of signing certificates (UMB and Pyxis)
+
+## Parameters
+
+| Name                       | Description                                                           | Optional | Default value |
+|----------------------------|-----------------------------------------------------------------------|----------|---------------|
+| umb_ssl_cert_secret_name   | Kubernetes secret name for UMB                                        | No       | -             |
+| umb_ssl_cert_file_name     | The name of the file with the UMB certificate in the secret           | No       | -             |
+| pyxis_ssl_cert_secret_name | Kubernetes secret name for Pyxis                                      | No       | -             |
+| pyxis_ssl_cert_file_name   | The name of the file with the Pyxis certificate in the secret         | No       | -             |
+| certExpirationWarnDays     | Number of days before expiration to warn about certificate expiration | Yes      | 7             |

--- a/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-signing-certificates
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task to verify the expiration of signing certificates (UMB and Pyxis)
+  params:
+    - name: umb_ssl_cert_secret_name
+      type: string
+      description: Kubernetes secret name for UMB
+    - name: umb_ssl_cert_file_name
+      type: string
+      description: The name of the file with the UMB certificate in the secret
+    - name: pyxis_ssl_cert_secret_name
+      type: string
+      description: Kubernetes secret name for Pyxis
+    - name: pyxis_ssl_cert_file_name
+      type: string
+      description: The name of the file with the Pyxis certificate in the secret
+    - name: certExpirationWarnDays
+      type: string
+      description: Number of days before expiration to warn about certificate expiration
+      default: "7"
+  volumes:
+    - name: umb-ssl-cert-secret
+      secret:
+        secretName: $(params.umb_ssl_cert_secret_name)
+        optional: false
+    - name: pyxis-ssl-cert-secret
+      secret:
+        secretName: $(params.pyxis_ssl_cert_secret_name)
+        optional: false
+  steps:
+    - name: check-certificates
+      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 100m
+      volumeMounts:
+        - name: umb-ssl-cert-secret
+          mountPath: /mnt/umb_ssl_cert_secret
+          readOnly: true
+        - name: pyxis-ssl-cert-secret
+          mountPath: /mnt/pyxis_ssl_cert_secret
+          readOnly: true
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        echo "=== Checking signing certificate expiration ==="
+
+        # Check UMB certificate
+        UMB_CERT_FILE="/mnt/umb_ssl_cert_secret/$(params.umb_ssl_cert_file_name)"
+        echo "Checking UMB certificate: ${UMB_CERT_FILE}"
+        if ! check_cert_expiration "${UMB_CERT_FILE}" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: UMB certificate validation failed"
+          exit 1
+        fi
+        echo "✓ UMB certificate is valid"
+
+        # Check Pyxis certificate
+        PYXIS_CERT_FILE="/mnt/pyxis_ssl_cert_secret/$(params.pyxis_ssl_cert_file_name)"
+        echo "Checking Pyxis certificate: ${PYXIS_CERT_FILE}"
+        if ! check_cert_expiration "${PYXIS_CERT_FILE}" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: Pyxis certificate validation failed"
+          exit 1
+        fi
+        echo "✓ Pyxis certificate is valid"
+
+        echo "=== All signing certificates are valid ==="

--- a/tasks/internal/check-signing-certificates/tests/mocks.sh
+++ b/tasks/internal/check-signing-certificates/tests/mocks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function check_cert_expiration() {
+  local cert_file="$1"
+  echo "Mock check_cert_expiration called with: $cert_file"
+  # Mock: always return success (certificate is valid)
+  echo "Certificate $cert_file is valid (mocked)"
+  return 0
+}
+

--- a/tasks/internal/check-signing-certificates/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-signing-certificates/tests/pre-apply-task-hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Add mocks to the beginning of task step script
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create dummy secrets for UMB and Pyxis (and delete them first if they exist)
+kubectl delete secret umb-ssl-cert --ignore-not-found
+kubectl create secret generic umb-ssl-cert --from-literal=cert=myumbcert --from-literal=key=myumbkey
+
+kubectl delete secret pyxis-ssl-cert --ignore-not-found
+kubectl create secret generic pyxis-ssl-cert --from-literal=cert=mypyxiscert --from-literal=key=mypyxiskey
+

--- a/tasks/internal/check-signing-certificates/tests/test-check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/tests/test-check-signing-certificates.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-signing-certificates
+spec:
+  description: |
+    Run the check-signing-certificates task
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: check-signing-certificates
+      params:
+        - name: umb_ssl_cert_secret_name
+          value: umb-ssl-cert
+        - name: umb_ssl_cert_file_name
+          value: cert
+        - name: pyxis_ssl_cert_secret_name
+          value: pyxis-ssl-cert
+        - name: pyxis_ssl_cert_file_name
+          value: cert

--- a/tasks/internal/pulp-push-disk-images/README.md
+++ b/tasks/internal/pulp-push-disk-images/README.md
@@ -4,15 +4,16 @@ Tekton task to push disk images with Pulp
 
 ## Parameters
 
-| Name                 | Description                                                           | Optional | Default value |
-|----------------------|-----------------------------------------------------------------------|----------|---------------|
-| snapshot_json        | String containing a JSON representation of the snapshot spec          | No       | -             |
-| concurrentLimit      | The maximum number of images to be pulled at once                     | Yes      | 3             |
-| exodusGwSecret       | Env specific secret containing the Exodus Gateway configs             | No       | -             |
-| exodusGwEnv          | Environment to use in the Exodus Gateway. Options are [live, pre]     | No       | -             |
-| pulpSecret           | Env specific secret containing the rhsm-pulp credentials              | No       | -             |
-| udcacheSecret        | Env specific secret containing the udcache credentials                | No       | -             |
-| cgwHostname          | Env specific hostname for content gateway                             | No       | -             |
-| cgwSecret            | Env specific secret containing the content gateway credentials        | No       | -             |
-| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
-| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |
+| Name                   | Description                                                           | Optional | Default value |
+|------------------------|-----------------------------------------------------------------------|----------|---------------|
+| snapshot_json          | String containing a JSON representation of the snapshot spec          | No       | -             |
+| concurrentLimit        | The maximum number of images to be pulled at once                     | Yes      | 3             |
+| exodusGwSecret         | Env specific secret containing the Exodus Gateway configs             | No       | -             |
+| exodusGwEnv            | Environment to use in the Exodus Gateway. Options are [live, pre]     | No       | -             |
+| pulpSecret             | Env specific secret containing the rhsm-pulp credentials              | No       | -             |
+| udcacheSecret          | Env specific secret containing the udcache credentials                | No       | -             |
+| cgwHostname            | Env specific hostname for content gateway                             | No       | -             |
+| cgwSecret              | Env specific secret containing the content gateway credentials        | No       | -             |
+| caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
+| caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |
+| certExpirationWarnDays | Number of days before expiration to warn about certificate expiration | Yes      | 7             |

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -43,6 +43,10 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
+    - name: certExpirationWarnDays
+      type: string
+      description: Number of days before expiration to warn about certificate expiration
+      default: "7"
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -82,7 +86,7 @@ spec:
 
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
       computeResources:
         limits:
           memory: 512Mi
@@ -109,6 +113,33 @@ spec:
         #!/usr/bin/env bash
         set -e
 
+        # Check certificate expiration for all certificates used in this step
+        echo "=== Checking certificate expiration ==="
+
+        # Check Exodus Gateway certificate
+        echo "Checking Exodus Gateway certificate"
+        if ! check_cert_expiration "/mnt/exodusGwSecret/cert" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: Exodus Gateway certificate validation failed"
+          exit 1
+        fi
+
+        # Check Pulp certificate
+        echo "Checking Pulp certificate"
+        if ! check_cert_expiration "/mnt/pulpSecret/konflux-release-rhsm-pulp.crt" \
+            "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: Pulp certificate validation failed"
+          exit 1
+        fi
+
+        # Check UDCache certificate
+        echo "Checking UDCache certificate"
+        if ! check_cert_expiration "/mnt/udcacheSecret/cert" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: UDCache certificate validation failed"
+          exit 1
+        fi
+
+        echo "=== All certificates are valid ==="
+
         EXODUS_CERT="$(cat /mnt/exodusGwSecret/cert)"
         EXODUS_KEY="$(cat /mnt/exodusGwSecret/key)"
         EXODUS_URL="$(cat /mnt/exodusGwSecret/url)"
@@ -122,7 +153,7 @@ spec:
 
         CGW_USERNAME="$(cat "/mnt/cgwSecret/username")"
         CGW_PASSWORD="$(cat "/mnt/cgwSecret/token")"
-  
+
         # export the variables used by the scripts in release-service-utils
         export CGW_USERNAME CGW_PASSWORD
 

--- a/tasks/internal/pulp-push-disk-images/tests/mocks.sh
+++ b/tasks/internal/pulp-push-disk-images/tests/mocks.sh
@@ -3,6 +3,14 @@ set -ex
 
 # mocks to be injected into task step scripts
 
+function check_cert_expiration() {
+  local cert_file="$1"
+  echo "Mock check_cert_expiration called with: $cert_file"
+  # Mock: always return success (certificate is valid)
+  echo "Certificate $cert_file is valid (mocked)"
+  return 0
+}
+
 function select-oci-auth() {
     echo Mock select-oci-auth called with: $*
 }

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -10,26 +10,27 @@ data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 
 ## Parameters
 
-| Name                  | Description                                                                     | Optional | Default value             |
-|-----------------------|---------------------------------------------------------------------------------|----------|---------------------------|
-| snapshot_json         | String containing a JSON representation of the snapshot spec                    | No       | -                         |
-| concurrentLimit       | The maximum number of images to be pulled at once                               | Yes      | 3                         |
-| author                | Author taken from Release to be used for checksum signing                       | No       | -                         |
-| signingKeyName        | Signing key name to be used for checksum signing                                | No       | -                         |
-| quayURL               | Quay URL of the repo where content will be shared between tasks                 | Yes      | quay.io/konflux-artifacts |
-| quaySecret            | Secret to interact with Quay                                                    | Yes      | quay-credentials          |
-| windowsCredentials    | Secret to interact with the Windows signing host                                | Yes      | windows-credentials       |
-| windowsSSHKey         | Secret containing SSH private key for the Windows signing host                  | Yes      | windows-ssh-key           |
-| macHostCredentials    | Secret to interact with the Mac signing host                                    | Yes      | mac-host-credentials      |
-| macSigningCredentials | Secret to interact with the Mac signing utils                                   | Yes      | mac-signing-credentials   |
-| macSSHKey             | Secret containing SSH private key for the Mac signing host                      | Yes      | mac-ssh-key               |
-| checksumCredentials   | Secret containing the keytab, user, host, and fingerprint for the checksum host | Yes      | checksum-credentials      |
-| kerberosRealm         | Kerberos realm for the checksum host                                            | Yes      | IPA.REDHAT.COM            |
-| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs                       | No       | -                         |
-| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre]               | No       | -                         |
-| pulpSecret            | Env specific secret containing the rhsm-pulp credentials                        | No       | -                         |
-| udcacheSecret         | Env specific secret containing the udcache credentials                          | No       | -                         |
-| cgwHostname           | Env specific hostname for content gateway                                       | No       | -                         |
-| cgwSecret             | Env specific secret containing the content gateway credentials                  | No       | -                         |
-| caTrustConfigMapName  | The name of the ConfigMap to read CA bundle data from                           | Yes      | trusted-ca                |
-| caTrustConfigMapKey   | The name of the key in the ConfigMap that contains the CA bundle data           | Yes      | ca-bundle.crt             |
+| Name                   | Description                                                                     | Optional | Default value             |
+|------------------------|---------------------------------------------------------------------------------|----------|---------------------------|
+| snapshot_json          | String containing a JSON representation of the snapshot spec                    | No       | -                         |
+| concurrentLimit        | The maximum number of images to be pulled at once                               | Yes      | 3                         |
+| author                 | Author taken from Release to be used for checksum signing                       | No       | -                         |
+| signingKeyName         | Signing key name to be used for checksum signing                                | No       | -                         |
+| quayURL                | Quay URL of the repo where content will be shared between tasks                 | Yes      | quay.io/konflux-artifacts |
+| quaySecret             | Secret to interact with Quay                                                    | Yes      | quay-credentials          |
+| windowsCredentials     | Secret to interact with the Windows signing host                                | Yes      | windows-credentials       |
+| windowsSSHKey          | Secret containing SSH private key for the Windows signing host                  | Yes      | windows-ssh-key           |
+| macHostCredentials     | Secret to interact with the Mac signing host                                    | Yes      | mac-host-credentials      |
+| macSigningCredentials  | Secret to interact with the Mac signing utils                                   | Yes      | mac-signing-credentials   |
+| macSSHKey              | Secret containing SSH private key for the Mac signing host                      | Yes      | mac-ssh-key               |
+| checksumCredentials    | Secret containing the keytab, user, host, and fingerprint for the checksum host | Yes      | checksum-credentials      |
+| kerberosRealm          | Kerberos realm for the checksum host                                            | Yes      | IPA.REDHAT.COM            |
+| exodusGwSecret         | Env specific secret containing the Exodus Gateway configs                       | No       | -                         |
+| exodusGwEnv            | Environment to use in the Exodus Gateway. Options are [live, pre]               | No       | -                         |
+| pulpSecret             | Env specific secret containing the rhsm-pulp credentials                        | No       | -                         |
+| udcacheSecret          | Env specific secret containing the udcache credentials                          | No       | -                         |
+| cgwHostname            | Env specific hostname for content gateway                                       | No       | -                         |
+| cgwSecret              | Env specific secret containing the content gateway credentials                  | No       | -                         |
+| caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                           | Yes      | trusted-ca                |
+| caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data           | Yes      | ca-bundle.crt             |
+| certExpirationWarnDays | Number of days before expiration to warn about certificate expiration           | Yes      | 7                         |

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -93,6 +93,10 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
+    - name: certExpirationWarnDays
+      type: string
+      description: Number of days before expiration to warn about certificate expiration
+      default: "7"
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -1195,7 +1199,7 @@ spec:
         echo "$SNAPSHOT_JSON" > /shared/snapshot.json
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:d26b427ea3024a0bd0e8dafb996bba3570760e00
+      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
       computeResources:
         limits:
           memory: 512Mi
@@ -1219,6 +1223,33 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
+
+        # Check certificate expiration for all certificates used in this step
+        echo "=== Checking certificate expiration ==="
+
+        # Check Exodus Gateway certificate
+        echo "Checking Exodus Gateway certificate"
+        if ! check_cert_expiration "/mnt/exodusGwSecret/cert" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: Exodus Gateway certificate validation failed"
+          exit 1
+        fi
+
+        # Check Pulp certificate
+        echo "Checking Pulp certificate"
+        if ! check_cert_expiration "/mnt/pulpSecret/konflux-release-rhsm-pulp.crt" \
+            "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: Pulp certificate validation failed"
+          exit 1
+        fi
+
+        # Check UDCache certificate
+        echo "Checking UDCache certificate"
+        if ! check_cert_expiration "/mnt/udcacheSecret/cert" "$(params.certExpirationWarnDays)"; then
+          echo "ERROR: UDCache certificate validation failed"
+          exit 1
+        fi
+
+        echo "=== All certificates are valid ==="
 
         # Use the modified snapshot from shared volume if available
         if [ -f /shared/snapshot.json ]; then

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -3,6 +3,14 @@ set -ex
 
 # mocks to be injected into task step scripts
 
+function check_cert_expiration() {
+  local cert_file="$1"
+  echo "Mock check_cert_expiration called with: $cert_file"
+  # Mock: always return success (certificate is valid)
+  echo "Certificate $cert_file is valid (mocked)"
+  return 0
+}
+
 function select-oci-auth() {
     echo Mock select-oci-auth called with: $*
 }

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -72,7 +72,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -70,7 +70,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
## Describe your changes
Adds certificate expiration validation to internal tasks that use certificates and updates to latest release-service-utils which includes the check_cert_expiration.py utility ([#592](https://github.com/konflux-ci/release-service-utils/pull/592))

### What This Does
- Validates certificate expiration before use
- Logs certificate expiration dates to task output
- Fails with clear error messages if certificates are expired (exit code 1)
- Prevents silent failures in production like those seen in previous incidents

### Note
Certificate checks were added to pulp-push-disk-images and push-artifacts-to-cdn-task for Exodus Gateway, Pulp, and UDCache certificates.

Unfortunately, for the request-and-upload-signature task, the check_cert_expiration utility cannot be used directly. There is a conflict with the overridden image: the task uses a pipeline_image parameter which is overridden by managed tasks (rh-sign-image, sign-index-image) to operator-pipelines-images:released - required for signing tools like pubtools-sign. However, this image does not contain the check_cert_expiration function which only exists in release-service-utils image.

To solve this problem, a separate task check-signing-certificates was created and inserted into simple-signing-pipeline before request-and-upload-signature. 
This new task:
- Uses a hardcoded release-service-utils image (guarantees check_cert_expiration availability)
- Validates both UMB and Pyxis certificates early in the pipeline
- Runs independently without interfering with the signing task's image requirements

## Relevant Jira
[RELEASE-1963](https://issues.redhat.com/browse/RELEASE-1963)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Cursor
