### PR TITLE
 feat(STONEINTG-1266): make data-acceptable-bundles repos public update-trusted-tasks

### DIFF
--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -356,43 +356,6 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - collect-data
-    - name: make-repo-public
-      retries: 5
-      when:
-        - input: "$(tasks.collect-registry-token-secret.results.registrySecret)"
-          operator: notin
-          values: [""]
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: $(params.taskGitUrl)
-          - name: revision
-            value: $(params.taskGitRevision)
-          - name: pathInRepo
-            value: tasks/managed/make-repo-public/make-repo-public.yaml
-      params:
-        - name: dataPath
-          value: "$(tasks.collect-data.results.data)"
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: registrySecret
-          value: $(tasks.collect-registry-token-secret.results.registrySecret)
-        - name: ociStorage
-          value: $(params.ociStorage)
-        - name: sourceDataArtifact
-          value: "$(tasks.push-snapshot.results.sourceDataArtifact)"
-        - name: dataDir
-          value: $(params.dataDir)
-        - name: trustedArtifactsDebug
-          value: "$(params.trustedArtifactsDebug)"
-        - name: taskGitUrl
-          value: "$(params.taskGitUrl)"
-        - name: taskGitRevision
-          value: "$(params.taskGitRevision)"
-      runAfter:
-        - collect-registry-token-secret
-        - push-snapshot
     - name: update-trusted-tasks
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
@@ -423,7 +386,79 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - make-repo-public
+        - push-snapshot
+    - name: prepare-data-acceptable-bundles
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/prepare-data-acceptable-bundles/prepare-data-acceptable-bundles.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.update-trusted-tasks.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - update-trusted-tasks
+    - name: make-repo-public
+      retries: 5
+      when:
+        - input: "$(tasks.apply-mapping.results.mapped)"
+          operator: in
+          values: ["true"]
+        - input: "$(tasks.collect-registry-token-secret.results.registrySecret)"
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/make-repo-public/make-repo-public.yaml
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: registrySecret
+          value: $(tasks.collect-registry-token-secret.results.registrySecret)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.prepare-data-acceptable-bundles.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - prepare-data-acceptable-bundles
     - name: update-cr-status
       params:
         - name: resource

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -157,6 +157,7 @@ spec:
           set -x
         }
 
+        # Read repositories from snapshot
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."

