### PR TITLE
fix: hide token

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -200,6 +200,8 @@ spec:
           local hrefs_json="$2"
           local domain="${PULP_DOMAIN}"
           
+          # Disable command echoing for sensitive operations
+          set +x
           local access_token
           access_token=$(get_access_token) || return 1
           
@@ -208,6 +210,7 @@ spec:
           repo_href=$(curl --retry 3 -s -H "Authorization: Bearer $access_token" \
             "${PULP_BASE_URL}/api/pulp/${domain}/api/v3/repositories/rpm/rpm/?name=${repo_name}" \
             | jq -r '.results[0].pulp_href')
+          set -x
           
           if [[ -z "$repo_href" || "$repo_href" == "null" ]]; then
             echo "Error: Could not find repository href for ${repo_name}"
@@ -220,10 +223,12 @@ spec:
           
           # Add content to repository
           echo "Calling API: POST ${PULP_BASE_URL}${repo_href}modify/"
+          set +x
           curl --retry 3 -s -X POST "${PULP_BASE_URL}${repo_href}modify/" \
             -H "Authorization: Bearer $access_token" \
             -H "Content-Type: application/json" \
             -d "{\"add_content_units\": $add_content_units}"
+          set -x
         }
 
         set -x


### PR DESCRIPTION
Hide Bearer token

## Describe your changes

We leak the bearer token in the konflux logs when running

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
