### PR TITLE
chore(RELEASE-1901): up push-rpm-data task memory

### DIFF
--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -130,9 +130,9 @@ spec:
         quay.io/konflux-ci/release-service-utils@sha256:f10b4ad888634a7633f76ede29003ce1471aec2b76a7d9e01ad282a3011eb78f
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 1Gi
         requests:
-          memory: 512Mi
+          memory: 1Gi
           cpu: 500m
       script: |
         #!/usr/bin/env bash
@@ -302,9 +302,9 @@ spec:
         quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 1Gi
         requests:
-          memory: 512Mi
+          memory: 1Gi
           cpu: '1'
       volumeMounts:
         - name: pyxis-secret-vol


### PR DESCRIPTION
This commit ups the memory limits from 512Mi to 1Gi for both the download sbom step and the push to pyxis step of the push-rpm-data-to-pyxis managed task. 512Mi is proving insufficient, as 63 user RPAs are overriding this value, setting it to 1Gi instead.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
