### PR TITLE
fix: local registry install in task tests workflow

### DIFF
--- a/.github/resources/cert-manager/kustomization.yml
+++ b/.github/resources/cert-manager/kustomization.yml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+  - cert-manager.yaml
 
 patches:
   - patch: |

--- a/.github/scripts/deploy_registry.sh
+++ b/.github/scripts/deploy_registry.sh
@@ -24,6 +24,9 @@ retry() {
 }
 
 deploy_cert_manager() {
+  # Download cert-manager.yaml first - kustomize misinterprets github.com release URLs as git repos
+  curl -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml \
+    -o "${script_path}/../resources/cert-manager/cert-manager.yaml"
   kubectl apply -k "${script_path}/../resources/cert-manager"
   sleep 5
   retry "kubectl wait --for=condition=Ready --timeout=120s -l app.kubernetes.io/instance=cert-manager -n cert-manager pod" \

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build_json
 
 # Kind cluster and setup files
 .kind/
+.github/resources/cert-manager/cert-manager.yaml
 test-kubeconfig
 .local/
 internal-services/


### PR DESCRIPTION
## Describe your changes

It started failing. Supposedly it's because newer versions of kustomize treat the github url as a repository path. So a workaround is to download the file first.

Assisted-by: Cursor

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
