### PR TITLE
fix: use sparse-checkout add for multi-arch builds

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -159,7 +159,7 @@ spec:
             TARGET_DIR="${DRIVER_VENDOR}_${DRIVER_VERSION}_${KERNEL_VERSION}${arch_suffix}"
             echo "Target directory for $arch_name: $TARGET_DIR"
 
-            git sparse-checkout set "$TARGET_DIR"
+            git sparse-checkout add "$TARGET_DIR"
             git checkout
             mkdir -p "$TARGET_DIR"
 
@@ -239,6 +239,7 @@ spec:
             # Create multi-arch summary file in the repository
             if [ -f "${SIGNED_KMODS_PATH}/signing_summary.txt" ]; then
                 summary_target_dir="multi-arch-summary_$(date +%Y%m%d_%H%M%S)"
+                git sparse-checkout add "$summary_target_dir"
                 mkdir -p "$summary_target_dir"
                 cp "${SIGNED_KMODS_PATH}/signing_summary.txt" "$summary_target_dir/"
                 cp "${SIGNED_KMODS_PATH}/extraction_summary.txt" "$summary_target_dir/" 2>/dev/null || true


### PR DESCRIPTION
In multi-arch builds, git sparse-checkout set replaces previous patterns instead of adding to them. This causes issues when:
1. Processing multiple architectures - second arch removes first
2. Adding summary directory - sparse-checkout blocks the add

Changed to use git sparse-checkout add in both locations:
- In push_arch_artifacts function for each architecture directory
- When creating the multi-arch summary directory

This ensures all architecture patterns and summary directories accumulate in the sparse-checkout configuration rather than replacing each other.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
