### PR TITLE
fix(RELEASE-2127): use rh-registry-repo

### DIFF
--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -153,9 +153,9 @@ spec:
             if [[ "$num_repos" -eq 1 ]]; then
                 # --- SINGLE REPOSITORY LOGIC ---
                 # Must match the derived URL name. Component-level canonicalName is ignored.
-                url=$(jq -r '.repositories[0].url // empty' <<< "$component")
+                url=$(jq -r '.repositories[0]."rh-registry-repo" // empty' <<< "$component")
                 if [[ -z "$url" ]]; then
-                    echo "Error: Component '$name' repositories[0].url is missing" >&2
+                    echo "Error: Component '$name' repositories[0].\"rh-registry-repo\" is missing" >&2
                     exit 1
                 fi
 

--- a/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
@@ -79,10 +79,10 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/foo:one"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/foo"
                       },
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/bar:two"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/bar"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
@@ -99,10 +99,10 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/foo:one"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/foo"
                       },
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/bar:two"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/bar"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
@@ -80,10 +80,10 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/foo:one"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/foo"
                       },
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/bar:two"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/bar"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
@@ -79,7 +79,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
@@ -85,7 +85,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
@@ -83,7 +83,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
@@ -70,7 +70,7 @@ spec:
                 "components": [
                   {
                     "name": "comp1",
-                    "canonicalName": "openshift-gitops-1/gitops-rhel8-operator,
+                    "canonicalName": "openshift-gitops-1/gitops-rhel8-operator",
                     "metadata": {
                       "labels": [
                         {
@@ -81,10 +81,10 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/foo:one"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/foo"
                       },
                       {
-                        "url": "registry.redhat.io/openshift-gitops-1/bar:two"
+                        "rh-registry-repo": "registry.redhat.io/openshift-gitops-1/bar"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
@@ -80,7 +80,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
@@ -78,7 +78,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }

--- a/tasks/managed/check-labels/tests/test-check-labels.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels.yaml
@@ -82,7 +82,7 @@ spec:
                     },
                     "repositories": [
                       {
-                        "url": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator:v1.15.2-4"
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
                       }
                     ]
                   }


### PR DESCRIPTION
## Describe your changes

The task was using the wrong url (quay one). This commit updates the task to use rh-registry-repo.

## Relevant Jira
RELEASE-2127

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
