### PR TITLE
feat(RELEASE-1001): update MintMaker utils image rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,11 +101,14 @@ Before a pull request can be merged:
 ### Image References
 
 Most tasks in this repo use the release-service-utils image defined in [the release-service-utils repo](https://github.com/konflux-ci/release-service-utils).
-When referencing this image, the url should be `quay.io/konflux-ci/release-service-utils:$tag` where `$tag` is the Git SHA based tag.
+When referencing this image, the image URL must be in digest form, for example: `quay.io/konflux-ci/release-service-utils@sha256:...`, where `sha256:...` is the image digest.
 
-For other images, the reference should always either specify an image by a non-moving tag (e.g. `registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881`)
-or by its digest (e.g. `registry.access.redhat.com/ubi8/ubi@sha256:c94bc309b197f9fc465052123ead92bf50799ba72055bd040477ded`).
-Floating tags like `latest` or `8.8` in the case of the ubi image should be avoided.
+This repo uses [MintMaker](https://konflux-ci.dev/docs/mintmaker/user/) to automatically update images referenced in tasks, stepactions, and pipelines. The MintMaker configuration is defined in [renovate.json](renovate.json).
+
+All other images should be referenced the same way as the release-service-utils image, by digest. For example:
+`registry.access.redhat.com/ubi8/ubi@sha256:c94bc309b197f9fc465052123ead92bf50799ba72055bd040477ded` This allows MintMaker to 
+automatically manage and update image versions. When adding a new image, you must also add it to the MintMaker configuration
+in `renovate.json` so it can be updated automatically.
 
 ### Compute Resources
 

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -221,7 +221,7 @@ spec:
               optional: true
         steps:
           - name: send-result-to-slack
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             volumeMounts:
               - name: slack-token
                 mountPath: "/tmp/secrets"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,44 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "rebaseWhen": "behind-base-branch",
   "tekton": {
-    "schedule": ["* 0 * * *"]
+    "schedule": ["* 0 * * *"],
+    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
+    "packageRules": [
+      {
+        "description": "Enable utils image updates for tekton tasks",
+        "schedule": ["* 5-9 * * *"],
+        "matchDepTypes": ["tekton-step-image"],
+        "matchPackageNames": [
+          "quay.io/konflux-ci/release-service-utils",
+          "quay.io/conforma/cli",
+          "quay.io/konflux-ci/appstudio-utils",
+          "quay.io/konflux-ci/charon",
+          "amazon/aws-cli"
+        ],
+        "matchFileNames": [
+          "tasks/**"
+        ]
+      },
+      {
+        "description": "Enable utils image updates for tekton pipelines",
+        "schedule": ["* 5-9 * * *"],
+        "matchDepTypes": ["tekton-step-image"],
+        "matchPackageNames": [
+          "quay.io/konflux-ci/release-service-utils"
+        ]
+      }
+    ]
+  },
+  "kubernetes": {
+    "managerFilePatterns": ["stepactions/**/*.yaml"],
+    "packageRules": [
+      {
+        "description": "Enable build-trusted-artifacts image updates in StepActions",
+        "schedule": ["* 5-9 * * *"],
+        "matchDatasources": ["docker"],
+        "matchPackageNames": ["quay.io/redhat-appstudio/build-trusted-artifacts"]
+      }
+    ]
   }
 }

--- a/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
@@ -73,7 +73,7 @@ spec:
         readOnly: true
   steps:
     - name: collect-collectors-resources
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       env:
         - name: "PREVIOUS_RELEASE"
           value: '$(params.previousRelease)'

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-empty-previous-release-value.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-empty-previous-release-value.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -90,7 +90,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -103,7 +103,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data-fail-missing-cr.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -68,7 +68,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data.yaml
+++ b/tasks/collectors/collect-collectors-resources/tests/test-collect-collectors-data.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -101,7 +101,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -124,7 +124,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -61,7 +61,7 @@ spec:
         readOnly: true
   steps:
     - name: run-collectors
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       script: |
         #!/usr/bin/env bash
         set -xeo pipefail

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-fail-timeout.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-fail-timeout.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-no-resource.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-no-resource.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/run-collectors/tests/test-run-collectors-parallel.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors-parallel.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -89,7 +89,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/run-collectors/tests/test-run-collectors.yaml
+++ b/tasks/collectors/run-collectors/tests/test-run-collectors.yaml
@@ -13,7 +13,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -88,7 +88,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/collectors/save-collectors-results/save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/save-collectors-results.yaml
@@ -52,7 +52,7 @@ spec:
         readOnly: true
   steps:
     - name: save-collectors-results
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-file-not-json.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-multiple-result-files.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -81,7 +81,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-no-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-nonexistent-status-field.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -62,7 +62,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-not-valid-name.yaml
@@ -15,7 +15,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -63,7 +63,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -83,7 +83,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results-resource-nonexistent.yaml
@@ -16,7 +16,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/collectors/save-collectors-results/tests/test-save-collectors-results.yaml
+++ b/tasks/collectors/save-collectors-results/tests/test-save-collectors-results.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -52,7 +52,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-embargoed-cve.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-access-cve.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
+++ b/tasks/internal/check-embargoed-cves-task/tests/test-check-embargoed-cves-task-no-embargo.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c9eaaf83f50b44697b08a491e815db64ad6148d8
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -73,7 +73,7 @@ spec:
         readOnly: true
   steps:
     - name: check-opt-in
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
@@ -37,7 +37,7 @@ spec:
         optional: false
   steps:
     - name: check-certificates
-      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
+++ b/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
@@ -44,7 +44,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: collect-blob-signing-params
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/internal/collect-blob-signing-params/tests/test-collect-blob-signing-params.yaml
+++ b/tasks/internal/collect-blob-signing-params/tests/test-collect-blob-signing-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -106,7 +106,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "sig_key_name"
                 value: '$(params.sig_key_name)'

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -68,7 +68,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: collect-simple-signing-params
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/internal/collect-simple-signing-params/tests/test-collect-multiple-signing-keys.yaml
+++ b/tasks/internal/collect-simple-signing-params/tests/test-collect-multiple-signing-keys.yaml
@@ -19,7 +19,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:a5072c6da901bc9cf4d767da82e700784c7df981
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "sig_key_names"
                 value: '$(params.sig_key_names)'

--- a/tasks/internal/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/tests/test-collect-simple-signing-params.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "sig_key_names"
                 value: '$(params.sig_key_names)'

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -62,7 +62,7 @@ spec:
 
   steps:
     - name: create-advisory-oci-artifact
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/tests/test-create-advisory-oci-artifact-task.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -86,7 +86,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
@@ -65,7 +65,7 @@ spec:
             type: string
         steps:
           - name: verify-latest-advisory-returned
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-jsonschema.yaml
@@ -54,7 +54,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -66,7 +66,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: filter-images
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-all-components-released.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-all-components-released.yaml
@@ -46,7 +46,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images-multi-arch.yaml
@@ -45,7 +45,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -39,7 +39,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -38,7 +38,7 @@ spec:
             type: string
         steps:
           - name: validate
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -57,7 +57,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -37,7 +37,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
@@ -16,7 +16,7 @@ spec:
             type: string
         steps:
           - name: record-time
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
@@ -17,7 +17,7 @@ spec:
             type: string
         steps:
           - name: record-time
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -89,7 +89,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -139,7 +139,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-error.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -86,7 +86,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: fileUpdatesInfo
                 value: "$(params.fileUpdatesInfo)"
@@ -114,7 +114,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -89,7 +89,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-missing-file.yaml
@@ -20,7 +20,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -81,7 +81,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-success-one-error.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -88,7 +88,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             env:
@@ -118,7 +118,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -89,7 +89,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -132,7 +132,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed-error.yaml
@@ -20,7 +20,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -68,7 +68,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -19,7 +19,7 @@ spec:
           - name: pipeline
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -112,7 +112,7 @@ spec:
             type: string
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -64,7 +64,7 @@ spec:
       securityContext:
         runAsUser: 1001
       image: >-
-        quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
@@ -29,7 +29,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-registry-proxy.yaml
@@ -30,7 +30,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
@@ -29,7 +29,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -86,7 +86,7 @@ spec:
 
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -168,7 +168,7 @@ spec:
 
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       securityContext:
         runAsUser: 1001
       computeResources:
@@ -391,7 +391,7 @@ spec:
           fi
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi
@@ -547,7 +547,7 @@ spec:
           fi
         done
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi
@@ -715,7 +715,7 @@ spec:
           ssh "${SSH_OPTS[@]}" "${MAC_USER}@${MAC_HOST}" "rm -rf ${TEMP_DIR} ${mac_signing_script}"
         done
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi
@@ -867,7 +867,7 @@ spec:
             Remove-Item -LiteralPath ${WINDOWS_SIGNING_SCRIPT_PATH} -Force"
         done
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi
@@ -1067,7 +1067,7 @@ spec:
         done
 
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi
@@ -1234,7 +1234,7 @@ spec:
         echo "$SNAPSHOT_JSON" > /shared/snapshot.json
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
@@ -69,7 +69,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -72,7 +72,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -70,7 +70,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -108,7 +108,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -73,7 +73,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
@@ -79,7 +79,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
@@ -90,7 +90,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -77,7 +77,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:7072b5b5aa2cc0fc44baf8fb9f8e4a3540fc4fed
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -62,7 +62,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: request-advisory-oci-artifact
-      image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/request-advisory-oci-artifact/tests/test-request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/tests/test-request-advisory-oci-artifact.yaml
@@ -31,7 +31,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -43,7 +43,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -100,7 +100,7 @@ spec:
         name: request-and-upload-signature
       params:
         - name: pipeline_image
-          value: "quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: manifest_digests
           value: "sha256:0000 sha256:1111"
         - name: references
@@ -145,7 +145,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:34dd4b265f02b0890efdbc7b1be4d1187d8881f0
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -127,7 +127,7 @@ spec:
         name: request-and-upload-signature
       params:
         - name: pipeline_image
-          value: "quay.io/konflux-ci/release-service-utils:34dd4b265f02b0890efdbc7b1be4d1187d8881f0"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: manifest_digests
           value: "sha256:0000 sha256:0001"
         - name: references
@@ -178,7 +178,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:3729a54989514da6a777579feabbd9b346c73551
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failed-messages.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failed-messages.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -100,7 +100,7 @@ spec:
         name: request-and-upload-signature
       params:
         - name: pipeline_image
-          value: "quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: manifest_digests
           value: "sha256:0000 sha256:0001"
         - name: references

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failure.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-failure.yaml
@@ -20,7 +20,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -75,7 +75,7 @@ spec:
         name: request-and-upload-signature
       params:
         - name: pipeline_image
-          value: "quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: manifest_digests
           value: "sha256:0000"
         - name: references
@@ -122,7 +122,7 @@ spec:
           - name: data
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |
@@ -71,7 +71,7 @@ spec:
         name: request-and-upload-signature
       params:
         - name: pipeline_image
-          value: "quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: manifest_digests
           value: "sha256:0000"
         - name: references
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             securityContext:
               runAsUser: 1001
             script: |

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-auth-failure.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-auth-failure.yaml
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-empty-fragments-array.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-empty-fragments-array.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -x

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-index-mismatch.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-index-mismatch.yaml
@@ -41,7 +41,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -96,7 +96,7 @@ spec:
   steps:
     - name: update-fbc-catalog-prepare-and-call-iib-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       securityContext:
         runAsUser: 1001
       computeResources:
@@ -409,7 +409,7 @@ spec:
         echo "${iib_response}" | gzip -c | base64 -w0 > "$(results.jsonBuildInfo.path)"
     - name: update-fbc-catalog-wait-for-iib-build-step
       image: >-
-        quay.io/konflux-ci/release-service-utils:82012e03002128f2a226acb23dc5c6fc1c37f5b6
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -160,7 +160,7 @@ spec:
         - name: orasOptions
           value: $(params.orasOptions)
     - name: add-contribution
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
@@ -65,7 +65,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
             type: string
         steps:
           - name: check-sanitization
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -146,7 +146,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-basic.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-basic.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -133,7 +133,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-multi-components.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-multi-components.yaml
@@ -64,7 +64,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-staged-processing
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
@@ -63,7 +63,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-staged-processing
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               #
@@ -257,7 +257,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -140,7 +140,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-both.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-old.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats-old.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion-old.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:c7879b6f785da823ce1b66aba6cfd70599e35b4d
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -109,7 +109,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: base64-encode-checksum
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/tests/test-base64-encode-checksum.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -98,7 +98,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
@@ -111,7 +111,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: build-rpm-packages
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-output-path.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-output-path.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.orasOptions)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: validate-custom-path
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-incomplete-envfile.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-incomplete-envfile.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-missing-envfile.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-missing-envfile.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -109,7 +109,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-multiarch.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-multiarch.yaml
@@ -45,7 +45,7 @@ spec:
               value: 1d
         steps:
           - name: setup-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: validate-rpm
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-no-modules.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-no-modules.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -108,7 +108,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-source-integrity.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-source-integrity.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-integrity
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -151,7 +151,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -121,7 +121,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-data-keys
-      image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-false-missing-data.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-dynamic-true-missing-data.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-invalid-releasenotes-key.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-malformed-cve-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-malformed-cve-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cdn-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-intention.yaml
@@ -58,7 +58,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-schema.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-unsupported-system.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-incorrect-type-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-invalid-issues-in-releasenotes-key.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-pass-undeclared-system.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-strip-git-suffix.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:8ba7aa37b68e7a647e27e2e2456c26d29aa85b45
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -94,7 +94,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: enforce-name-label
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 100Mi
@@ -181,7 +181,7 @@ spec:
             fi
         done
     - name: enforce-cpe-label
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 100Mi

