### PR TITLE
fix: align push tasks with sign task checksum filenames

### DIFF
--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -137,12 +137,9 @@ spec:
         upload_arch_artifacts() {
             local arch_name="$1"
             local source_dir="$2"
-            local arch_suffix=""
 
-            # Add architecture suffix for multi-arch builds
-            if [ "$arch_count" -gt 1 ]; then
-                arch_suffix="/${arch_name}"
-            fi
+            # Always include architecture suffix for consistent hierarchy
+            local arch_suffix="/${arch_name}"
 
             echo "Processing Azure upload for architecture: $arch_name"
 
@@ -179,31 +176,17 @@ spec:
                 return 1
             fi
 
-            # Upload checksum file
-            if [ "$arch_count" -gt 1 ]; then
-                if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
-                    echo "Uploading architecture-specific checksums for $arch_name"
-                    CHECKSUM_BLOB_NAME="${AZURE_TARGET_PATH}signed_kmods_checksums_${arch_name}.txt"
-                    az storage blob upload \
-                      --account-name "$ACCOUNT" \
-                      --container-name "$CONTAINER" \
-                      --name "$CHECKSUM_BLOB_NAME" \
-                      --file "$source_dir/signed_kmods_checksums_${arch_name}.txt" \
-                      --auth-mode login \
-                      --overwrite
-                fi
-            else
-                if [ -f "$source_dir/signed_kmods_checksums.txt" ]; then
-                    echo "Uploading checksums for single architecture"
-                    CHECKSUM_BLOB_NAME="${AZURE_TARGET_PATH}signed_kmods_checksums.txt"
-                    az storage blob upload \
-                      --account-name "$ACCOUNT" \
-                      --container-name "$CONTAINER" \
-                      --name "$CHECKSUM_BLOB_NAME" \
-                      --file "$source_dir/signed_kmods_checksums.txt" \
-                      --auth-mode login \
-                      --overwrite
-                fi
+            # Upload checksum file (always use arch-specific filename)
+            if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
+                echo "Uploading architecture-specific checksums for $arch_name"
+                CHECKSUM_BLOB_NAME="${AZURE_TARGET_PATH}signed_kmods_checksums_${arch_name}.txt"
+                az storage blob upload \
+                  --account-name "$ACCOUNT" \
+                  --container-name "$CONTAINER" \
+                  --name "$CHECKSUM_BLOB_NAME" \
+                  --file "$source_dir/signed_kmods_checksums_${arch_name}.txt" \
+                  --auth-mode login \
+                  --overwrite
             fi
 
             # Upload envfile for reference
@@ -274,10 +257,19 @@ spec:
         else
             echo "Single architecture build, using standard upload"
 
-            if upload_arch_artifacts "single" "${SIGNED_KMODS_FULL_PATH}"; then
-                echo "Successfully uploaded single architecture to Azure"
+            # Get the actual architecture directory name
+            arch_dir=$(find "${SIGNED_KMODS_FULL_PATH}" -mindepth 1 -maxdepth 1 -type d | head -1)
+            if [ -z "$arch_dir" ]; then
+                echo "ERROR: No architecture directory found in ${SIGNED_KMODS_FULL_PATH}"
+                exit 1
+            fi
+            actual_arch=$(basename "$arch_dir")
+            echo "Detected architecture: $actual_arch"
+
+            if upload_arch_artifacts "$actual_arch" "$arch_dir"; then
+                echo "Successfully uploaded single architecture to Azure: $actual_arch"
             else
-                echo "ERROR: Failed to upload single architecture to Azure"
+                echo "ERROR: Failed to upload single architecture to Azure: $actual_arch"
                 exit 1
             fi
         fi

--- a/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
@@ -64,15 +64,24 @@ function az() {
                             echo "WARNING: Unexpected multiarch upload pattern, but allowing: $*"
                         fi
                     else
-                        # Single arch mode - original validation logic
+                        # Single arch mode - now expects arch suffix (x86_64)
                         if [ "$COUNT" -eq 0 ]; then
-                            if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/mod1.ko"* ]]; then
+                            if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod1.ko"* ]]; then
                                 echo "ERROR: First az blob upload call has wrong name param for mod1.ko"
+                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod1.ko"
                                 return 1
                             fi
                         elif [ "$COUNT" -eq 1 ]; then
-                             if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/mod2.ko"* ]]; then
+                             if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod2.ko"* ]]; then
                                 echo "ERROR: Second az blob upload call has wrong name param for mod2.ko"
+                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod2.ko"
+                                return 1
+                            fi
+                        elif [ "$COUNT" -eq 2 ]; then
+                            # Checksum file with arch-specific name
+                            if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/signed_kmods_checksums_x86_64.txt"* ]]; then
+                                echo "ERROR: Third az blob upload call has wrong name param for checksum file"
+                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/signed_kmods_checksums_x86_64.txt"
                                 return 1
                             fi
                         elif [ "$COUNT" -gt 10 ]; then
@@ -114,13 +123,13 @@ check_upload_count() {
     echo "Total upload count: $COUNT"
 
     # For multiarch, expect at least 4 uploads (2 .ko files + 2 envfiles minimum)
-    # For single arch, expect exactly 3 uploads (2 .ko files + 1 envfile)
-    if [ "$COUNT" -ge 4 ]; then
+    # For single arch, expect exactly 4 uploads (2 .ko files + 1 checksum file + 1 envfile)
+    if [ "$COUNT" -ge 5 ]; then
         echo "SUCCESS: az blob upload was called $COUNT times (multiarch scenario detected)"
-    elif [ "$COUNT" -eq 3 ]; then
-        echo "SUCCESS: az blob upload was called exactly 3 times (single arch scenario: 2 .ko files + envfile)"
+    elif [ "$COUNT" -eq 4 ]; then
+        echo "SUCCESS: az blob upload was called exactly 4 times (single arch scenario: 2 .ko files + checksum + envfile)"
     else
-        echo "ERROR: az blob upload was called $COUNT times, expected 3 (single arch) or 4+ (multiarch)"
+        echo "ERROR: az blob upload was called $COUNT times, expected 4 (single arch) or 5+ (multiarch)"
         return 1
     fi
 }

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
@@ -2,16 +2,23 @@ set -x
 
 echo "Setting up test data for push-oot-kmods task..."
 
-echo "Creating dummy signed kmods and envfile in dataDir..."
-mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/"
-echo "AZURE_SIGNED_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko"
-echo "AZURE_SIGNED_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/mod2.ko"
+echo "Creating dummy signed kmods and envfile in dataDir with arch-specific structure..."
+# Create architecture-specific directory structure
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+echo "AZURE_SIGNED_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
+echo "AZURE_SIGNED_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
 
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/envfile" << EOF
+cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-azure"
 DRIVER_VERSION="1.2.3-az"
 KERNEL_VERSION="6.5.0-az"
 EOF
 
+# Create architecture-specific checksum file
+cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/signed_kmods_checksums_x86_64.txt" << EOF
+$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '{print $1}')  mod1.ko
+$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
+EOF
+
 echo "Test data setup complete:"
-ls -la "$(params.dataDir)/$(params.signedKmodsPath)"
+ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -169,17 +169,10 @@ spec:
                 return 1
             fi
 
-            # Copy architecture-specific checksum file
-            if [ "$arch_count" -gt 1 ]; then
-                if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
-                    cp "$source_dir/signed_kmods_checksums_${arch_name}.txt" "$TARGET_DIR/"
-                    echo "Copied architecture-specific checksums for $arch_name"
-                fi
-            else
-                if [ -f "$source_dir/signed_kmods_checksums.txt" ]; then
-                    cp "$source_dir/signed_kmods_checksums.txt" "$TARGET_DIR/"
-                    echo "Copied checksums for single architecture"
-                fi
+            # Copy architecture-specific checksum file (always use arch suffix)
+            if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
+                cp "$source_dir/signed_kmods_checksums_${arch_name}.txt" "$TARGET_DIR/"
+                echo "Copied architecture-specific checksums for $arch_name"
             fi
 
             # Copy envfile for reference
@@ -264,14 +257,14 @@ spec:
             echo "Detected architecture: $actual_arch"
 
             cd "$arch_dir"
-            # Validate checksum file exists for single-arch
-            if [ ! -f "signed_kmods_checksums.txt" ]; then
-                echo "ERROR: signed_kmods_checksums.txt not found for single architecture build"
+            # Validate checksum file exists for single-arch (arch-specific filename)
+            if [ ! -f "signed_kmods_checksums_${actual_arch}.txt" ]; then
+                echo "ERROR: signed_kmods_checksums_${actual_arch}.txt not found for single architecture build"
                 exit 1
             fi
 
             # Verify checksums
-            sha256sum -c signed_kmods_checksums.txt
+            sha256sum -c "signed_kmods_checksums_${actual_arch}.txt"
             cd "${GIT_WORK_DIR}/local-artifacts"
 
             if push_arch_artifacts "$actual_arch" "$arch_dir"; then

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -120,12 +120,9 @@ spec:
         upload_arch_artifacts() {
             local arch_name="$1"
             local source_dir="$2"
-            local arch_suffix=""
 
-            # Add architecture suffix for multi-arch builds
-            if [ "$arch_count" -gt 1 ]; then
-                arch_suffix="/${arch_name}"
-            fi
+            # Always include architecture suffix for consistent hierarchy
+            local arch_suffix="/${arch_name}"
 
             echo "Processing S3 upload for architecture: $arch_name"
 
@@ -156,23 +153,13 @@ spec:
                 return 1
             fi
 
-            # Upload checksum file
-            if [ "$arch_count" -gt 1 ]; then
-                if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
-                    echo "Uploading architecture-specific checksums for $arch_name"
-                    aws s3 cp \
-                      "$source_dir/signed_kmods_checksums_${arch_name}.txt" \
-                      "s3://$(params.s3Bucket)/${S3_TARGET_PATH}signed_kmods_checksums_${arch_name}.txt" \
-                      --endpoint-url "$(params.s3Endpoint)"
-                fi
-            else
-                if [ -f "$source_dir/signed_kmods_checksums.txt" ]; then
-                    echo "Uploading checksums for single architecture"
-                    aws s3 cp \
-                      "$source_dir/signed_kmods_checksums.txt" \
-                      "s3://$(params.s3Bucket)/${S3_TARGET_PATH}signed_kmods_checksums.txt" \
-                      --endpoint-url "$(params.s3Endpoint)"
-                fi
+            # Upload checksum file (always use arch-specific filename)
+            if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
+                echo "Uploading architecture-specific checksums for $arch_name"
+                aws s3 cp \
+                  "$source_dir/signed_kmods_checksums_${arch_name}.txt" \
+                  "s3://$(params.s3Bucket)/${S3_TARGET_PATH}signed_kmods_checksums_${arch_name}.txt" \
+                  --endpoint-url "$(params.s3Endpoint)"
             fi
 
             # Upload envfile for reference
@@ -233,10 +220,19 @@ spec:
         else
             echo "Single architecture build, using standard upload"
 
-            if upload_arch_artifacts "single" "${SIGNED_KMODS_FULL_PATH}"; then
-                echo "Successfully uploaded single architecture to S3"
+            # Get the actual architecture directory name
+            arch_dir=$(find "${SIGNED_KMODS_FULL_PATH}" -mindepth 1 -maxdepth 1 -type d | head -1)
+            if [ -z "$arch_dir" ]; then
+                echo "ERROR: No architecture directory found in ${SIGNED_KMODS_FULL_PATH}"
+                exit 1
+            fi
+            actual_arch=$(basename "$arch_dir")
+            echo "Detected architecture: $actual_arch"
+
+            if upload_arch_artifacts "$actual_arch" "$arch_dir"; then
+                echo "Successfully uploaded single architecture to S3: $actual_arch"
             else
-                echo "ERROR: Failed to upload single architecture to S3"
+                echo "ERROR: Failed to upload single architecture to S3: $actual_arch"
                 exit 1
             fi
         fi

--- a/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
@@ -34,10 +34,11 @@ aws() {
     fi
 
     # Single-arch validation - handle both directory and individual file uploads
+    # Now expects arch-specific paths (x86_64)
     case "$3" in
-        "/var/workdir/release/signed-kmods")
+        "/var/workdir/release/signed-kmods/x86_64")
             # Directory upload with recursive flags
-            EXPECTED_TARGET="s3://mock-bucket/mocked-vendor-s3/1.2.3-s3/6.5.0-s3/"
+            EXPECTED_TARGET="s3://mock-bucket/mocked-vendor-s3/1.2.3-s3/6.5.0-s3/x86_64/"
             if [ "$4" != "$EXPECTED_TARGET" ]; then
                 echo "ERROR: Wrong target S3 path: $4"
                 echo "Expected: $EXPECTED_TARGET"
@@ -54,9 +55,23 @@ aws() {
                  exit 1
             fi
             ;;
-        "/var/workdir/release/signed-kmods/envfile")
+        "/var/workdir/release/signed-kmods/x86_64/signed_kmods_checksums_x86_64.txt")
+            # Checksum file upload
+            EXPECTED_TARGET="s3://mock-bucket/mocked-vendor-s3/1.2.3-s3/6.5.0-s3/x86_64/signed_kmods_checksums_x86_64.txt"
+            if [ "$4" != "$EXPECTED_TARGET" ]; then
+                echo "ERROR: Wrong target S3 path for checksum file: $4"
+                echo "Expected: $EXPECTED_TARGET"
+                exit 1
+            fi
+
+            if [ "$5" != "--endpoint-url" ] || [ "$6" != "https://s3.mock.endpoint.com" ]; then
+                echo "ERROR: Wrong endpoint-url for checksum file: $5 $6"
+                exit 1
+            fi
+            ;;
+        "/var/workdir/release/signed-kmods/x86_64/envfile")
             # Individual envfile upload
