### PR TITLE
feat(RELEASE-1630): added slack notification option

### DIFF
--- a/pipelines/internal/push-artifacts-to-cdn/README.md
+++ b/pipelines/internal/push-artifacts-to-cdn/README.md
@@ -4,17 +4,19 @@ Tekton Pipeline to push artifacts to CDN and/or Dev Portal
 
 ## Parameters
 
-| Name            | Description                                                                           | Optional | Default value                                             |
-|-----------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| snapshot_json   | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
-| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
-| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
-| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
-| udcacheSecret   | Env specific secret containing the udcache credentials                                | No       | -                                                         |
-| cgwHostname     | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
-| cgwSecret       | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
-| author          | Author taken from Release to be used for checksum signing                             | No       | -                                                         |
-| signingKeyName  | signing key name to be used for checksum signing                                      | No       | -                                                         |
-| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
-| quayURL         | Quay URL of the repo where content will be shared between tasks                       | Yes      | quay.io/konflux-artifacts                                 |
+| Name                  | Description                                                                           | Optional | Default value                                             |
+|-----------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json         | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
+| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
+| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
+| pulpSecret            | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
+| udcacheSecret         | Env specific secret containing the udcache credentials                                | No       | -                                                         |
+| cgwHostname           | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
+| cgwSecret             | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
+| author                | Author taken from Release to be used for checksum signing                             | No       | -                                                         |
+| signingKeyName        | signing key name to be used for checksum signing                                      | No       | -                                                         |
+| taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision       | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+| quayURL               | Quay URL of the repo where content will be shared between tasks                       | Yes      | quay.io/konflux-artifacts                                 |
+| sendSlackNotification | Whether to send Slack notifications for certificate expiration alerts                 | Yes      | true                                                      |
+| slackWebhookUrl       | Override default Slack webhook URL for notifications (optional)                       | Yes      | ""                                                        |

--- a/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/internal/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -49,6 +49,14 @@ spec:
       description: Quay URL of the repo where content will be shared between tasks
       type: string
       default: "quay.io/konflux-artifacts"
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   tasks:
     - name: push-artifacts-to-cdn-task
       timeout: "24h00m0s"
@@ -82,6 +90,10 @@ spec:
           value: $(params.signingKeyName)
         - name: quayURL
           value: $(params.quayURL)
+        - name: sendSlackNotification
+          value: $(params.sendSlackNotification)
+        - name: slackWebhookUrl
+          value: $(params.slackWebhookUrl)
   results:
     - name: result
       value: $(tasks.push-artifacts-to-cdn-task.results.result)

--- a/pipelines/internal/push-disk-images/README.md
+++ b/pipelines/internal/push-disk-images/README.md
@@ -4,14 +4,16 @@ Tekton Pipeline to push disk images with Pulp
 
 ## Parameters
 
-| Name            | Description                                                                           | Optional | Default value                                             |
-|-----------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| snapshot_json   | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
-| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
-| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
-| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
-| udcacheSecret   | Env specific secret containing the udcache credentials                                | No       | -                                                         |
-| cgwHostname     | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
-| cgwSecret       | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
-| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+| Name                  | Description                                                                           | Optional | Default value                                             |
+|-----------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json         | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
+| exodusGwSecret        | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
+| exodusGwEnv           | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
+| pulpSecret            | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
+| udcacheSecret         | Env specific secret containing the udcache credentials                                | No       | -                                                         |
+| cgwHostname           | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
+| cgwSecret             | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
+| taskGitUrl            | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision       | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+| sendSlackNotification | Whether to send Slack notifications for certificate expiration alerts                 | Yes      | true                                                      |
+| slackWebhookUrl       | Override default Slack webhook URL for notifications (optional)                       | Yes      | ""                                                        |

--- a/pipelines/internal/push-disk-images/push-disk-images.yaml
+++ b/pipelines/internal/push-disk-images/push-disk-images.yaml
@@ -39,6 +39,14 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   tasks:
     - name: pulp-push-disk-images
       timeout: "24h00m0s"
@@ -66,6 +74,10 @@ spec:
           value: $(params.cgwHostname)
         - name: cgwSecret
           value: $(params.cgwSecret)
+        - name: sendSlackNotification
+          value: $(params.sendSlackNotification)
+        - name: slackWebhookUrl
+          value: $(params.slackWebhookUrl)
   results:
     - name: result
       value: $(tasks.pulp-push-disk-images.results.result)

--- a/pipelines/internal/simple-signing-pipeline/README.md
+++ b/pipelines/internal/simple-signing-pipeline/README.md
@@ -17,3 +17,5 @@ pipeline.
 | taskGitRevision        | The revision in the taskGitUrl repo to be used                                                                        | No       | -                                                         |
 | pyxisServer            | The server type to use. Options are 'production' and 'stage'                                                          | Yes      | production                                                |
 | certExpirationWarnDays | Number of days before expiration to warn about certificate expiration                                                 | Yes      | 7                                                         |