--- a/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/check-labels/tests/test-check-labels.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:1d0f44656336b012945d5f4af5e289b0dfe176ba
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -38,7 +38,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: cleanup-internal-requests
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/tests/test-cleanup-internal-requests.yaml
@@ -18,7 +18,7 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -65,7 +65,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -48,7 +48,7 @@ spec:
         readOnly: true
   steps:
     - name: cleanup
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace-internalrequests.yaml
@@ -20,7 +20,7 @@ spec:
             type: string
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -72,7 +72,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/sh
               set -ex

--- a/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/tests/test-cleanup-workspace.yaml
@@ -19,7 +19,7 @@ spec:
           - name: input
         steps:
           - name: put-content-in-workspace
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -52,7 +52,7 @@ spec:
           - name: input
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: close-issues
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-closed-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -143,7 +143,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-no-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -128,7 +128,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-atlas-params
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-bad-value.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-nonexistent.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -105,7 +105,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-prod.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage-custom-secret.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -109,7 +109,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
+++ b/tasks/managed/collect-atlas-params/tests/test-collect-atlas-params-stage.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -148,7 +148,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi
@@ -308,7 +308,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -106,7 +106,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -240,7 +240,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -233,7 +233,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -264,7 +264,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -221,7 +221,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -213,7 +213,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -232,7 +232,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -230,7 +230,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -237,7 +237,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -275,7 +275,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -121,7 +121,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-gh-params
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/tests/test-collect-gh-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -ex

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -112,7 +112,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-index-images
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -134,7 +134,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-multiple-versions.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -138,7 +138,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-single-version.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -134,7 +134,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/collect-mrrc-params.yaml
@@ -124,7 +124,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-mrrc-params
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
+++ b/tasks/managed/collect-mrrc-params/tests/test-collect-mrrc-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -182,7 +182,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -106,7 +106,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: collect-secret
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-fail-no-secret.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret-no-secret-required.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -109,7 +109,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/tests/test-collect-registry-token-secret.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -115,7 +115,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "SECRET"
                 value: '$(params.secret)'

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -127,7 +127,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-message
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params-no-secret-in-data.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -148,7 +148,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/tests/test-collect-slack-notification-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "MESSAGE"
                 value: '$(params.message)'

