### PR TITLE
feat(CWFHEALTH-4583): Add RHACS auth to run-collectors pipeline

### DIFF
--- a/pipelines/run-collectors/README.md
+++ b/pipelines/run-collectors/README.md
@@ -16,3 +16,5 @@ results.
 | collectorsRepositoryRevision | Git repository revision                                                                                           | Yes      | development                                                  |
 | taskGitUrl                   | The url to the git repo where the release-service-catalog tasks to be used are stored                             | Yes      | https://github.com/konflux-ci/release-service-catalog.git    |
 | taskGitRevision              | The revision in the taskGitUrl repo to be used                                                                    | No       | -                                                            |
+| roxCentralEndpoint           | The url for RHACS Central                                                                                         | Yes      | https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com             |
+| roxInsecureSkipTlsVerify     | Do not verify TLS certificates for ACS connection                                                                 | Yes      | false                                                        |

--- a/pipelines/run-collectors/run-collectors.yaml
+++ b/pipelines/run-collectors/run-collectors.yaml
@@ -44,6 +44,14 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: roxCentralEndpoint
+      type: string
+      description: The url for RHACS Central
+      default: https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com
+    - name: roxInsecureSkipTlsVerify
+      type: string
+      description: Do not verify TLS certificates for ACS connection
+      default: "false"
   workspaces:
     - name: release-workspace
   tasks:
@@ -71,6 +79,32 @@ spec:
       workspaces:
         - name: data
           workspace: release-workspace
+    - name: exchange-service-account-token
+      when:
+        - input: "$(tasks.collect-collectors-resources.results.hasSbomdiffCollector)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collectors/exchange-service-account-token/exchange-service-account-token.yaml
+      params:
+        - name: roxCentralEndpoint
+          value: $(params.roxCentralEndpoint)
+        - name: insecureSkipTlsVerify
+          value: $(params.roxInsecureSkipTlsVerify)
+        - name: roxConfigDir
+          value: $(tasks.collect-collectors-resources.results.roxConfigDir)
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - collect-collectors-resources
     - name: run-collectors
       taskRef:
         resolver: "git"
@@ -96,11 +130,14 @@ spec:
           value: $(tasks.collect-collectors-resources.results.release)
         - name: previousReleasePath
           value: $(tasks.collect-collectors-resources.results.previousRelease)
+        - name: roxConfigDir
+          value: $(tasks.collect-collectors-resources.results.roxConfigDir)
       workspaces:
         - name: data
           workspace: release-workspace
       runAfter:
         - collect-collectors-resources
+        - exchange-service-account-token
     - name: save-collectors-results
       taskRef:
         resolver: "git"

--- a/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
+++ b/tasks/collectors/collect-collectors-resources/collect-collectors-resources.yaml
@@ -58,6 +58,12 @@ spec:
     - name: resultsDir
       type: string
       description: The relative path in the workspace to the results directory
+    - name: hasSbomdiffCollector
+      type: string
+      description: Whether the sbomdiff collector is present in the collectors configuration (true/false)
+    - name: roxConfigDir
+      type: string
+      description: The relative path in the workspace to the roxctl configuration directory (empty if no sbomdiff)
   volumes:
     - name: trusted-ca
       configMap:
@@ -112,3 +118,18 @@ spec:
         echo -n "$COLLECTORS_RESOURCE_PATH" > "$(results.collectorsResource.path)"
         get-resource "${COLLECTORS_RESOURCE_TYPE}" "${COLLECTORS_RESOURCE}" | \
           tee "$(workspaces.data.path)/$COLLECTORS_RESOURCE_PATH"
+
+        # Detect if sbomdiff collector is present
+        HAS_SBOMDIFF="false"
+        ROX_CONFIG_DIR=""
+        if [ -f "$(workspaces.data.path)/$COLLECTORS_RESOURCE_PATH" ]; then
+          SBOMDIFF_COUNT=$(jq '[.spec.collectors.items[]? | select(.type == "sbomdiff")] | length' \
+            "$(workspaces.data.path)/$COLLECTORS_RESOURCE_PATH")
+          if [ "$SBOMDIFF_COUNT" -gt 0 ]; then
+            HAS_SBOMDIFF="true"
+            # Set the roxctl config directory path (will be created by exchange-service-account-token task)
+            ROX_CONFIG_DIR="$(params.subdirectory)/roxctl-config"
+          fi
+        fi
+        echo -n "$HAS_SBOMDIFF" > "$(results.hasSbomdiffCollector.path)"
+        echo -n "$ROX_CONFIG_DIR" > "$(results.roxConfigDir.path)"

