### PR TITLE
feat: add custom spec file support to build-oot-kmods-rpms

### DIFF
--- a/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/build-oot-kmods-rpms.yaml
@@ -231,8 +231,6 @@ spec:
             PACKAGE_RELEASE="1.$(echo "${KERNEL_VERSION_NO_ARCH}" | tr '.-' '_')"
             SPEC_FILE="${RPM_BUILD_ROOT}/SPECS/${PACKAGE_NAME}.spec"
 
-            echo "Creating RPM spec file for $arch_name: ${SPEC_FILE}"
-
             # Determine target architecture based on arch_name or kernel version
             local target_arch
             if [ "$arch_count" -gt 1 ]; then
@@ -259,52 +257,63 @@ spec:
 
             echo "Using RPM BuildArch: $rpm_arch for architecture: $arch_name (kernel modules are pre-built)"
 
-            # Create RPM spec file
-            {
-              echo "Name:           ${PACKAGE_NAME}"
-              echo "Version:        ${PACKAGE_VERSION}"
-              echo "Release:        ${PACKAGE_RELEASE}"
-              echo "Summary:        ${DRIVER_VENDOR} out-of-tree kernel modules for kernel ${KERNEL_VERSION}"
-              echo "License:        Proprietary"
-              echo "Group:          System Environment/Kernel"
-              echo "BuildArch:      ${rpm_arch}"
-              echo "Requires:       kernel = ${KERNEL_VERSION}"
-              # Prevent rpmbuild from stripping or modifying already-signed .ko files
-              echo "%undefine _debugsource_packages"
-              echo "%undefine _debuginfo_subpackages"
-              echo "%undefine debug_package"
-              echo "%global __brp_strip /bin/true"
-              echo "%global __brp_strip_comment_note /bin/true"
-              echo "%global __brp_strip_static_archive /bin/true"
-              echo "%global __os_install_post %{nil}"
-              echo ""
-              echo "%description"
-              echo "This package contains signed out-of-tree kernel modules for ${DRIVER_VENDOR}"
-              echo "driver version ${PACKAGE_VERSION}, built for kernel ${KERNEL_VERSION}."
-              echo ""
-              echo "%prep"
-              echo "# No prep needed"
-              echo ""
-              echo "%build"
-              echo "# No build needed"
-              echo ""
-              echo "%install"
-              echo "mkdir -p %{buildroot}/lib/modules/${KERNEL_VERSION}/extra/${DRIVER_VENDOR}"
-              echo "cp %{_sourcedir}/*.ko %{buildroot}/lib/modules/${KERNEL_VERSION}/extra/${DRIVER_VENDOR}/"
-              echo ""
-              echo "%files"
-              echo "/lib/modules/${KERNEL_VERSION}/extra/${DRIVER_VENDOR}/*.ko"
-              echo ""
-              echo "%post"
-              echo "/sbin/depmod -a ${KERNEL_VERSION} || :"
-              echo ""
-              echo "%postun"
-              echo "/sbin/depmod -a ${KERNEL_VERSION} || :"
-              echo ""
-              echo "%changelog"
-              echo "* $(date '+%a %b %d %Y') Konflux CI <konflux-ci@redhat.com> - ${PACKAGE_VERSION}-${PACKAGE_RELEASE}"
-              echo "- Automated build of signed ${DRIVER_VENDOR} kernel modules for ${KERNEL_VERSION}"
-            } > "${SPEC_FILE}"
+            # Check for custom spec file at repository root
+            CUSTOM_SPEC_FILE="$(params.dataDir)/${PACKAGE_NAME}.spec"
+            if [ -f "${CUSTOM_SPEC_FILE}" ]; then
+                echo "Using custom spec file for $arch_name: ${CUSTOM_SPEC_FILE}"
+                cp "${CUSTOM_SPEC_FILE}" "${SPEC_FILE}"
+            else
+                echo "Creating RPM spec file for $arch_name: ${SPEC_FILE}"
+
+                # Create RPM spec file using RPM macros
+                {
+                  echo "Name:           %{package_name}"
+                  echo "Version:        %{package_version}"
+                  echo "Release:        %{package_release}"
+                  echo "Summary:        %{driver_vendor} out-of-tree kernel modules for kernel %{kernel_version}"
+                  echo "License:        Proprietary"
+                  echo "Group:          System Environment/Kernel"
+                  echo "BuildArch:      %{rpm_arch}"
+                  echo "Requires:       kernel = %{kernel_version}"
+                  # Prevent rpmbuild from stripping or modifying already-signed .ko files
+                  echo "%undefine _debugsource_packages"
+                  echo "%undefine _debuginfo_subpackages"
+                  echo "%undefine debug_package"
+                  echo "%global __brp_strip /bin/true"
+                  echo "%global __brp_strip_comment_note /bin/true"
+                  echo "%global __brp_strip_static_archive /bin/true"
+                  echo "%global __os_install_post %{nil}"
+                  echo ""
+                  echo "%description"
+                  echo "This package contains signed out-of-tree kernel modules for %{driver_vendor}"
+                  echo "driver version %{package_version}, built for kernel %{kernel_version}."
+                  echo ""
+                  echo "%prep"
+                  echo "# No prep needed"
+                  echo ""
+                  echo "%build"
+                  echo "# No build needed"
+                  echo ""
+                  echo "%install"
+                  echo "mkdir -p %{buildroot}/lib/modules/%{kernel_version}/extra/%{driver_vendor}"
+                  echo "cp %{_sourcedir}/*.ko %{buildroot}/lib/modules/%{kernel_version}/extra/%{driver_vendor}/"
+                  echo ""
+                  echo "%files"
+                  echo "/lib/modules/%{kernel_version}/extra/%{driver_vendor}/*.ko"
+                  echo ""
+                  echo "%post"
+                  echo "/sbin/depmod -a %{kernel_version} || :"
+                  echo ""
+                  echo "%postun"
+                  echo "/sbin/depmod -a %{kernel_version} || :"
+                  echo ""
+                  echo "%changelog"
+                  echo "* $(date '+%a %b %d %Y') Konflux CI <konflux-ci@redhat.com> -" \
+                       "%{package_version}-%{package_release}"
+                  echo "- Automated build of signed %{driver_vendor} kernel modules for" \
+                       "%{kernel_version}"
+                } > "${SPEC_FILE}"
+            fi
 
             # Copy signed .ko files to SOURCES directory
             echo "Copying signed .ko files to RPM SOURCES for $arch_name..."
