### PR TITLE
fix(RELEASE-2055): remove metadata from snapshot in tasks

### DIFF
--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -92,7 +92,7 @@ spec:
         optional: true
   stepTemplate:
     securityContext:
-      runAsUser: 1001 
+      runAsUser: 1001
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
@@ -174,7 +174,9 @@ spec:
           requestK8sType=internalrequest
         fi
 
-        snapshot=$(jq -c '.' "$(params.dataDir)/$(params.snapshotPath)")
+        # Remove .metadata from each component to avoid "arg list too long" errors
+        # The internal task doesn't need metadata (env_variables, labels, etc.)
+        snapshot=$(jq -c '.components |= map(del(.metadata))' "$(params.dataDir)/$(params.snapshotPath)")
         # .cdn.env is likely to change in the future. This is just for POC
         env=$(jq -r '.cdn.env' "$(params.dataDir)/$(params.dataPath)")
         AUTHOR=$(jq -r '.status.attribution.author' "$(params.dataDir)/$(params.releasePath)")

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -127,7 +127,9 @@ spec:
         set -ex
 
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
-        snapshot=$(jq -c '.' "$(params.dataDir)/$(params.snapshotPath)")
+        # Remove .metadata from each component to avoid "arg list too long" errors
+        # The internal task doesn't need metadata (env_variables, labels, etc.)
+        snapshot=$(jq -c '.components |= map(del(.metadata))' "$(params.dataDir)/$(params.snapshotPath)")
         # .cdn.env is likely to change in the future. This is just for POC
         env=$(jq -r '.cdn.env' "$(params.dataDir)/$(params.dataPath)")
 


### PR DESCRIPTION
## Describe your changes

This was already fixed in other places and these are two more tasks where there is a potential risk that it will cause issues.

The pattern is that the snapshot spec json is passed to internal-request as a cli argument, so it's sensitive to being large.

So let's just remove the metadata right at the start, because these tasks don't need them (env vars, labels).

## Relevant Jira

RELEASE-2055

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