--- a/tasks/collectors/exchange-service-account-token/README.md
+++ b/tasks/collectors/exchange-service-account-token/README.md
@@ -1,0 +1,16 @@
+# exchange-service-account-token
+
+Tekton task to exchange a Kubernetes service account token for an ACS (Advanced Cluster Security)
+authentication token using machine-to-machine (M2M) authentication. The resulting roxctl configuration
+is stored in the workspace for use by downstream tasks.
+
+## Parameters
+
+| Name                  | Description                                                           | Optional | Default value                                                                                                                           |
+|-----------------------|-----------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| roxImage              | Image providing the roxctl tool                                       | Yes      | registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:d6d5e50d1deda1e7b232d4e3f60fda6f3d27266b6fc007c8ec48a324e1c6c15c |
+| roxCentralEndpoint    | The address:port tuple for RHACS Stackrox Central                     | Yes      | https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com                                                                                        |
+| insecureSkipTlsVerify | Do not verify TLS certificates when set to "true"                     | Yes      | false                                                                                                                                   |
+| roxConfigDir          | The relative path in the workspace to store the roxctl configuration  | No       | -                                                                                                                                       |
+| caTrustConfigMapName  | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca                                                                                                                              |
+| caTrustConfigMapKey   | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt                                                                                                                           |

--- a/tasks/collectors/exchange-service-account-token/exchange-service-account-token.yaml
+++ b/tasks/collectors/exchange-service-account-token/exchange-service-account-token.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: exchange-service-account-token
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task to exchange a Kubernetes service account token for an ACS (Advanced Cluster Security)
+    authentication token using machine-to-machine (M2M) authentication. The resulting roxctl configuration
+    is stored in the workspace for use by downstream tasks.
+  params:
+    - name: roxImage
+      type: string
+      description: Image providing the roxctl tool
+      default: 'registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:d6d5e50d1deda1e7b232d4e3f60fda6f3d27266b6fc007c8ec48a324e1c6c15c'
+    - name: roxCentralEndpoint
+      type: string
+      description: The address:port tuple for RHACS Stackrox Central
+      default: https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com
+    - name: insecureSkipTlsVerify
+      type: string
+      description: Do not verify TLS certificates when set to "true"
+      default: "false"
+    - name: roxConfigDir
+      type: string
+      description: The relative path in the workspace to store the roxctl configuration
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+  workspaces:
+    - name: data
+      description: Workspace to store the roxctl configuration
+  volumes:
+    - name: service-account-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              audience: rhacs
+              path: token
+              expirationSeconds: 3600
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+  steps:
+    - name: exchange-token
+      image: $(params.roxImage)
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 64Mi
+          cpu: 50m
+      volumeMounts:
+        - name: service-account-token
+          mountPath: /service-account-token
+          readOnly: true
+      env:
+        - name: ROX_ENDPOINT
+          value: $(params.roxCentralEndpoint)
+        - name: INSECURE
+          value: $(params.insecureSkipTlsVerify)
+        - name: ROX_EXECUTION_ENV
+          value: Tekton
+        - name: ROX_CONFIG_DIR
+          value: $(workspaces.data.path)/$(params.roxConfigDir)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        mkdir -p "${ROX_CONFIG_DIR}"
+
+        echo "Exchanging service account token for ACS authentication..."
+        echo "ROX_ENDPOINT: ${ROX_ENDPOINT}"
+        echo "ROX_CONFIG_DIR: ${ROX_CONFIG_DIR}"
+
+        # Perform M2M token exchange
+        roxctl central m2m exchange \
+          --insecure-skip-tls-verify="${INSECURE}" \
+          --token-file=/service-account-token/token
+
+        echo "Token exchange completed successfully"

--- a/tasks/collectors/exchange-service-account-token/tests/pre-apply-task-hook.sh
+++ b/tasks/collectors/exchange-service-account-token/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# No special setup required for this task's mock tests
+# The actual M2M exchange cannot be tested in CI without real ACS access

