### PR TITLE
Fix: a typo of the mrrc signing schema check

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -882,7 +882,7 @@
           "type": "string",
           "description": "The k8s secret containing the aws credential for MRRC aws access"
         },
-        "sign": {
+        "signing": {
           "type": "object",
           "description": "The signing configuration through RADAS",
           "properties": {


### PR DESCRIPTION
## Describe your changes
There is a typo in the dataKeys for MRRC signing properties.
## Relevant Jira
N/A
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
