### PR TITLE
fix: handle single-arch with subdirectory in sign-oot-kmods

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -362,30 +362,50 @@ spec:
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
 
             else
-                echo "Single architecture, using existing signing logic"
-                cd "$SIGNED_KMODS_PATH"
+                echo "Single architecture, processing with subdirectory structure"
+
+                # Find the architecture subdirectory (extract task always creates one)
+                arch_subdir_name=""
+                for potential_arch_dir in "$SIGNED_KMODS_PATH"/*/; do
+                    if [ -d "$potential_arch_dir" ]; then
+                        arch_subdir_name=$(basename "$potential_arch_dir")
+                        echo "Found architecture subdirectory: $arch_subdir_name"
+                        break
+                    fi
+                done
+
+                if [ -z "$arch_subdir_name" ]; then
+                    echo "ERROR: No architecture subdirectory found for single-arch build"
+                    echo "Expected structure: $SIGNED_KMODS_PATH/<arch>/"
+                    ls -la "$SIGNED_KMODS_PATH" || true
+                    exit 1
+                fi
+
+                arch_dir="$SIGNED_KMODS_PATH/$arch_subdir_name"
 
                 # Create unique remote directory for this TaskRun to ensure isolation
                 task_uid="$(context.taskRun.uid)"
                 echo "Using unique remote directory: ~/$task_uid"
 
-                # Backup envfile before signing process
-                if [ -f "envfile" ]; then
-                    cp envfile /tmp/envfile.backup
+                # Backup envfile if present
+                if [ -f "$arch_dir/envfile" ]; then
+                    cp "$arch_dir/envfile" "/tmp/envfile.backup.$arch_subdir_name"
                 fi
 
                 # Copy unsigned kmods to signing server
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/${task_uid}/kmods"
-                scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
+
+                echo "Copying unsigned .ko files from $arch_subdir_name to signing server..."
+                scp "${SSH_OPTS[@]}" "$arch_dir"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
 
                 # Sign kmods
                 sign_kmods_for_arch "single"
 
                 # Copy back signed kmods to workspace
-                echo "Copying back signed .ko files for single architecture..."
-                rm -f "${SIGNED_KMODS_PATH}"/*.ko
+                echo "Copying back signed .ko files for $arch_subdir_name..."
+                rm -f "$arch_dir"/*.ko
                 # Get list of .ko files from remote server and copy them individually
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
@@ -396,31 +416,33 @@ spec:
                         if [ -n "$kmod_file" ]; then
                             echo "Copying back signed file: $kmod_file"
                             scp "${SSH_OPTS[@]}" \
-                                "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" "${SIGNED_KMODS_PATH}"/
+                                "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" \
+                                "$arch_dir/"
                         fi
                     done
                 else
-                    echo "WARNING: No .ko files found on remote server for single architecture"
+                    echo "ERROR: No .ko files found on remote server"
+                    exit 1
                 fi
 
-                # Restore envfile after signing process
-                if [ -f "/tmp/envfile.backup" ]; then
-                    cp /tmp/envfile.backup envfile
+                # Restore envfile
+                if [ -f "/tmp/envfile.backup.$arch_subdir_name" ]; then
+                    cp "/tmp/envfile.backup.$arch_subdir_name" "$arch_dir/envfile"
                 fi
 
-                # Generate checksums for signed .ko files
-                echo "Generating checksums for signed .ko files..."
-                if ls "${SIGNED_KMODS_PATH}"/*.ko >/dev/null 2>&1; then
-                    cd "${SIGNED_KMODS_PATH}"
-                    sha256sum ./*.ko > signed_kmods_checksums.txt
-                    echo "Generated checksums:"
-                    cat signed_kmods_checksums.txt
+                # Generate checksums
+                echo "Generating checksums for $arch_subdir_name .ko files..."
+                cd "$arch_dir"
+                if ls ./*.ko >/dev/null 2>&1; then
+                    sha256sum ./*.ko > "signed_kmods_checksums_${arch_subdir_name}.txt"
+                    echo "Generated checksums for $arch_subdir_name:"
+                    cat "signed_kmods_checksums_${arch_subdir_name}.txt"
                 else
                     echo "ERROR: No .ko files found after signing process"
                     exit 1
                 fi
 
-                # Clean up unique remote directory for supply chain integrity
+                # Clean up unique remote directory
                 echo "Cleaning up remote directory ~/$task_uid"
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -71,8 +71,11 @@ function rm() {
 
   case "$*" in
     "-f "*"/*.ko")
+      # Actually remove the files for the mock to work correctly
+      /bin/rm "$@"
       ;;
     "-f "*signed-kmods*)
+      /bin/rm "$@"
       ;;
     *)
       echo "Error: Unexpected rm parameters: $*"

--- a/tasks/managed/sign-oot-kmods/tests/test-setup.sh
+++ b/tasks/managed/sign-oot-kmods/tests/test-setup.sh
@@ -4,17 +4,27 @@ set -x
 # INJECTED TEST SETUP - Create test data for signing task
 echo "Setting up test data for sign-oot-kmods task..."
 
-# Create the signed kmods directory and dummy modules in dataDir for trusted artifacts mode
-echo "Creating dummy kmods to be signed in dataDir..."
-mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/"
-echo "MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko"
-echo "MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/mod2.ko"
+# Ensure dataDir exists
+mkdir -p "$(params.dataDir)"
+
+# Create arch_count.txt to indicate single-arch build with subdirectory structure
+# This triggers the new single-arch subdirectory logic instead of the fallback
+echo "1" > "$(params.dataDir)/arch_count.txt"
+
+# Create the signed kmods directory with architecture subdirectory structure
+# This matches the extract task output which always creates an arch subdirectory
+echo "Creating dummy kmods to be signed in dataDir with architecture subdirectory..."
+ARCH_SUBDIR="x86_64"
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}"
+echo "MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod1.ko"
+echo "MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod2.ko"
 
 echo "Test data setup complete:"
 echo "DataDir contents:"
 ls -la "$(params.dataDir)" || echo "dataDir does not exist"
 if [ -d "$(params.dataDir)/$(params.signedKmodsPath)" ]; then
     ls -la "$(params.dataDir)/$(params.signedKmodsPath)"
+    ls -la "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}"
 fi
 
 # ORIGINAL TASK LOGIC STARTS HERE 

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -119,14 +119,20 @@ spec:
               SCP_FILE="$(params.dataDir)/mock_scp.txt"
               RM_FILE="$(params.dataDir)/mock_rm.txt"
 
-              # Also verify that the signed kmods exist in the dataDir
-              if [ -d "$(params.dataDir)/$(params.signedKmodsPath)" ]; then
-                echo "SUCCESS: signed-kmods directory found in dataDir"
+              # Verify that the signed kmods exist in the dataDir with architecture subdirectory
+              ARCH_SUBDIR="x86_64"
+              if [ -d "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}" ]; then
+                echo "SUCCESS: signed-kmods architecture subdirectory found in dataDir"
                 ls -la "$(params.dataDir)/$(params.signedKmodsPath)" || true
+                ls -la "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}" || true
               else
-                echo "WARNING: signed-kmods directory not found in dataDir"
+                echo "ERROR: signed-kmods architecture subdirectory not found in dataDir"
                 echo "Available directories in dataDir:"
                 ls -la "$(params.dataDir)" || echo "dataDir does not exist"
+                if [ -d "$(params.dataDir)/$(params.signedKmodsPath)" ]; then
+                  ls -la "$(params.dataDir)/$(params.signedKmodsPath)" || true
+                fi
+                exit 1
               fi
 
               # Check that rm command was called to remove unsigned .ko files
@@ -164,8 +170,8 @@ spec:
               fi
 
               # Verify that the signed files now contain "SIGNED" content to confirm replacement
-              if [ -f "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko" ]; then
-                content=$(cat "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko")
+              if [ -f "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod1.ko" ]; then
+                content=$(cat "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod1.ko")
                 if [[ "$content" == "SIGNED_MODULE1" ]]; then
                   echo "SUCCESS: mod1.ko contains signed content"
                 else
@@ -173,12 +179,12 @@ spec:
                   exit 1
                 fi
               else
-                echo "ERROR: mod1.ko not found after signing process"
+                echo "ERROR: mod1.ko not found after signing process in ${ARCH_SUBDIR}"
                 exit 1
               fi
 
-              # Verify that checksums file was generated
-              CHECKSUMS_FILE="$(params.dataDir)/$(params.signedKmodsPath)/signed_kmods_checksums.txt"
+              # Verify that checksums file was generated with architecture suffix
+              CHECKSUMS_FILE="$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/signed_kmods_checksums_${ARCH_SUBDIR}.txt"
               if [ -f "$CHECKSUMS_FILE" ]; then
                 echo "SUCCESS: Checksums file found: $CHECKSUMS_FILE"
                 echo "Checksums file contents:"
@@ -193,8 +199,8 @@ spec:
                 fi
 
                 # Verify checksums can be validated
-                cd "$(params.dataDir)/$(params.signedKmodsPath)"
-                if sha256sum -c signed_kmods_checksums.txt; then
+                cd "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}"
+                if sha256sum -c "signed_kmods_checksums_${ARCH_SUBDIR}.txt"; then
                   echo "SUCCESS: Checksum validation passed"
                 else
                   echo "ERROR: Checksum validation failed"
@@ -202,6 +208,7 @@ spec:
                 fi
               else
                 echo "ERROR: Checksums file not found - should be generated after signing"
+                echo "Expected: $CHECKSUMS_FILE"
                 exit 1
               fi
 


### PR DESCRIPTION
The extract-oot-kmods task always creates architecture subdirectories (e.g., signed-kmods/arm64/) even for single-architecture images. However, sign-oot-kmods expected flat structure for single-arch builds, causing scp failures when trying to copy .ko files.

This fix simplifies the single-arch logic to always expect and process architecture subdirectories, matching the extract task behavior.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
