### PR TITLE
fix: use hierarchical paths for Git kmod storage

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -230,7 +230,10 @@ spec:
 
         if [ "$arch_count" -eq 1 ]; then
             echo "Single architecture image, using standard extraction"
-            extract_single_arch "$source_image" "$(params.dataDir)/$SIGNED_KMODS_PATH" "single"
+            # Extract the actual architecture name
+            actual_arch=$(jq -r '.platform.architecture' "$(params.dataDir)/architectures.json")
+            echo "Architecture: $actual_arch"
+            extract_single_arch "$source_image" "$(params.dataDir)/$SIGNED_KMODS_PATH/$actual_arch" "$actual_arch"
         else
             echo "Multi-architecture image detected, processing each architecture separately"
 

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -138,12 +138,9 @@ spec:
         push_arch_artifacts() {
             local arch_name="$1"
             local source_dir="$2"
-            local arch_suffix=""
 
-            # Add architecture suffix for multi-arch builds
-            if [ "$arch_count" -gt 1 ]; then
-                arch_suffix="_${arch_name}"
-            fi
+            # Always include architecture suffix for consistent hierarchy
+            local arch_suffix="/${arch_name}"
 
             echo "Processing artifacts for architecture: $arch_name"
 
@@ -156,7 +153,7 @@ spec:
                 return 1
             fi
 
-            TARGET_DIR="${DRIVER_VENDOR}_${DRIVER_VERSION}_${KERNEL_VERSION}${arch_suffix}"
+            TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}"
             echo "Target directory for $arch_name: $TARGET_DIR"
 
             git sparse-checkout add "$TARGET_DIR"
@@ -238,18 +235,35 @@ spec:
 
             # Create multi-arch summary file in the repository
             if [ -f "${SIGNED_KMODS_PATH}/signing_summary.txt" ]; then
-                summary_target_dir="multi-arch-summary_$(date +%Y%m%d_%H%M%S)"
-                git sparse-checkout add "$summary_target_dir"
-                mkdir -p "$summary_target_dir"
-                cp "${SIGNED_KMODS_PATH}/signing_summary.txt" "$summary_target_dir/"
-                cp "${SIGNED_KMODS_PATH}/extraction_summary.txt" "$summary_target_dir/" 2>/dev/null || true
-                git add "$summary_target_dir"
+                # Use first architecture's envfile for base path information
+                first_arch_dir=$(find "${SIGNED_KMODS_PATH}" -mindepth 1 -maxdepth 1 -type d | head -1)
+                if [ -n "$first_arch_dir" ] && [ -f "$first_arch_dir/envfile" ]; then
+                    # shellcheck source=/dev/null
+                    . "$first_arch_dir/envfile"
+                    summary_target_dir="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/multi-arch-summary"
+
+                    echo "Creating multi-architecture summary in Git: ${summary_target_dir}"
+                    git sparse-checkout add "$summary_target_dir"
+                    mkdir -p "$summary_target_dir"
+                    cp "${SIGNED_KMODS_PATH}/signing_summary.txt" "$summary_target_dir/"
+                    cp "${SIGNED_KMODS_PATH}/extraction_summary.txt" "$summary_target_dir/" 2>/dev/null || true
+                    git add "$summary_target_dir"
+                fi
             fi
 
         else
             echo "Single architecture build, using standard upload"
 
-            cd "${SIGNED_KMODS_PATH}"
+            # Get the actual architecture directory name
+            arch_dir=$(find "${SIGNED_KMODS_PATH}" -mindepth 1 -maxdepth 1 -type d | head -1)
+            if [ -z "$arch_dir" ]; then
+                echo "ERROR: No architecture directory found in ${SIGNED_KMODS_PATH}"
+                exit 1
+            fi
+            actual_arch=$(basename "$arch_dir")
+            echo "Detected architecture: $actual_arch"
+
+            cd "$arch_dir"
             # Validate checksum file exists for single-arch
             if [ ! -f "signed_kmods_checksums.txt" ]; then
                 echo "ERROR: signed_kmods_checksums.txt not found for single architecture build"
@@ -260,10 +274,10 @@ spec:
             sha256sum -c signed_kmods_checksums.txt
             cd "${GIT_WORK_DIR}/local-artifacts"
 
-            if push_arch_artifacts "single" "${SIGNED_KMODS_PATH}"; then
-                echo "Successfully processed single architecture"
+            if push_arch_artifacts "$actual_arch" "$arch_dir"; then
+                echo "Successfully processed single architecture: $actual_arch"
             else
-                echo "ERROR: Failed to process single architecture"
+                echo "ERROR: Failed to process single architecture: $actual_arch"
                 exit 1
             fi
         fi

--- a/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
@@ -30,7 +30,7 @@ git() {
                     # For multi-arch, check for architecture-specific directories
                     expected_archs=("amd64" "arm64")
                     for arch in "${expected_archs[@]}"; do
-                        TARGET_DIR="${DRIVER_VENDOR}_${DRIVER_VERSION}_${KERNEL_VERSION}_${arch}"
+                        TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/${arch}"
                         echo "Checking for files in architecture-specific target directory: ${TARGET_DIR}"
 
                         if [ -d "${TARGET_DIR}" ] && ls "${TARGET_DIR}"/*.ko 1> /dev/null 2>&1; then
@@ -42,15 +42,16 @@ git() {
                         fi
                     done
 
-                    # Also check for summary directory
-                    if ls multi-arch-summary_* 1> /dev/null 2>&1; then
-                        echo "SUCCESS: Found multi-arch summary directory"
+                    # Also check for summary directory under the kernel version path
+                    SUMMARY_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/multi-arch-summary"
+                    if [ -d "${SUMMARY_DIR}" ]; then
+                        echo "SUCCESS: Found multi-arch summary directory at ${SUMMARY_DIR}"
                     else
-                        echo "WARNING: No multi-arch summary directory found"
+                        echo "WARNING: No multi-arch summary directory found at ${SUMMARY_DIR}"
                     fi
                 else
                     # Single architecture
-                    TARGET_DIR="${DRIVER_VENDOR}_${DRIVER_VERSION}_${KERNEL_VERSION}"
+                    TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}"
                     echo "Checking for files in single-arch target directory: ${TARGET_DIR}"
 
                     if [ -f "${TARGET_DIR}/mod1.ko" ] && [ -f "${TARGET_DIR}/mod2.ko" ]; then
@@ -63,7 +64,7 @@ git() {
                 fi
             else
                 # Fallback to original single-arch logic
-                TARGET_DIR="${DRIVER_VENDOR}_${DRIVER_VERSION}_${KERNEL_VERSION}"
+                TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}"
                 echo "Checking for files in target directory: ${TARGET_DIR}"
 
                 if [ -f "${TARGET_DIR}/mod1.ko" ] && [ -f "${TARGET_DIR}/mod2.ko" ]; then


### PR DESCRIPTION
Changes the push-oot-kmods-to-git task to use slash-delimited hierarchical directory structure (vendor/version/kernel/arch) instead of underscore-delimited flat structure (vendor_version_kernel_arch).

This aligns the Git storage format with S3 and Azure tasks, providing better organization and easier navigation. The hierarchical structure allows browsing by driver version, then drilling down to specific kernel versions and architectures.

Before: nvidia-opengpu_580.95.05_5.14.0-570.32.1.el9_6_x86_64/
After:  nvidia-opengpu/580.95.05/5.14.0-570.32.1.el9_6/x86_64/

This change makes all three storage backends (Git, S3, Azure) use the same consistent path structure.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
