### PR TITLE
fix: use 'repository' instead of 'repo' in batch signer output

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -391,7 +391,7 @@ spec:
               |(.[0].signed_claims|to_entries|.[]) as $x
               |{reference:(.[0].claim_file | @base64d | fromjson | .critical.identity."docker-reference"),
                 manifest_digest:.[0].manifest_digest,
-                repo:.[1],
+                repository:.[1],
                 signature_data: $x.value,
                 sig_key_id: $x.key}
             ]')


### PR DESCRIPTION
## Describe your changes

The batch signer jq query was outputting 'repo' but Pyxis API expects 'repository', causing signature upload to fail with: "Additional properties are not allowed ('repo' was unexpected)"

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
