### PR TITLE
feat(RELEASE-2035): add cpu limits to managed tasks

### DIFF
--- a/.github/scripts/tkn_check_compute_resources.sh
+++ b/.github/scripts/tkn_check_compute_resources.sh
@@ -30,12 +30,6 @@ for file in ${CHANGED_FILES}; do
     limits=$(yq '.limits' <<< "$compute_resources")
     requests=$(yq '.requests' <<< "$compute_resources")
 
-    # Ensure limits.cpu is not defined
-    if yq -e 'has("cpu")' <<< "$limits" > /dev/null 2>&1; then
-      echo "ERROR: $file step $step_name (index $i) has limits.cpu defined. This should not be set"
-      fail=1
-    fi
-
     # Ensure requests.cpu is defined
     if ! yq -e 'has("cpu")' <<< "$requests" > /dev/null 2>&1; then
       echo "ERROR: $file step $step_name (index $i) does not have requests.cpu defined"
@@ -55,9 +49,9 @@ for file in ${CHANGED_FILES}; do
       echo "ERROR: $file step $step_name (index $i) computeResources has extra or missing keys"
       fail=1
     else
-      # Check that limits only has memory and requests only has cpu and memory (order-agnostic)
-      if ! yq -e 'keys | contains(["memory"]) and length == 1' <<< "$limits" > /dev/null 2>&1; then
-        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory"
+      # Check that limits only has memory and/or cpu, requests only has cpu and memory (order-agnostic)
+      if ! yq -e 'keys - ["cpu","memory"] | length == 0' <<< "$limits" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory and cpu"
         fail=1
       fi
       if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$requests" > /dev/null 2>&1; then

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -121,6 +121,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -143,6 +144,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: '1'
         requests:
           memory: 64Mi
           cpu: '1'
@@ -618,6 +620,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -90,6 +90,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -113,6 +114,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -103,6 +103,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -125,6 +126,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 10m
         requests:
           memory: 64Mi  # was exiting with code 137 when set to 32Mi
           cpu: 10m
@@ -157,6 +159,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -76,6 +76,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -98,6 +99,7 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
+          cpu: 10m
         requests:
           memory: 100Mi
           cpu: 10m
@@ -194,9 +196,10 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
+          cpu: 300m
         requests:
           memory: 100Mi
-          cpu: 10m
+          cpu: 300m
       script: |
         #!/usr/bin/env bash
         set -ex

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -42,6 +42,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 200m
         requests:
           memory: 128Mi
           cpu: 200m

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -52,6 +52,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 60m
         requests:
           memory: 64Mi
           cpu: 60m

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -99,6 +99,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -121,9 +122,10 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 100m
         requests:
           memory: 32Mi
-          cpu: 50m
+          cpu: 100m
       volumeMounts:
         - name: access-token-secret-vol
           mountPath: "/etc/secrets"
@@ -209,6 +211,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -109,6 +109,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -132,6 +133,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-charon-params/collect-charon-params.yaml
+++ b/tasks/managed/collect-charon-params/collect-charon-params.yaml
@@ -109,6 +109,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -131,6 +132,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -179,6 +181,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -152,9 +152,10 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 50m
         requests:
           memory: 64Mi
-          cpu: 10m
+          cpu: 50m
       env:
         - name: "RELEASE"
           value: '$(params.release)'
@@ -312,6 +313,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -361,6 +363,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -102,6 +102,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -125,6 +126,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -93,6 +93,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -116,6 +117,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -183,6 +185,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -87,6 +87,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -110,6 +111,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -109,6 +109,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -131,6 +132,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -281,6 +283,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -100,6 +100,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -122,6 +123,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -139,6 +139,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -161,6 +162,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -385,9 +387,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 650m
         requests:
           memory: 512Mi
-          cpu: 350m
+          cpu: 650m
       script: |
         #!/bin/bash
         set -ex
@@ -553,6 +556,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -110,6 +110,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -132,6 +133,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -176,6 +178,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -107,6 +107,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -129,6 +130,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 50m
         requests:
           memory: 64Mi
           cpu: 50m
@@ -252,6 +254,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m
@@ -317,6 +320,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -104,6 +104,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -126,6 +127,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -196,6 +198,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -96,6 +96,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -119,6 +120,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -148,6 +150,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -98,6 +98,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -154,6 +155,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 500m
         requests:
           memory: 1Gi
           cpu: 500m
@@ -373,6 +375,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -127,6 +127,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -149,9 +150,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 650m
         requests:
           memory: 512Mi
-          cpu: 350m
+          cpu: 650m
       script: |
         #!/bin/bash
         set -x
@@ -387,6 +389,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
+++ b/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
@@ -85,6 +85,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -107,6 +108,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -280,6 +282,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -83,6 +83,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -105,6 +106,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -125,6 +127,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -539,6 +542,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -91,6 +91,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -115,6 +116,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -201,6 +203,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -98,6 +98,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,6 +121,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -199,6 +201,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -112,6 +112,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -134,6 +135,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 450m
         requests:
           memory: 1Gi
           cpu: 450m
@@ -284,6 +286,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -113,6 +113,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,6 +136,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -225,6 +227,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: '1'
         requests:
           memory: 64Mi
           cpu: '1'