@@ -329,6 +338,12 @@ spec:
             rpmbuild --target "${target_arch}" \
                      --define "_topdir ${RPM_BUILD_ROOT}" \
                      --define "_sourcedir ${RPM_BUILD_ROOT}/SOURCES" \
+                     --define "package_name ${PACKAGE_NAME}" \
+                     --define "package_version ${PACKAGE_VERSION}" \
+                     --define "package_release ${PACKAGE_RELEASE}" \
+                     --define "kernel_version ${KERNEL_VERSION}" \
+                     --define "driver_vendor ${DRIVER_VENDOR}" \
+                     --define "rpm_arch ${rpm_arch}" \
                      -bb "${SPEC_FILE}"
 
             # Move built RPMs to architecture-specific output directory

--- a/tasks/managed/build-oot-kmods-rpms/tests/mocks.sh
+++ b/tasks/managed/build-oot-kmods-rpms/tests/mocks.sh
@@ -6,11 +6,12 @@ set -eux
 function rpmbuild() {
   echo "Mock rpmbuild called with: $*"
 
-  # Parse arguments to find topdir, sourcedir, and spec file
+  # Parse arguments to find topdir, sourcedir, spec file, and macro definitions
   local topdir=""
   local sourcedir=""
   local spec_file=""
   local build_binary=false
+  declare -A macros  # Associative array for macro definitions
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -20,6 +21,11 @@ function rpmbuild() {
           topdir="${1#_topdir }"
         elif [[ $1 == "_sourcedir "* ]]; then
           sourcedir="${1#_sourcedir }"
+        else
+          # Parse macro definition: "name value"
+          local macro_name="${1%% *}"
+          local macro_value="${1#* }"
+          macros["$macro_name"]="$macro_value"
         fi
         shift
         ;;
@@ -41,32 +47,126 @@ function rpmbuild() {
   if [ "$build_binary" = true ] && [ -n "$topdir" ] && [ -n "$spec_file" ] && [ -f "$spec_file" ]; then
     echo "Mock rpmbuild: Creating dummy RPM from spec: $spec_file"
 
-    # Extract package info from spec file
+    # Function to expand a single macro reference
+    expand_macro() {
+      local value="$1"
+      # Expand %{macro_name} references
+      for macro_name in "${!macros[@]}"; do
+        value="${value//\%\{${macro_name}\}/${macros[$macro_name]}}"
+      done
+      echo "$value"
+    }
+
+    # Extract package info from spec file and expand macros
     local package_name=$(grep "^Name:" "$spec_file" | awk '{print $2}' | head -1)
+    package_name=$(expand_macro "$package_name")
+
     local package_version=$(grep "^Version:" "$spec_file" | awk '{print $2}' | head -1)
+    package_version=$(expand_macro "$package_version")
+
     local package_release=$(grep "^Release:" "$spec_file" | awk '{print $2}' | head -1)
+    package_release=$(expand_macro "$package_release")
+
     local build_arch=$(grep "^BuildArch:" "$spec_file" | awk '{print $2}' | head -1 || echo "x86_64")
+    build_arch=$(expand_macro "$build_arch")
 
     # Create output directory
     local rpms_dir="$topdir/RPMS/$build_arch"
     mkdir -p "$rpms_dir"
 
+    # Extract additional metadata from spec file
+    local license=$(grep "^License:" "$spec_file" | awk '{print $2}' | head -1)
+    license=$(expand_macro "$license")
+
+    local summary=$(grep "^Summary:" "$spec_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//' | head -1)
+    summary=$(expand_macro "$summary")
+
+    # Extract description (first non-empty line after %description)
+    local description=$(awk '/^%description/,/^%/ {if (NF && !/^%/) print}' "$spec_file" | head -1)
+    description=$(expand_macro "$description")
+
     # Create dummy RPM file
     local rpm_filename="${package_name}-${package_version}-${package_release}.${build_arch}.rpm"
     local rpm_path="$rpms_dir/$rpm_filename"
 
-    # Create a simple dummy file that just needs to exist and not be empty
+    # Create a simple dummy file with metadata
     echo "MOCK RPM FILE" > "$rpm_path"
-    echo "Package: $package_name" >> "$rpm_path"
+    echo "Name: $package_name" >> "$rpm_path"
     echo "Version: $package_version" >> "$rpm_path"
     echo "Release: $package_release" >> "$rpm_path"
     echo "Architecture: $build_arch" >> "$rpm_path"
+    echo "License: $license" >> "$rpm_path"
+    echo "Summary: $summary" >> "$rpm_path"
+    echo "Description: $description" >> "$rpm_path"
     echo "Created by mock rpmbuild for testing" >> "$rpm_path"
 
     echo "Mock rpmbuild: Created dummy RPM: $rpm_path"
     return 0
   else
     echo "Mock rpmbuild: Missing required arguments or spec file"
+    return 1
+  fi
+}
+
+function rpm() {
+  echo "Mock rpm called with: $*" >&2
+
+  # Parse arguments
+  local query_package=false
+  local query_format=""
+  local rpm_file=""
+
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -qp)
+        query_package=true
+        shift
+        ;;
+      --queryformat)
+        shift
+        query_format="$1"
+        shift
+        ;;
+      *.rpm)
+        rpm_file="$1"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  # If querying a package file
+  if [ "$query_package" = true ] && [ -n "$rpm_file" ] && [ -f "$rpm_file" ]; then
+    # Extract the requested field from the mock RPM file
+    case "$query_format" in
+      '%{LICENSE}')
+        grep "^License:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      '%{SUMMARY}')
+        grep "^Summary:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      '%{DESCRIPTION}')
+        grep "^Description:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      '%{NAME}')
+        grep "^Name:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      '%{VERSION}')
+        grep "^Version:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      '%{RELEASE}')
+        grep "^Release:" "$rpm_file" | cut -d':' -f2- | sed 's/^[[:space:]]*//'
+        ;;
+      *)
+        echo "Mock rpm: Unknown query format: $query_format" >&2
+        return 1
+        ;;
+    esac
+    return 0
+  else
+    echo "Mock rpm: Invalid arguments" >&2
     return 1
   fi
 }

