### PR TITLE
fix(RELEASE-2051): push-artifacts-to-cdn needs pubmapfile support

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -231,6 +231,15 @@ spec:
             # Use component.name for directory isolation
             COMPONENT_NAME=$(jq -er '.name' <<< "${COMPONENT}") \
                   || (echo "Component ${COMPONENT_NUM} is missing 'name'" >&2 && exit 1 )
+            
+            # Check if component has files or staged.files - skip if neither exists
+            NUM_FILES=$(jq '.files | length // 0' <<< "${COMPONENT}")
+            NUM_STAGED_FILES=$(jq '.staged.files | length // 0' <<< "${COMPONENT}")
+            if [ "$NUM_FILES" -eq 0 ] && [ "$NUM_STAGED_FILES" -eq 0 ]; then
+              echo "Skipping component '${COMPONENT_NAME}' - no files defined (not a binary artifact component)"
+              return 0
+            fi
+            
             PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}") \
                   || (echo "Component ${COMPONENT_NAME} is missing 'containerImage'" >&2 && exit 1 )
             DESTINATION="${CONTENT_DIR}/${COMPONENT_NAME}"
@@ -250,7 +259,9 @@ spec:
 
             cd "$TMP_DIR"
 
-            # Determine which directories to extract from source paths in files or staged.files
+            # Build list of specific files to extract from files[] and staged.files[]
+            # We only want files explicitly listed in the RPA, not everything in the container
+            WANTED_FILES=()
             EXTRACT_DIRS=()
 
             # Check .files[].source paths
@@ -258,7 +269,9 @@ spec:
             for ((i = 0; i < NUM_FILES; i++)); do
                 SOURCE_PATH=$(jq -r --arg i "$i" '.files[$i|tonumber].source // empty' <<< "${COMPONENT}")
                 if [ -n "$SOURCE_PATH" ]; then
-                    # Extract directory part (e.g., "/releases/file.gz" -> "releases")
+                    # Store the full path (without leading /) for extraction
+                    WANTED_FILES+=("${SOURCE_PATH#/}")
+                    # Extract directory part for tar extraction
                     DIR_PATH=$(dirname "$SOURCE_PATH" | sed 's|^/||')
                     if [ "$DIR_PATH" != "." ] && [ -n "$DIR_PATH" ]; then
                         EXTRACT_DIRS+=("$DIR_PATH")
@@ -271,7 +284,9 @@ spec:
             for ((i = 0; i < NUM_STAGED_FILES; i++)); do
                 SOURCE_PATH=$(jq -r --arg i "$i" '.staged.files[$i|tonumber].source // empty' <<< "${COMPONENT}")
                 if [ -n "$SOURCE_PATH" ]; then
-                    # Extract directory part (e.g., "/releases/file.gz" -> "releases")
+                    # Store the full path (without leading /) for extraction
+                    WANTED_FILES+=("${SOURCE_PATH#/}")
+                    # Extract directory part for tar extraction
                     DIR_PATH=$(dirname "$SOURCE_PATH" | sed 's|^/||')
                     if [ "$DIR_PATH" != "." ] && [ -n "$DIR_PATH" ]; then
                         EXTRACT_DIRS+=("$DIR_PATH")
@@ -284,9 +299,13 @@ spec:
                 EXTRACT_DIRS=("releases")
             fi
 
-            # Remove duplicates and extract each unique directory
+            # Remove duplicates
             mapfile -t UNIQUE_DIRS < <(printf "%s\n" "${EXTRACT_DIRS[@]}" | sort -u)
+            mapfile -t UNIQUE_FILES < <(printf "%s\n" "${WANTED_FILES[@]}" | sort -u)
 
+            echo "Files to extract from RPA: ${UNIQUE_FILES[*]}"
+
+            # Extract the directories from container layers
             for IMAGE_PATH in "${UNIQUE_DIRS[@]}"; do
                 echo "Looking for directory: $IMAGE_PATH"
                 for DIGEST in $(jq -r ".layers[].digest" manifest.json); do