-            EXPECTED_TARGET="s3://mock-bucket/mocked-vendor-s3/1.2.3-s3/6.5.0-s3/envfile"
+            EXPECTED_TARGET="s3://mock-bucket/mocked-vendor-s3/1.2.3-s3/6.5.0-s3/x86_64/envfile"
             if [ "$4" != "$EXPECTED_TARGET" ]; then
                 echo "ERROR: Wrong target S3 path for envfile: $4"
                 echo "Expected: $EXPECTED_TARGET"

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
@@ -2,16 +2,23 @@ set -x
 
 echo "Setting up test data for push-oot-kmods-s3 task..."
 
-echo "Creating dummy signed kmods and envfile in dataDir..."
-mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/"
-echo "S3_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/mod1.ko"
-echo "S3_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/mod2.ko"
+echo "Creating dummy signed kmods and envfile in dataDir with arch-specific structure..."
+# Create architecture-specific directory structure
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+echo "S3_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
+echo "S3_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
 
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/envfile" << EOF
+cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-s3"
 DRIVER_VERSION="1.2.3-s3"
 KERNEL_VERSION="6.5.0-s3"
 EOF
 
+# Create architecture-specific checksum file
+cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/signed_kmods_checksums_x86_64.txt" << EOF
+$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '{print $1}')  mod1.ko
+$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
+EOF
+
 echo "Test data setup complete:"
-ls -la "$(params.dataDir)/$(params.signedKmodsPath)"
+ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"


### PR DESCRIPTION
The sign-oot-kmods task was updated to always use
architecture-specific checksum filenames (e.g.,
signed_kmods_checksums_arm64.txt) for consistency with subdirectory structure. However, push tasks expected different filenames for single-arch vs multi-arch builds.

This fix updates all three push tasks (git, azure, s3) to:
- Always expect arch-specific checksum filenames
- Always include architecture suffix in storage paths
- Detect actual architecture from subdirectory name

Aligns with extract-oot-kmods (creates subdirs) and sign-oot-kmods (creates arch-specific checksums).

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
