### PR TITLE
fix(KFLUXSPRT-6330): push-artifacts-to-cdn don't require releaseNotes

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -301,10 +301,13 @@ spec:
         - name: schema
           value:  $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
         - name: systems
+          # Advisory creation is temporarily disabled,
+          # see https://issues.redhat.com/browse/RELEASE-2000
+          # Readd the following once reenabled
+          # {"systemName": "releaseNotes", "dynamic": false},
           value: |
             [
               {"systemName": "cdn", "dynamic": false},
-              {"systemName": "releaseNotes", "dynamic": false},
               {"systemName": "intention", "dynamic": false}
             ]
         - name: ociStorage


### PR DESCRIPTION
The push-artifacts-to-cdn pipeline disabled advisory creation (see RELEASE-2000 for details). As such, the check-data-keys task in the pipeline should not fail for the releaseNotes keys missing, as they are used for the advisory tasks.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
