### PR TITLE
fix(RELEASE-2078): reverted increased find_signatures memory request

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -262,9 +262,9 @@ spec:
       image: "$(params.pipeline_image)"
       computeResources:
         limits:
-          memory: 256Mi
+          memory: 128Mi
         requests:
-          memory: 256Mi
+          memory: 128Mi
           cpu: 100m
       workingDir: "$(workspaces.data.path)"
       volumeMounts:


### PR DESCRIPTION
Since find_signatures calls are now deduplicated, there's no need to have increased memory limit and reserve more than necessary on the cluster

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
