### PR TITLE
feat: add artifact-browser-url to PR comment task

### DIFF
--- a/integration-tests/pipelines/e2e-tests-kind-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-kind-pipeline.yaml
@@ -38,6 +38,10 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
     - name: pipeline-test-suite
       type: string
       description: 'The name of the test corresponding to a defined Konflux integration test.'
@@ -45,7 +49,7 @@ spec:
       default: ''
       type: string
       description: |
-        The pipeline that is used by the test suite. 
+        The pipeline that is used by the test suite.
         If empty, use the pipeline-test-suite as the pipeline to be used
   tasks:
     - name: test-metadata
@@ -270,6 +274,8 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"

--- a/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-stage-pipeline.yaml
@@ -38,6 +38,10 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
     - name: pipeline-test-suite
       type: string
       description: 'The name of the test corresponding to a defined Konflux integration test.'
@@ -45,7 +49,7 @@ spec:
       default: ''
       type: string
       description: |
-        The pipeline that is used by the test suite. 
+        The pipeline that is used by the test suite.
         If empty, use the pipeline-test-suite as the pipeline to be used
   tasks:
     - name: test-metadata
@@ -168,6 +172,8 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -39,6 +39,10 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
   tasks:
     - name: test-metadata
       taskRef:
@@ -226,6 +230,8 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)
     - name: store-pipeline-status
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"


### PR DESCRIPTION
## Describe your changes
Add the artifact-browser-url pipeline parameter and pass it to the pull-request-comment task. This enables linking to the OCI artifact browser in PR comments when the URL is provided.

## Relevant Jira
KFLUXDP-448

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
