### PR TITLE
fix: set -x after setting required variables

### DIFF
--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -96,12 +96,14 @@ spec:
           readOnly: true
       script: |
         #!/usr/bin/env bash
-        set -euxo pipefail
+        set -euo pipefail
 
         AWS_ACCESS_KEY_ID=$(cat /var/secrets/s3/aws_access_key_id)
         export AWS_ACCESS_KEY_ID
         AWS_SECRET_ACCESS_KEY=$(cat /var/secrets/s3/aws_secret_access_key)
         export AWS_SECRET_ACCESS_KEY
+
+        set -x
 
         SIGNED_KMODS_FULL_PATH="$(params.dataDir)/$(params.signedKmodsPath)"
 


### PR DESCRIPTION
In push-oot-kmods-to-s3, don't set -x until after the secrets are exported.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