--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -118,7 +118,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-task-params
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-empty-keys.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-empty-keys.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-invalid-index.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-invalid-index.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-missing-resultindex.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-missing-resultindex.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-data.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-default.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-no-default.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-non-integer-index.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-non-integer-index.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-array.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-array.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-json.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params-fail-not-json.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/tests/test-collect-task-params.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -139,7 +139,7 @@ spec:
             type: string
         steps:
           - name: verify-results
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -155,7 +155,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-purl
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi
@@ -324,7 +324,7 @@ spec:
           .releaseNotes.content.artifacts = $updated
         ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-default-type.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -255,7 +255,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -234,7 +234,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -269,7 +269,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-rpa.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-rhsa-no-cve.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-fail-wrong-type.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-marketplace-skip-purl.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -269,7 +269,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -302,7 +302,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-pending-repo.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -206,7 +206,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -278,7 +278,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-prod-repo.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -295,7 +295,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -263,7 +263,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -306,7 +306,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -279,7 +279,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -360,7 +360,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -128,7 +128,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-release-from-binaries
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-exist-release.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -138,7 +138,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-github-release/tests/test-create-github-release.yaml
+++ b/tasks/managed/create-github-release/tests/test-create-github-release.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -137,7 +137,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -153,7 +153,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -194,7 +194,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -125,7 +125,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi
@@ -248,7 +248,7 @@ spec:
         fi
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -122,7 +122,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: extract-binaries-from-image
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-from-image.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components-desired-only.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -204,7 +204,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
+++ b/tasks/managed/extract-binaries-from-image/tests/test-extract-binaries-multiple-components.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -176,7 +176,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -115,7 +115,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: extract-index-image
       image: >-
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-fail-no-inputdatafile.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image-multiple-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -204,7 +204,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/tests/test-extract-index-image.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -116,7 +116,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: detect-architectures
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi
@@ -150,7 +150,7 @@ spec:
             echo "  Architecture: $platform_arch, Digest: $arch_digest"
         done
     - name: extract-kmods
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-from-image.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-from-image.yaml
@@ -42,7 +42,7 @@ spec:
             type: string
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -121,7 +121,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
@@ -42,7 +42,7 @@ spec:
             type: string
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -129,7 +129,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-multiarch-extraction
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -145,7 +145,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-advisory-fail-both-prod-and-pending.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -240,7 +240,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -353,7 +353,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -48,7 +48,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -193,7 +193,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -319,7 +319,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -51,7 +51,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -46,7 +46,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-rpa-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -46,7 +46,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-missing-snapshot-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -51,7 +51,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-skip-filter.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: create-inputs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -169,7 +169,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: verify
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
+++ b/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
@@ -103,7 +103,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: filter-already-released-images
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/filter-already-released-images/tests/test-filter-all-released.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-all-released.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-all-tags-complete.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-all-tags-complete.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-keep-no-repositories.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-keep-no-repositories.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-large-snapshot.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-large-snapshot.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -177,7 +177,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-multi-repos.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-multi-repos.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-none-released.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-none-released.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-partial-tags.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-partial-tags.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-registry-error.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-registry-error.yaml
@@ -50,7 +50,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-some-released.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-some-released.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/filter-already-released-images/tests/test-filter-wrong-digest.yaml
+++ b/tasks/managed/filter-already-released-images/tests/test-filter-wrong-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -111,7 +111,7 @@ spec:
         - name: orasOptions
           value: $(params.orasOptions)
     - name: get-ocp-version
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-docker-v2s2.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-docker-v2s2.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -140,7 +140,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-mismatch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-mismatch.yaml
@@ -43,7 +43,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -107,7 +107,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -140,7 +140,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/tests/test-get-ocp-version.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -140,7 +140,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             env:
               - name: "OCP_VERSION"
                 value: '$(params.stored-version)'

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -116,7 +116,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: make-repo-public
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
+++ b/tasks/managed/make-repo-public/tests/test-make-repo-public-fail-curl.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/make-repo-public/tests/test-make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/tests/test-make-repo-public.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -183,7 +183,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: pull-and-push-images-to-marketplaces
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-pre-push.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-pre-push.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/usr/bin/env bash

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
@@ -50,7 +50,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/usr/bin/env bash

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -127,7 +127,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-cve-issues-in-cves
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi
@@ -217,7 +217,7 @@ spec:
         fi
         exit $RC
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi
@@ -360,7 +360,7 @@ spec:
             done
         done
     - name: populate-release-notes-artifacts
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi
@@ -504,7 +504,7 @@ spec:
             fi
         done
     - name: populate-release-notes-github
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi
@@ -612,7 +612,7 @@ spec:
                 /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
         done
     - name: populate-release-notes-type-and-references
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -196,7 +196,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-added.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -209,7 +209,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-artifacts.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -229,7 +229,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-disk-images.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -258,7 +258,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -246,7 +246,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-fail-missing-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-marketplace-disk-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-marketplace-disk-images.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -233,7 +233,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/usr/bin/env bash

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-no-overwrite.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -186,7 +186,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-non-rhsa-references.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-overwrite-type.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -210,7 +210,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rhsa-references.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -179,7 +179,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-unique-tag-from-label.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-unique-tag-from-label.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
@@ -71,7 +71,7 @@ spec:
         value: $(params.trustedArtifactsDebug)
   steps:
     - name: select-artifact
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 64Mi

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -140,7 +140,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-parameters
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-failure-propagation.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-failure-propagation.yaml
@@ -56,7 +56,7 @@ spec:
             description: Location of trusted artifacts to be used to populate data directory
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-integration.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-integration.yaml
@@ -54,7 +54,7 @@ spec:
             description: Location of trusted artifacts to be used to populate data directory
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multiple-modes.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multiple-modes.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
 

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -116,7 +116,7 @@ spec:
         - name: orasOptions
           value: $(params.orasOptions)
     - name: update-snapshot
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-basic.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-basic.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-no-data.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-ocp-version-mismatch.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-hotfix.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-hotfix.yaml
@@ -68,7 +68,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-hotfix-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-hotfix
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-placeholder-replace.yaml
@@ -57,7 +57,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -184,7 +184,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-staged.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-staged.yaml
@@ -68,7 +68,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot.yaml
@@ -68,7 +68,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-test-data
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -187,7 +187,7 @@ spec:
               - name: orasOptions
                 value: $(params.orasOptions)
           - name: verify-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -46,7 +46,7 @@ spec:
   steps:
     - name: prepare-validation
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/tests/test-promote-koji-draft-build.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -150,7 +150,7 @@ spec:
         - name: pushSecret
           value: "push-koji-test"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -125,7 +125,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: publish-index-image
       image: >-
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -223,7 +223,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -152,7 +152,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: publish-pyxis-repository
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -151,7 +151,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-pyxis-repository.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-missing-snapshot.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-data-json.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-no-terms-required.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-omitted.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-omitted.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-container-true.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-multiple-components.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-source-multiple-components.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-wrong-server.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -166,7 +166,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: prepare-repo
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-charon-config.yaml
@@ -57,7 +57,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-failure-no-mrrc-file.yaml
@@ -57,7 +57,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-mount-certs.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc-mount-certs.yaml
@@ -55,7 +55,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/tests/test-publish-to-mrrc.yaml
@@ -55,7 +55,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -129,7 +129,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-ir-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-contentgateway-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-release-author.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-fail-plr-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -182,7 +182,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-production.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -211,7 +211,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -276,7 +276,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-qa.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -211,7 +211,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -270,7 +270,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results-plr.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -231,7 +231,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -249,7 +249,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-results.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -229,7 +229,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -247,7 +247,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-stage.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -211,7 +211,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -269,7 +269,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-staging-intention.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-staging-intention.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -210,7 +210,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -233,7 +233,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-artifacts-to-storage/tests/test-push-artifacts-to-storage.yaml
+++ b/tasks/managed/push-artifacts-to-storage/tests/test-push-artifacts-to-storage.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -210,7 +210,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -115,7 +115,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -203,7 +203,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-push-oot-kmods-to-azure-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-push-oot-kmods-to-azure-multiarch.yaml
@@ -22,7 +22,7 @@ spec:
             type: string
         steps:
           - name: setup-and-validate
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -86,7 +86,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-to-git
-      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git-multiarch.yaml
@@ -25,7 +25,7 @@ spec:
             type: string
         steps:
           - name: setup-and-validate
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git.yaml
@@ -24,7 +24,7 @@ spec:
             type: string
         steps:
           - name: setup-and-validate
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
@@ -22,7 +22,7 @@ spec:
             type: string
         steps:
           - name: setup-and-validate
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -127,7 +127,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: download-sbom-files
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi
@@ -299,7 +299,7 @@ spec:
         fi
     - name: push-rpm-data-to-pyxis
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-deduplication.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -223,7 +223,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-no-pyxis-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-parallel.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -195,7 +195,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-retry.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/test-push-rpm-data-to-pyxis-single-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/tests/test-push-rpm-to-koji.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -150,7 +150,7 @@ spec:
         - name: pushSecret
           value: "push-koji-test"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -208,7 +208,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -152,7 +152,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-rpms-to-pulp
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-fail-missing-creds.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -146,7 +146,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eu

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +150,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-disabled-single-component-mode.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-missing-resource.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-labels.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -154,7 +154,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -170,7 +170,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-no-namespace-parameter.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -176,7 +176,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot-wrong-component.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/tests/test-reduce-snapshot.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -173,7 +173,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 2.5Gi

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -166,7 +166,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:70be98cc78c9ef52526c4f2be437321aa943b516
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -151,7 +151,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-ir-failure.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components-multi-batch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -224,7 +224,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -297,7 +297,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -317,7 +317,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-push-source-container.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -245,7 +245,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -339,7 +339,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-arch.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -236,7 +236,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-repos.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-multi-repos.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -299,7 +299,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr-alreadysigned.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -221,7 +221,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component-plr.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -200,7 +200,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -267,7 +267,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -280,7 +280,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-timeout.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -131,7 +131,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-addons.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -ex
@@ -275,7 +275,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-first-fails.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -168,7 +168,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -ex
@@ -202,7 +202,7 @@ spec:
               test "$MR" == ""
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates-multiple-ir-last-fails.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -169,7 +169,7 @@ spec:
               name: workdir
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -ex
@@ -204,7 +204,7 @@ spec:
               test "$MR" == "https://g/r/-/merge_requests/18"
 
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/tests/test-run-file-updates.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -180,7 +180,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -ex
@@ -281,7 +281,7 @@ spec:
 
               echo "All checks passed successfully."
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: send-message
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification-no-secret.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/tests/test-send-slack-notification.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -115,7 +115,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: set-severity
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-generic-artifact.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-ir-failure.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-no-release-notes.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa-user-severity.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -131,7 +131,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-not-rhsa.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity-rhsa-no-cves.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/tests/test-set-advisory-severity.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -144,7 +144,7 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: sign-base64-blob
       image:
