### PR TITLE
feat(RELEASE-1996): save annotations for all images

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -21,9 +21,8 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ digest_sha }}" -> The image digest of the respective component
 * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
   repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
-* "{{ oci_version }}" -> The version from OCI image annotations for Helm charts as media type, and from OCI image
-  labels for the other supported media types (extracts org.opencontainers.image.version and converts + to _ for
-  tag compliance)
+* "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
+  to OCI image labels if not present in annotations (converts + to _ for tag compliance)
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -29,9 +29,8 @@ spec:
     * "{{ digest_sha }}" -> The image digest of the respective component
     * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
       repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
-    * "{{ oci_version }}" -> The version from OCI image annotations for Helm charts as media type, and from OCI image
-      labels for the other supported media types (extracts org.opencontainers.image.version and converts + to _ for
-      tag compliance)
+    * "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
+      to OCI image labels if not present in annotations (converts + to _ for tag compliance)
 
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
   params:
@@ -394,30 +393,28 @@ spec:
             arch="$(jq -rs 'map(.platform.architecture) | .[0]' <<< "$arch_json")"
             os="$(jq -rs 'map(.platform.os) | .[0]' <<< "$arch_json")"
 
-            # Get configMediaType from architecture info to determine artifact type
-            config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
+            # Get first digest from architecture info to construct image reference
+            first_digest="$(jq -rs '.[0].digest' <<< "$arch_json")"
 
-            # Check if this is a Helm chart - handle Helm artifacts specifically
-            if [[ "$config_media_type" == "application/vnd.cncf.helm.config.v1+json" ]]; then
-                # This is a Helm chart - use raw manifest approach
-                echo "Detected Helm chart artifact for ${NAME}, using raw manifest"
-                raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${IMAGE_REF}" | jq -c)"
-                oci_version_raw="$(jq -r '.annotations."org.opencontainers.image.version" // ""' <<< "$raw_manifest")"
-                build_date="$(jq -r '.annotations."org.opencontainers.image.created" // ""' <<< "$raw_manifest")"
-                env_variables="[]"
-                labels="{}"
-            else
-                # This is a regular container image - use standard skopeo inspect
-                image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
-                  --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
-                # For timestamp, use Labels.build-date and fallback to Created
-                build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
-                # Get org.opencontainers.image.version from annotations, and fallback to Labels if not.
-                oci_version_raw="$(jq -r \
-                  '.Labels."org.opencontainers.image.version" // ""'\
-                  <<< "$image_metadata")"
-                env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
-                labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+            # Construct image reference with the first architecture's digest for annotations
+            image_with_digest="${IMAGE_REF%@*}@${first_digest}"
+
+            # Get raw manifest to extract annotations
+            raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${image_with_digest}" | jq -c)"
+            annotations="$(jq -c '.annotations // {}' <<< "$raw_manifest")"
+
+            # Get image metadata for labels, env, build_date (standard inspect)
+            image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
+              --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
+            # For timestamp, use Labels.build-date and fallback to Created
+            build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
+            env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
+            labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+
+            # Get oci_version_raw from annotations, fallback to labels
+            oci_version_raw="$(jq -r '.["org.opencontainers.image.version"] // ""' <<< "$annotations")"
+            if [ -z "$oci_version_raw" ]; then
+              oci_version_raw="$(jq -r '.["org.opencontainers.image.version"] // ""' <<< "$labels")"
             fi
 
             # Add image env_variables metadata to component
@@ -426,6 +423,17 @@ spec:
               echo "$env_variables" > "$env_file"
               jq --argjson i "$i" --slurpfile env "$env_file" \
                 '.components[$i].metadata = (.components[$i].metadata // {}) * {env_variables: $env[0]}' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            fi
