### PR TITLE
fix: prevent git clone inside signed-kmods path

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -107,7 +107,7 @@ spec:
         REPO_URL="$(params.gitRepoUrl)"
 
         mkdir -p "${SIGNED_KMODS_PATH}"
-        cd "${SIGNED_KMODS_PATH}"
+        cd "$(params.dataDir)"
 
         # Check if this is a multi-architecture build
         if [ -f "$(params.dataDir)/arch_count.txt" ]; then

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -105,9 +105,11 @@ spec:
         SIGNED_KMODS_PATH="$(params.dataDir)/$(params.signedKmodsPath)"
         RPM_FULL_PATH="$(params.dataDir)/$(params.rpmPath)"
         REPO_URL="$(params.gitRepoUrl)"
+        GIT_WORK_DIR="$(params.dataDir)/git-work"
 
         mkdir -p "${SIGNED_KMODS_PATH}"
-        cd "$(params.dataDir)"
+        mkdir -p "${GIT_WORK_DIR}"
+        cd "${GIT_WORK_DIR}"
 
         # Check if this is a multi-architecture build
         if [ -f "$(params.dataDir)/arch_count.txt" ]; then
@@ -246,6 +248,7 @@ spec:
         else
             echo "Single architecture build, using standard upload"
 
+            cd "${SIGNED_KMODS_PATH}"
             # Validate checksum file exists for single-arch
             if [ ! -f "signed_kmods_checksums.txt" ]; then
                 echo "ERROR: signed_kmods_checksums.txt not found for single architecture build"
@@ -254,6 +257,7 @@ spec:
 
             # Verify checksums
             sha256sum -c signed_kmods_checksums.txt
+            cd "${GIT_WORK_DIR}/local-artifacts"
 
             if push_arch_artifacts "single" "${SIGNED_KMODS_PATH}"; then
                 echo "Successfully processed single architecture"


### PR DESCRIPTION
The script was cloning the git repository into the signed-kmods directory, which caused it to be incorrectly processed as an architecture directory during multi-arch builds. This resulted in failures when the script tried to find an envfile in the git clone directory.

The fix changes the working directory from SIGNED_KMODS_PATH to dataDir before cloning, ensuring the git repository is created alongside (not inside) the signed-kmods directory, preventing iteration conflicts.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
