### PR TITLE
fix: apply-mapping issue with helm charts

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -399,17 +399,28 @@ spec:
             # Construct image reference with the first architecture's digest for annotations
             image_with_digest="${IMAGE_REF%@*}@${first_digest}"
 
-            # Get raw manifest to extract annotations
+            # Get raw manifest to extract annotations (works for all image types)
             raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${image_with_digest}" | jq -c)"
             annotations="$(jq -c '.annotations // {}' <<< "$raw_manifest")"
 
-            # Get image metadata for labels, env, build_date (standard inspect)
-            image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
-              --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
-            # For timestamp, use Labels.build-date and fallback to Created
-            build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
-            env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
-            labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+            # Get configMediaType from architecture info to determine if this is a Helm chart
+            config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
+
+            # Get image metadata for labels, env, build_date
+            if [[ "$config_media_type" == "application/vnd.cncf.helm.config.v1+json" ]]; then
+                # Helm charts don't support standard skopeo inspect - get build_date from annotations
+                build_date="$(jq -r '.["org.opencontainers.image.created"] // ""' <<< "$annotations")"
+                env_variables="[]"
+                labels="{}"
+            else
+                # Standard container images - use standard skopeo inspect
+                image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
+                  --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
+                # For timestamp, use Labels.build-date and fallback to Created
+                build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
+                env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
+                labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+            fi
 
             # Get oci_version_raw from annotations, fallback to labels
             oci_version_raw="$(jq -r '.["org.opencontainers.image.version"] // ""' <<< "$annotations")"

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -108,11 +108,12 @@ function skopeo() {
 
 function get-image-architectures() {
     if [[ "$1" == *"helm-chart"* ]]; then
-        # Return Helm chart format (single arch)
+        # Return Helm chart format (single arch) with configMediaType
         jq -nc '{
             "platform": {"architecture": "amd64", "os": "linux"},
             "digest": "sha256:789abcdef123456",
-            "multiarch": false
+            "multiarch": false,
+            "configMediaType": "application/vnd.cncf.helm.config.v1+json"
         }'
     else
         # Return regular container image format (multi-arch)


### PR DESCRIPTION
## Describe your changes

In RELEASE-1996 we removed the condition to check for helm charts. The goal was to fetch both annotations and env vars and labels for all images. But while we can fetch annotations for all images (using skopeo inspect --raw), we cannot do normal skopeo inspect on helm images, it will fail with:

unsupported image-specific operation on artifact with type "application/vnd.cncf.helm.config.v1+json"

So let's skip this for helm charts.

Slack thread: https://redhat-internal.slack.com/archives/C031USXS2FJ/p1766067302763459

## Relevant Jira

[RELEASE-2093](https://issues.redhat.com/browse/RELEASE-2093)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