@@ -368,6 +371,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -587,6 +591,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -695,6 +700,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -747,6 +753,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
@@ -75,6 +75,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -98,6 +99,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -132,6 +134,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -122,6 +122,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -144,9 +145,10 @@ spec:
       computeResources:
         limits:
           memory: 3Gi
+          cpu: '1'
         requests:
           memory: 3Gi
-          cpu: 500m
+          cpu: '1'
       script: |
         #!/usr/bin/env bash
         set -e

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -96,6 +96,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,6 +121,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -430,6 +432,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -50,6 +50,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -105,6 +105,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -128,6 +129,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m
@@ -242,6 +244,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -106,6 +106,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -129,6 +130,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 200m
         requests:
           memory: 512Mi
           cpu: 200m
@@ -199,6 +201,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -134,6 +134,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -156,9 +157,10 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 450m
         requests:
           memory: 32Mi
-          cpu: 300m
+          cpu: 450m
       volumeMounts:
         - name: pyxis-secret-vol
           mountPath: "/etc/secrets"
@@ -307,6 +309,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -114,6 +114,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -136,9 +137,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 650m
         requests:
           memory: 512Mi
-          cpu: 250m
+          cpu: 650m
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -266,6 +268,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -104,6 +104,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -127,6 +128,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m
@@ -179,6 +181,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -97,6 +97,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -119,9 +120,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 650m
         requests:
           memory: 512Mi
-          cpu: 250m
+          cpu: 650m
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -209,6 +211,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -65,6 +65,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -87,6 +88,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -64,6 +64,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -86,9 +87,10 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '1'
         requests:
           memory: 1Gi
-          cpu: 250m
+          cpu: '1'
       volumeMounts:
         - name: git-token-secret-vol
           mountPath: /var/secrets/git-token

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -65,6 +65,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -87,6 +88,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -105,6 +105,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -128,9 +129,10 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 325m
         requests:
           memory: 256Mi
-          cpu: 250m
+          cpu: 325m
       env:
         - name: SNAPSHOT_SPEC_FILE
           value: $(params.dataDir)/$(params.snapshotPath)
@@ -324,6 +326,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -137,6 +137,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -159,6 +160,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m
@@ -921,6 +923,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -102,6 +102,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -124,9 +125,10 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '2'
         requests:
           memory: 1Gi
-          cpu: "2"
+          cpu: '2'
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -524,6 +526,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -105,6 +105,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -182,6 +183,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 10m
         requests:
           memory: 128Mi
           cpu: 10m
@@ -191,6 +193,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -133,6 +133,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -156,9 +157,10 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
+          cpu: '2'
         requests:
           memory: 4Gi
-          cpu: "2"
+          cpu: '2'
       volumeMounts:
         - name: pyxis-secret-vol
           mountPath: "/etc/secrets"
@@ -659,6 +661,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+++ b/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
@@ -104,6 +104,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -126,9 +127,10 @@ spec:
       computeResources:
         limits:
           memory: 2.5Gi
+          cpu: '2'
         requests:
           memory: 2.5Gi
-          cpu: "2"
+          cpu: '2'
       volumeMounts:
         - name: secret-vol
           mountPath: "/etc/secrets"
@@ -304,6 +306,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -113,6 +113,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,9 +136,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 650m
         requests:
           memory: 512Mi
-          cpu: 100m
+          cpu: 650m
       script: |
         #!/bin/bash
         #
@@ -234,6 +236,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -102,6 +102,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -124,6 +125,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -190,6 +192,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -97,6 +97,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -119,6 +120,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -207,6 +209,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -125,6 +125,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -148,6 +149,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m
@@ -221,6 +223,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -140,6 +140,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -162,6 +163,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -370,6 +372,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -117,6 +117,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -139,6 +140,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -644,6 +646,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -96,6 +96,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 20m
         requests:
           memory: 128Mi
           cpu: 20m
@@ -116,6 +117,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -116,6 +116,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -138,6 +139,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -155,6 +157,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -200,6 +203,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -216,6 +220,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -475,6 +480,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -113,6 +113,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,6 +136,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '1'
         requests:
           memory: 1Gi
           cpu: "1"
@@ -688,6 +690,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -97,6 +97,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -119,6 +120,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 500m
         requests:
           memory: 1Gi
           cpu: 500m
@@ -198,6 +200,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -89,6 +89,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -111,6 +112,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -61,6 +61,7 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
+          cpu: 10m
         requests:
           memory: 100Mi
           cpu: 10m


### PR DESCRIPTION
## Describe your changes

Set limits.cpu = requests.cpu for managed task steps to ensure
predictable resource allocation.

Changes:
- Updated 5 under-provisioned steps based on Prometheus data
  collected from 9 clusters (7 external + 2 internal)
- Added CPU limits across 64 files (63 managed tasks + CI script)
- Increased requests for high-usage steps like push-snapshot,
  download-sbom-files, create-pyxis-image

### How we got the numbers
Collected CPU usage data from 9 production clusters over several days. 
Heavy teams like ART already override these values via RPA (100+ do this).

Collaborated with infra and perf teams who are working on similar
improvements in build-definitions (KONFLUX-6712).


## Relevant Jira
RELEASE-2035

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
