### PR TITLE
fix: correct batch signer jq query for repository field

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -382,18 +382,14 @@ spec:
           SIGNATURE_DATA=$(
             cat "$(workspaces.data.path)/${signature_data_file}" | \
             jq -cM '[
-              [(.operation_results|.[]|.[0].msg.claims),
-               [range(0; (.operation_results|.[]|.[0].msg.claims)|length) as $x |
-                (.operation_results|.[]|.[0].msg.repo)]
-              ]
-              |transpose
+              (.operation_results|.[]|.[0].msg.claims)
               |.[]
-              |(.[0].signed_claims|to_entries|.[]) as $x
-              |{reference:(.[0].claim_file | @base64d | fromjson | .critical.identity."docker-reference"),
-                manifest_digest:.[0].manifest_digest,
-                repository:.[1],
-                signature_data: $x.value,
-                sig_key_id: $x.key}
+              |. as $claim | .signed_claims | to_entries | .[]
+              |{reference:($claim.claim_file | @base64d | fromjson | .critical.identity."docker-reference"),
+                manifest_digest:$claim.manifest_digest,
+                repository:$claim.repo,
+                signature_data: .value,
+                sig_key_id: .key}
             ]')
         else
           echo "Unknown signer_type: $signer_type"

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
@@ -70,7 +70,6 @@ spec:
                         "created": "2025-10-23T10:54:09.191275Z",
                         "errors": [],
                         "pub_task_id": "13",
-                        "repo": "repo1",
                         "request_id": "f1a99acf-1372-483c-977a-fe89fdd14731",
                         "request_received_time": "2025-10-23T10:54:10.459475",
                         "requested_by": "hacbs-testing",


### PR DESCRIPTION
## Describe your changes

The previous fix (f36516c6) renamed 'repo' to 'repository' but was not sufficient - the jq query was trying to access msg.repo which doesn't exist in real batch signing responses. The repo field only exists inside each claim object.

This fix:
- Restructures the jq query to access repo from each claim directly
- Fixes jq variable scoping so $claim is available where needed
- Updates test mock data to match real response structure (removes non-existent msg.repo field)

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
