### PR TITLE
chore: limit digest updates to utils and conforma cli

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,19 @@
       "integration-tests/**",
       "tasks/**",
       "pipelines/**"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": ["*"],
+        "enabled": false
+      },
+      {
+        "matchPackageNames": [
+          "quay.io/konflux-ci/release-service-utils",
+          "quay.io/conforma/cli"
+        ],
+        "enabled": true
+      }
     ]
-  },
-  "kubernetes": {
-    "managerFilePatterns": ["stepactions/**/*.yaml"],
-    "schedule": ["* 0-4 * * *"]
   }
 }


### PR DESCRIPTION
## Describe your changes
Configure Mintmaker to only match quay.io/konflux-ci/release-service-utils and quay.io/conforma/cli for digest bumps.
## Relevant Jira
Slack: https://redhat-internal.slack.com/archives/C04J47GL936/p1768322122138689?thread_ts=1768312717.973299&cid=C04J47GL936


## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