--- a/tasks/managed/make-repo-public/tests/mocks.sh
+++ b/tasks/managed/make-repo-public/tests/mocks.sh
@@ -7,13 +7,15 @@ function curl() {
   echo Mock curl called with: $* >&2
   echo $* >> $(params.dataDir)/mock_curl.txt
 
-  if [[ "$*" == '-X POST --fail-with-body --retry 3 --header Authorization: Bearer myquaytoken --header Content-Type: application/json --data {"visibility": "public"} https://quay.io/api/v1/repository/redhat-services-'*'/myrepo'*'/changevisibility' ]]
+  if [[ "$*" == '-X POST --fail-with-body --retry 3 --header Authorization: Bearer myquaytoken --header Content-Type: application/json --data {"visibility": "public"} https://quay.io/api/v1/repository/'*'/changevisibility' ]]
   then
     if [[ "$*" == *redhat-services-prod/myrepofailing* ]]
     then
       echo Simulating failing curl >&2
       return 1
     fi
+    # All other valid quay.io repository calls succeed
+    return 0
   else
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/prepare-data-acceptable-bundles/README.md
+++ b/tasks/managed/prepare-data-acceptable-bundles/README.md
@@ -1,0 +1,31 @@
+# prepare-data-acceptable-bundles
+
+Tekton task to prepare data-acceptable-bundles repositories by modifying the snapshot.
+
+This task reads the snapshot file, extracts repository URLs from components that have
+public: true set, transforms them to the corresponding data-acceptable-bundles repository
+format, and adds them to the snapshot as components marked with public: true.
+For example: quay.io/org/source-repo -> quay.io/org/data-acceptable-bundles
+
+Only components with explicit public: true are processed, as these are the components
+that will be processed by the make-repo-public task. Components without public: true
+(or with public: false) are ignored.
+
+This task does NOT call external APIs, mount secrets, or use tokens.
+It only processes the snapshot data and modifies it to include data-acceptable-bundles repositories.
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                         | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |

--- a/tasks/managed/prepare-data-acceptable-bundles/prepare-data-acceptable-bundles.yaml
+++ b/tasks/managed/prepare-data-acceptable-bundles/prepare-data-acceptable-bundles.yaml
@@ -1,0 +1,220 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: prepare-data-acceptable-bundles
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task to prepare data-acceptable-bundles repositories by modifying the snapshot.
+    
+    This task reads the snapshot file, extracts repository URLs from components that have
+    public: true set, transforms them to the corresponding data-acceptable-bundles repository
+    format, and adds them to the snapshot as components marked with public: true.
+    For example: quay.io/org/source-repo -> quay.io/org/data-acceptable-bundles
+    
+    Only components with explicit public: true are processed, as these are the components
+    that will be processed by the make-repo-public task. Components without public: true
+    (or with public: false) are ignored.
+    
+    This task does NOT call external APIs, mount secrets, or use tokens.
+    It only processes the snapshot data and modifies it to include data-acceptable-bundles repositories.
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: prepare-data-acceptable-bundles
+      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        
+        # Check if snapshot exists
+        if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
+            echo "No valid snapshot file was found at ${SNAPSHOT_SPEC_FILE}."
+            exit 1
+        fi
+
+        # Read the snapshot
+        SNAPSHOT=$(cat "${SNAPSHOT_SPEC_FILE}")
+
+        # Extract, transform, and deduplicate data-acceptable-bundles repositories in one pass
+        # This processes all components and repositories in a single jq operation, which is much
+        # more efficient than parsing the JSON multiple times in nested loops.
+        # The jq expression:
+        #   - Filters components that have public: true (only these will be processed by make-repo-public)
+        #   - Extracts repository URLs from those components
+        #   - Filters for quay.io repositories only
+        #   - Transforms each URL to data-acceptable-bundles format (replaces last path segment)
+        #   - Deduplicates the results
+        #   - Outputs one repository per line for readarray
+        readarray -t REPOSITORIES < <(jq -r '
+          [
+            .components[]
+            | select(.public == true)
+            | .repositories[].url 
+            | select(startswith("quay.io")) 
+            | sub("/[^/]+$"; "/data-acceptable-bundles")
+          ] 
+          | unique 
+          | .[]
+        ' "${SNAPSHOT_SPEC_FILE}")
+
+        # Get the number of unique repositories to add
+        NUM_REPOS=${#REPOSITORIES[@]}
+
+        if [ "$NUM_REPOS" -eq 0 ]; then
+            echo "No data-acceptable-bundles repositories found. Snapshot unchanged."
+        else
+            echo "Adding ${NUM_REPOS} data-acceptable-bundles repository/repositories to snapshot..."
+
+            # Add each repository as a component with public: true
+            for repo in "${REPOSITORIES[@]}"; do
+                # Create a component name by replacing / and . with - for valid component names
+                COMPONENT_NAME="data-acceptable-bundles-$(echo "$repo" | tr '/.' '-')"
+                
+                # Create a component for this data-acceptable-bundles repository
+                NEW_COMPONENT=$(jq -n \
+                  --arg name "$COMPONENT_NAME" \
+                  --arg url "$repo" \
+                  '{
+                    "name": $name,
+                    "repositories": [{"url": $url}],
+                    "public": true
+                  }')
+                
+                # Add the component to the snapshot
+                SNAPSHOT=$(echo "$SNAPSHOT" | jq --argjson component "$NEW_COMPONENT" '.components += [$component]')
+                
+                echo "Added component for repository: ${repo}"
+            done
+
+            # Write the modified snapshot back to the file
+            echo "$SNAPSHOT" | jq . > "${SNAPSHOT_SPEC_FILE}"
+            echo "Snapshot updated with ${NUM_REPOS} data-acceptable-bundles repository/repositories"
+        fi
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles-empty-snapshot.yaml
+++ b/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles-empty-snapshot.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-data-acceptable-bundles-empty-snapshot
+spec:
+  description: |
+    Run the prepare-data-acceptable-bundles task with an empty snapshot
+    (no components). Should not add any new components.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the OCI repository
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - name: trusted-ca
+              mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "test-app",
+                "components": []
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: prepare-data-acceptable-bundles
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - name: trusted-ca
+              mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            computeResources:
+              limits:
+                memory: 64Mi
+              requests:
+                memory: 64Mi
+                cpu: 30m
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json"
+              
+              # Verify snapshot exists
+              if [ ! -f "${SNAPSHOT_FILE}" ]; then
+                echo "Error: Snapshot file not found at ${SNAPSHOT_FILE}"
+                exit 1
+              fi
+
+              # Verify snapshot still has 0 components (no data-acceptable-bundles added)
+              NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
+              if [ "$NUM_COMPONENTS" != "0" ]; then
+                echo "Error: Expected 0 components, got $NUM_COMPONENTS"
+                echo "Components:"
+                jq '.components' "${SNAPSHOT_FILE}"
+                exit 1
+              fi
+
+              echo "Success: Snapshot unchanged (no components to process)"
+      runAfter:
+        - run-task

--- a/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles-fail-no-snapshot.yaml
+++ b/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles-fail-no-snapshot.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-data-acceptable-bundles-fail-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the prepare-data-acceptable-bundles task with no snapshot file present.
+    The task should fail.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+  tasks:
+    - name: run-task
+      taskRef:
+        name: prepare-data-acceptable-bundles
+      params:
+        - name: snapshotPath
+          value: "missing/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: ""
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"

--- a/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles.yaml
+++ b/tasks/managed/prepare-data-acceptable-bundles/tests/test-prepare-data-acceptable-bundles.yaml
@@ -1,0 +1,276 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-data-acceptable-bundles
+spec:
+  description: |
+    Run the prepare-data-acceptable-bundles task and verify
+    that it correctly modifies the snapshot to include data-acceptable-bundles
+    repositories as components marked as public.
+    
+    This test verifies that the task only processes components with public: true
+    and creates corresponding data-acceptable-bundles components for them.
+  params:
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the OCI repository
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - name: trusted-ca
+              mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "component1",
+                    "repositories": [
+                      {
+                        "url": "quay.io/konflux-ci/my-repo"
+                      }
+                    ],
+                    "public": true
+                  },
+                  {
+                    "name": "component2",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-services-prod/another-repo"
+                      },
+                      {
+                        "url": "quay.io/redhat-services-stage/third-repo"
+                      }
+                    ],
+                    "public": true
+                  },
+                  {
+                    "name": "component3",
+                    "repositories": [
+                      {
+                        "url": "myregistry.org/myspace/my-repo"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: prepare-data-acceptable-bundles
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - name: trusted-ca
+              mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            computeResources:
+              limits:
+                memory: 64Mi
+              requests:
+                memory: 64Mi
+                cpu: 30m
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json"
+              
+              # Verify snapshot exists
+              if [ ! -f "${SNAPSHOT_FILE}" ]; then
+                echo "Error: Snapshot file not found at ${SNAPSHOT_FILE}"
+                exit 1
+              fi
+
+              # Verify snapshot has the original 3 components plus new data-acceptable-bundles components
+              NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_FILE}")
+              if [ "$NUM_COMPONENTS" -lt 3 ]; then
+                echo "Error: Expected at least 3 components, got $NUM_COMPONENTS"
+                exit 1
+              fi
+
+              # Verify data-acceptable-bundles components were added
+              # Should have 3 new components: konflux-ci, redhat-services-prod, and redhat-services-stage
+              # Only components with public: true are processed (component1 and component2)
+              # Non-quay.io repos are filtered out (component3 has non-quay.io repo and no public: true)
+              DATA_ACCEPTABLE_COUNT=$(jq \
+                '[.components[] | select(.name | startswith("data-acceptable-bundles-"))] | length' \
+                "${SNAPSHOT_FILE}")
+              if [ "$DATA_ACCEPTABLE_COUNT" != "3" ]; then
+                echo "Error: Expected 3 data-acceptable-bundles components, got $DATA_ACCEPTABLE_COUNT"
+                echo "Components:"
+                jq '.components[] | select(.name | startswith("data-acceptable-bundles-"))' "${SNAPSHOT_FILE}"
+                exit 1
+              fi
+
+              # Verify each data-acceptable-bundles component has public: true
+              for ((i = 0; i < NUM_COMPONENTS; i++)); do
+                COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
+                COMPONENT_NAME=$(jq -r '.name' <<< "$COMPONENT")
+                
+                if [[ "$COMPONENT_NAME" == data-acceptable-bundles-* ]]; then
+                  PUBLIC=$(jq -r '.public // false' <<< "$COMPONENT")
+                  if [ "$PUBLIC" != "true" ]; then
+                    echo "Error: Component $COMPONENT_NAME should have public: true, got public: $PUBLIC"
+                    exit 1
+                  fi
+                  
+                  # Verify it has the correct repository URL
+                  REPO_URL=$(jq -r '.repositories[0].url' <<< "$COMPONENT")
+                  if [[ "$REPO_URL" != quay.io/*/data-acceptable-bundles ]]; then
+                    echo "Error: Component $COMPONENT_NAME has invalid repository URL: $REPO_URL"
+                    exit 1
+                  fi
+                fi
+              done
+
+              # Check for expected repositories (non-quay.io repos filtered out)
+              COMPONENT_NAME_1="data-acceptable-bundles-quay-io-konflux-ci-data-acceptable-bundles"
+              if ! jq -e --arg name "$COMPONENT_NAME_1" \
+                '[.components[] | select(.name == $name)] | length > 0' \
+                "${SNAPSHOT_FILE}" > /dev/null 2>&1; then
+                echo "Error: Expected $COMPONENT_NAME_1 component not found"
+                exit 1
+              fi
+
+              COMPONENT_NAME_2="data-acceptable-bundles-quay-io-redhat-services-prod-data-acceptable-bundles"
+              if ! jq -e --arg name "$COMPONENT_NAME_2" \
+                '[.components[] | select(.name == $name)] | length > 0' \
+                "${SNAPSHOT_FILE}" > /dev/null 2>&1; then
+                echo "Error: Expected $COMPONENT_NAME_2 component not found"
+                exit 1
+              fi
+
+              # Verify redhat-services-stage/data-acceptable-bundles is present
+              COMPONENT_NAME_3="data-acceptable-bundles-quay-io-redhat-services-stage-data-acceptable-bundles"
+              if ! jq -e --arg name "$COMPONENT_NAME_3" \
+                '[.components[] | select(.name == $name)] | length > 0' \
+                "${SNAPSHOT_FILE}" > /dev/null 2>&1; then
+                echo "Error: Expected $COMPONENT_NAME_3 component not found"
+                exit 1
+              fi
+
+              echo "Success: Snapshot correctly modified with data-acceptable-bundles components"
+      runAfter:
+        - run-task


### PR DESCRIPTION
**Summary** 
Automatically makes data-acceptable-bundles repositories public after update-trusted-tasks runs.
**Changes**
1. New task: prepare-data-acceptable-bundles
 - Runs after update-trusted-tasks
 - Extracts repository URLs from the snapshot and transforms them to data-acceptable-bundles format (e.g.,      quay.io/org/repo → quay.io/org/data-acceptable-bundles)
 - Adds these repositories as new components in the snapshot with public: true
 - Outputs a modified snapshot as a trusted artifact

2. Refactored pipeline flow
 - Removed the early make-repo-public task that ran before update-trusted-tasks
 - make-repo-public now runs after prepare-data-acceptable-bundles
 - make-repo-public uses the modified snapshot to make all repositories public (original + data-acceptable-bundles)

[STONEINTG-1266](https://issues.redhat.com/browse/STONEINTG-1266)