### PR TITLE
better system for find_signatures deduplication

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -314,14 +314,17 @@ spec:
         echo "${PyxisKey:?}" > "${PYXIS_KEY_PATH}"
 
         declare -a find_signatures_jobs=()
+        declare -A find_signatures_runs=()
 
         for i in "${!reference_a[@]}"; do
           reference="${reference_a[$i]}"
           digest="${digests_a[$i]}"
           repository="${repositories_a[$i]}"
           repository_no_slashes="${repository//\//----}"
+          repo_digest="${repository_no_slashes}@${digest}"
 
-          if [ ! -f "/tmp/${repository_no_slashes}-${digest}" ]; then
+          if [[ -z "${find_signatures_runs[$repo_digest]:-}" ]]; then
+            find_signatures_runs[$repo_digest]=1
             find_signatures --pyxis-graphql-api "${PYXIS_GRAPHQL_URL}" \
             --manifest_digest "${digest}" \
             --repository "${repository}" \


### PR DESCRIPTION
## Describe your changes

Better system for deduplication find_signature calls. Now                                                                                                                                                                                     mapping in bash is used to track what repo and digest were                                                                                                                                                                                    already used in find_signature calls as it can happen                                                                                                                                                                                         two find_signature calls with same arguments can run in                                                                                                                                                                                       parallel and cause overwritting the output file                                                                                                                                                                                           

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