--- a/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-spec.yaml
+++ b/tasks/managed/build-oot-kmods-rpms/tests/test-build-oot-kmods-rpms-custom-spec.yaml
@@ -1,0 +1,273 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-oot-kmods-rpms-custom-spec
+spec:
+  description: |
+    Test the build-oot-kmods-rpms task with a custom spec file
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/"
+
+              # Create test environment file with driver information
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/envfile" << EOF
+              DRIVER_VENDOR=test-vendor
+              DRIVER_VERSION=2.1.3
+              KERNEL_VERSION=6.5.0-1.el9.x86_64
+              EOF
+
+              # Create mock signed kernel module files
+              echo -e "\x7fELF" > "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/test-driver.ko"
+              echo -e "\x7fELF" > "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/test-helper.ko"
+
+              # Make them look like kernel modules (minimal binary header)
+              for ko in "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/"*.ko; do
+                printf "\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00" > "$ko"
+                printf "test kernel module data" >> "$ko"
+              done
+
+              # Generate checksums file to match the sign-oot-kmods task output
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)/signed-kmods/"
+              sha256sum ./*.ko > signed_kmods_checksums.txt
+              echo "Generated checksums file for test .ko files"
+
+              # Create custom spec file at repository root with PACKAGE_NAME
+              # PACKAGE_NAME will be "test-vendor-kmods" based on the envfile
+              cat > "$(params.dataDir)/test-vendor-kmods.spec" << 'SPECEOF'
+              Name:           %{package_name}
+              Version:        %{package_version}
+              Release:        %{package_release}
+              Summary:        CUSTOM SPEC: %{driver_vendor} kernel modules for %{kernel_version}
+              License:        Custom-Test-License
+              Group:          System Environment/Kernel
+              BuildArch:      %{rpm_arch}
+              Requires:       kernel = %{kernel_version}
+
+              # Prevent rpmbuild from stripping or modifying already-signed .ko files
+              %undefine _debugsource_packages
+              %undefine _debuginfo_subpackages
+              %undefine debug_package
+              %global __brp_strip /bin/true
+              %global __brp_strip_comment_note /bin/true
+              %global __brp_strip_static_archive /bin/true
+              %global __os_install_post %{nil}
+
+              %description
+              This is a CUSTOM SPEC FILE test for %{driver_vendor} version %{package_version}.
+              Built for kernel %{kernel_version}.
+
+              %prep
+              # No prep needed
+
+              %build
+              # No build needed
+
+              %install
+              mkdir -p %{buildroot}/lib/modules/%{kernel_version}/extra/%{driver_vendor}
+              cp %{_sourcedir}/*.ko %{buildroot}/lib/modules/%{kernel_version}/extra/%{driver_vendor}/
+
+              %files
+              /lib/modules/%{kernel_version}/extra/%{driver_vendor}/*.ko
+
+              %post
+              /sbin/depmod -a %{kernel_version} || :
+
+              %postun
+              /sbin/depmod -a %{kernel_version} || :
+
+              %changelog
+              * Wed Dec 18 2024 Custom Spec Test <test@example.com> - %{package_version}-%{package_release}
+              - Custom spec file test build
+              SPECEOF
+
+              echo "Created custom spec file: $(params.dataDir)/test-vendor-kmods.spec"
+              cat "$(params.dataDir)/test-vendor-kmods.spec"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: build-oot-kmods-rpms
+      params:
+        - name: signedKmodsPath
+          value: $(context.pipelineRun.uid)/signed-kmods
+        - name: rpmOutputPath
+          value: $(context.pipelineRun.uid)/rpms
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+          - name: pipelineRunUid
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              RPM_OUTPUT_PATH="$(params.dataDir)/$(params.pipelineRunUid)/rpms"
+
+              echo "Checking RPM output directory: ${RPM_OUTPUT_PATH}"
+
+              # Check that RPMs were created
+              if ! ls "${RPM_OUTPUT_PATH}"/*.rpm >/dev/null 2>&1; then
+                echo "ERROR: No RPM files found in ${RPM_OUTPUT_PATH}"
+                echo "Contents of RPM output directory:"
+                ls -la "${RPM_OUTPUT_PATH}" || echo "Directory does not exist"
+                exit 1
+              fi
+
+              echo "Found RPM files:"
+              ls -la "${RPM_OUTPUT_PATH}"/*.rpm
+
+              # Verify expected RPM naming pattern
+              expected_rpm="${RPM_OUTPUT_PATH}/test-vendor-kmods-2.1.3-1.6_5_0_1_el9.x86_64.rpm"
+              if [ ! -f "$expected_rpm" ]; then
+                echo "ERROR: Expected RPM file not found: $expected_rpm"
+                echo "Available RPM files:"
+                ls -la "${RPM_OUTPUT_PATH}"/*.rpm
+                exit 1
+              fi
+
+              echo "Found expected RPM: $expected_rpm"
+
+              # Verify the custom spec file was used by checking mock RPM file content
+              echo "Checking mock RPM file content to verify custom spec was used..."
+
+              # The mock RPM file contains metadata as plain text fields
+              echo "Mock RPM file contents:"
+              cat "$expected_rpm"
+              echo ""
+
+              # Check for custom license
+              if ! grep -q "^License: Custom-Test-License$" "$expected_rpm"; then
+                echo "ERROR: Expected custom license 'Custom-Test-License' not found in mock RPM"
+                echo "This indicates the custom spec file was not used"
+                exit 1
+              fi
+              echo "SUCCESS: Found custom license"
+
+              # Check for custom summary
+              if ! grep -q "Summary:.*CUSTOM SPEC" "$expected_rpm"; then
+                echo "ERROR: Expected summary to contain 'CUSTOM SPEC'"
+                echo "This indicates the custom spec file was not used"
+                exit 1
+              fi
+              echo "SUCCESS: Found custom summary with 'CUSTOM SPEC'"
+
+              # Basic file validation
+              file_size=$(stat -c%s "$expected_rpm")
+              if [ "$file_size" -eq 0 ]; then
+                echo "ERROR: RPM file is empty"
+                exit 1
+              fi
+
+              echo "RPM file validation successful:"
+              echo "  File: $expected_rpm"
+              echo "  Size: $file_size bytes"
+
+              echo "SUCCESS: Custom spec file was used correctly!"
+      runAfter:
+        - setup


### PR DESCRIPTION
Allow using a custom RPM spec file by placing it at the repository root with the name ${PACKAGE_NAME}.spec. If not found, falls back to the existing inline spec generation.

Updated inline spec to use RPM macros (%{package_name}, %{package_version}, %{package_release}, %{kernel_version}, %{driver_vendor}, %{rpm_arch}) which are passed to rpmbuild via --define flags, creating a consistent API for custom spec files.