### PR TITLE
fix: pulp-cli bug

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -171,6 +171,61 @@ spec:
         set +x
         echo "${CONFIG_FILE_CONTENT:?}" > "/tmp/cli.toml"
         export PULP_CONFIG_FILE="/tmp/cli.toml"
+
+        # Extract OAuth2 credentials from cli.toml
+        PULP_BASE_URL=$(grep -E "^base_url\s*=" "$PULP_CONFIG_FILE" | sed 's/.*=\s*"\(.*\)"/\1/' | sed 's:/*$::')
+        CLIENT_ID=$(grep -E "^client_id\s*=" "$PULP_CONFIG_FILE" | sed 's/.*=\s*"\(.*\)"/\1/')
+        CLIENT_SECRET=$(grep -E "^client_secret\s*=" "$PULP_CONFIG_FILE" | sed 's/.*=\s*"\(.*\)"/\1/')
+        TOKEN_URL="https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+
+        # Function to get OAuth2 access token
+        
+        get_access_token() {
+          local token
+          token=$(curl --retry 3 -s -X POST "$TOKEN_URL" \
+            -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+            -d "grant_type=client_credentials" \
+            -d "scope=api.console" | jq -r '.access_token')
+          
+          if [[ -z "$token" || "$token" == "null" ]]; then
+            echo "Error: Failed to get OAuth2 access token" >&2
+            return 1
+          fi
+          echo "$token"
+        }
+
+        # Function to add content to a repository via API
+        add_content_to_repo() {
+          local repo_name="$1"
+          local hrefs_json="$2"
+          local domain="${PULP_DOMAIN}"
+          
+          local access_token
+          access_token=$(get_access_token) || return 1
+          
+          # Get repository href
+          local repo_href
+          repo_href=$(curl --retry 3 -s -H "Authorization: Bearer $access_token" \
+            "${PULP_BASE_URL}/api/pulp/${domain}/api/v3/repositories/rpm/rpm/?name=${repo_name}" \
+            | jq -r '.results[0].pulp_href')
+          
+          if [[ -z "$repo_href" || "$repo_href" == "null" ]]; then
+            echo "Error: Could not find repository href for ${repo_name}"
+            return 1
+          fi
+          
+          # Convert hrefs format: [{"pulp_href": "..."}] -> ["..."]
+          local add_content_units
+          add_content_units=$(echo "$hrefs_json" | jq '[.[].pulp_href]')
+          
+          # Add content to repository
+          echo "Calling API: POST ${PULP_BASE_URL}${repo_href}modify/"
+          curl --retry 3 -s -X POST "${PULP_BASE_URL}${repo_href}modify/" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "{\"add_content_units\": $add_content_units}"
+        }
+
         set -x
 
         DOMAIN_EXISTS=$(pulp --config "$PULP_CONFIG_FILE" domain show --name "${PULP_DOMAIN}" \
@@ -347,14 +402,10 @@ spec:
             fi
           done
 
-          # Bulk add all collected hrefs to repository
+          # Bulk add all collected hrefs to repository via API
           if [[ $(jq 'length' <<< "$HREFS_JSON") -gt 0 ]]; then
             echo "Adding $(jq 'length' <<< "$HREFS_JSON") packages to $arch repository..."
-            set +e
-            pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm repository content modify \
-              --repository "$arch" \
-              --add-content "$HREFS_JSON"
-            set -e
+            add_content_to_repo "$arch" "$HREFS_JSON"
           fi
         done
 
@@ -383,14 +434,10 @@ spec:
           fi
         done
 
-        # Bulk add all source rpms to source repository
+        # Bulk add all source rpms to source repository via API
         if [[ $(jq 'length' <<< "$SRC_HREFS_JSON") -gt 0 ]]; then
           echo "Adding $(jq 'length' <<< "$SRC_HREFS_JSON") source packages to source repository..."
-          set +e
-          pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm repository content modify \
-            --repository "source" \
-            --add-content "$SRC_HREFS_JSON"
-          set -e
+          add_content_to_repo "source" "$SRC_HREFS_JSON"
         fi
 
         echo "Results written to: $RESULTS_FILE"

--- a/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
@@ -6,6 +6,37 @@ set -ex
 # Counter for generating unique hrefs
 UPLOAD_COUNTER=0
 
+function curl() {
+    # Mock curl for OAuth2 and API calls
+    local args="$*"
+    
+    if [[ "$args" == *"sso.redhat.com"* ]]; then
+        # OAuth2 token request
+        echo '{"access_token": "mock-access-token", "expires_in": 3600}'
+    elif [[ "$args" == *"repositories/rpm/rpm"* ]]; then
+        # Repository list API call - extract repo name from URL
+        if [[ "$args" == *"name=source"* ]]; then
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/source-uuid/"}]}'
+        elif [[ "$args" == *"name=x86_64"* ]]; then
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/x86_64-uuid/"}]}'
+        elif [[ "$args" == *"name=aarch64"* ]]; then
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/aarch64-uuid/"}]}'
+        elif [[ "$args" == *"name=ppc64le"* ]]; then
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/ppc64le-uuid/"}]}'
+        elif [[ "$args" == *"name=s390x"* ]]; then
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/s390x-uuid/"}]}'
+        else
+            echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/default-uuid/"}]}'
+        fi
+    elif [[ "$args" == *"modify"* ]]; then
+        # Repository content modify API call
+        echo '{"task": "/api/pulp/mock/api/v3/tasks/mock-task-id/"}'
+    else
+        # Fall back to real curl for other calls
+        command curl "$@"
+    fi
+}
+
 function pulp() {
     echo $* >> $(params.dataDir)/mock_pulp.txt
     if [[ "$*" == *"domain show"* ]]; then

--- a/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
@@ -10,7 +10,10 @@ yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret --ignore-not-found
-kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml=abcdef123
+kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml='base_url = "https://console.redhat.com"
+client_id = "mock-client-id"
+client_secret = "mock-client-secret"
+'
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret-missing --ignore-not-found

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
@@ -162,8 +162,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 13   ]; then
-                echo Error: pulp was expected to be called 13 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 9   ]; then
+                echo Error: pulp was expected to be called 9 times. Actual calls:
                 cat "$(params.dataDir)/mock_pulp.txt"
                 exit 1
               fi

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
@@ -162,8 +162,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 4   ]; then
-                echo Error: pulp was expected to be called 4 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 3   ]; then
+                echo Error: pulp was expected to be called 3 times. Actual calls:
                 cat "$(params.dataDir)/mock_pulp.txt"
                 exit 1
               fi

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
@@ -162,8 +162,8 @@ spec:
                 exit 1
               fi
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 19   ]; then
-                echo Error: pulp was expected to be called 19 times. Actual calls:
+              if [ "$(wc -l < "$(params.dataDir)/mock_pulp.txt")" != 14   ]; then
+                echo Error: pulp was expected to be called 14 times. Actual calls:
                 cat "$(params.dataDir)/mock_pulp.txt"
                 exit 1
               fi


### PR DESCRIPTION
Pulp-cli bug uses wrong api parameter

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
