### PR TITLE
fix: add --target flag to rpmbuild for cross-arch builds

### DIFF
--- a/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
@@ -326,7 +326,8 @@ spec:
 
             # Build the RPM
             echo "Building RPM package for $arch_name..."
-            rpmbuild --define "_topdir ${RPM_BUILD_ROOT}" \
+            rpmbuild --target "${target_arch}" \
+                     --define "_topdir ${RPM_BUILD_ROOT}" \
                      --define "_sourcedir ${RPM_BUILD_ROOT}/SOURCES" \
                      -bb "${SPEC_FILE}"
 


### PR DESCRIPTION
Add --target flag to rpmbuild to enable cross-architecture RPM packaging. This fixes the "No compatible architectures found" error when building aarch64 RPMs on x86_64 hosts.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