+
+            # Add image annotations metadata to component
+            if [ "$(jq 'length' <<< "$annotations")" -ne 0 ] ; then
+              annotations_file=$(mktemp)
+              # Convert annotations from {key: value} to [{name: key, value: value}]
+              jq -c 'if . then to_entries | map({name: .key, value: .value}) else [] end' \
+               <<< "$annotations" > "$annotations_file"
+              jq --argjson i "$i" --slurpfile annotations "$annotations_file" \
+                '.components[$i].metadata = (.components[$i].metadata // {}) * {annotations: $annotations[0]}' \
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
     Run the apply-mapping task with a snapshot containing both container image components
-    and Helm chart components. Verify that oci_version expansion works for Helm charts.
+    and Helm chart components. Verify that oci_version expansion works using annotations.
   workspaces:
     - name: tests-workspace
   params:
@@ -249,5 +249,19 @@ spec:
                 jq -r '.components[] | select(.name=="helm-chart") | ."rh-registry-repo"' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == "registry.redhat.io/myorg/helm-chart"
+
+              echo Test that web-app has annotations from OCI manifest
+              test "$(
+                jq -c '.components[] | select(.name=="web-app") | .metadata.annotations' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '[{"name":"org.opencontainers.image.version","value":"1.2.3-beta"},'\
+              '{"name":"org.opencontainers.image.created","value":"2024-07-29T02:17:29Z"}]'
+
+              echo Test that helm-chart has annotations from OCI manifest
+              test "$(
+                jq -c '.components[] | select(.name=="helm-chart") | .metadata.annotations' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '[{"name":"org.opencontainers.image.version","value":"2.0.1+alpha"},'\
+              '{"name":"org.opencontainers.image.created","value":"2024-07-29T02:17:29Z"}]'
 
               echo All tests passed!

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -180,3 +180,8 @@ spec:
               )" == '[{"name":"build-date","value":"2024-07-29T02:17:29"},'\
               '{"name":"com.redhat.component","value":"app01"},'\
               '{"name":"description","value":"it is some app"}]'
+
+              echo "Test that component 0 has the correct annotations"
+              test "$(
+                jq -c '.components[0] | .metadata.annotations // []' < "$TEST_SNAPSHOT"
+              )" == '[{"name":"org.opencontainers.image.created","value":"2024-07-29T02:17:29Z"}]'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
     Run the apply-mapping task with a snapshot containing a helm chart component
-    and verify that the resulting snapshot contains no metadata.
+    and verify that the resulting snapshot contains annotations but no labels or env_variables.
   workspaces:
     - name: tests-workspace
   params:
@@ -188,3 +188,9 @@ spec:
               test "$(
                 jq '.components[0] | .metadata.labels // [] | length' < "$TEST_SNAPSHOT"
               )" -eq 0
+
+              echo "Test that component has annotations metadata from OCI manifest"
+              test "$(
+                jq -c '.components[0] | .metadata.annotations // []' < "$TEST_SNAPSHOT"
+              )" == '[{"name":"org.opencontainers.image.version","value":"2.0.1+alpha"},'\
+              '{"name":"org.opencontainers.image.created","value":"2024-07-29T02:17:29Z"}]'


### PR DESCRIPTION
## Describe your changes

We were only getting image annotations for helm charts. Fetching it for all images will make it more consistent. Also, a future change will read migration annotations in another task - see RELEASE-1870 .

Changes:
- Remove Helm chart-specific conditional handling for annotations
- Get annotations for all images using skopeo inspect with the digest from the first architecture in arch_json
- Save annotations as metadata.annotations in the snapshot spec file (same format as labels: array of {name, value} objects)
- Change oci_version_raw to check annotations first, then fall back to labels if not present
- Fix tests

We use the first digest from get-image-architectures because for multi-arch images, the top-level index manifest doesn't contain annotations - only the individual architecture manifests do. By using the first result from get-image-architectures, this approach works for all image types: multi-arch images get annotations from one of their architecture manifests, while single-arch images simply return their original digest.

Assisted-by: Cursor

## Relevant Jira

RELEASE-1996

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