--- a/tasks/collectors/exchange-service-account-token/tests/test-exchange-service-account-token.yaml
+++ b/tasks/collectors/exchange-service-account-token/tests/test-exchange-service-account-token.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-exchange-service-account-token
+spec:
+  description: |
+    Test the exchange-service-account-token task by verifying it creates the config directory
+    and outputs the correct path. Uses a mock implementation since actual M2M exchange cannot
+    be tested in CI.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: roxConfigDir
+            type: string
+        steps:
+          - name: mock-exchange
+            image: quay.io/konflux-ci/release-service-utils@sha256:f10b4ad888634a7633f76ede29003ce1471aec2b76a7d9e01ad282a3011eb78f
+            env:
+              - name: ROX_CONFIG_DIR
+                value: $(workspaces.data.path)/$(params.roxConfigDir)
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Simulate what the real task does (without actual roxctl call)
+              mkdir -p "${ROX_CONFIG_DIR}"
+
+              # Create a mock config file to simulate successful exchange
+              echo '{"mock": "token-config"}' > "${ROX_CONFIG_DIR}/config.json"
+      params:
+        - name: roxConfigDir
+          value: $(context.pipelineRun.uid)/roxctl-config
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: roxConfigDir
+          value: $(context.pipelineRun.uid)/roxctl-config
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: roxConfigDir
+            type: string
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:f10b4ad888634a7633f76ede29003ce1471aec2b76a7d9e01ad282a3011eb78f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Test that roxConfigDir result is set"
+              test -n "$(params.roxConfigDir)"
+
+              echo "Test that roxConfigDir contains roxctl-config"
+              [[ "$(params.roxConfigDir)" == *"roxctl-config"* ]]
+
+              echo "Test that config directory was created"
+              test -d "$(workspaces.data.path)/$(params.roxConfigDir)"
+
+              echo "Test that mock config file exists"
+              test -f "$(workspaces.data.path)/$(params.roxConfigDir)/config.json"
+
+              echo "All tests passed"

--- a/tasks/collectors/run-collectors/README.md
+++ b/tasks/collectors/run-collectors/README.md
@@ -16,3 +16,4 @@ resultsDir, one file per collector.
 | previousReleasePath          | Path to the json data file of the previous successful Release prior to the current one  | No       | -             |
 | caTrustConfigMapName         | The name of the ConfigMap to read CA bundle data from                                   | Yes      | trusted-ca    |
 | caTrustConfigMapKey          | The name of the key in the ConfigMap that contains the CA bundle data                   | Yes      | ca-bundle.crt |
+| roxConfigDir                 | The relative path in the workspace to the roxctl configuration directory (optional)     | Yes      | ""            |

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -43,6 +43,10 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
+    - name: roxConfigDir
+      type: string
+      description: The relative path in the workspace to the roxctl configuration directory (optional)
+      default: ""
   workspaces:
     - name: data
       description: Workspace where the CRs are stored
@@ -75,6 +79,14 @@ spec:
         CONCURRENT_LIMIT=4
         RELEASE_FILE="$(workspaces.data.path)/$(params.releasePath)"
         PREVIOUS_RELEASE_FILE="$(workspaces.data.path)/$(params.previousReleasePath)"
+
+        # Set ROX_CONFIG_DIR if provided (for sbomdiff collector)
+        ROX_CONFIG_DIR_PARAM="$(params.roxConfigDir)"
+        if [ -n "${ROX_CONFIG_DIR_PARAM}" ]; then
+          ROX_CONFIG_DIR="$(workspaces.data.path)/${ROX_CONFIG_DIR_PARAM}"
+          export ROX_CONFIG_DIR
+          echo "ROX_CONFIG_DIR set to: ${ROX_CONFIG_DIR}"
+        fi
 
         execute_collector() { # Expected arguments are [collector json, type of collector]
             collector="$1"


### PR DESCRIPTION
## Describe your changes

Add conditional ACS (Advanced Cluster Security) machine-to-machine authentication to the run-collectors pipeline, enabling sbomdiff collectors to authenticate with RHACS Central and access security vulnerability data.

  - **New task**: `exchange-service-account-token` - exchanges a Kubernetes service account token for an ACS authentication token using M2M authentication
  - **Conditional execution**: authentication only runs when an sbomdiff collector is configured, ensuring zero overhead for pipelines that don't require ACS access
  - **Single source of truth**: `collect-collectors-resources` outputs the `roxConfigDir` path, which is passed to both the authentication task and `run-collectors`

 ### How it works

  1. `collect-collectors-resources` detects if any collector has `type: "sbomdiff"` and outputs `hasSbomdiffCollector` result
  2. `exchange-service-account-token` runs only when `hasSbomdiffCollector == "true"`, performing M2M token exchange with ACS Central
  3. `run-collectors` receives the `roxConfigDir` path and exports `ROX_CONFIG_DIR` for sbomdiff collectors to use

## Relevant Jira

CWFHEALTH-4583

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [X] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
