### PR TITLE
fix: switch to root for installs after utils moved to non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/konflux-ci/release-service-utils@sha256:aa18816418dbec54abef7213ff92e594dee4f9c2f173df81e96c867ba1ce4042
+FROM quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
 
 ARG TKN_VERSION=0.40.0
 ARG KUSTOMIZE_VERSION=5.6.0
@@ -11,23 +11,42 @@ LABEL io.k8s.display-name="release-service-catalog"
 LABEL summary="Konflux Release Service Catalog"
 LABEL com.redhat.component="release-service-catalog"
 
+# Switch to root to install dependencies
+USER 0
+
 RUN curl -L https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tektoncd-cli-${TKN_VERSION}_Linux-64bit.rpm \
     -o /tmp/tektoncd-cli-Linux-64bit.rpm
 RUN dnf install -y /tmp/tektoncd-cli-Linux-64bit.rpm
-RUN tkn version --component client
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     gettext \
     procps-ng \
     && dnf clean all
 
-RUN python3 -m pip install --user ansible
-RUN ansible-vault --version
-RUN kubectl version --client=true
-RUN echo $HOME
-
 RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
     | tar -C /usr/bin/ -xzf - kustomize &&\
     chmod +x /usr/bin/kustomize
 
+# Install ansible system-wide so it's in /usr/local/bin (accessible by all users)  
+RUN python3 -m pip install --no-cache-dir ansible  
+
 ADD integration-tests/ /home/e2e/tests/
+
+# Configure non-root user (UID 1001) for security and compatibility (inherited 
+# from the release-service-utils base image). Ensure E2E tests can write under
+# /home/e2e when running as non-root. OpenShift may assign a random UID/GID at
+# runtime, so below sets the ownership and permissions to ensure write access
+# for E2E tests at runtime.
+RUN chown -R 1001:1001 /home/e2e && \
+    # Make all files group-owned by root to allow OpenShift's random UID to work.
+    chgrp -R 0 /home/e2e && \
+    chmod -R g+rwX /home/e2e && \
+    # Ensure group permissions are inherited by new subdirectories
+    find /home/e2e -type d -exec chmod g+s {} +
+
+# Switch back to the non-root user
+USER 1001
+
+RUN tkn version --component client
+RUN ansible-vault --version
+RUN kubectl version --client=true


### PR DESCRIPTION
## Describe your changes
release-service-utils now runs as non-root (UID 1001), so catalog builds failed when running dnf/curl installs.
Use USER 0 for deps, then switch back to 1001. 
Also, add /home/e2e perms with utils so e2e tests can write under non-root on OpenShift.
Noticed after MintMaker updates.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
