### PR TITLE
test(RELEASE-1942): add coverage for componentTags

### DIFF
--- a/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
@@ -19,6 +19,7 @@ spec:
         - name: ${component_name}
           componentTags:
             - 'latest'
+            - '{{ release_timestamp }}'
           repositories:
             - url: quay.io/hacbs-release-tests/${component_name}
               tags:


### PR DESCRIPTION
## Describe your changes

Add verification to push-to-external-registry integration test to ensure componentTags are properly combined with default and repository tags.

## Relevant Jira

https://issues.redhat.com/browse/RELEASE-1942

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
