### PR TITLE
fix: integrity issue in sign-oot-kmods

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -176,9 +176,14 @@ spec:
         # Function to sign kernel modules for a specific architecture
         sign_kmods_for_arch() {
             local arch_name="$1"
-            local remote_dir="$HOME/kmods"
+            local task_uid
+            task_uid="$(context.taskRun.uid)"
+            local remote_base_dir="$HOME/$task_uid"
+            local remote_dir
             if [ "$arch_name" != "single" ]; then
-                remote_dir="$HOME/kmods/$arch_name"
+                remote_dir="$remote_base_dir/kmods/$arch_name"
+            else
+                remote_dir="$remote_base_dir/kmods"
             fi
 
             signing_author="$signingAuthor"
@@ -187,21 +192,31 @@ spec:
             echo "Executing SSH command to sign OOT kernel modules for architecture: $arch_name"
             # shellcheck disable=SC2029  # Intentional client-side expansion
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-            "export KEY='${signKey}'; export ARCH='${arch_name}'; export REMOTE_DIR='${remote_dir}'; \
+            "export KEY='${signKey}'; export ARCH='${arch_name}'; \
+             export TASK_UID='${task_uid}'; \
+             export REMOTE_DIR='${remote_dir}'; \
              bash -s" <<'EOF'
         echo "Remote: Signing OOT kernel modules for architecture $ARCH using $KEY key..."
-        for kmod in $REMOTE_DIR/*.ko; do
-            if [ -f "$kmod" ]; then
-                echo "Remote: Signing kernel module $kmod for $ARCH"
-                rh-signing-client --key "$KEY" --onbehalfof "${signing_author}" --lkmsign "$kmod"
-                if [ $? -ne 0 ]; then
-                    echo "Remote: ERROR failed to sign $kmod for $ARCH"
-                    exit 1
+
+        # Check if any .ko files exist in the remote directory
+        if ls "$REMOTE_DIR"/*.ko 1> /dev/null 2>&1; then
+            for kmod in "$REMOTE_DIR"/*.ko; do
+                if [ -f "$kmod" ]; then
+                    echo "Remote: Signing kernel module $kmod for $ARCH"
+                    rh-signing-client --key "$KEY" --onbehalfof "${signing_author}" --lkmsign "$kmod"
+                    if [ $? -ne 0 ]; then
+                        echo "Remote: ERROR failed to sign $kmod for $ARCH"
+                        exit 1
+                    fi
+                else
+                    echo "Remote: Skipping entry $kmod (not a regular file)"
                 fi
-            else
-                echo "Remote: Skipping entry $kmod (not a regular file or no .ko files found for $ARCH)"
-            fi
-        done
+            done
+        else
+            echo "Remote: ERROR: No .ko files found in $REMOTE_DIR for $ARCH"
+            exit 1
+        fi
+
         echo "Remote: Finished signing process for architecture $ARCH"
         EOF
         }
@@ -224,8 +239,12 @@ spec:
             if [ "$arch_count" -gt 1 ]; then
                 echo "Multi-architecture signing process"
 
-                # Clean up any existing remote kmods directory
-                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/kmods && mkdir -p ~/kmods"
+                # Create unique remote directory for this TaskRun to ensure isolation
+                task_uid="$(context.taskRun.uid)"
+                echo "Using unique remote directory: ~/$task_uid"
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/$task_uid"
 
                 # Process each architecture directory
                 for arch_dir in "$SIGNED_KMODS_PATH"/*/; do
@@ -251,22 +270,48 @@ spec:
 
                         if [ "$ko_files_found" = true ]; then
                             # Create architecture-specific directory on signing server
+                            # Intentional client-side expansion: task_uid expands locally for unique remote directories
                             # shellcheck disable=SC2029
                             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                                "mkdir -p \$HOME/kmods/${arch_name}"
+                                "mkdir -p ~/${task_uid}/kmods/${arch_name}"
 
                             # Copy unsigned kmods to signing server for this architecture
+                            echo "Copying unsigned .ko files to signing server for $arch_name..."
                             scp "${SSH_OPTS[@]}" "$arch_dir"/*.ko \
-                                "${signUser}@${signHost}:~/kmods/${arch_name}/"
+                                "${signUser}@${signHost}:~/${task_uid}/kmods/${arch_name}/"
+
+                            # Verify files were copied to remote server
+                            echo "Verifying files on remote server for $arch_name..."
+                            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                            # shellcheck disable=SC2029
+                            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                                "ls -la ~/${task_uid}/kmods/${arch_name}/ || \
+                                 echo 'WARNING: Directory not found on remote server'"
 
                             # Sign kmods for this architecture
                             sign_kmods_for_arch "$arch_name"
 
                             # Copy back signed kmods to workspace
                             # Remove unsigned files first to ensure complete replacement
+                            echo "Copying back signed .ko files for $arch_name..."
                             rm -f "$arch_dir"/*.ko
-                            scp "${SSH_OPTS[@]}" \
-                                "${signUser}@${signHost}:~/kmods/${arch_name}/*.ko" "$arch_dir/"
+                            # Get list of .ko files from remote server and copy them individually
+                            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                            # shellcheck disable=SC2029
+                            kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                                "cd ~/${task_uid}/kmods/${arch_name}/ && ls -1 *.ko 2>/dev/null || echo ''" )
+                            if [ -n "$kmod_files" ]; then
+                                echo "$kmod_files" | while IFS= read -r kmod_file; do
+                                    if [ -n "$kmod_file" ]; then
+                                        echo "Copying back signed file: $kmod_file"
+                                        scp "${SSH_OPTS[@]}" \
+                                            "${signUser}@${signHost}:~/${task_uid}/kmods/${arch_name}/$kmod_file" \
+                                            "$arch_dir/"
+                                    fi
+                                done
+                            else
+                                echo "WARNING: No .ko files found on remote server for $arch_name"
+                            fi
 
                             # Restore envfile
                             if [ -f "/tmp/envfile.backup.$arch_name" ]; then
@@ -310,9 +355,19 @@ spec:
                 echo "Multi-architecture signing completed. Summary:"
                 cat "$SIGNED_KMODS_PATH/signing_summary.txt"
 
+                # Clean up unique remote directory for supply chain integrity
+                echo "Cleaning up remote directory ~/$task_uid"
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
+
             else
                 echo "Single architecture, using existing signing logic"
                 cd "$SIGNED_KMODS_PATH"
+
+                # Create unique remote directory for this TaskRun to ensure isolation
+                task_uid="$(context.taskRun.uid)"
+                echo "Using unique remote directory: ~/$task_uid"
 
                 # Backup envfile before signing process
                 if [ -f "envfile" ]; then
@@ -320,15 +375,33 @@ spec:
                 fi
 
                 # Copy unsigned kmods to signing server
-                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/kmods"
-                scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/kmods/"
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/${task_uid}/kmods"
+                scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
 
                 # Sign kmods
                 sign_kmods_for_arch "single"
 
                 # Copy back signed kmods to workspace
+                echo "Copying back signed .ko files for single architecture..."
                 rm -f "${SIGNED_KMODS_PATH}"/*.ko
-                scp "${SSH_OPTS[@]}" "${signUser}@${signHost}:~/kmods/*.ko" "${SIGNED_KMODS_PATH}"/
+                # Get list of .ko files from remote server and copy them individually
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                    "cd ~/${task_uid}/kmods/ && ls -1 *.ko 2>/dev/null || echo ''" )
+                if [ -n "$kmod_files" ]; then
+                    echo "$kmod_files" | while IFS= read -r kmod_file; do
+                        if [ -n "$kmod_file" ]; then
+                            echo "Copying back signed file: $kmod_file"
+                            scp "${SSH_OPTS[@]}" \
+                                "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" "${SIGNED_KMODS_PATH}"/
+                        fi
+                    done
+                else
+                    echo "WARNING: No .ko files found on remote server for single architecture"
+                fi
 
                 # Restore envfile after signing process
                 if [ -f "/tmp/envfile.backup" ]; then
@@ -346,10 +419,20 @@ spec:
                     echo "ERROR: No .ko files found after signing process"
                     exit 1
                 fi
+
+                # Clean up unique remote directory for supply chain integrity
+                echo "Cleaning up remote directory ~/$task_uid"
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
             fi
         else
             echo "No architecture information found, falling back to single-arch logic"
             cd "$SIGNED_KMODS_PATH"
+
+            # Create unique remote directory for this TaskRun to ensure isolation
+            task_uid="$(context.taskRun.uid)"
+            echo "Using unique remote directory: ~/$task_uid"
 
             # Backup envfile before signing process
             if [ -f "envfile" ]; then
@@ -357,15 +440,33 @@ spec:
             fi
 
             # Copy unsigned kmods to signing server
-            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/kmods"
-            scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/kmods/"
+            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+            # shellcheck disable=SC2029
+            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/${task_uid}/kmods"
+            scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
 
             # Sign kmods
             sign_kmods_for_arch "single"
 
             # Copy back signed kmods to workspace
+            echo "Copying back signed .ko files for fallback single architecture..."
             rm -f "${SIGNED_KMODS_PATH}"/*.ko
-            scp "${SSH_OPTS[@]}" "${signUser}@${signHost}:~/kmods/*.ko" "${SIGNED_KMODS_PATH}"/
+            # Get list of .ko files from remote server and copy them individually
+            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+            # shellcheck disable=SC2029
+            kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                "cd ~/${task_uid}/kmods/ && ls -1 *.ko 2>/dev/null || echo ''" )
+            if [ -n "$kmod_files" ]; then
+                echo "$kmod_files" | while IFS= read -r kmod_file; do
+                    if [ -n "$kmod_file" ]; then
+                        echo "Copying back signed file: $kmod_file"
+                        scp "${SSH_OPTS[@]}" \
+                            "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" "${SIGNED_KMODS_PATH}"/
+                    fi
+                done
+            else
+                echo "WARNING: No .ko files found on remote server for fallback case"
+            fi
 
             # Restore envfile after signing process
             if [ -f "/tmp/envfile.backup" ]; then
@@ -383,6 +484,12 @@ spec:
                 echo "ERROR: No .ko files found after signing process"
                 exit 1
             fi
+
+            # Clean up unique remote directory for supply chain integrity
+            echo "Cleaning up remote directory ~/$task_uid"
+            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+            # shellcheck disable=SC2029
+            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
         fi
     - name: create-trusted-artifact
       computeResources:

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -20,11 +20,42 @@ function kinit() {
 
 function ssh() {
   echo "Mock ssh called with: $*"
-  
+
   echo "$*" >> "$(params.dataDir)/mock_ssh.txt"
 
   case "$*" in
     "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
+      # Handle directory creation commands with TaskRun UID
+      if [[ "$*" == *"mkdir -p ~/"*"/kmods"* ]]; then
+        echo "Mock ssh: Creating unique TaskRun directory structure"
+        return 0
+      fi
+      # Handle cleanup commands with TaskRun UID
+      if [[ "$*" == *"rm -rf ~/"*"/kmods"* ]] || [[ "$*" == *"rm -rf ~/"*[a-f0-9\-]* ]]; then
+        echo "Mock ssh: Cleaning up unique TaskRun directory"
+        return 0
+      fi
+      # Handle ls commands for verification
+      if [[ "$*" == *"ls -la ~/"* ]]; then
+        echo "Mock ssh: Listing directory contents"
+        return 0
+      fi
+      # Handle ls commands for getting file lists (used for downloading)
+      if [[ "$*" == *"cd ~/"*"/kmods"* && "$*" == *"ls -1 *.ko"* ]]; then
+        echo "Mock ssh: Listing .ko files for download"
+        # Return the list of .ko files that should be available after signing
+        if [[ "$*" == *"/amd64/"* ]]; then
+          echo "amd64-mod1.ko"
+          echo "amd64-mod2.ko"
+        elif [[ "$*" == *"/arm64/"* ]]; then
+          echo "arm64-mod1.ko"
+          echo "arm64-mod2.ko"
+        else
+          echo "mod1.ko"
+          echo "mod2.ko"
+        fi
+        return 0
+      fi
       ;;
     *)
       echo "Error: Incorrect ssh parameters"
@@ -57,60 +88,63 @@ function scp() {
 
   case "$*" in
     "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
-      # Check if this is the download command (contains *.ko in remote path)
-      if [[ "$*" == *"~/kmods/*.ko"* ]]; then
-        # This is the download command for single arch - extract destination directory (last argument)
-        local args=($*)
-        local dest_path="${args[-1]}"
-        echo "Mock scp: Creating signed files in destination: $dest_path"
-        if [ -d "$dest_path" ]; then
-          echo "SIGNED_MODULE1" > "$dest_path/mod1.ko"
-          echo "SIGNED_MODULE2" > "$dest_path/mod2.ko"
-          echo "Mock scp: Created signed files in $dest_path"
+      local args=($*)
 
-          # Generate checksums file to match the actual task behavior
-          cd "$dest_path"
-          sha256sum *.ko > signed_kmods_checksums.txt
-          echo "Mock scp: Generated checksums file in $dest_path"
-        else
-          echo "Mock scp: Warning - destination directory $dest_path does not exist"
-        fi
-      elif [[ "$*" == *"~/kmods/amd64/*.ko"* ]]; then
-        # This is the download command for amd64 arch
-        local args=($*)
-        local dest_path="${args[-1]}"
-        echo "Mock scp: Creating signed amd64 files in destination: $dest_path"
-        if [ -d "$dest_path" ]; then
-          echo "SIGNED_AMD64_MODULE1" > "$dest_path/amd64-mod1.ko"
-          echo "SIGNED_AMD64_MODULE2" > "$dest_path/amd64-mod2.ko"
-          echo "Mock scp: Created signed amd64 files in $dest_path"
+      # Determine if this is an upload or download operation
+      # Upload: local files followed by remote destination (last arg contains @host:)
+      # Download: remote source (contains @host:) followed by local destination
+      local is_download=false
+      local remote_source=""
+      local local_dest=""
+      local last_arg="${args[-1]}"
 
-          # Generate architecture-specific checksums file
-          cd "$dest_path"
-          sha256sum *.ko > signed_kmods_checksums_amd64.txt
-          echo "Mock scp: Generated amd64 checksums file in $dest_path"
-        else
-          echo "Mock scp: Warning - destination directory $dest_path does not exist"
-        fi
-      elif [[ "$*" == *"~/kmods/arm64/*.ko"* ]]; then
-        # This is the download command for arm64 arch
-        local args=($*)
-        local dest_path="${args[-1]}"
-        echo "Mock scp: Creating signed arm64 files in destination: $dest_path"
-        if [ -d "$dest_path" ]; then
-          echo "SIGNED_ARM64_MODULE1" > "$dest_path/arm64-mod1.ko"
-          echo "SIGNED_ARM64_MODULE2" > "$dest_path/arm64-mod2.ko"
-          echo "Mock scp: Created signed arm64 files in $dest_path"
+      # Check if the last argument is a remote destination (contains @host:)
+      if [[ "$last_arg" == *"@"*":"* ]]; then
+        # This is an upload operation (last arg is remote destination)
+        echo "Mock scp: Upload operation to $last_arg"
+        # For upload commands, we don't need to create files locally
+      else
+        # Look for remote source in the arguments (not the last one)
+        for arg in "${args[@]:0:${#args[@]}-1}"; do
+          if [[ "$arg" == *"@"*":"* ]]; then
+            is_download=true
+            remote_source="$arg"
+            local_dest="$last_arg"
+            break
+          fi
+        done
 
-          # Generate architecture-specific checksums file
-          cd "$dest_path"
-          sha256sum *.ko > signed_kmods_checksums_arm64.txt
-          echo "Mock scp: Generated arm64 checksums file in $dest_path"
+        if [[ "$is_download" == true ]]; then
+          # This is a download operation
+          echo "Mock scp: Download operation from $remote_source to $local_dest"
+
+          # Extract filename from remote path
+          local filename=$(basename "${remote_source#*:}")
+
+          # Create signed content based on architecture in path and filename
+          if [[ "$remote_source" == *"/amd64/"* ]]; then
+            echo "SIGNED_AMD64_MODULE" > "$local_dest/$filename"
+          elif [[ "$remote_source" == *"/arm64/"* ]]; then
+            echo "SIGNED_ARM64_MODULE" > "$local_dest/$filename"
+          else
+            # For single architecture, use filename to determine content
+            case "$filename" in
+              "mod1.ko")
+                echo "SIGNED_MODULE1" > "$local_dest/$filename"
+                ;;
+              "mod2.ko")
+                echo "SIGNED_MODULE2" > "$local_dest/$filename"
+                ;;
+              *)
+                echo "SIGNED_MODULE" > "$local_dest/$filename"
+                ;;
+            esac
+          fi
+          echo "Mock scp: Created signed file $local_dest/$filename"
         else
-          echo "Mock scp: Warning - destination directory $dest_path does not exist"
+          echo "Mock scp: Unable to determine operation type"
         fi
       fi
-      # For upload commands, we don't need to do anything special
       ;;
     *)
       echo "Error: Incorrect scp parameters"

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-cleanup.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-cleanup.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sign-oot-kmods-cleanup
+spec:
+  description: |
+    Test the sign-oot-kmods task to verify TaskRun UID isolation and cleanup functionality
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+    - name: taskGitUrl
+      type: string
+      description: The git repository URL for task and StepAction resolution
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The git revision for task and StepAction resolution
+      default: main
+  tasks:
+    - name: run-task
+      taskRef:
+        name: sign-oot-kmods
+      params:
+        - name: dataPath
+          value: data.json
+        - name: signedKmodsPath
+          value: signed-kmods
+        - name: signingAuthor
+          value: The dummy signer
+        - name: kerberosRealm
+          value: IPA.REDHAT.COM
+        - name: signing-secret
+          value: my-mocked-secret
+        - name: checksumFingerprint
+          value: checksum-fingerprint
+        - name: checksumKeytab
+          value: build-and-sign-keytab
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: ""
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+    - name: check-cleanup-and-isolation
+      taskSpec:
+        params:
+          - name: dataDir
+            type: string
+          - name: ociStorage
+            type: string
+          - name: sourceDataArtifact
+            type: string
+            default: ""
+          - name: taskGitUrl
+            type: string
+          - name: taskGitRevision
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: "ORAS_OPTIONS"
+              value: "--insecure"
+            - name: "DEBUG"
+              value: ""
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: validate-supply-chain-integrity
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "=== Supply Chain Integrity Validation ==="
+
+              SSH_FILE="$(params.dataDir)/mock_ssh.txt"
+              SCP_FILE="$(params.dataDir)/mock_scp.txt"
+
+              # Verify SSH commands were logged
+              if [ ! -f "$SSH_FILE" ]; then
+                echo "ERROR: SSH commands were not logged"
+                exit 1
+              fi
+
+              echo "SSH Commands executed:"
+              cat "$SSH_FILE"
+              echo ""
+
+              # Test 1: Verify TaskRun UID directory creation
+              echo "Test 1: TaskRun UID Directory Creation"
+              if grep -E "mkdir -p ~/[a-f0-9\-]{8,}/kmods" "$SSH_FILE"; then
+                echo "✅ PASS: TaskRun UID directory creation found"
+              else
+                echo "❌ FAIL: TaskRun UID directory creation NOT found"
+                exit 1
+              fi
+
+              # Test 2: Verify TaskRun UID directory cleanup
+              echo "Test 2: TaskRun UID Directory Cleanup"
+              if grep -E "rm -rf ~/[a-f0-9\-]{8,}" "$SSH_FILE"; then
+                echo "✅ PASS: TaskRun UID directory cleanup found"
+              else
+                echo "❌ FAIL: TaskRun UID directory cleanup NOT found"
+                exit 1
+              fi
+
+              # Test 3: Verify unique directory pattern consistency
+              echo "Test 3: Directory Pattern Consistency"
+              # Extract TaskRun UIDs from mkdir and rm commands
+              MKDIR_UIDS=$(grep -oE "mkdir -p ~/[a-f0-9\-]{8,}" "$SSH_FILE" | sed 's/mkdir -p ~\///' | sort -u)
+              RM_UIDS=$(grep -oE "rm -rf ~/[a-f0-9\-]{8,}" "$SSH_FILE" | sed 's/rm -rf ~\///' | sort -u)
+
+              echo "Mkdir UIDs: $MKDIR_UIDS"
+              echo "Cleanup UIDs: $RM_UIDS"
+
+              # Verify that the UIDs match (each created directory is cleaned up)
+              for uid in $MKDIR_UIDS; do
+                if echo "$RM_UIDS" | grep -q "$uid"; then
+                  echo "✅ PASS: TaskRun UID $uid was properly cleaned up"
+                else
+                  echo "❌ FAIL: TaskRun UID $uid was created but NOT cleaned up"
+                  exit 1
+                fi
+              done
+
+              # Test 4: Verify SCP commands use TaskRun UID structure
+              if [ -f "$SCP_FILE" ]; then
+                echo "Test 4: SCP TaskRun UID Usage"
+                echo "SCP Commands executed:"
+                cat "$SCP_FILE"
+                echo ""
+
+                # Check if any SCP commands contain TaskRun UID paths
+                if grep -E "/[a-f0-9\-]{8,}/kmods/" "$SCP_FILE"; then
+                  echo "✅ PASS: SCP commands use TaskRun UID directory structure"
+                else
+                  echo "⚠️  WARNING: SCP commands may use individual file transfer (acceptable)"
+                fi
+              fi
+
+              # Test 5: Verify no hardcoded ~/kmods paths (supply chain integrity)
+              echo "Test 5: No Hardcoded Paths"
+              EXCLUDE_PATTERN="/[a-f0-9\-]{8,}/kmods|Creating unique TaskRun directory"
+              EXCLUDE_PATTERN="${EXCLUDE_PATTERN}|Cleaning up unique TaskRun directory"
+              if grep -v -E "$EXCLUDE_PATTERN" "$SSH_FILE" | grep -q "$HOME/kmods"; then
+                echo "❌ FAIL: Found hardcoded ~/kmods paths (supply chain integrity violation)"
+                grep -v -E "/[a-f0-9\-]{8,}/kmods" "$SSH_FILE" | grep "$HOME/kmods" || true
+                exit 1
+              else
+                echo "✅ PASS: No hardcoded ~/kmods paths found"
+              fi
+
+              # Test 6: Verify isolation (each TaskRun uses unique directory)
+              echo "Test 6: Process Isolation"
+              UNIQUE_UID_COUNT=$(echo "$MKDIR_UIDS" | wc -w)
+              if [ "$UNIQUE_UID_COUNT" -eq 1 ]; then
+                echo "✅ PASS: Single unique TaskRun UID used (proper isolation)"
+              elif [ "$UNIQUE_UID_COUNT" -gt 1 ]; then
+                echo "❌ FAIL: Multiple TaskRun UIDs found (unexpected)"
+                exit 1
+              else
+                echo "❌ FAIL: No TaskRun UID found"
+                exit 1
+              fi
+
+              echo ""
+              echo "=== Supply Chain Integrity Tests: ALL PASSED ✅ ==="
+              echo "TaskRun UID isolation and cleanup working correctly"
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(tasks.run-task.results.sourceDataArtifact)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - run-task

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-multiarch.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods-multiarch.yaml
@@ -147,6 +147,9 @@ spec:
 
               echo "SUCCESS: All multiarch structure validation checks passed"
               echo "Task would process kernel modules for multiarch deployment"
+
+              # Note: This test validates the multiarch structure setup
+              # For TaskRun UID and cleanup validation, see test-sign-oot-kmods-cleanup.yaml
       params:
         - name: dataDir
           value: $(params.dataDir)

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -204,6 +204,46 @@ spec:
                 echo "ERROR: Checksums file not found - should be generated after signing"
                 exit 1
               fi
+
+              # Check for TaskRun UID usage in SSH commands
+              SSH_FILE="$(params.dataDir)/mock_ssh.txt"
+              if [ -f "$SSH_FILE" ]; then
+                echo "Mock ssh file found: $SSH_FILE"
+                echo "SSH commands:"
+                cat "$SSH_FILE"
+
+                # Check for unique directory creation with TaskRun UID pattern
+                if grep -E "mkdir -p ~/[a-f0-9\-]{8,}/kmods" "$SSH_FILE"; then
+                  echo "SUCCESS: Found unique TaskRun UID directory creation in SSH commands"
+                else
+                  echo "ERROR: Unique TaskRun UID directory creation not found in SSH commands"
+                  exit 1
+                fi
+
+                # Check for cleanup with TaskRun UID pattern
+                if grep -E "rm -rf ~/[a-f0-9\-]{8,}" "$SSH_FILE"; then
+                  echo "SUCCESS: Found TaskRun UID directory cleanup in SSH commands"
+                else
+                  echo "ERROR: TaskRun UID directory cleanup not found in SSH commands"
+                  exit 1
+                fi
+              else
+                echo "ERROR: Mock ssh file not found - ssh commands were not logged"
+                exit 1
+              fi
+
+              # Check for TaskRun UID usage in SCP commands
+              if [ -f "$SCP_FILE" ]; then
+                echo "Checking SCP commands for TaskRun UID usage:"
+                cat "$SCP_FILE"
+
+                # Check for TaskRun UID pattern in SCP paths
+                if grep -E "/[a-f0-9\-]{8,}/kmods/" "$SCP_FILE"; then
+                  echo "SUCCESS: Found TaskRun UID usage in SCP commands"
+                else
+                  echo "WARNING: TaskRun UID pattern not found in SCP commands (may use individual file transfer)"
+                fi
+              fi
       params:
         - name: signedKmodsPath
           value: signed-kmods


### PR DESCRIPTION
A bug compromising the the supply chain integrity
was detected by @mizdebsk and shared by @johnbieren as
we use a shared directory for all the signing
pipelines. This commit creates a directory with a
unique ID that prevents overwriting files created
by a pipeline from another different pipeline.
