### PR TITLE
fix(RELEASE-2085): add retry logic rename-github-file.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ test-results/
 **/tests/temp/
 **/tests/.temp/
 
+# Cached utilities
+integration-tests/scripts/.curl-with-retry
+
 # OS and editor files
 .DS_Store
 .vscode/


### PR DESCRIPTION
## Describe your changes
The release-to-github test fails intermittently because GitHub's API has eventual consistency - a newly created branch may not be immediately visible via the Branches API.
This adds retry logic (5 attempts, 2s wait) to check_branch_exists() to handle the propagation delay.

## Relevant Jira
[RELEASE-2085](https://issues.redhat.com/browse/RELEASE-2085)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
