### PR TITLE
fix: resolve remote path mismatch in sign-oot-kmods

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -178,13 +178,6 @@ spec:
             local arch_name="$1"
             local task_uid
             task_uid="$(context.taskRun.uid)"
-            local remote_base_dir="$HOME/$task_uid"
-            local remote_dir
-            if [ "$arch_name" != "single" ]; then
-                remote_dir="$remote_base_dir/kmods/$arch_name"
-            else
-                remote_dir="$remote_base_dir/kmods"
-            fi
 
             signing_author="$signingAuthor"
             export signing_author
@@ -194,16 +187,23 @@ spec:
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
             "export KEY='${signKey}'; export ARCH='${arch_name}'; \
              export TASK_UID='${task_uid}'; \
-             export REMOTE_DIR='${remote_dir}'; \
+             export SIGNING_AUTHOR='${signing_author}'; \
              bash -s" <<'EOF'
         echo "Remote: Signing OOT kernel modules for architecture $ARCH using $KEY key..."
+
+        # Construct the remote directory path using the remote server's HOME
+        if [ "$ARCH" != "single" ]; then
+            REMOTE_DIR="$HOME/$TASK_UID/kmods/$ARCH"
+        else
+            REMOTE_DIR="$HOME/$TASK_UID/kmods"
+        fi
 
         # Check if any .ko files exist in the remote directory
         if ls "$REMOTE_DIR"/*.ko 1> /dev/null 2>&1; then
             for kmod in "$REMOTE_DIR"/*.ko; do
                 if [ -f "$kmod" ]; then
                     echo "Remote: Signing kernel module $kmod for $ARCH"
-                    rh-signing-client --key "$KEY" --onbehalfof "${signing_author}" --lkmsign "$kmod"
+                    rh-signing-client --key "$KEY" --onbehalfof "${SIGNING_AUTHOR}" --lkmsign "$kmod"
                     if [ $? -ne 0 ]; then
                         echo "Remote: ERROR failed to sign $kmod for $ARCH"
                         exit 1


### PR DESCRIPTION
Fixes two bugs in sign_kmods_for_arch function:

1. Path mismatch: REMOTE_DIR was calculated using local $HOME (/tekton/home) instead of remote server's home, causing "No .ko files found" errors. Fixed by moving path construction to remote heredoc where $HOME expands correctly.

2. Missing export: signing_author was not exported to remote server. Fixed by exporting as SIGNING_AUTHOR and updating rh-signing-client reference.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
