### PR TITLE
fix(RELEASE-1001): add ignorePaths to Tekton manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "tekton": {
     "schedule": ["* 0-4 * * *"],
     "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
+    "ignorePaths": [],
     "includePaths": [
       ".tekton/**",
       "integration-tests/**",


### PR DESCRIPTION

## Describe your changes
* Add ignorePaths for Tekton manager (MintMaker) so it overides defaults and allow /tests/ dir.

docs:https://docs.renovatebot.com/presets-default/#ignoremodulesandtests

## Relevant Jira
RELEASE-1001)
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