-        quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+        quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-corrupted.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-corrupted.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -149,7 +149,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -212,7 +212,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-idempotent.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob-idempotent.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +150,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -143,7 +143,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -197,7 +197,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -158,7 +158,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-index-image
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -208,7 +208,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-plr.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -147,7 +147,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -218,7 +218,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-plrs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-with-pullspec-rewrite.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -149,7 +149,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -188,7 +188,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -145,7 +145,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -135,7 +135,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-files
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-multiarch.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-multiarch.yaml
@@ -47,7 +47,7 @@ spec:
             type: string
         steps:
           - name: setup-and-validate
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -109,7 +109,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-array-union.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -128,7 +128,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-missing-rbac.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -119,7 +119,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-multiple-result-files.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -130,7 +130,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-overwrite.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -117,7 +117,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-no-results.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-nonexistent-status-field.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-resource-nonexistent.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-results-not-json.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -111,7 +111,7 @@ spec:
       taskSpec:
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -125,7 +125,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -112,7 +112,7 @@ spec:
         - name: sourceDataArtifacts
           value: $(params.resultArtifacts)
     - name: update-cr-status
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -134,7 +134,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: git-clone-infra-deployments
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 256Mi
@@ -151,7 +151,7 @@ spec:
         echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi
@@ -196,7 +196,7 @@ spec:
         echo "$PATCHED_SCRIPT"
         echo "$PATCHED_SCRIPT" | sh
     - name: get-diff-files
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 128Mi
@@ -212,7 +212,7 @@ spec:
         git status -s --porcelain | cut -c4- > ../updated_files.txt
     # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-pr
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/update-package-collection/tests/test-update-package-collection-after-promote.yaml
+++ b/tasks/managed/update-package-collection/tests/test-update-package-collection-after-promote.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -161,7 +161,7 @@ spec:
         - name: pushType
           value: "promote"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -225,7 +225,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/update-package-collection/tests/test-update-package-collection-after-push.yaml
