### PR TITLE
fix(KFLUXSPRT-6442): failing skopeo inspect for model artifacts

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -403,16 +403,18 @@ spec:
             raw_manifest="$(skopeo inspect --retry-times 3 --no-tags --raw docker://"${image_with_digest}" | jq -c)"
             annotations="$(jq -c '.annotations // {}' <<< "$raw_manifest")"
 
-            # Get configMediaType from architecture info to determine if this is a Helm chart
-            config_media_type="$(jq -rs '.[0].configMediaType' <<< "$arch_json")"
+            # Get config.mediaType from raw manifest to determine if this is a standard container image
+            config_media_type="$(jq -r '.config.mediaType // ""' <<< "$raw_manifest")"
 
             # Get image metadata for labels, env, build_date
-            if [[ "$config_media_type" == "application/vnd.cncf.helm.config.v1+json" ]]; then
-                # Helm charts don't support standard skopeo inspect - get build_date from annotations
-                build_date="$(jq -r '.["org.opencontainers.image.created"] // ""' <<< "$annotations")"
-                env_variables="[]"
-                labels="{}"
-            else
+            # Only standard container images support skopeo inspect without --raw
+            # Standard config types are:
+            #   - application/vnd.oci.image.config.v1+json (OCI images)
+            #   - application/vnd.docker.container.image.v1+json (Docker images)
+            # All other artifacts (Helm charts, ML models, empty configs, etc.) don't have
+            # labels/env and would fail with skopeo inspect
+            if [[ "$config_media_type" == "application/vnd.oci.image.config.v1+json" ]] || \
+               [[ "$config_media_type" == "application/vnd.docker.container.image.v1+json" ]]; then
                 # Standard container images - use standard skopeo inspect
                 image_metadata="$(skopeo inspect --retry-times 3 --no-tags \
                   --override-os "${os}" --override-arch "${arch}" docker://"${IMAGE_REF}" | jq -c)"
@@ -420,6 +422,12 @@ spec:
                 build_date="$(jq -r '.Labels."build-date" // .Created // ""' <<< "$image_metadata")"
                 env_variables="$(jq -c '.Env // []' <<< "${image_metadata}")"
                 labels="$(jq -c '.Labels // {}' <<< "${image_metadata}")"
+            else
+                # Non-standard artifacts (Helm charts, ML models, etc.) don't support
+                # standard skopeo inspect - get build_date from annotations if available
+                build_date="$(jq -r '.["org.opencontainers.image.created"] // ""' <<< "$annotations")"
+                env_variables="[]"
+                labels="{}"
             fi
 
             # Get oci_version_raw from annotations, fallback to labels

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -46,23 +46,24 @@ function skopeo() {
       return
   fi
 
-  # Raw manifest inspections (for annotations) - these use the digest from get-image-architectures
+  # Raw manifest inspections (for annotations and config.mediaType) - these use the digest from get-image-architectures
   if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/helm-chart"* ]]
   then
-    echo '{"annotations": {"org.opencontainers.image.version": "2.0.1+alpha", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
+    # Helm chart - has helm config mediaType, not a standard container image
+    echo '{"config": {"mediaType": "application/vnd.cncf.helm.config.v1+json"}, "annotations": {"org.opencontainers.image.version": "2.0.1+alpha", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
     return
   elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/web-app"* ]]
   then
-    echo '{"annotations": {"org.opencontainers.image.version": "1.2.3-beta", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
+    echo '{"config": {"mediaType": "application/vnd.oci.image.config.v1+json"}, "annotations": {"org.opencontainers.image.version": "1.2.3-beta", "org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
     return
   elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/metadata"* ]]
   then
-    echo '{"annotations": {"org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
+    echo '{"config": {"mediaType": "application/vnd.oci.image.config.v1+json"}, "annotations": {"org.opencontainers.image.created": "2024-07-29T02:17:29Z"}}'
     return
   elif [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://"* ]]
   then
-    # Default: return empty annotations for images that don't have specific ones
-    echo '{"annotations": {}}'
+    # Default: standard OCI container image config
+    echo '{"config": {"mediaType": "application/vnd.oci.image.config.v1+json"}, "annotations": {}}'
     return
   fi
 


### PR DESCRIPTION
## Describe your changes

We only excluded helm charts from calling skopeo inspect (without --raw). But it causes issues with other artifacts as well - the user that reported the ticket is releasing ml models.

So let's only call skopeo inspect for normal images (the two known config media types).

Note that while we recently changed this logic as part of RELEASE-1996, this issue has actually been there for a long time and it was just recently exposed when we did RELEASE-1887 which enabled pipefail in the task.

## Relevant Jira

KFLUXSPRT-6442

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
