### PR TITLE
feat(RELEASE-2073) : find_signatures only once per repo and digest

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -320,11 +320,14 @@ spec:
           repository="${repositories_a[$i]}"
           repository_no_slashes="${repository//\//----}"
 
-          find_signatures --pyxis-graphql-api "${PYXIS_GRAPHQL_URL}" \
-          --manifest_digest "${digest}" \
-          --repository "${repository}" \
-          --output_file "/tmp/${digest}" > "/tmp/find-signatures.${digest}.${repository_no_slashes}.out" 2>&1 &
-          find_signatures_jobs+=($!)
+          if [ ! -f "/tmp/${repository_no_slashes}-${digest}" ]; then
+            find_signatures --pyxis-graphql-api "${PYXIS_GRAPHQL_URL}" \
+            --manifest_digest "${digest}" \
+            --repository "${repository}" \
+            --output_file "/tmp/${repository_no_slashes}-${digest}" \
+              > "/tmp/find-signatures.${digest}.${repository_no_slashes}.out" 2>&1 &
+            find_signatures_jobs+=($!)
+          fi
         done
 
         success=true
@@ -361,7 +364,9 @@ spec:
           for i in "${!reference_a[@]}"; do
             reference="${reference_a[$i]}"
             digest="${digests_a[$i]}"
-            if ! grep -q "^${reference} ${sig_key_name}$" "/tmp/${digest}" ; then
+            repository="${repositories_a[$i]}"
+            repository_no_slashes="${repository//\//----}"
+            if ! grep -q "^${reference} ${sig_key_name}$" "/tmp/${repository_no_slashes}-${digest}" ; then
               echo "Signature ${reference} ${sig_key_name} ${digest} not found"
               to_sign_references+=("${reference}")
               to_sign_digests+=("${digest}")


### PR DESCRIPTION
Find signatures should be called only if result file doesn't exist as in current implementation it's called per reference and if there are multiple tags which points to the same manifest digest, find_signature calls contain duplicates.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