+++ b/tasks/managed/update-package-collection/tests/test-update-package-collection-after-push.yaml
@@ -51,7 +51,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -161,7 +161,7 @@ spec:
         - name: pushType
           value: "import"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -225,7 +225,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/tasks/managed/update-package-collection/tests/test-update-package-collection-missing-json.yaml
+++ b/tasks/managed/update-package-collection/tests/test-update-package-collection-missing-json.yaml
@@ -54,7 +54,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               set -eux
 
@@ -117,7 +117,7 @@ spec:
         - name: pushType
           value: "import"
         - name: pipelineImage
-          value: "quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f"
+          value: "quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -126,7 +126,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -100,7 +100,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component-multiple-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/tests/test-validate-single-component.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: add-snapshot
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -107,7 +107,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-single-component
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
+++ b/tasks/managed/verify-access-to-resources/tests/test-verify-access-to-resources-permissions.yaml
@@ -11,7 +11,7 @@ spec:
       taskSpec:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -85,7 +85,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -57,7 +57,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: verify-access-to-resources
-      image: quay.io/konflux-ci/release-service-utils:02a8ddcd16113371a255fd1ef0a196399d300162
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
           memory: 100Mi


### PR DESCRIPTION
## Describe your changes
Update Renovate config to manage the following images:
* quay.io/konflux-ci/release-service-utils
* quay.io/conforma/cli
* quay.io/redhat-appstudio/build-trusted-artifacts
* quay.io/konflux-ci/appstudio-utils
* quay.io/konflux-ci/charon
* amazon/aws-cli

Paths of images to update:
* tasks/managed
* tasks/internal
* tasks/collectors
* stepActions
* integration-tests/pipelines

StepActions are currently unsupported by the tekton manager, so using the kubernetes manager as a workaround.

Each image gets its own PR, with MintMaker creating PRs between 05:00 and 09:00 UTC each day.

Testing: updating all utils images took 2h27m to complete unit tests.

## Relevant Jira
[RELEASE-1001](https://issues.redhat.com/browse/RELEASE-1001)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
