### PR TITLE
fix(ROK-1411): Fix selecting a latest build to promote

### DIFF
--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -224,7 +224,7 @@ spec:
               draft=True
           )
           # Get the latest build ID
-          build_id=$(jq -r 'max_by(".creation_time").build_id' <<< "$builds")
+          build_id=$(jq -r 'max_by(.creation_time).build_id' <<< "$builds")
 
           printf "Promoting build %s ...\n" "$build_id"
           koji-cmd call promoteBuild "$build_id"

--- a/tasks/managed/promote-koji-draft-build/tests/mocks.sh
+++ b/tasks/managed/promote-koji-draft-build/tests/mocks.sh
@@ -45,7 +45,7 @@ EOF
 function koji() {
     echo "koji $@" >> "$(params.dataDir)/koji_calls.txt"
     if [[ "$*" == *listBuilds*source=git+https://gitlab.example.com/rpms/test-foo* ]]; then
-        echo '[{"build_id": 1001, "creation_time": "2025-01-01 00:00:00.000000"}, {"build_id": 1002, "creation_time": "2025-01-01 01:00:00.000000"}]'
+        echo '[{"build_id": 1002, "creation_time": "2025-01-01 01:00:00.000000"}, {"build_id": 1001, "creation_time": "2025-01-01 00:00:00.000000"}]'
     elif [[ "$*" == *listBuilds*source=git+https://gitlab.example.com/rpms/test-bar* ]]; then
         echo '[{"build_id": 2001, "creation_time": "2025-01-01 00:00:00.000000"}]'
     fi


### PR DESCRIPTION
## Describe your changes

`max_by()` expects a filter expression, not a string

```
$ builds='[{"build_id":3923282,"creation_time":"2026-01-05 15:43:36.277760"},{"build_id":3923211,"creation_time":"2026-01-05 13:42:44.020493"}]'`

$ jq -r 'max_by(".creation_time").build_id' <<< "$builds"
3923211

$ jq -r 'max_by(.creation_time).build_id' <<< "$builds"
3923282
```

## Relevant Jira

https://issues.redhat.com/browse/ROK-1411