### PR TITLE
fix(RELEASE-2107): nest konflux-artifacts under prod/nonprod in quay

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -565,7 +565,7 @@ spec:
           if [ -f "$COMPONENT_DIR/has_mac" ]; then
             pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Macos content for $COMPONENT_NAME to $(params.quayURL)..."
-            output=$(oras push "$(params.quayURL)/${COMPONENT_NAME}/unsigned" macos)
+            output=$(oras push "$(params.quayURL)/unsigned/${COMPONENT_NAME}" macos)
             mac_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME mac content: $mac_digest"
             echo -n "$mac_digest" > "$COMPONENT_DIR/unsigned_mac_digest.txt"
@@ -578,7 +578,7 @@ spec:
           if [ -f "$COMPONENT_DIR/has_windows" ]; then
             pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Windows content for $COMPONENT_NAME to $(params.quayURL)..."
-            output=$(oras push "$(params.quayURL)/${COMPONENT_NAME}/unsigned" windows)
+            output=$(oras push "$(params.quayURL)/unsigned/${COMPONENT_NAME}" windows)
             windows_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME windows content: $windows_digest"
             echo -n "$windows_digest" > "$COMPONENT_DIR/unsigned_windows_digest.txt"
@@ -701,7 +701,7 @@ spec:
           set +x
           /usr/local/bin/oras login quay.io -u ${QUAY_USER} -p ${QUAY_PASS}
           set -x
-          /usr/local/bin/oras pull $(params.quayURL)/${COMPONENT_NAME}/unsigned@$unsigned_digest -o "$BINARY_PATH"
+          /usr/local/bin/oras pull $(params.quayURL)/unsigned/${COMPONENT_NAME}@$unsigned_digest -o "$BINARY_PATH"
           # The content is extracted to BINARY_PATH/macos (no nesting since we pull to unsigned, not unsigned/macos)
           CONTENT_DIR_MAC="$BINARY_PATH/macos"
 
@@ -732,7 +732,7 @@ spec:
 
           SIGNED_TAG="$(context.taskRun.uid)-mac"
           PUSH_OUTPUT=\$(/usr/local/bin/oras push \
-            "$QUAY_URL/${COMPONENT_NAME}/signed:\$SIGNED_TAG" macos)
+            "$QUAY_URL/signed/${COMPONENT_NAME}:\$SIGNED_TAG" macos)
           SIGNED_DIGEST=\$(echo "\$PUSH_OUTPUT" | grep 'Digest:' | awk '{print \$2}')
           echo -n "\$SIGNED_DIGEST" >> "$DIGEST_FILE"
           echo "Process completed successfully."
@@ -856,7 +856,7 @@ spec:
           @echo off
           oras login quay.io -u ${QUAY_USER} -p ${QUAY_PASS}
           @echo on
-          oras pull $(params.quayURL)/${COMPONENT_NAME}/unsigned@${unsigned_digest} -o unsigned
+          oras pull $(params.quayURL)/unsigned/${COMPONENT_NAME}@${unsigned_digest} -o unsigned
           REM The content is extracted to unsigned\windows with os/arch/ subdirectories (e.g., unsigned\windows\amd64\)
 
           REM Recursively sign all files in unsigned\windows directory tree
@@ -885,7 +885,7 @@ spec:
           echo [%DATE% %TIME%] Signing of Windows binaries for ${COMPONENT_NAME} completed successfully
 
           cd unsigned
-          oras push $(params.quayURL)/${COMPONENT_NAME}/signed:$(context.taskRun.uid)-windows windows \
+          oras push $(params.quayURL)/signed/${COMPONENT_NAME}:$(context.taskRun.uid)-windows windows \
           > oras_push_output.txt 2>&1
 
           for /f "tokens=2,3 delims=: " %%a in ('findstr "Digest:" oras_push_output.txt') do @echo %%a:%%b > digest.txt
@@ -1054,7 +1054,7 @@ spec:
             signed_mac_digest=$(cat "$COMPONENT_DIR/signed_mac_digest.txt")
             # shellcheck disable=SC2086
             # Pull directly to current directory ($SIGNED_DIR) - oras will create macos/ directory
-            oras pull "$(params.quayURL)/${COMPONENT_NAME}/signed@${signed_mac_digest}"
+            oras pull "$(params.quayURL)/signed/${COMPONENT_NAME}@${signed_mac_digest}"
           fi
 
           # Pull signed Windows binaries for this component (if windows content exists)
@@ -1064,7 +1064,7 @@ spec:
             signed_windows_digest=${signed_windows_digest//[[:space:]]/}
             # shellcheck disable=SC2086
             # Pull directly to current directory ($SIGNED_DIR) - oras will create windows/ directory
-            oras pull "$(params.quayURL)/${COMPONENT_NAME}/signed@${signed_windows_digest}"
+            oras pull "$(params.quayURL)/signed/${COMPONENT_NAME}@${signed_windows_digest}"
           fi
 
           # Generate checksums for all binaries

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -163,6 +163,9 @@ spec:
         QUAY_URL="$(params.quayURL)"
         if [[ "$INTENTION" == "staging" ]]; then
           QUAY_URL="quay.io/konflux-artifacts/nonprod"
+        else
+          # For production releases, use prod path
+          QUAY_URL="quay.io/konflux-artifacts/prod"
         fi
 
         # Remove .metadata from each component to avoid "arg list too long" errors


### PR DESCRIPTION
The push-artifacts-to-cdn pipeline is not nesting the artifacts under the environment folders. This change should resolve the issue.

Code assisted with Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