@@ -299,10 +318,14 @@ spec:
                         echo "skipping $FILE. It doesn't contain the $IMAGE_PATH dir"
                     fi
                 done
+            done
 
-                # Copy extracted files directly to destination (flattened like extract-binaries-from-image)
-                if [ -d "$IMAGE_PATH" ]; then
-                    cp "$IMAGE_PATH"/* "$DESTINATION"/ 2>/dev/null || echo "No files found in $IMAGE_PATH directory"
+            # Copy ONLY files explicitly listed in the RPA (not all files from the directory)
+            for wanted_file in "${UNIQUE_FILES[@]}"; do
+                if [ -f "$wanted_file" ]; then
+                    cp "$wanted_file" "$DESTINATION"/
+                else
+                    echo "Warning: Expected file not found in container: $wanted_file"
                 fi
             done
 
@@ -433,6 +456,15 @@ spec:
           COMPONENT_NAME=$(jq -r '.name' <<< "$COMPONENT")
           
           echo "Processing component: $COMPONENT_NAME"
+          
+          # Skip components without files or staged.files (not binary artifact components)
+          NUM_FILES=$(jq '.files | length // 0' <<< "$COMPONENT")
+          NUM_STAGED_FILES=$(jq '.staged.files | length // 0' <<< "$COMPONENT")
+          if [ "$NUM_FILES" -eq 0 ] && [ "$NUM_STAGED_FILES" -eq 0 ]; then
+            echo "Skipping component '$COMPONENT_NAME' - no files or staged.files defined"
+            continue
+          fi
+          
           COMPONENT_DIR="$CONTENT_DIR/$COMPONENT_NAME"
           UNSIGNED_DIR="$COMPONENT_DIR/unsigned"
           MAC_CONTENT="$UNSIGNED_DIR/macos"
@@ -445,6 +477,7 @@ spec:
           [ -f "$COMPONENT_DIR/has_linux" ] && mkdir -p "$LINUX_CONTENT"
 
           # First unpack all archives in place (removing the archives)
+          # Note: The || true prevents the while loop's exit code (1 from read at EOF) from triggering set -e
           find "$COMPONENT_DIR" -maxdepth 1 -type f -iregex ".*\.zip\|.*\.gz" 2>/dev/null | while read -r file; do
             dir=$(dirname "$file")
             case "$file" in
@@ -458,11 +491,12 @@ spec:
                 unzip "$file" -d "$dir" && rm "$file"
                 ;;
             esac
-          done
+          done || true
 
           # Then move unpacked files to appropriate directories based on OS
           # Note: Skip has_* flag files - they must stay in the component root directory
           # Only move files if the target directory exists (i.e., that OS type is configured in RPA)
+          # Note: The || true at the end prevents the while loop's exit code from triggering set -e
           find "$COMPONENT_DIR" -maxdepth 1 -type f 2>/dev/null | while read -r file; do
             case "$file" in
               (*/has_mac)
@@ -484,32 +518,33 @@ spec:
                 [ -d "$LINUX_CONTENT" ] && mv "$file" "$LINUX_CONTENT/"
                 ;;
             esac
-          done
+          done || true
 
-          # Push unsigned content for this component
-          cd "$UNSIGNED_DIR"
-
+          # Push unsigned Mac content
           if [ -f "$COMPONENT_DIR/has_mac" ]; then
+            pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Macos content for $COMPONENT_NAME to $(params.quayURL)..."
             output=$(oras push "$(params.quayURL)/${COMPONENT_NAME}/unsigned" macos)
             mac_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME mac content: $mac_digest"
             echo -n "$mac_digest" > "$COMPONENT_DIR/unsigned_mac_digest.txt"
+            popd > /dev/null
           else
             echo "No macOS content for $COMPONENT_NAME, skipping unsigned push..."
           fi
 
+          # Push unsigned Windows content
           if [ -f "$COMPONENT_DIR/has_windows" ]; then
