### PR TITLE
fix: fix bug of filtering builds

### DIFF
--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -273,17 +273,16 @@ spec:
             builds=$(koji-cmd call --json-output listBuilds \
                 userID="$user_name" \
                 state=1 \
-                source="$commit_url" \
-                draft=True)
+                source="$commit_url")
 
-            if [[ -z "$builds" || "$builds" == "null" ]]; then
+            if [[ -z "$builds" || "$builds" == null ]]; then
                 log_error "No builds found for component"
                 return 1
             fi
 
             build_id=$(jq -r 'max_by(.creation_time).build_id' <<< "$builds")
 
-            if [[ -z "$build_id" || "$build_id" == "null" ]]; then
+            if [[ -z "$build_id" || "$build_id" == null ]]; then
                 log_error "Required variable is missing or empty: $build_id"
                 return 1
             fi


### PR DESCRIPTION
## Describe your changes
Remove the draft=True filter for listBuilds as we always fetch latest build and
the build can be promoted.

This can help fix:
https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/rhel-10/pipelineruns/managed-6c94l?releaseName=promote-rhel-10-qh5mm-577ed

## Relevant Jira
ROK-1335


## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
