### PR TITLE
chore(RELEASE-2134): reduce simple-signing-pipeline retries

### DIFF
--- a/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -86,7 +86,7 @@ spec:
       runAfter:
         - collect-simple-signing-params
     - name: request-and-upload-signature
-      retries: 5
+      retries: 2
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
## Describe your changes

Currently, we have 3 retries for the rh-sign-image task and then 5 retries in the internal simple-signing-pipeline for each task. And then pubtools also retries twice.

This many retries just makes things even worse when UMB starts being overloaded which happened repeatedly in the last weeks.

So let's start with a reduction from 5 to 2 for
the request-and-upload-signature internal task.

## Relevant Jira

RELEASE-2134

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