+| sendSlackNotification  | Whether to send Slack notifications for certificate expiration alerts                                                 | Yes      | true                                                      |
+| slackWebhookUrl        | Override default Slack webhook URL for notifications (optional)                                                       | Yes      | ""                                                        |

--- a/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -50,6 +50,14 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   workspaces:
     - name: pipeline
   tasks:
@@ -89,6 +97,10 @@ spec:
           value: $(tasks.collect-simple-signing-params.results.pyxis_ssl_cert_file_name)
         - name: certExpirationWarnDays
           value: $(params.certExpirationWarnDays)
+        - name: sendSlackNotification
+          value: $(params.sendSlackNotification)
+        - name: slackWebhookUrl
+          value: $(params.slackWebhookUrl)
       runAfter:
         - collect-simple-signing-params
     - name: request-and-upload-signature

--- a/tasks/internal/check-signing-certificates/README.md
+++ b/tasks/internal/check-signing-certificates/README.md
@@ -11,3 +11,5 @@ Tekton task to verify the expiration of signing certificates (UMB and Pyxis)
 | pyxis_ssl_cert_secret_name | Kubernetes secret name for Pyxis                                      | No       | -             |
 | pyxis_ssl_cert_file_name   | The name of the file with the Pyxis certificate in the secret         | No       | -             |
 | certExpirationWarnDays     | Number of days before expiration to warn about certificate expiration | Yes      | 7             |
+| sendSlackNotification      | Whether to send Slack notifications for certificate expiration alerts | Yes      | true          |
+| slackWebhookUrl            | Override default Slack webhook URL for notifications (optional)       | Yes      | ""            |

--- a/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
@@ -26,6 +26,14 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   volumes:
     - name: umb-ssl-cert-secret
       secret:
@@ -51,6 +59,11 @@ spec:
         - name: pyxis-ssl-cert-secret
           mountPath: /mnt/pyxis_ssl_cert_secret
           readOnly: true
+      env:
+        - name: SEND_SLACK_NOTIFICATION
+          value: "$(params.sendSlackNotification)"
+        - name: SLACK_WEBHOOK_URL
+          value: "$(params.slackWebhookUrl)"
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -60,6 +73,7 @@ spec:
         # Check UMB certificate
         UMB_CERT_FILE="/mnt/umb_ssl_cert_secret/$(params.umb_ssl_cert_file_name)"
         echo "Checking UMB certificate: ${UMB_CERT_FILE}"
+        export CERT_IDENTIFIER="UMB Certificate"
         if ! check_cert_expiration "${UMB_CERT_FILE}" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: UMB certificate validation failed"
           exit 1
@@ -69,6 +83,7 @@ spec:
         # Check Pyxis certificate
         PYXIS_CERT_FILE="/mnt/pyxis_ssl_cert_secret/$(params.pyxis_ssl_cert_file_name)"
         echo "Checking Pyxis certificate: ${PYXIS_CERT_FILE}"
+        export CERT_IDENTIFIER="Pyxis Certificate"
         if ! check_cert_expiration "${PYXIS_CERT_FILE}" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: Pyxis certificate validation failed"
           exit 1

--- a/tasks/internal/check-signing-certificates/tests/test-check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/tests/test-check-signing-certificates.yaml
@@ -21,3 +21,5 @@ spec:
           value: pyxis-ssl-cert
         - name: pyxis_ssl_cert_file_name
           value: cert
+        - name: sendSlackNotification
+          value: "false"

--- a/tasks/internal/pulp-push-disk-images/README.md
+++ b/tasks/internal/pulp-push-disk-images/README.md
@@ -17,3 +17,5 @@ Tekton task to push disk images with Pulp
 | caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
 | caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |
 | certExpirationWarnDays | Number of days before expiration to warn about certificate expiration | Yes      | 7             |
+| sendSlackNotification  | Whether to send Slack notifications for certificate expiration alerts | Yes      | true          |
+| slackWebhookUrl        | Override default Slack webhook URL for notifications (optional)       | Yes      | ""            |

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -47,6 +47,14 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -109,6 +117,10 @@ spec:
       env:
         - name: "SNAPSHOT_JSON"
           value: "$(params.snapshot_json)"
+        - name: SEND_SLACK_NOTIFICATION
+          value: "$(params.sendSlackNotification)"
+        - name: SLACK_WEBHOOK_URL
+          value: "$(params.slackWebhookUrl)"
       script: |
         #!/usr/bin/env bash
         set -e
@@ -118,6 +130,7 @@ spec:
 
         # Check Exodus Gateway certificate
         echo "Checking Exodus Gateway certificate"
+        export CERT_IDENTIFIER="Exodus Gateway Certificate"
         if ! check_cert_expiration "/mnt/exodusGwSecret/cert" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: Exodus Gateway certificate validation failed"
           exit 1
