### PR TITLE
fix(ROK-1335): specify build type in update-package-collection

### DIFF
--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -269,13 +269,16 @@ spec:
             commit_hash=$(jq -r '.source.git.revision' <<< "$component_json")
             commit_url="git+$git_url#$commit_hash"
             user_name=$(echo "$PRINCIPAL" | cut -d'@' -f1)
+            # List draft builds after import, list normal builds after promote
+            [[ "$PUSH_TYPE" == "import" && "$KOJI_IMPORT_DRAFT" != "false" ]] && draft=True || draft=False
 
             builds=$(koji-cmd call --json-output listBuilds \
                 userID="$user_name" \
                 state=1 \
-                source="$commit_url")
+                source="$commit_url" \
+                draft="$draft")
 
-            if [[ -z "$builds" || "$builds" == null ]]; then
+            if [[ -z "$builds" || "$builds" == null || "$builds" == "[]" ]]; then
                 log_error "No builds found for component"
                 return 1
             fi


### PR DESCRIPTION
## Describe your changes

In `push-rpm-to-koji` pipeline, the task is run after `promote-koji-draft-build` which promotes the build, i.e. makes it draft=False.

Previously, the `update-package-collection` task ran after promotion failed because of no draft build available.
This was improved in 07c0dde but we can still do better, i.e. specify whether we want a draft build or not.
We want to list draft builds only after 'import' and list normal builds after 'promote'.

## Relevant Jira

https://issues.redhat.com/browse/ROK-1335

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
