### PR TITLE
fix(RELEASE-2114): tag was not pushed in push-snapshot

### DIFF
--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -206,7 +206,7 @@ spec:
                   && break
               else
                 # Fallback to classic image copy
-                cosign copy -f --only=att,sbom "$3" "$4:$5" && break
+                cosign copy -f "$3" "$4:$5" && break
               fi
               attempt=$((attempt+1))
             done

--- a/tasks/managed/push-snapshot/tests/mocks.sh
+++ b/tasks/managed/push-snapshot/tests/mocks.sh
@@ -7,7 +7,7 @@ function cosign() {
   echo Mock cosign called with: $*
   echo $* >> "$(params.dataDir)/mock_cosign.txt"
 
-  if [[ "$*" == "copy -f --only=att,sbom registry.io/parallel-image:tag"*" "*":"* ]]
+  if [[ "$*" == "copy -f registry.io/parallel-image:tag"*" "*":"* ]]
   then
     LOCK_FILE="$(params.dataDir)/${RANDOM}.lock"
     touch $LOCK_FILE
@@ -20,14 +20,14 @@ function cosign() {
   fi
 
   # mock cosign failing for the no-permission test
-  if [[ "$*" == "copy -f --only=att,sbom registry.io/no-permmission:tag "*":"* ]]
+  if [[ "$*" == "copy -f registry.io/no-permmission:tag "*":"* ]]
   then
     echo Invalid credentials for registry.io/no-permmission:tag
     return 1
   fi
 
   # mock cosign failing the first 3x for the retry test
-  if [[ "$*" == "copy -f --only=att,sbom registry.io/retry-image:tag "*":"* ]]
+  if [[ "$*" == "copy -f registry.io/retry-image:tag "*":"* ]]
   then
     if [[ "$(wc -l < "$(params.dataDir)/mock_cosign.txt")" -le 3 ]]
     then
@@ -36,7 +36,7 @@ function cosign() {
     fi
   fi
 
-  if [[ "$*" == "copy -f --only=att,sbom private-registry.io/image:tag "*":"* ]]
+  if [[ "$*" == "copy -f private-registry.io/image:tag "*":"* ]]
   then
     if [[ $(cat /etc/ssl/certs/ca-custom-bundle.crt) != "mycert" ]]
     then
@@ -45,7 +45,7 @@ function cosign() {
     fi
   fi
 
-  if [[ "$*" != "copy -f --only=att,sbom "*":"*" "*":"* ]]
+  if [[ "$*" != "copy -f "*":"*" "*":"* ]]
   then
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-copy-artifacts.yaml
@@ -206,10 +206,10 @@ spec:
               # For hijklmn (no artifacts), it should fall back to cosign copy
               # Count cosign copy calls (tag1, tag2, tag3)
               COPIES=$(grep -c \
-                '^copy -f --only=att,sbom reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
+                '^copy -f reg.io/test@sha256:abcdefg registry.com/repository:tag[12]$' \
                 "$(params.dataDir)/mock_cosign.txt" || true)
               COPIES2=$(grep -c \
-                '^copy -f --only=att,sbom reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
+                '^copy -f reg.io/test@sha256:hijklmn registry.com/repository:tag3$' \
                 "$(params.dataDir)/mock_cosign.txt" || true)
               TOTAL=$((COPIES + COPIES2))
               # We expect 1 cosign copy (tag3) and 0 for tag1/tag2 (handled by oras cp -r)

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-component.yaml
@@ -206,26 +206,26 @@ spec:
               # The sha 4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03 is calculated
               # from the origin image pull spec - see oras() in mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f --only=att,sbom\
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f --only=att,sbom\
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-defaults-true.yaml
@@ -171,11 +171,11 @@ spec:
               # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
               # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f --only=att,sbom\
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -158,7 +158,7 @@ spec:
               set -eux
 
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f --only=att,sbom reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
+              copy -f reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
               EOF
 
               if [ "$(md5sum < "$(params.dataDir)/cosign_expected_calls.txt")" \

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-omitted.yaml
@@ -163,11 +163,11 @@ spec:
               # The sha 570fd5a1e41b5545a24828be5a3df2e85e4a5a67703385f39594837e77e2478e is calculated
               # from the origin image pull spec - see mocks.sh
               cat > "$(params.dataDir)/cosign_expected_calls.txt" << EOF
-              copy -f --only=att,sbom\
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src
-              copy -f --only=att,sbom registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
-              copy -f --only=att,sbom\
+              copy -f registry.io/image@sha256:abcdefg prod-registry.io/prod-location:testtag
+              copy -f\
                registry.io/image:sha256-4c0020cf1fd28563704fb5f05396899faf8ae642b94950c72c6282a507df1a03.src\
                prod-registry.io/prod-location:testtag-source
               EOF


### PR DESCRIPTION
## Describe your changes

We added `--only=att,sbom` when calling `cosign copy` in push-snaphot. The goal was to skip copying signatures. But it turns out this will also skip pushing the tag.

So let's remove that parameter for now to quickly fix this and let's do it properly later.

The PR that introduced the issue: https://github.com/konflux-ci/release-service-catalog/pull/1687

## Relevant Jira

RELEASE-2114

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