@@ -125,6 +138,7 @@ spec:
 
         # Check Pulp certificate
         echo "Checking Pulp certificate"
+        export CERT_IDENTIFIER="Pulp Certificate"
         if ! check_cert_expiration "/mnt/pulpSecret/konflux-release-rhsm-pulp.crt" \
             "$(params.certExpirationWarnDays)"; then
           echo "ERROR: Pulp certificate validation failed"
@@ -133,6 +147,7 @@ spec:
 
         # Check UDCache certificate
         echo "Checking UDCache certificate"
+        export CERT_IDENTIFIER="UDCache Certificate"
         if ! check_cert_expiration "/mnt/udcacheSecret/cert" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: UDCache certificate validation failed"
           exit 1

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -31,6 +31,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -32,6 +32,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -31,6 +31,8 @@ spec:
           value: "https://content-gateway.com"
         - name: cgwSecret
           value: "pulp-task-cgw-secret"
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/README.md
+++ b/tasks/internal/push-artifacts-to-cdn-task/README.md
@@ -34,3 +34,5 @@ data only, artifacts are pushed to the Developer Portal (exodus-rsync) and CGW.
 | caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                           | Yes      | trusted-ca                |
 | caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data           | Yes      | ca-bundle.crt             |
 | certExpirationWarnDays | Number of days before expiration to warn about certificate expiration           | Yes      | 7                         |
+| sendSlackNotification  | Whether to send Slack notifications for certificate expiration alerts           | Yes      | true                      |
+| slackWebhookUrl        | Override default Slack webhook URL for notifications (optional)                 | Yes      | ""                        |

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -97,6 +97,14 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: sendSlackNotification
+      type: string
+      description: Whether to send Slack notifications for certificate expiration alerts
+      default: "true"
+    - name: slackWebhookUrl
+      type: string
+      description: Override default Slack webhook URL for notifications (optional)
+      default: ""
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -1220,6 +1228,10 @@ spec:
       env:
         - name: "SNAPSHOT_JSON"
           value: "$(params.snapshot_json)"
+        - name: SEND_SLACK_NOTIFICATION
+          value: "$(params.sendSlackNotification)"
+        - name: SLACK_WEBHOOK_URL
+          value: "$(params.slackWebhookUrl)"
       script: |
         #!/usr/bin/env bash
         set -e
@@ -1229,6 +1241,7 @@ spec:
 
         # Check Exodus Gateway certificate
         echo "Checking Exodus Gateway certificate"
+        export CERT_IDENTIFIER="Exodus Gateway Certificate"
         if ! check_cert_expiration "/mnt/exodusGwSecret/cert" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: Exodus Gateway certificate validation failed"
           exit 1
@@ -1236,6 +1249,7 @@ spec:
 
         # Check Pulp certificate
         echo "Checking Pulp certificate"
+        export CERT_IDENTIFIER="Pulp Certificate"
         if ! check_cert_expiration "/mnt/pulpSecret/konflux-release-rhsm-pulp.crt" \
             "$(params.certExpirationWarnDays)"; then
           echo "ERROR: Pulp certificate validation failed"
@@ -1244,6 +1258,7 @@ spec:
 
         # Check UDCache certificate
         echo "Checking UDCache certificate"
+        export CERT_IDENTIFIER="UDCache Certificate"
         if ! check_cert_expiration "/mnt/udcacheSecret/cert" "$(params.certExpirationWarnDays)"; then
           echo "ERROR: UDCache certificate validation failed"
           exit 1

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -60,6 +60,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -58,6 +58,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -66,6 +66,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -61,6 +61,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -66,6 +66,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
@@ -66,6 +66,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -96,6 +96,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
@@ -66,6 +66,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-compressed.yaml
@@ -62,6 +62,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn-only-raw.yaml
@@ -63,6 +63,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -61,6 +61,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-raw-and-compressed.yaml
@@ -63,6 +63,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -65,6 +65,8 @@ spec:
           value: testuser
         - name: signingKeyName
           value: testkey
+        - name: sendSlackNotification
+          value: "false"
     - name: check-result
       runAfter:
         - run-task


### PR DESCRIPTION
## Describe your changes
Adds Slack notification capability for certificate expiration monitoring, integrating with the feature implemented in [release-service-utils#598](https://github.com/konflux-ci/release-service-utils/pull/598).

### New Parameters
- **`sendSlackNotification`** - Enable/disable Slack notifications (default: `"true"` for production)
- **`slackWebhookUrl`** - Optional webhook URL override (default: `""`)

### Key Features
✅ Certificate identifiers added for clear Slack messages (e.g., "UMB Certificate", "Pulp Certificate")  
✅ Notifications sent to `#konflux-release-cert-expiry` channel for:
  - 🔴 Expired certificates
  - 🟠 Certificates expiring soon (< 7 days)
  - 🟢 Recently renewed certificates

## Relevant Jira
[RELEASE-1630](https://issues.redhat.com/browse/RELEASE-1630)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
