### PR TITLE
fix: update resource limits for push-to-git task

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -67,10 +67,10 @@ spec:
     - name: use-trusted-artifact
       computeResources:
         limits:
-          memory: 64Mi
+          memory: 256Mi
         requests:
-          memory: 64Mi
-          cpu: 30m
+          memory: 256Mi
+          cpu: 100m
       ref:
         resolver: "git"
         params:


### PR DESCRIPTION
Task gets stuck and timeout after 1h.
Updating resources for the pod.

