### PR TITLE
fix(RELEASE-2076): support '*-internal' pyxisServer

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -295,14 +295,15 @@ spec:
         # production in this task means internal instances of pyxis as the task needs to run
         # on internal cluster which doesn't have access to public pyxis instance. Same applies
         # for stage
-        if [[ "$(params.pyxisServer)" == "production" ]]
+        if [[ "$(params.pyxisServer)" == "production"  || "$(params.pyxisServer)" == "production-internal" ]]
         then
           PYXIS_GRAPHQL_URL="https://graphql.pyxis.engineering.redhat.com/graphql/"
-        elif [[ "$(params.pyxisServer)" == "stage" ]]
+        elif [[ "$(params.pyxisServer)" == "stage" || "$(params.pyxisServer)" == "stage-internal" ]]
         then
           PYXIS_GRAPHQL_URL="https://graphql.pyxis.stage.engineering.redhat.com/graphql/"
         else
-          echo "Invalid pyxisServer parameter. Only 'production' and 'stage' are allowed."
+          echo "Invalid pyxisServer parameter."
+          echo "Only 'production', 'stage', 'production-internal', 'stage-internal' are allowed."
           exit 1
         fi
         PyxisCert="$(cat "/mnt/pyxis_ssl_cert_secret/$(params.pyxis_ssl_cert_file_name)")"


### PR DESCRIPTION
Support stage-internal, prod-internal values for pyxisServer in request-and-upload-signature which were previously removed

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