+            pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Windows content for $COMPONENT_NAME to $(params.quayURL)..."
             output=$(oras push "$(params.quayURL)/${COMPONENT_NAME}/unsigned" windows)
             windows_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME windows content: $windows_digest"
             echo -n "$windows_digest" > "$COMPONENT_DIR/unsigned_windows_digest.txt"
+            popd > /dev/null
           else
             echo "No Windows content for $COMPONENT_NAME, skipping unsigned push..."
           fi
-
-          cd "$CONTENT_DIR"
         done
     - name: sign-mac-binaries
       image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -1119,101 +1119,122 @@ spec:
           # Per-component directories
           COMPONENT_DIR="$CONTENT_DIR/$COMPONENT_NAME"
           SIGNED_DIR="$COMPONENT_DIR/signed"
-          COMPRESSED_DIR="$COMPONENT_DIR/compressed"
+          READY_FOR_DIST_DIR="$COMPONENT_DIR/ready_for_distribution"
           
-          mkdir -p "$COMPRESSED_DIR"
+          mkdir -p "$READY_FOR_DIST_DIR"
           echo "Compressing artifacts for component: $COMPONENT_NAME"
 
-          NUM_MAPPED_FILES=$(jq '.files | length' <<< "${COMPONENT_JSON}")
-          UPDATED_FILES="[]"
-
-          for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
-            FILE=$(jq -c --arg i "$i" '.files[$i|tonumber]' <<< "$COMPONENT_JSON")
+          # Helper function to compress a single file entry
+          # Args: $1 = FILE JSON, $2 = "files" or "staged" (for logging)
+          compress_file_entry() {
+            local FILE="$1"
+            local ARRAY_NAME="$2"
+            local SOURCE
             if ! SOURCE=$(jq -er '.source' <<< "$FILE" 2>/dev/null); then
-              echo "Missing files.source for component." >&2
-              exit 1
+              echo "Missing source in ${ARRAY_NAME} for component." >&2
+              return 1
             fi
             # Extract just the filename from the source path (remove /releases/ prefix)
+            local SOURCE_FILENAME
             SOURCE_FILENAME=$(basename "$SOURCE")
+            local DELIVERY_FORMAT
             DELIVERY_FORMAT=$(jq -r '.delivery_format // ["compressed"] | sort | .[]' <<< "$FILE")
-
-            # Track actual filenames created for this file entry
-            ACTUAL_FILES="[]"
 
             for FORMAT in $DELIVERY_FORMAT; do
               if [ "$FORMAT" = "compressed" ]; then
                 case "${SOURCE}" in
                   (*darwin*)
-                    # Archive the signed macos binaries (if macos content exists)
                     if [ -d "${SIGNED_DIR}/macos" ]; then
-                      tar -czf "${COMPRESSED_DIR}/${SOURCE_FILENAME}" -C "${SIGNED_DIR}" macos
-                      # Add file to actual files (filename derived from source)
-                      ACTUAL_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$ACTUAL_FILES")
-                    else
-                      echo "No macos directory found, skipping darwin archive"
+                      # Skip if already created
+                      if [ ! -f "${READY_FOR_DIST_DIR}/${SOURCE_FILENAME}" ]; then
+                        tar -czf "${READY_FOR_DIST_DIR}/${SOURCE_FILENAME}" -C "${SIGNED_DIR}" macos
+                        echo "  Created (${ARRAY_NAME}): ${SOURCE_FILENAME}"
+                      fi
                     fi
                     ;;
                   (*linux*)
-                    # Archive the linux binaries (if linux content exists)
                     if [ -d "${SIGNED_DIR}/linux" ]; then
-                      tar -czf "${COMPRESSED_DIR}/${SOURCE_FILENAME}" -C "${SIGNED_DIR}" linux
-                      # Add file to actual files (filename derived from source)
-                      ACTUAL_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$ACTUAL_FILES")
-                    else
-                      echo "No linux directory found, skipping linux archive"
+                      if [ ! -f "${READY_FOR_DIST_DIR}/${SOURCE_FILENAME}" ]; then
+                        tar -czf "${READY_FOR_DIST_DIR}/${SOURCE_FILENAME}" -C "${SIGNED_DIR}" linux
+                        echo "  Created (${ARRAY_NAME}): ${SOURCE_FILENAME}"
+                      fi
                     fi
                     ;;
                   (*windows*)
-                    # Archive the signed windows binaries (if windows content exists)
                     if [ -d "${SIGNED_DIR}/windows" ]; then
-                      WINDOWS_FILENAME="${SOURCE_FILENAME%.tar.gz}.zip"
-                      (cd "${SIGNED_DIR}" && zip -r "${COMPRESSED_DIR}/${WINDOWS_FILENAME}" windows)
-                      # Add file with updated source path (.zip instead of .tar.gz)
-                      WINDOWS_SOURCE="${SOURCE%.tar.gz}.zip"
-                      ACTUAL_FILES=$(jq --arg src "$WINDOWS_SOURCE" --argjson file "$FILE" \
-                        '. + [($file | .source = $src)]' <<< "$ACTUAL_FILES")
-                    else
-                      echo "No windows directory found, skipping windows archive"
+                      local WINDOWS_FILENAME="${SOURCE_FILENAME%.tar.gz}.zip"
+                      if [ ! -f "${READY_FOR_DIST_DIR}/${WINDOWS_FILENAME}" ]; then
+                        (cd "${SIGNED_DIR}" && zip -r "${READY_FOR_DIST_DIR}/${WINDOWS_FILENAME}" windows)
+                        echo "  Created (${ARRAY_NAME}): ${WINDOWS_FILENAME}"
+                      fi
                     fi
                     ;;
                 esac
               fi
 
-              # if "raw" is listed in the delivery_mode, copy the specific platform's raw files
               if [ "$FORMAT" = "raw" ]; then
                 case "${SOURCE}" in
                   (*darwin*)
                     if [ -d "${SIGNED_DIR}/macos" ]; then
-                      find "${SIGNED_DIR}/macos" -type f -exec cp "{}" "${COMPRESSED_DIR}/" \;
-                      ACTUAL_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$ACTUAL_FILES")
+                      find "${SIGNED_DIR}/macos" -type f -exec cp -n "{}" "${READY_FOR_DIST_DIR}/" \;
                     fi
                     ;;
                   (*linux*)
                     if [ -d "${SIGNED_DIR}/linux" ]; then
-                      find "${SIGNED_DIR}/linux" -type f -exec cp "{}" "${COMPRESSED_DIR}/" \;
-                      ACTUAL_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$ACTUAL_FILES")
+                      find "${SIGNED_DIR}/linux" -type f -exec cp -n "{}" "${READY_FOR_DIST_DIR}/" \;
                     fi
                     ;;
                   (*windows*)
                     if [ -d "${SIGNED_DIR}/windows" ]; then
-                      find "${SIGNED_DIR}/windows" -type f -exec cp "{}" "${COMPRESSED_DIR}/" \;
-                      ACTUAL_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$ACTUAL_FILES")
+                      find "${SIGNED_DIR}/windows" -type f -exec cp -n "{}" "${READY_FOR_DIST_DIR}/" \;
                     fi
                     ;;
                 esac
               fi
             done
+          }
 
