### PR TITLE
fix(RELEASE-2124): add missing CM to sign-index-image tests

### DIFF
--- a/tasks/managed/sign-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/sign-index-image/tests/pre-apply-task-hook.sh
@@ -13,6 +13,11 @@ kubectl delete internalrequests --all -A
 kubectl delete secret test-create-pyxis-image-cert --ignore-not-found
 kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=mycert --from-literal=key=mykey
 
+# Create signing-config-map ConfigMap required by sign-index-image task
+kubectl delete configmap signing-config-map --ignore-not-found
+kubectl create configmap signing-config-map \
+  --from-literal=SIG_KEY_NAME=test-signing-key
+
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
## Describe your changes
Fixes tests execution broken by commit 55dd6669 (RELEASE-2098).

The task now requires `signing-config-map` ConfigMap to exist, but test setup didn't create it.

Added ConfigMap creation to `pre-apply-task-hook.sh` with test signing key.

Fixes:
- test-sign-index-image-multicomponent
- test-sign-index-image
- test-sign-index-image-plr
- test-sign-index-image-with-pullspec-rewrite

## Relevant Jira
[RELEASE-2124](https://issues.redhat.com/browse/RELEASE-2124)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
