### PR TITLE
fix: use tilde instead of \$HOME in scp paths for multiarch signing

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -257,7 +257,7 @@ spec:
 
                             # Copy unsigned kmods to signing server for this architecture
                             scp "${SSH_OPTS[@]}" "$arch_dir"/*.ko \
-                                "${signUser}@${signHost}:\$HOME/kmods/${arch_name}/"
+                                "${signUser}@${signHost}:~/kmods/${arch_name}/"
 
                             # Sign kmods for this architecture
                             sign_kmods_for_arch "$arch_name"
@@ -266,7 +266,7 @@ spec:
                             # Remove unsigned files first to ensure complete replacement
                             rm -f "$arch_dir"/*.ko
                             scp "${SSH_OPTS[@]}" \
-                                "${signUser}@${signHost}:\$HOME/kmods/${arch_name}/*.ko" "$arch_dir/"
+                                "${signUser}@${signHost}:~/kmods/${arch_name}/*.ko" "$arch_dir/"
 
                             # Restore envfile
                             if [ -f "/tmp/envfile.backup.$arch_name" ]; then


### PR DESCRIPTION
## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