-            # Add all actual files for this original file entry to the updated files list
-            UPDATED_FILES=$(jq --argjson actual_files "$ACTUAL_FILES" '. + $actual_files' <<< "$UPDATED_FILES")
-          done
+          # Process files[] array (Developer Portal files)
+          NUM_MAPPED_FILES=$(jq '.files | length // 0' <<< "${COMPONENT_JSON}")
+          UPDATED_FILES="[]"
+          
+          if [ "$NUM_MAPPED_FILES" -gt 0 ]; then
+            echo "  Processing ${NUM_MAPPED_FILES} files from files[] (Developer Portal):"
+            for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
+              FILE=$(jq -c --arg i "$i" '.files[$i|tonumber]' <<< "$COMPONENT_JSON")
+              compress_file_entry "$FILE" "files"
+              
+              # Track files for SNAPSHOT_JSON update
+              SOURCE=$(jq -er '.source' <<< "$FILE" 2>/dev/null) || continue
+              SOURCE_FILENAME=$(basename "$SOURCE")
+              if [[ "$SOURCE" == *"windows"* ]]; then
+                WINDOWS_SOURCE="${SOURCE%.tar.gz}.zip"
+                UPDATED_FILES=$(jq --arg src "$WINDOWS_SOURCE" --argjson file "$FILE" \
+                  '. + [($file | .source = $src)]' <<< "$UPDATED_FILES")
+              else
+                UPDATED_FILES=$(jq --argjson file "$FILE" '. + [$file]' <<< "$UPDATED_FILES")
+              fi
+            done
+          fi
 
