### PR TITLE
chore: update release-service-utils to multi-arch cosign

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+      image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eu

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-digests-match.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-credentials.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-fail-tagless-component.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-mount-certs.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -175,7 +175,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-multi-repos.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-parallel.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -198,7 +198,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -163,7 +163,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -155,7 +155,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-skip-existing.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-retries.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -150,7 +150,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -171,7 +171,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+      image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
       computeResources:
         limits:
           memory: 2.5Gi

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -178,7 +178,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-multiple-repositories.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -172,7 +172,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-retries.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -166,7 +166,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-single-component.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-with-image-digests.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            image: quay.io/konflux-ci/release-service-utils@sha256:99014f690d299e0a6d1bb2b7f9a03ebcdddc827b76762db0f837f0d504828896
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
Update image digest to version with multi-architecture cosign binary support in tasks that invoke cosign:
- rh-sign-image-cosign: uses cosign for signing containers
- push-snapshot: uses cosign copy for pushing with attestations

The updated image fixes crashes on ARM64 systems by extracting architecture-specific cosign binaries instead of using the default amd64 binary on all platforms.

Assisted-by: Claude Code (Sonnet 4.5)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