-          # Copy checksum files to compressed directory
-          cp "${SIGNED_DIR}/sha256sum.txt" "${COMPRESSED_DIR}/" 2>/dev/null || true
-          cp "${SIGNED_DIR}/sha256sum.txt.sig" "${COMPRESSED_DIR}/" 2>/dev/null || true
-          cp "${SIGNED_DIR}/sha256sum.txt.gpg" "${COMPRESSED_DIR}/" 2>/dev/null || true
+          # Process staged.files[] array (Customer Portal files)
+          # These may be different files than files[], need separate compression
+          NUM_STAGED_FILES=$(jq '.staged.files | length // 0' <<< "${COMPONENT_JSON}")
+          
+          if [ "$NUM_STAGED_FILES" -gt 0 ]; then
+            echo "  Processing ${NUM_STAGED_FILES} files from staged.files[] (Customer Portal):"
+            for ((i = 0; i < NUM_STAGED_FILES; i++)) ; do
+              FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT_JSON")
+              compress_file_entry "$FILE" "staged.files"
+            done
+          fi
 
-          # Update the component in SNAPSHOT_JSON with the corrected filenames
+          # Copy checksum files to ready_for_distribution directory (for Developer Portal)
+          cp "${SIGNED_DIR}/sha256sum.txt" "${READY_FOR_DIST_DIR}/" 2>/dev/null || true
+          cp "${SIGNED_DIR}/sha256sum.txt.sig" "${READY_FOR_DIST_DIR}/" 2>/dev/null || true
+          cp "${SIGNED_DIR}/sha256sum.txt.gpg" "${READY_FOR_DIST_DIR}/" 2>/dev/null || true
+
+          # Update the component in SNAPSHOT_JSON with the corrected filenames (for files[] array)
           SNAPSHOT_JSON=$(jq --arg name "$COMPONENT_NAME" --argjson updated_files "$UPDATED_FILES" '
             .components |= map(
               if .name == $name then
@@ -1361,8 +1382,8 @@ spec:
 
         CONTENT_DIR="/shared/artifacts"
 
-        # save the results - list all files from all component compressed directories
-        find "${CONTENT_DIR}"/*/compressed -type f -exec basename {} \; 2>/dev/null \
+        # save the results - list all files from all component ready_for_distribution directories
+        find "${CONTENT_DIR}"/*/ready_for_distribution -type f -exec basename {} \; 2>/dev/null \
           | tail -c 512 | tee "$(results.publishedFiles.path)"
 
         create_exodus_conf() {
@@ -1385,7 +1406,7 @@ spec:
 
         push_component_to_pulp() {
           local component_name=$1
-          local component_dir="${CONTENT_DIR}/${component_name}/compressed"
+          local component_dir="${CONTENT_DIR}/${component_name}/ready_for_distribution"
           
           # Get version and destination from the component's staged config
           version=$(jq -cr --arg name "$component_name" '
@@ -1403,8 +1424,53 @@ spec:
           fi
 
           echo "Pushing component $component_name to customer portal with pulp"
-          cd "$component_dir"
           
+          # Create proper directory structure for Pulp with the destination (pulp repo) path
+          # The relative_path in staged.yaml must include the pulp repo name for content
+          # to be properly mapped and exposed via repo notes on the Customer Portal
+          staging_dir=$(mktemp -d)
+          mkdir -p "${staging_dir}/${staged_destination}/FILES"
+          
+          # Get the list of files to include from RPA - Customer Portal uses staged.files ONLY
+          # Checksums go to Developer Portal automatically but NOT to Customer Portal unless listed
+          COMPONENT_JSON=$(jq -c --arg name "$component_name" '
+            .components[] | select(.name == $name)
+          ' <<< "$SNAPSHOT_JSON")
+          
+          # Customer Portal requires staged.files - it's separate from the files array
+          NUM_STAGED_FILES=$(jq '.staged.files | length // 0' <<< "$COMPONENT_JSON")
+          if [[ "$NUM_STAGED_FILES" -eq 0 ]]; then
+            echo "Warning: No staged.files specified in RPA for Customer Portal push" >&2
+            echo "  Customer Portal requires explicit staged.files array" >&2
+            rm -rf "$staging_dir"
+            return 0
+          fi
+          
+          # Copy only the files listed in staged.files to the staging directory
+          for ((i = 0; i < NUM_STAGED_FILES; i++)); do
+            source_path=$(jq -r --arg i "$i" '.staged.files[$i|tonumber].source // empty' <<< "$COMPONENT_JSON")
+            if [[ -n "$source_path" ]]; then
+              # Get the filename from source path (basename)
+              filename=$(basename "$source_path")
+              # Handle windows files that may have been converted from .tar.gz to .zip
+              if [[ "$filename" == *"windows"* && "$filename" == *.tar.gz ]]; then
+                zip_filename="${filename%.tar.gz}.zip"
+                if [[ -f "$component_dir/$zip_filename" ]]; then
+                  filename="$zip_filename"
+                fi
+              fi
+              if [[ -f "$component_dir/$filename" ]]; then
+                cp "$component_dir/$filename" "${staging_dir}/${staged_destination}/FILES/"
+                echo "  Including file for Customer Portal: $filename"
+              else
+                echo "  Warning: File not found: $filename" >&2
+              fi
+            fi
+          done
+          
+          cd "$staging_dir"
+          
+          # Generate staged.yaml only for files that were copied
           staged_json='{"header":{"version": "0.2"},"payload":{"files":[]}}'
           # shellcheck disable=SC2035
           while IFS= read -r -d '' file ; do
@@ -1415,16 +1481,24 @@ spec:
           done < <(find * -type f -print0)
           echo "$staged_json" | yq -P -I 4 > staged.yaml
 
-          pulp_push_wrapper --debug --source "$component_dir" --pulp-url "$PULP_URL" \
+          # TODO: Remove this debug output after testing
+          echo "=== staging directory contents ==="
+          find "$staging_dir" -type f | sort
+          echo "=== staged.yaml contents ==="
+          cat staged.yaml
+          echo "=== end debug output ==="
+
+          # TODO: Remove --dry-run after testing
+          pulp_push_wrapper --debug --dry-run --source "$staging_dir" --pulp-url "$PULP_URL" \
             --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL"
 
-          rm -f staged.yaml
+          rm -rf "$staging_dir"
           cd "$CONTENT_DIR"
         }
 
         push_component_to_cdn() {
           local component_name=$1
-          local component_dir="${CONTENT_DIR}/${component_name}/compressed"
+          local component_dir="${CONTENT_DIR}/${component_name}/ready_for_distribution"
           
           echo "Pushing component $component_name to CDN with exodus-rsync"
           create_exodus_conf
@@ -1446,7 +1520,7 @@ spec:
 
         publish_component_to_cgw() {
           local component_name=$1
-          local component_dir="${CONTENT_DIR}/${component_name}/compressed"
+          local component_dir="${CONTENT_DIR}/${component_name}/ready_for_distribution"
           
           # Update contentDir for this component in SNAPSHOT_JSON
           SNAPSHOT_JSON=$(

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -88,6 +88,12 @@ EOF
             create_mock_tgz "testproduct3-binary-windows-amd64.tar.gz"
             create_mock_tgz "testproduct3-binary-darwin-amd64.tar.gz"
             create_mock_tgz "testproduct3-binary-linux-amd64.tar.gz"
+        elif [[ "$*" =~ extrafiles999 ]]; then
+            # Test component with extra files in container not in RPA
+            # The RPA will only list linux, but container has all three
+            create_mock_tgz "extrafiles-binary-windows-amd64.tar.gz"
+            create_mock_tgz "extrafiles-binary-darwin-amd64.tar.gz"
+            create_mock_tgz "extrafiles-binary-linux-amd64.tar.gz"
         else
             # Default test component (abcdef12345 or any other SHA)
             create_mock_tgz "testproduct-binary-windows-amd64.tar.gz"

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-extra-files-in-container
+spec:
+  description: |
+    Test that only files listed in the RPA are extracted from the container.
+    The container has windows, darwin, and linux files, but the RPA only lists linux.
+    Windows and darwin files should NOT be extracted or processed.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {
+              "application": "extra-files-test",
+              "artifacts": {},
+              "components": [
+                {
+                  "containerImage": "quay.io/org/tenant/test@sha256:extrafiles999",
+                  "contentGateway": {
+                    "productCode": "Code",
+                    "productName": "ExtraFilesTest",
+                    "productVersionName": "1.0-staging"
+                  },
+                  "name": "extrafiles",
+                  "staged": {
+                    "destination": "extrafiles-amd64",
+                    "version": "1.0"
+                  },
+                  "files": [
+                    {
+                      "filename": "extrafiles-binary-linux-amd64.tar.gz",
+                      "source": "/releases/extrafiles-binary-linux-amd64.tar.gz",
+                      "os": "linux"
+                    }
+                  ]
+                }
+              ]
+            }
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+        - name: author
+          value: testuser
+        - name: signingKeyName
+          value: testkey
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # The task should succeed - only linux files were in RPA
+              # Windows and darwin files in container should have been ignored
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                echo "Result was: $(params.result)"
+                exit 1
+              fi
+
+              echo "Test passed: Task succeeded with only RPA-listed files extracted"

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-skip-no-files-component
+spec:
+  description: |
+    Test that components without files or staged.files are skipped gracefully.
+    This simulates a snapshot with an operator image (no files array) alongside
+    a binary component (has files array). The task should skip the operator
+    and only process the binary component.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {
+              "application": "mixed-components-test",
+              "artifacts": {},
+              "components": [
+                {
+                  "containerImage": "quay.io/org/tenant/operator@sha256:operatoronly123",
+                  "name": "operator-component",
+                  "source": {
+                    "git": {
+                      "url": "https://github.com/example/operator.git",
+                      "revision": "main"
+                    }
+                  }
+                },
+                {
+                  "containerImage": "quay.io/org/tenant/test@sha256:abcdef12345",
+                  "contentGateway": {
+                    "productCode": "Code",
+                    "productName": "BinaryProduct",
+                    "productVersionName": "1.0-staging"
+                  },
+                  "name": "testproduct",
+                  "staged": {
+                    "destination": "testproduct-amd64",
+                    "version": "1.0"
+                  },
+                  "files": [
+                    {
+                      "filename": "testproduct-binary-linux-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-linux-amd64.tar.gz",
+                      "os": "linux"
+                    },
+                    {
+                      "filename": "testproduct-binary-darwin-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-darwin-amd64.tar.gz",
+                      "os": "darwin"
+                    },
+                    {
+                      "filename": "testproduct-binary-windows-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-windows-amd64.tar.gz",
+                      "os": "windows"
+                    }
+                  ]
+                }
+              ]
+            }
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+        - name: author
+          value: testuser
+        - name: signingKeyName
+          value: testkey
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # The task should succeed - operator component should be skipped,
+              # binary component should be processed normally
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                echo "Result was: $(params.result)"
+                exit 1
+              fi
+
+              echo "Test passed: Task succeeded, skipping component without files"


### PR DESCRIPTION
This change copies the logic from the disk-image pipeline that uses this same pub script.

It will be expected still that the customer portal files are configured in the RPA with staged.destination field.

Code assisted with Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
