### PR TITLE
feat(RELEASE-1265): rh-push-to-registry-redhat-io pipeline idempotency

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -156,6 +156,8 @@ cleanup_resources() {
   local err=${1:-0} # Default to 0 if no error code passed
   local line=${2:-"N/A"}
   local command=${3:-"N/A"}
+  local cleanup_log_file
+  cleanup_log_file=$(mktemp) # Always set so later echo >> "${cleanup_log_file}" is valid (e.g. when CLEANUP != true)
 
   if [ "$err" -ne 0 ] ; then
     echo "$0: ERROR: Command '$command' failed at line $line - exited with status $err"
@@ -166,7 +168,6 @@ cleanup_resources() {
     # cleanup...so we can ignore errors
     set +eo pipefail
 
-    local cleanup_log_file
     cleanup_log_file=$(mktemp)
     echo "Cleanup log file: ${cleanup_log_file}"
     echo -e "\n--- Cleanup Log ---" > "${cleanup_log_file}"
@@ -203,7 +204,7 @@ cleanup_resources() {
   fi
 
   echo "Killing any child processes..." >> "${cleanup_log_file}"
-  pkill -e  -P $$
+  pkill -e -P $$ || true
 
   if [ "$err" -ne 0 ]; then
     exit "$err"
@@ -245,22 +246,29 @@ create_github_repository() {
 }
 
 # Function to set up Kubernetes namespaces
+# Creates managed_namespace and tenant_namespace if they do not exist (for local/dev runs).
 # Relies on global variables: managed_namespace, tenant_namespace
 setup_namespaces() {
     echo "Setting up namespaces..."
-    set +eo pipefail # Temporarily disable exit on error for checks
+    set +e
     echo "Checking managed namespace: ${managed_namespace}"
-    kubectl get ns "${managed_namespace}" > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-      log_error "Managed namespace ${managed_namespace} does not exist." 2
+    if ! kubectl get ns "${managed_namespace}" > /dev/null 2>&1; then
+        echo "Creating managed namespace: ${managed_namespace}"
+        if ! kubectl create namespace "${managed_namespace}"; then
+            set -e
+            log_error "Managed namespace ${managed_namespace} does not exist and could not be created. Create it with: kubectl create namespace ${managed_namespace}" 2
+        fi
     fi
 
     echo "Checking tenant namespace: ${tenant_namespace}"
-    kubectl get ns "${tenant_namespace}" > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-      log_error "Tenant namespace ${tenant_namespace} does not exist." 2
+    if ! kubectl get ns "${tenant_namespace}" > /dev/null 2>&1; then
+        echo "Creating tenant namespace: ${tenant_namespace}"
+        if ! kubectl create namespace "${tenant_namespace}"; then
+            set -e
+            log_error "Tenant namespace ${tenant_namespace} does not exist and could not be created. Create it with: kubectl create namespace ${tenant_namespace}" 2
+        fi
     fi
-    set -eo pipefail # Re-enable exit on error
+    set -eo pipefail
     kubectl config set-context --current --namespace="$tenant_namespace"
     echo "Namespaces setup complete. Current namespace set to ${tenant_namespace}."
 }
@@ -490,8 +498,8 @@ wait_for_plr_to_complete() {
 
         sleep 5
 
-        # Check if the pipeline run is completed
-        completed=$(kubectl get pipelinerun "${component_push_plr_name}" -n "${tenant_namespace}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null)
+        # Check if the pipeline run is completed (kubectl exits 1 if PipelineRun missing; avoid failing script)
+        completed=$(kubectl get pipelinerun "${component_push_plr_name}" -n "${tenant_namespace}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null) || completed=""
 
         # If completed, check the status
         if [ -n "$completed" ]; then

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -100,8 +100,8 @@ spec:
               success_test_cases=()
 
               ALL_TESTCASES=("e2e" "collectors" "fbc-release" "release-to-github" "push-to-external-registry" \
-                "rhtap-service-push" "rh-push-to-registry-redhat-io" "rh-push-to-external-registry" \
-                "push-to-addons-registry")
+                "rhtap-service-push" "rh-push-to-registry-redhat-io" "rh-push-to-registry-redhat-io-idempotent" \
+                "rh-push-to-external-registry" "push-to-addons-registry")
                 # push-rpms-to-pulp fails, will be fixed in RELEASE-2049
                 # "push-to-addons-registry" "push-rpms-to-pulp")
               overall_test_count=${#ALL_TESTCASES[@]}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/README.md
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/README.md
@@ -1,0 +1,25 @@
+# rh-push-to-registry-redhat-io-idempotent-multi-arch
+
+## Overview
+
+Idempotency test with a multi-architecture component: uses `docker-build-multi-platform-oci-ta`
+so the build produces a manifest list and the snapshot contains a manifest list digest. Same
+two-release idempotent flow as the base test — validates that the filter handles manifest
+list digests correctly via the `image_id` field query.
+
+## Setup
+
+Same as [rh-push-to-registry-redhat-io-idempotent](../rh-push-to-registry-redhat-io-idempotent/README.md).
+Symlink `vault/` from that suite for secrets. Build may take longer than single-arch.
+
+## How It Works
+
+Sources the base idempotent `test.sh` without overrides. The manifest list digest is stored
+by `create-pyxis-image` as `image_id`, which the filter task queries directly. No special
+handling is needed for multi-arch images — the query and completeness check are identical.
+
+## Running
+
+```shell
+integration-tests/run-test.sh rh-push-to-registry-redhat-io-idempotent-multi-arch
+```

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/ec-policy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: standard-${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  description: >-
+    Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: "k8s://openshift-pipelines/public-key"
+  sources:
+    - name: Release Policies
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+      volatileConfig:
+        exclude:
+          - value: cve.cve_blockers
+            effectiveUntil: "2025-02-01T00:00:00Z"
+      config:
+        exclude: []
+        include:
+          - '@slsa3'

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: ${managed_namespace}
+resources:
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rpa.yaml
+  - ec-policy.yaml
+  - secrets/managed-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/rpa.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: false
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+    # No fileUpdates: idempotent test validates Pyxis-only filtering.
+    # fileUpdates MRs in hacbs-release-tests GitLab are not auto-merged, so requiring
+    # file_updates_complete would make the second release never filter. Pyxis propagation
+    # after the first release is sufficient for this e2e test.
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-release-pipeline-resource-role-binding-for-${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/sa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/managed/sa.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+secrets:
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}
+  - name: push-${component_name}
+  - name: pyxis-${component_name}
+  - name: konflux-cosign-signing-stage-${component_name}
+imagePullSecrets:
+  - name: push-${component_name}
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/application.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/application.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: ${application_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  displayName: ${application_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/component.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    # Multi-platform build produces manifest list; snapshot containerImage will have manifest list digest.
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-multi-platform-oci-ta", "bundle": "latest"}'
+  name: ${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component_branch}
+      url: "${component_git_url}"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/rp.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/rp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-pipeline-resource-role-binding-for-${component_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.env
@@ -1,0 +1,27 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+uuid="${uuid:0:8}"
+
+export originating_tool="rh-push-to-registry-redhat-io-idempotent-multi-arch-e2e-test"
+
+export tenant_namespace=dev-release-team-tenant
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-redhat-idem-ma-app-${uuid}
+export component_type=rh-push-to-registry-redhat-io-idempotent
+export component_name=${component_type}-ma-${uuid}
+export component_branch=${component_name}
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=rh-push-to-registry-redhat-io-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+export release_plan_name=rh-push-to-registry-redhat-io-idempotent-ma-rp-${uuid}
+
+export managed_sa_name=rh-push-to-registry-redhat-io-idempotent-ma-sa-${uuid}
+export release_plan_admission_name=rh-push-to-registry-redhat-io-idempotent-ma-rpa-${uuid}
+
+# Max wait for Pyxis to have image_id record AND rpm_manifest.rpms populated.
+export IDEMPOTENT_WAIT_SECONDS=${IDEMPOTENT_WAIT_SECONDS:-60}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.sh
@@ -8,3 +8,173 @@
 
 # shellcheck source=../rh-push-to-registry-redhat-io-idempotent/test.sh
 source "${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent/test.sh"
+
+# Override decrypt_secrets: always pull the GitHub token fresh from the base suite's
+# vault so we never rely on a stale token baked into resources/tenant/secrets/.
+# Managed secrets are already baked into resources/managed/secrets/ and stay as-is.
+decrypt_secrets() {
+    local base_suite_dir="${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent"
+    (
+        . "${LIB_DIR}/test-functions.sh"
+        decrypt_secrets "${base_suite_dir}"
+    )
+    # Copy the freshly-decrypted tenant secret (valid GitHub token) into this suite.
+    local base_tenant_secrets="${base_suite_dir}/resources/tenant/secrets/tenant-secrets.yaml"
+    local tenant_secrets_file="${SUITE_DIR}/resources/tenant/secrets/tenant-secrets.yaml"
+    mkdir -p "${SUITE_DIR}/resources/tenant/secrets"
+    cp "${base_tenant_secrets}" "${tenant_secrets_file}"
+}
+
+# Override resolve_pyxis_poll_digest: for a manifest list digest, resolve to
+# the first per-arch digest so the polling job queries Pyxis correctly.
+# Pyxis stores per-arch records (not manifest list records), so polling by the
+# manifest list digest always returns 0 results.
+resolve_pyxis_poll_digest() {
+    local image_digest="$1"
+    local snapshot_name="$2"
+
+    if [ -z "${image_digest}" ] || [ "${image_digest}" = "null" ] \
+        || [ -z "${snapshot_name}" ] || [ "${snapshot_name}" = "null" ]; then
+        echo "${image_digest}"
+        return 0
+    fi
+
+    local container_image
+    container_image=$(kubectl get snapshot -n "${tenant_namespace}" "${snapshot_name}" \
+        -o jsonpath='{.spec.components[0].containerImage}' 2>/dev/null || echo "")
+
+    if [ -z "${container_image}" ] || [[ "${container_image}" != *@sha256:* ]]; then
+        echo "${image_digest}"
+        return 0
+    fi
+
+    local ml_registry="${container_image%%/*}"
+    local ml_repo="${container_image#*/}"; ml_repo="${ml_repo%@*}"
+    local ml_token
+    ml_token=$(curl -sf --max-time 10 \
+        "https://${ml_registry}/v2/auth?service=${ml_registry}&scope=repository:${ml_repo}:pull" \
+        | jq -r '.token // ""' 2>/dev/null || echo "")
+    local ml_accept="application/vnd.docker.distribution.manifest.list.v2+json"
+    ml_accept="${ml_accept},application/vnd.oci.image.index.v1+json"
+    local ml_manifest
+    ml_manifest=$(curl -sf --max-time 15 \
+        -H "Authorization: Bearer ${ml_token}" \
+        -H "Accept: ${ml_accept}" \
+        "https://${ml_registry}/v2/${ml_repo}/manifests/${image_digest}" \
+        2>/dev/null || echo "{}")
+    local first_arch_digest
+    first_arch_digest=$(echo "${ml_manifest}" \
+        | jq -r '.manifests[0]?.digest // ""' 2>/dev/null || echo "")
+
+    if [ -n "${first_arch_digest}" ]; then
+        echo "Manifest list detected — polling by first arch digest: ${first_arch_digest}" >&2
+        echo "${first_arch_digest}"
+    else
+        echo "${image_digest}"
+    fi
+}
+
+# Override patch_component_source_before_merge:
+# configure-pac generates .tekton/<component>-push.yaml (with correct hardcoded branch
+# name) and .tekton/<component>-pull-request.yaml. The push file uses
+# docker-build-multi-platform-oci-ta:devel (from the pipeline annotation on the
+# component) but does NOT include build-platforms or build-image-index, so the build
+# defaults to linux/x86_64 only.
+# This function:
+#  1. Patches .tekton/<component>-push.yaml to add build-platforms + build-image-index
+#  2. Deletes .tekton/<component>-pull-request.yaml (not needed for the test)
+#  3. Deletes .tekton/push.yaml from e2e-base-multi-arch (its {{target_branch}} CEL
+#     expression is never substituted by PaC, so it would never trigger a build)
+patch_component_source_before_merge() {
+    echo "Patching PR: injecting multi-arch params into configure-pac push pipeline..."
+
+    local pr_branch
+    pr_branch=$(gh api "repos/${component_repo_name}/pulls/${pr_number}" \
+        --jq '.head.ref' 2>/dev/null || echo "")
+    if [ -z "${pr_branch}" ]; then
+        echo "⚠️  Could not determine PR branch — skipping patch"
+        return 0
+    fi
+    echo "PR branch: ${pr_branch}"
+
+    # --- 1. Patch <component>-push.yaml: add build-platforms + build-image-index ---
+    local push_file=".tekton/${component_name}-push.yaml"
+    local push_sha push_content
+    push_sha=$(gh api \
+        "repos/${component_repo_name}/contents/${push_file}?ref=${pr_branch}" \
+        --jq '.sha' 2>/dev/null || echo "")
+    push_content=$(gh api \
+        "repos/${component_repo_name}/contents/${push_file}?ref=${pr_branch}" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+    if [ -n "${push_content}" ]; then
+        # Replace build-platforms value with multi-arch list and ensure build-image-index is set
+        local patched_content
+        patched_content=$(printf '%s' "${push_content}" | python3 -c '
+import sys, re
+
+content = sys.stdin.read()
+
+# Replace configure-pac single-arch value with multi-arch list
+content = re.sub(
+    r"(  - name: build-platforms\n    value:\n)    - linux/[^\n]+\n",
+    r"\1    - linux/amd64\n    - linux/arm64\n",
+    content
+)
+
+# Add build-image-index to spec.params if not already there (check before pipelineSpec:)
+spec_section = content.split("  pipelineSpec:")[0] if "  pipelineSpec:" in content else content
+if "build-image-index" not in spec_section:
+    content = re.sub(
+        r"(    - linux/ppc64le\n)",
+        r"\1  - name: build-image-index\n    value: \"true\"\n",
+        content, count=1
+    )
+
+sys.stdout.write(content)
+')
+        local encoded
+        encoded=$(printf '%s' "${patched_content}" | base64 -w 0)
+        gh api -X PUT \
+            "repos/${component_repo_name}/contents/${push_file}" \
+            -F message="chore: add multi-arch build-platforms to push pipeline" \
+            -F content="${encoded}" \
+            -F sha="${push_sha}" \
+            -F branch="${pr_branch}" > /dev/null \
+            && echo "✅ Patched ${push_file} with multi-arch build-platforms" \
+            || echo "⚠️  Failed to patch ${push_file}"
+    else
+        echo "⚠️  ${push_file} not found in PR branch — cannot patch"
+    fi
+
+    # --- 2. Delete <component>-pull-request.yaml (unwanted, creates noisy cancelled PLRs) ---
+    local pr_file=".tekton/${component_name}-pull-request.yaml"
+    local pr_file_sha
+    pr_file_sha=$(gh api \
+        "repos/${component_repo_name}/contents/${pr_file}?ref=${pr_branch}" \
+        --jq '.sha' 2>/dev/null || echo "")
+    if [ -n "${pr_file_sha}" ]; then
+        gh api -X DELETE \
+            "repos/${component_repo_name}/contents/${pr_file}" \
+            -F message="chore: remove pull-request pipeline (not needed for test)" \
+            -F sha="${pr_file_sha}" \
+            -F branch="${pr_branch}" > /dev/null 2>&1 \
+            && echo "✅ Deleted ${pr_file}" \
+            || echo "⚠️  Could not delete ${pr_file}"
+    fi
+
+    # --- 3. Delete push.yaml from e2e-base-multi-arch (broken {{target_branch}} CEL) ---
+    local base_push_sha
+    base_push_sha=$(gh api \
+        "repos/${component_repo_name}/contents/.tekton/push.yaml?ref=${pr_branch}" \
+        --jq '.sha' 2>/dev/null || echo "")
+    if [ -n "${base_push_sha}" ]; then
+        gh api -X DELETE \
+            "repos/${component_repo_name}/contents/.tekton/push.yaml" \
+            -F message="chore: remove template push.yaml (CEL {{target_branch}} not substituted by PaC)" \
+            -F sha="${base_push_sha}" \
+            -F branch="${pr_branch}" > /dev/null 2>&1 \
+            && echo "✅ Deleted .tekton/push.yaml (broken template)" \
+            || echo "⚠️  Could not delete .tekton/push.yaml"
+    fi
+}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-arch/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# test.sh - Multi-arch / manifest list idempotency
+#
+# Same flow as base idempotent test; component uses docker-build-multi-platform-oci-ta
+# so the snapshot has a manifest list digest. Filter queries Pyxis by that digest.
+#
+
+# shellcheck source=../rh-push-to-registry-redhat-io-idempotent/test.sh
+source "${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent/test.sh"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/README.md
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/README.md
@@ -1,0 +1,28 @@
+# rh-push-to-registry-redhat-io-idempotent-multi-component
+
+## Overview
+
+Multi-component idempotency test: two components in one snapshot. First release pushes both;
+second release with the same snapshot filters both (idempotent). Validates that the
+`filter-already-released-by-pyxis-and-file-updates` task handles multiple components correctly,
+each checked independently via `image_id` in Pyxis.
+
+## Setup
+
+Same as [rh-push-to-registry-redhat-io-idempotent](../rh-push-to-registry-redhat-io-idempotent/README.md).
+Symlink `vault/` from that suite (or from `rh-push-to-registry-redhat-io`) for secrets.
+
+## How It Works
+
+Sources the base idempotent `test.sh` and overrides the GitHub repo/PR/PipelineRun/Release
+flow to handle two components. The `verify_release_contents` logic is inherited from the base:
+
+1. First release pushes both components (Pyxis records created for each)
+2. Test polls Pyxis for the first component's `image_id` with `rpm_manifest.rpms` check
+3. Second release: filter checks each component independently — both are filtered out
+
+## Running
+
+```shell
+integration-tests/run-test.sh rh-push-to-registry-redhat-io-idempotent-multi-component
+```

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/ec-policy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: standard-${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  description: >-
+    Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: "k8s://openshift-pipelines/public-key"
+  sources:
+    - name: Release Policies
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+      volatileConfig:
+        exclude:
+          - value: cve.cve_blockers
+            effectiveUntil: "2025-02-01T00:00:00Z"
+      config:
+        exclude: []
+        include:
+          - '@slsa3'

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: ${managed_namespace}
+resources:
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rpa.yaml
+  - ec-policy.yaml
+  - secrets/managed-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/rpa.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: false
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+        - name: ${component2_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-release-pipeline-resource-role-binding-for-${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/sa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/managed/sa.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+secrets:
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}
+  - name: push-${component_name}
+  - name: pyxis-${component_name}
+  - name: konflux-cosign-signing-stage-${component_name}
+imagePullSecrets:
+  - name: push-${component_name}
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/application.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/application.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: ${application_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  displayName: ${application_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/component.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
+  name: ${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component_branch}
+      url: "${component_git_url}"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/component2.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/component2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
+  name: ${component2_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component2_name}
+  secret: pipelines-as-code-secret-${component2_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component2_branch}
+      url: "${component2_git_url}"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - component2.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml
+  - secrets/tenant-secrets-component2.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/rp.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/rp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-pipeline-resource-role-binding-for-${component_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/test.env
@@ -1,0 +1,33 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+uuid="${uuid:0:8}"
+
+# Kubernetes labels must be <= 63 chars; full suite name is 65
+export originating_tool="rh-push-registry-rh-io-idem-multi-comp-e2e-test"
+
+export tenant_namespace=dev-release-team-tenant
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-redhat-idem-mc-app-${uuid}
+export component_type=rh-push-to-registry-redhat-io-idempotent
+export component_name=${component_type}-${uuid}
+export component_branch=${component_name}
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=rh-push-to-registry-redhat-io-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+export component2_name=${component_type}-comp2-${uuid}
+export component2_branch=${component2_name}
+export component2_repo_name=${component_repo_name}
+export component2_git_url=https://github.com/${component2_repo_name}
+
+export release_plan_name=rh-push-to-registry-redhat-io-idempotent-mc-rp-${uuid}
+
+export managed_sa_name=rh-push-to-registry-redhat-io-idempotent-mc-sa-${uuid}
+export release_plan_admission_name=rh-push-to-registry-redhat-io-idempotent-mc-rpa-${uuid}
+
+# Max wait for Pyxis to have image_id record AND rpm_manifest.rpms populated.
+export IDEMPOTENT_WAIT_SECONDS=${IDEMPOTENT_WAIT_SECONDS:-60}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-multi-component/test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#
+# test.sh - Multi-component idempotent test (Heterogeneous Snapshot Filtering)
+#
+# Validates filter and idempotency with 2 components: first release pushes both,
+# second release filters both. Reuses idempotent verify logic; overrides repo/PR/PLR/release flow.
+#
+
+# --- Load idempotent test logic (helpers + verify_release_contents) ---
+# shellcheck source=../rh-push-to-registry-redhat-io-idempotent/test.sh
+source "${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent/test.sh"
+
+# --- Overrides for multi-component flow ---
+
+decrypt_secrets() {
+    # Use base suite's vault — multi-component shares the same credentials
+    local base_suite_dir="${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent"
+    (
+        . "${LIB_DIR}/test-functions.sh"
+        decrypt_secrets "${base_suite_dir}"
+    )
+    # Copy decrypted tenant secrets from base suite (contains real GitHub token)
+    local base_tenant_secrets="${base_suite_dir}/resources/tenant/secrets/tenant-secrets.yaml"
+    local tenant_secrets_file="${SUITE_DIR}/resources/tenant/secrets/tenant-secrets.yaml"
+    mkdir -p "${SUITE_DIR}/resources/tenant/secrets"
+    cp "${base_tenant_secrets}" "${tenant_secrets_file}"
+
+    local component2_file="${SUITE_DIR}/resources/tenant/secrets/tenant-secrets-component2.yaml"
+    if [ -f "${tenant_secrets_file}" ] && [ -n "${component2_name:-}" ]; then
+        sed -e 's/\${component_name}/\${component2_name}/g' -e "s|\${component_repo_name}|\${component2_repo_name}|g" \
+            "${tenant_secrets_file}" > "${component2_file}"
+        echo "Created ${component2_file} for component2."
+    fi
+}
+
+create_github_repository() {
+    echo "Creating repositories for both components (same repo, two branches)..."
+    "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
+        "${component_base_repo_name}" "${component_base_branch}" \
+        "${component_repo_name}" "${component_branch}"
+    "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
+        "${component_base_repo_name}" "${component_base_branch}" \
+        "${component2_repo_name}" "${component2_branch}"
+}
+
+wait_for_single_component_initialization() {
+    local comp_name=$1
+    local max_attempts=90
+    local attempt=1
+    local component_annotations=""
+
+    while [ $attempt -le $max_attempts ]; do
+        component_annotations=$(kubectl get component/"${comp_name}" -n "${tenant_namespace}" -ojson 2>/dev/null | \
+            jq -r --arg k "build.appstudio.openshift.io/status" '.metadata.annotations[$k] // ""' 2>/dev/null) || component_annotations=""
+
+        if [ -n "${component_annotations}" ]; then
+            component_pr=$(jq -r '.pac."merge-url" // ""' <<< "${component_annotations}")
+            if [ -n "${component_pr}" ]; then
+                echo "✅ Component ${comp_name} initialized"
+                pr_number=$(cut -f7 -d/ <<< "${component_pr}")
+                return 0
+            fi
+        fi
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo "   Still waiting for ${comp_name} (attempt ${attempt}/${max_attempts})..."
+        fi
+        attempt=$((attempt + 1))
+        sleep 10
+    done
+
+    # Debug: dump component state on timeout so we can see why PaC didn't set merge-url
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "DEBUG: Component initialization timeout for ${comp_name}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    if ! kubectl get component/"${comp_name}" -n "${tenant_namespace}" &>/dev/null; then
+        echo "  Component does not exist in ${tenant_namespace}."
+        echo "  Check: kubectl get component -n ${tenant_namespace}"
+    else
+        echo "  Component exists. Annotation build.appstudio.openshift.io/status:"
+        local status_annot
+        status_annot=$(kubectl get component/"${comp_name}" -n "${tenant_namespace}" -o jsonpath='{.metadata.annotations.build\.appstudio\.openshift\.io/status}' 2>/dev/null)
+        if [ -z "${status_annot}" ]; then
+            echo "  (missing - PaC has not set it yet)"
+        else
+            echo "${status_annot}" | jq '.' 2>/dev/null || echo "${status_annot}"
+        fi
+        echo ""
+        echo "  Spec (repo/branch):"
+        kubectl get component/"${comp_name}" -n "${tenant_namespace}" -o json 2>/dev/null | jq -r '.spec' 2>/dev/null || \
+            kubectl get component/"${comp_name}" -n "${tenant_namespace}" -o yaml 2>/dev/null | grep -A 20 '^spec:'
+        echo ""
+        echo "  To inspect full resource:"
+        echo "    kubectl get component ${comp_name} -n ${tenant_namespace} -o yaml"
+        echo "  To check Pipelines as Code / build controller logs:"
+        echo "    kubectl logs -n openshift-pipelines -l app.kubernetes.io/name=pipelines-as-code --tail=100"
+        echo "    kubectl logs -n build-service -l app.kubernetes.io/name=build-service --tail=100"
+    fi
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    log_error "Component ${comp_name} failed to initialize after ${max_attempts} attempts"
+}
+
+wait_for_component_initialization() {
+    echo "Waiting for both components to initialize..."
+    wait_for_single_component_initialization "${component_name}"
+    component_pr_number="${pr_number}"
+    wait_for_single_component_initialization "${component2_name}"
+    component2_pr_number="${pr_number}"
+    pr_number="${component_pr_number}"
+}
+
+merge_github_pr() {
+    echo "Merging PRs for both components..."
+    merge_single_component_pr "${component_pr_number}" "${component_repo_name}"
+    component_sha="${SHA}"
+    merge_single_component_pr "${component2_pr_number}" "${component2_repo_name}"
+    component2_sha="${SHA}"
+    SHA="${component_sha}"
+}
+
+merge_single_component_pr() {
+    local pr_num=$1
+    local repo_name=$2
+    local commit_message="e2e test"
+    local merge_result
+    merge_result=$(curl -L -X PUT \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${repo_name}/pulls/${pr_num}/merge" \
+        -d "{\"commit_title\":\"e2e test\",\"commit_message\":\"${commit_message}\"}" --silent --show-error --fail-with-body)
+    SHA=$(jq -r '.sha' <<< "${merge_result}")
+}
+
+wait_for_single_plr_to_appear() {
+    local sha=$1
+    local timeout=300
+    local start_time=$(date +%s)
+    local found_plr_name=""
+
+    # Status output goes to stderr so command substitution only captures the PLR name
+    echo -n "Waiting for PipelineRun for SHA ${sha}..." >&2
+    while [ -z "$found_plr_name" ]; do
+        if [ $(($(date +%s) - start_time)) -ge $timeout ]; then
+            echo "" >&2
+            log_error "Timeout waiting for PipelineRun for SHA ${sha}"
+        fi
+        sleep 5
+        echo -n "." >&2
+        found_plr_name=$(kubectl get pr -l "pipelinesascode.tekton.dev/sha=$sha" -n "${tenant_namespace}" --no-headers 2>/dev/null | { grep "Running" || true; } | awk '{print $1}')
+    done
+    echo "" >&2
+    echo "✅ Found PipelineRun: ${found_plr_name}" >&2
+    echo "${found_plr_name}"
+}
+
+wait_for_plr_to_appear() {
+    echo "Waiting for PipelineRuns for both components..."
+    comp1_plr=$(wait_for_single_plr_to_appear "${component_sha}")
+    component_push_plr_name="${comp1_plr}"
+    comp2_plr=$(wait_for_single_plr_to_appear "${component2_sha}")
+    component2_push_plr_name="${comp2_plr}"
+}
+
+wait_for_single_plr_to_complete() {
+    local plr_name=$1
+    local timeout=1800
+    local start_time=$(date +%s)
+    local status=""
+
+    echo "Waiting for PipelineRun ${plr_name} to complete..."
+    while true; do
+        if [ $(($(date +%s) - start_time)) -ge $timeout ]; then
+            log_error "Timeout waiting for PipelineRun ${plr_name}"
+        fi
+        sleep 5
+        status=$(kubectl get pipelinerun "${plr_name}" -n "${tenant_namespace}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null) || status=""
+        if [ "${status}" = "True" ]; then
+            echo "✅ ${plr_name} completed"
+            break
+        elif [ "${status}" = "False" ]; then
+            echo "❌ ${plr_name} failed"
+            exit 1
+        fi
+        # status is empty (PLR not yet created/found) or "Unknown" (still running) — keep polling
+    done
+}
+
+wait_for_plr_to_complete() {
+    wait_for_single_plr_to_complete "${component_push_plr_name}"
+    wait_for_single_plr_to_complete "${component2_push_plr_name}"
+}
+
+# Find release whose snapshot has exactly 2 components; wait for it to complete.
+wait_for_releases() {
+    local timeout=300
+    local start_time=$(date +%s)
+    local release_names=""
+
+    echo "Waiting for release with 2-component snapshot..."
+    while [ -z "${release_names}" ]; do
+        if [ $(($(date +%s) - start_time)) -ge $timeout ]; then
+            log_error "Timeout waiting for Release with 2-component snapshot"
+        fi
+        sleep 5
+        echo -n "."
+        local candidates
+        candidates=$(kubectl get release -n "${tenant_namespace}" -l "appstudio.openshift.io/build-pipelinerun=${component_push_plr_name}" -o json 2>/dev/null | jq -r '.items[].metadata.name // empty')
+        candidates="${candidates} $(kubectl get release -n "${tenant_namespace}" -l "appstudio.openshift.io/build-pipelinerun=${component2_push_plr_name}" -o json 2>/dev/null | jq -r '.items[].metadata.name // empty')"
+        for r in $candidates; do
+            [ -z "$r" ] && continue
+            local snap
+            snap=$(kubectl get release "$r" -n "${tenant_namespace}" -o jsonpath='{.spec.snapshot}' 2>/dev/null)
+            [ -z "$snap" ] && continue
+            local snap_json
+            snap_json=$(kubectl get snapshot "$snap" -n "${tenant_namespace}" -o json 2>/dev/null)
+            [ -z "$snap_json" ] && continue
+            local count
+            count=$(jq -r '.spec.components | length' <<< "${snap_json}" 2>/dev/null || echo "0")
+            if [ "${count}" = "2" ]; then
+                release_names="$r"
+                break
+            fi
+        done
+    done
+    echo ""
+    echo "✅ Found release: $release_names"
+
+    export RELEASE_NAMESPACE="${tenant_namespace}"
+    export RELEASE_NAMES="$release_names"
+    for release in $release_names; do
+        export RELEASE_NAME="${release}"
+        "${SUITE_DIR}/../scripts/wait-for-release.sh"
+    done
+    export RELEASE_NAMES="$release_names"
+}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/README.md
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/README.md
@@ -1,0 +1,28 @@
+# rh-push-to-registry-redhat-io-idempotent-partial-fileupdates
+
+## Overview
+
+Partial completion test (Gap 3.2): RPA has `fileUpdates` configured. First release runs
+(Pyxis complete + MR created but not merged). Second release with the same snapshot must
+**proceed** (`push-snapshot` runs) because the `fileUpdates` MR is not yet merged —
+validates fail-safe behavior: the filter does not over-filter when `fileUpdates` are pending.
+
+## Setup
+
+Same as [rh-push-to-registry-redhat-io-idempotent](../rh-push-to-registry-redhat-io-idempotent/README.md).
+Symlink `vault/` from that suite for secrets.
+
+## How It Works
+
+Sources the base idempotent `test.sh` and overrides `verify_release_contents`:
+
+1. First release: Pyxis record written (`image_id` + `rpm_manifest.rpms`) AND MR created
+2. Test polls Pyxis until image is fully indexed (same check as base test)
+3. Second release: filter sees Pyxis complete but `fileUpdates` not merged → **keeps** component
+4. Verification: `push-snapshot` ran (not skipped) — fail-safe confirmed
+
+## Running
+
+```shell
+integration-tests/run-test.sh rh-push-to-registry-redhat-io-idempotent-partial-fileupdates
+```

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/ec-policy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: standard-${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  description: >-
+    Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: "k8s://openshift-pipelines/public-key"
+  sources:
+    - name: Release Policies
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+      volatileConfig:
+        exclude:
+          - value: cve.cve_blockers
+            effectiveUntil: "2025-02-01T00:00:00Z"
+      config:
+        exclude: []
+        include:
+          - '@slsa3'

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: ${managed_namespace}
+resources:
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rpa.yaml
+  - ec-policy.yaml
+  - secrets/managed-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/rpa.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: false
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+    # fileUpdates enabled to test partial completion (Pyxis ok, MR not merged)
+    fileUpdates:
+      - paths:
+          - path: data/teams/stonesoup/users/shebert.yml
+            replacements:
+              - key: .tag_on_cluster_updates
+                replacement: >-
+                  |^tag_on_cluster_updates:.*|tag_on_cluster_updates: {{ .components[0].containerImage }}|
+        repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        upstream_repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        ref: 'master'
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-release-pipeline-resource-role-binding-for-${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/sa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/managed/sa.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+secrets:
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}
+  - name: push-${component_name}
+  - name: pyxis-${component_name}
+  - name: konflux-cosign-signing-stage-${component_name}
+imagePullSecrets:
+  - name: push-${component_name}
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/application.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/application.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: ${application_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  displayName: ${application_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/component.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    # Use single-platform build pipeline to avoid kueue admission policy requiring
+    # an invalid annotation key derived from PLATFORM values like "linux/x86_64".
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
+  name: ${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component_branch}
+      url: "${component_git_url}"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/rp.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/rp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-pipeline-resource-role-binding-for-${component_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/test.env
@@ -1,0 +1,27 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+uuid="${uuid:0:8}"
+
+export originating_tool="rh-push-to-registry-redhat-io-idempotent-partial-fileupdates-e2e-test"
+
+export tenant_namespace=dev-release-team-tenant
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-redhat-idem-pf-app-${uuid}
+export component_type=rh-push-to-registry-redhat-io-idempotent
+export component_name=${component_type}-pf-${uuid}
+export component_branch=${component_name}
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=rh-push-to-registry-redhat-io-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+export release_plan_name=rh-push-to-registry-redhat-io-idempotent-pf-rp-${uuid}
+
+export managed_sa_name=rh-push-to-registry-redhat-io-idempotent-pf-sa-${uuid}
+export release_plan_admission_name=rh-push-to-registry-redhat-io-idempotent-pf-rpa-${uuid}
+
+# Max wait for Pyxis to have image_id record AND rpm_manifest.rpms populated.
+export IDEMPOTENT_WAIT_SECONDS=${IDEMPOTENT_WAIT_SECONDS:-60}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent-partial-fileupdates/test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# test.sh - Partial Completion States (Pyxis complete, fileUpdates not merged)
+#
+# Sources idempotent test for helpers and flow; overrides verify_release_contents
+# to assert second release PROCEEDS (push-snapshot runs) because fileUpdates MR is not merged.
+#
+
+# shellcheck source=../rh-push-to-registry-redhat-io-idempotent/test.sh
+source "${SUITE_DIR}/../rh-push-to-registry-redhat-io-idempotent/test.sh"
+
+# Override: expect second release to NOT skip (fileUpdates not complete)
+verify_release_contents() {
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Partial Completion Test - Phase 1: First Release Verification"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local first_release_name
+    first_release_name=$(echo "${RELEASE_NAMES}" | awk '{print $1}')
+    echo "First release: ${first_release_name}"
+
+    if were_all_components_filtered "${first_release_name}"; then
+        log_error "First release should NOT have filtered components, but push-snapshot was skipped"
+    fi
+    echo "✅ First release pushed components (expected)"
+
+    if ! verify_single_release "${first_release_name}"; then
+        log_error "First release verification failed"
+    fi
+    verify_pyxis_write_succeeded "${first_release_name}"
+
+    local first_release_json
+    first_release_json=$(get_release_json "${first_release_name}")
+    local snapshot_name
+    snapshot_name=$(jq -r '.spec.snapshot' <<< "${first_release_json}")
+    if [ -z "${snapshot_name}" ] || [ "${snapshot_name}" == "null" ]; then
+        log_error "Could not get snapshot name from first release"
+    fi
+    echo "Using snapshot: ${snapshot_name}"
+
+    local image_digest
+    image_digest=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${first_release_json}")
+    if [ -n "${image_digest}" ] && [ "${image_digest}" != "null" ]; then
+        echo "Image digest to verify: ${image_digest}"
+        if ! wait_for_pyxis_indexing_from_cluster "${managed_namespace}" "${component_name}" "${image_digest}"; then
+            log_error "Pyxis indexing timeout."
+        fi
+    else
+        local wait_seconds="${IDEMPOTENT_WAIT_SECONDS:-60}"
+        echo "Waiting ${wait_seconds}s for Pyxis propagation..."
+        sleep "${wait_seconds}"
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Partial Completion Test - Phase 2: Second Release (Expect Proceed)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local second_release_name="idempotent-retry-${uuid}"
+    echo "Creating second release: ${second_release_name}"
+    cat <<EOF | kubectl apply -f -
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${second_release_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "idempotent-partial-fileupdates"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    echo "Waiting for second release to complete..."
+    export RELEASE_NAME="${second_release_name}"
+    export RELEASE_NAMESPACE="${tenant_namespace}"
+    "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Partial Completion Test - Phase 3: Fail-Safe Verification"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    echo "Checking second release (fileUpdates not merged → should proceed, not skip)..."
+    if were_all_components_filtered "${second_release_name}"; then
+        echo ""
+        echo "🔴 Second release skipped push-snapshot, but fileUpdates MR is not merged."
+        echo "   Filter should have returned skip_release=false and allowed release to proceed."
+        log_error "Partial completion test failed: second release should have run push-snapshot"
+    fi
+    echo "✅ Second release proceeded as expected (push-snapshot ran; fileUpdates not complete)"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  ✅ PARTIAL COMPLETION TEST PASSED (Gap 3.2)"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "Summary: Pyxis complete, fileUpdates pending → filter did not over-filter; release proceeded."
+    echo ""
+}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/README.md
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/README.md
@@ -1,0 +1,172 @@
+# rh-push-to-registry-redhat-io-idempotent test
+
+## Overview
+
+This test validates idempotent release behavior for the `rh-push-to-registry-redhat-io` pipeline
+(RELEASE-1265). It verifies that when a second release is created with the same snapshot, the
+`filter-already-released-by-pyxis-and-file-updates` task correctly filters all components, and
+the `push-snapshot` task is skipped.
+
+## Setup
+
+### Dependencies
+
+* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
+* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**,
+  **repo** scopes.
+* The password to the vault files. (Contact a member of the Release team should you want to run
+  this test suite.)
+* Access to the target cluster and tenant and managed namespaces
+  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant
+    namespaces.
+
+### Required Environment Variables
+
+- GITHUB_TOKEN
+  - The GitHub personal access token needed for repo operations
+  - The repo in question can be located in [test.env](test.env)
+- VAULT_PASSWORD_FILE
+  - This is the path to a file that contains the ansible vault
+    password needed to decrypt the secrets needed for testing.
+- RELEASE_CATALOG_GIT_URL
+  - The release service catalog URL to use in the RPA
+  - This is provided when testing PRs
+- RELEASE_CATALOG_GIT_REVISION
+  - The release service catalog revision to use in the RPA
+  - This is provided when testing PRs
+
+### Optional Environment Variables
+
+- KUBECONFIG
+  - The KUBECONFIG file to used to login to the target cluster
+  - This is provided when testing PRs
+
+### Test Properties
+
+#### [test.env](test.env)
+
+- This file contains resource names and configuration values needed for testing.
+- Since this test requires internal services, the tenant and managed namespaces
+  should remain as-is.
+
+### Test Functions
+
+#### [lib/test-functions.sh](../lib/test-functions.sh)
+
+- This file contains re-usable functions for testing
+
+### Secrets
+
+- Secrets needed for testing are stored in ansible vault files (symlinked from
+  [rh-push-to-registry-redhat-io](../rh-push-to-registry-redhat-io)):
+  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
+  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
+
+### Running the test
+
+This test validates idempotent release behavior by creating two releases with the same snapshot
+and verifying that the second release correctly filters already-released components.
+
+**Pyxis-only filtering**: The RPA omits `fileUpdates` because hacbs-release-tests GitLab does
+not auto-merge MRs. The filter checks Pyxis using the `image_id` field (manifest digest stored
+by `create-pyxis-image`) and requires `rpm_manifest.rpms` to be non-empty (populated by
+`push-rpm-data-to-pyxis`). Both conditions must be true for a component to be filtered out.
+
+After the first release, the test polls Pyxis from within the cluster until both conditions
+are satisfied, then creates the second release.
+
+```shell
+integration-tests/run-test.sh rh-push-to-registry-redhat-io-idempotent
+```
+
+### Debugging
+
+There is a `--skip-cleanup` option to the script in the event that you want to examine the
+resources after a test has ended.
+
+### Pyxis Query Strategy
+
+The `filter-already-released-by-pyxis-and-file-updates` task queries Pyxis using:
+
+- **Query field**: `image_id==sha256:...`
+  - `image_id` is the manifest digest as stored by `create-pyxis-image`
+  - `docker_image_digest` does **not** exist in Pyxis records and always returns empty results
+- **Completeness check**: `rpm_manifest.rpms` must be non-empty
+  - Populated by `push-rpm-data-to-pyxis` after `create-pyxis-image`
+  - A record with no RPM data means `push-rpm-data-to-pyxis` has not yet completed
+
+The test's polling job mirrors this logic exactly: it waits until the `image_id` query returns
+a record **and** that record has non-empty `rpm_manifest.rpms` before creating the second release.
+
+#### Polling Strategy (from cluster)
+
+Polling runs as a Kubernetes Job inside the managed namespace (to use the cluster CA and Pyxis
+credentials). On each 30s poll cycle:
+
+1. **Primary** — `image_id` query with RPM data check: `image_id==sha256:...`
+   - Succeeds only when both `create-pyxis-image` and `push-rpm-data-to-pyxis` are complete
+   - This is the canonical check; matches exactly what the filter task requires
+2. **Fallback** — repository existence check: `repositories.repository==rhtap/rh-advisories-component`
+   - Note: Pyxis uses the short path form (slash-separated), not the full URL with dashes
+   - Used only as a diagnostic indicator; does not unlock Phase 2 on its own
+
+#### Expected Poll Output
+
+```
+[0s / 60s] Checking Pyxis...
+  ✅ image_id query (with RPM data): Found with RPM data (42 rpms)!
+
+✅ Image IS in Pyxis (found via image_id) with RPM data — filter task will skip this component
+```
+
+If RPM data isn't ready yet:
+```
+[0s / 60s] Checking Pyxis...
+  ⏳ image_id query (with RPM data): Image found but rpm_manifest.rpms empty (push-rpm-data-to-pyxis pending)
+[30s / 60s] Checking Pyxis...
+  ✅ image_id query (with RPM data): Found with RPM data (42 rpms)!
+```
+
+#### Troubleshooting
+
+If the test fails with "Pyxis indexing timeout":
+
+1. **Increase wait time**:
+   ```bash
+   export IDEMPOTENT_WAIT_SECONDS=300
+   ```
+
+2. **Verify first release wrote to Pyxis** — check `create-pyxis-image` and
+   `push-rpm-data-to-pyxis` task status in the first release's managed pipeline
+
+3. **Check the filter task logs** in the second release's managed pipeline:
+   ```bash
+   kubectl logs -n managed-release-team-tenant \
+     -l tekton.dev/taskRun=<filter-taskrun-name> \
+     -c step-filter-already-released-by-metadata --tail=100
+   ```
+   Look for: `Image found in Pyxis for <component> with RPM data (N rpms)`.
+   If it says `no RPM data` — `push-rpm-data-to-pyxis` hadn't finished when Phase 2 started.
+
+### Maintenance
+
+- Vault files are symlinked from `rh-push-to-registry-redhat-io`. To update secrets, edit the
+  vault files in that suite.
+- Should you require to add or update a secret, follow these steps in the
+  [rh-push-to-registry-redhat-io](../rh-push-to-registry-redhat-io) suite:
+
+```shell
+ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
+```
+
+```shell
+vi /tmp/tenant-secrets.yaml
+```
+
+```shell
+ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
+```
+
+```shell
+rm /tmp/tenant-secrets.yaml
+```

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/ec-policy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: standard-${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  description: >-
+    Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: "k8s://openshift-pipelines/public-key"
+  sources:
+    - name: Release Policies
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+      volatileConfig:
+        exclude:
+          - value: cve.cve_blockers
+            effectiveUntil: "2025-02-01T00:00:00Z"
+      config:
+        exclude: []
+        include:
+          - '@slsa3'

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: ${managed_namespace}
+resources:
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rpa.yaml
+  - ec-policy.yaml
+  - secrets/managed-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/rpa.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: false
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+    # No fileUpdates: idempotent test validates Pyxis-only filtering.
+    # fileUpdates MRs in hacbs-release-tests GitLab are not auto-merged, so requiring
+    # file_updates_complete would make the second release never filter. Pyxis propagation
+    # after the first release is sufficient for this e2e test.
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-release-pipeline-resource-role-binding-for-${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/sa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/managed/sa.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${managed_sa_name}
+  labels:
+    originating-tool: "${originating_tool}"
+secrets:
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}
+  - name: push-${component_name}
+  - name: pyxis-${component_name}
+  - name: konflux-cosign-signing-stage-${component_name}
+imagePullSecrets:
+  - name: push-${component_name}
+  - name: konflux-ci-konflux-release-trusted-artifacts-pull-secret-${component_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/application.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/application.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: ${application_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  displayName: ${application_name}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/component.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    # Use single-platform build pipeline to avoid kueue admission policy requiring
+    # an invalid annotation key derived from PLATFORM values like "linux/x86_64".
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
+  name: ${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component_branch}
+      url: "${component_git_url}"

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/rp.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/rp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-pipeline-resource-role-binding-for-${component_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: ${managed_sa_name}
+    namespace: ${managed_namespace}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/test.env
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/test.env
@@ -1,0 +1,38 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
+
+export originating_tool="rh-push-to-registry-redhat-io-idempotent-e2e-test"
+
+# Namespaces
+export tenant_namespace=dev-release-team-tenant
+#
+## Since this is a test that requires internal services,
+## this name should not change.
+#
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-redhat-idem-app-${uuid}
+export component_type=rh-push-to-registry-redhat-io-idempotent
+export component_name=${component_type}-${uuid}
+export component_branch=${component_name}
+## do not change this. it is a known branch created by Konflux
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=rh-push-to-registry-redhat-io-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+export release_plan_name=rh-push-to-registry-redhat-io-idempotent-rp-${uuid}
+
+export managed_sa_name=rh-push-to-registry-redhat-io-idempotent-sa-${uuid}
+export release_plan_admission_name=rh-push-to-registry-redhat-io-idempotent-rpa-${uuid}
+
+# Idempotency test timing configuration
+# Max wait for Pyxis to have the image (queried by image_id) AND rpm_manifest.rpms
+# populated (written by push-rpm-data-to-pyxis). The filter task requires both.
+# With the correct image_id query this is usually satisfied within 30s after the
+# first release completes, but 60s gives headroom for Pyxis stage variability.
+export IDEMPOTENT_WAIT_SECONDS=${IDEMPOTENT_WAIT_SECONDS:-60}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/test.sh
@@ -1,0 +1,1030 @@
+#!/usr/bin/env bash
+#
+# test.sh - Test-specific functions for rh-push-to-registry-redhat-io-idempotent
+#
+# This test validates idempotent release behavior for rh-push-to-registry-redhat-io by:
+#   1. Verifying the first (auto-created) release pushed components (pyxis, signing, fileUpdates)
+#   2. Creating a second release with the SAME snapshot
+#   3. Verifying the second release filtered all components (idempotency)
+#
+# This file is sourced by run-test.sh
+#
+
+# --- Global Script Variables (Defaults) ---
+CLEANUP="true"
+
+# Function called before test starts (before any releases are created)
+# This is the entry point for test initialization
+test_setup() {
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Test Setup: Pre-flight Checks"
+    echo "════════════════════════════════════════════════════════════════════"
+    
+    # Critical: Check Pyxis availability BEFORE wasting time on first release
+    # If Pyxis is down, abort early
+    # Run check FROM CLUSTER to avoid local SSL/CA issues
+    check_pyxis_from_cluster "${managed_namespace}" "${component_name}"
+    
+    echo "✅ Pre-flight checks passed. Proceeding with test..."
+    echo ""
+}
+
+# Helper: Get PipelineRun name from Release CR
+# Returns just the PipelineRun name (without namespace prefix)
+get_pipelinerun_name_from_release() {
+    local release_name=$1
+
+    local pipelinerun_full
+    pipelinerun_full=$(kubectl get release "${release_name}" -n "${tenant_namespace}" \
+        -o jsonpath='{.status.managedProcessing.pipelineRun}' 2>/dev/null)
+
+    if [ -z "${pipelinerun_full}" ]; then
+        return 1
+    fi
+
+    basename "${pipelinerun_full}"
+}
+
+# Helper: Get release as JSON
+get_release_json() {
+    local release_name=$1
+    kubectl get release "${release_name}" -n "${tenant_namespace}" -o json
+}
+
+# Check if all components were filtered (idempotency validation)
+# Returns 0 (true) if push-snapshot task was skipped, 1 (false) otherwise
+were_all_components_filtered() {
+    local release_name=$1
+
+    is_taskrun_skipped "${release_name}" "push-snapshot"
+}
+
+# Check if a specific task was skipped in the pipeline, given a known PipelineRun name.
+# Returns 0 (true) if task was skipped, 1 (false) otherwise
+is_task_skipped_in_plr() {
+    local pipelinerun_name=$1
+    local task_name=$2
+
+    local skipped_task
+    skipped_task=$(kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath="{.status.skippedTasks[?(@.name=='${task_name}')].name}" 2>/dev/null)
+
+    [[ -n "${skipped_task}" ]]
+}
+
+# Check if a specific task was skipped in the pipeline
+# Returns 0 (true) if task was skipped, 1 (false) otherwise
+is_taskrun_skipped() {
+    local release_name=$1
+    local task_name=$2
+
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
+
+    is_task_skipped_in_plr "${pipelinerun_name}" "${task_name}"
+}
+
+# Verify a single release has valid artifacts (catalog_url, file_update_mr_url, image)
+# Adapted from rh-push-to-registry-redhat-io verify_release_contents
+verify_single_release() {
+    local release_name=$1
+    echo "Verifying Release contents for ${release_name}..."
+
+    local release_json
+    release_json=$(get_release_json "${release_name}")
+    if [ -z "$release_json" ]; then
+        log_error "Could not retrieve Release JSON for ${release_name}"
+    fi
+
+    local failures=0
+    local image_url image_arch image_shasum
+    local catalog_url file_update_mr_url
+
+    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
+    image_arch=$(jq -r '.status.artifacts.images[0]?.arches[0] // ""' <<< "${release_json}")
+    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
+    catalog_url=$(jq -r '.status.artifacts.catalog_urls[]?.url // ""' <<< "${release_json}")
+    file_update_mr_url=$(jq -r '.status.artifacts.merge_requests[0]?.url // ""' <<< "${release_json}")
+
+    echo "Checking Catalog URL..."
+    if [ -n "${catalog_url}" ]; then
+        echo "✅️ catalog_url: ${catalog_url}"
+    else
+        echo "🔴 catalog_url was empty"
+        failures=$((failures+1))
+    fi
+
+    # file_update_mr_url is optional: idempotent test RPA has no fileUpdates
+    echo "Checking File Update MR URL..."
+    if [ -n "${file_update_mr_url}" ]; then
+        echo "✅️ file_update_mr_url: ${file_update_mr_url}"
+    else
+        echo "⚠️ file_update_mr_url empty (expected when RPA has no fileUpdates)"
+    fi
+
+    echo "Checking Image URL..."
+    if [ -n "${image_url}" ]; then
+        echo "✅️ image_url: ${image_url}"
+    else
+        echo "🔴 image_url was empty"
+        failures=$((failures+1))
+    fi
+
+    echo "Checking Image Arch..."
+    if [ -n "${image_arch}" ]; then
+        echo "✅️ image_arch: ${image_arch}"
+    else
+        echo "🔴 image_arch was empty"
+        failures=$((failures+1))
+    fi
+
+    echo "Checking Image Shasum..."
+    if [ -n "${image_shasum}" ]; then
+        echo "✅️ image_shasum: ${image_shasum}"
+    else
+        echo "🔴 image_shasum was empty"
+        failures=$((failures+1))
+    fi
+
+    echo "Verifying image pullability with skopeo..."
+    local ORIGINAL_PULLSPEC="${image_url}"
+    local STRIPPED_PULLSPEC
+
+    if [[ "$ORIGINAL_PULLSPEC" == *":"* && "$ORIGINAL_PULLSPEC" != *"@"* ]]; then
+        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%:*}"
+        echo "Stripped tag from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
+    elif [[ "$ORIGINAL_PULLSPEC" == *"@"* ]]; then
+        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%@*}"
+        echo "Stripped digest from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
+    else
+        STRIPPED_PULLSPEC="$ORIGINAL_PULLSPEC"
+        echo "No tag or digest found, using original as is: $STRIPPED_PULLSPEC"
+    fi
+
+    local COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
+    echo "New complete pullspec: $COMPLETE_PULLSPEC"
+
+    DOCKER_CONFIG="$(mktemp -d)"
+    export DOCKER_CONFIG
+
+    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${DOCKER_CONFIG}/config.json"
+
+    if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
+        echo "✅️ Image '$COMPLETE_PULLSPEC' can be pulled using skopeo."
+    else
+        echo "🔴 Failed to pull or inspect image '$COMPLETE_PULLSPEC'."
+        skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+        failures=$((failures+1))
+    fi
+
+    if [ "${failures}" -gt 0 ]; then
+        echo "🔴 Release verification FAILED with ${failures} failure(s)!"
+        return 1
+    else
+        echo "✅️ All release checks passed."
+        return 0
+    fi
+}
+
+# Function to verify Release contents - called by run-test.sh after first release completes
+# Implements idempotent test logic:
+#   1. Verify first release pushed components
+#   2. Create second release with same snapshot
+#   3. Verify second release filtered all components
+# Check Pyxis availability by running a Job in the cluster
+# This avoids local SSL/CA bundle issues and tests from the same network as pipeline tasks
+# Args: $1 = managed namespace, $2 = component name
+# Returns: 0 if available, exits on failure
+check_pyxis_from_cluster() {
+    local managed_namespace="$1"
+    local component_name="$2"
+    local pyxis_secret_name="pyxis-${component_name}"
+    local job_name="pyxis-preflight-${uuid}"
+    
+        echo "════════════════════════════════════════════════════════════════════"
+        echo "  Pre-flight Check: Pyxis Stage Availability (from cluster)"
+        echo "════════════════════════════════════════════════════════════════════"
+        
+        local max_job_attempts=2
+        local job_attempt=0
+        local job_created=false
+        
+        while [ $job_attempt -lt $max_job_attempts ]; do
+            job_attempt=$((job_attempt + 1))
+            echo "Creating verification Job (attempt $job_attempt/$max_job_attempts)..."
+            
+            # Create Job that checks Pyxis connectivity FROM the cluster
+            if cat <<EOF | kubectl apply -f - 2>&1
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${managed_namespace}
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 0
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: check
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+                      set +e
+                      echo "Testing Pyxis from cluster network..."
+                      echo "Endpoint: https://pyxis.preprod.api.redhat.com/v1/repositories?page_size=1"
+                      echo ""
+                      
+                      # Verify credentials exist
+                      if [ ! -f /etc/pyxis/cert ] || [ ! -f /etc/pyxis/key ]; then
+                        echo "❌ ERROR: Pyxis credentials not mounted"
+                        exit 1
+                      fi
+                      
+                      # Configure CA bundle if available
+                      if [ -f /mnt/trusted-ca/ca-bundle.crt ]; then
+                        CA_ARGS="--cacert /mnt/trusted-ca/ca-bundle.crt"
+                        echo "Using cluster CA bundle"
+                      else
+                        CA_ARGS=""
+                        echo "No CA bundle (using system defaults)"
+                      fi
+                      
+                      echo ""
+                      echo "Checking Pyxis with retries (max 3 attempts)..."
+                      
+                      max_retries=2
+                      retry_delay=5
+                      attempt=0
+                      
+                      while [ \$attempt -le \$max_retries ]; do
+                        http_code=\$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \$CA_ARGS \
+                          --cert /etc/pyxis/cert --key /etc/pyxis/key \
+                          "https://pyxis.preprod.api.redhat.com/v1/repositories?page_size=1" 2>/dev/null || echo "000")
+                        
+                        echo "Attempt \$((attempt + 1)): HTTP \${http_code}"
+                        
+                        if [ "\${http_code}" = "200" ]; then
+                          echo ""
+                          echo "✅ Pyxis stage is operational!"
+                          exit 0
+                        fi
+                        
+                        attempt=\$((attempt + 1))
+                        if [ \$attempt -le \$max_retries ]; then
+                          echo "   Retrying in \${retry_delay}s..."
+                          sleep \$retry_delay
+                        fi
+                      done
+                      
+          echo ""
+          echo "❌ Pyxis stage is unavailable (HTTP \${http_code}) after 3 attempts"
+          exit 1
+        volumeMounts:
+        - name: pyxis-secret
+          mountPath: /etc/pyxis
+          readOnly: true
+        - name: trusted-ca
+          mountPath: /mnt/trusted-ca
+          readOnly: true
+      volumes:
+      - name: pyxis-secret
+        secret:
+          secretName: ${pyxis_secret_name}
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
+          optional: true
+EOF
+            then
+                job_created=true
+                echo "✅ Job created successfully"
+                
+                # Check for FailedCreate events
+                sleep 2
+                local failed_create
+                failed_create=$(kubectl get events -n ${managed_namespace} --field-selector involvedObject.name=${job_name},reason=FailedCreate -o jsonpath='{.items[0].message}' 2>/dev/null)
+                
+                if [ -n "${failed_create}" ]; then
+                    echo "⚠️  Job creation failed: ${failed_create}"
+                    kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+                    job_created=false
+                    if [ $job_attempt -lt $max_job_attempts ]; then
+                        echo "Retrying in 3s..."
+                        sleep 3
+                    fi
+                else
+                    break
+                fi
+            else
+                echo "⚠️  kubectl apply failed"
+                if [ $job_attempt -lt $max_job_attempts ]; then
+                    echo "Retrying in 3s..."
+                    sleep 3
+                fi
+            fi
+        done
+        
+        if [ "$job_created" = "false" ]; then
+            echo "❌ ERROR: Failed to create verification Job after $max_job_attempts attempts"
+            log_error "Could not create Pyxis verification Job in cluster"
+        fi
+        
+        # Wait for Pod to start (max 60s, increased from 30s)
+        echo "Waiting for verification Pod to start..."
+        local wait_count=0
+        local pod_name=""
+        while [ $wait_count -lt 60 ]; do
+            pod_name=$(kubectl get pods -n ${managed_namespace} -l job-name=${job_name} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+            if [ -n "${pod_name}" ]; then
+                break
+            fi
+            sleep 1
+            wait_count=$((wait_count + 1))
+        done
+        
+        if [ -z "${pod_name}" ]; then
+            kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+            echo "❌ ERROR: Verification Pod did not start within 60s"
+            log_error "Pyxis pre-flight check failed: Pod not created"
+        fi
+    
+    echo "✅ Verification Pod started: ${pod_name}"
+    
+    # Check for Pod startup failures
+    local pod_phase
+    pod_phase=$(kubectl get pod ${pod_name} -n ${managed_namespace} -o jsonpath='{.status.phase}' 2>/dev/null)
+    
+    if [ "${pod_phase}" = "Failed" ]; then
+        echo "❌ ERROR: Verification Pod failed to start"
+        kubectl describe pod ${pod_name} -n ${managed_namespace} | grep -A 10 "Events:"
+        kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+        log_error "Pyxis pre-flight check failed: Pod startup failure"
+    fi
+    
+    # Wait for Job to complete (max 120s: activeDeadlineSeconds)
+    echo "Running verification checks..."
+    if ! kubectl wait --for=condition=complete job/${job_name} -n ${managed_namespace} --timeout=120s 2>/dev/null; then
+        echo "⚠️  Job did not complete in time, checking status..."
+    fi
+    
+    echo ""
+    echo "────────────────────────────────────────────────────────────────────"
+    kubectl logs ${pod_name} -n ${managed_namespace} 2>/dev/null || echo "(no logs available)"
+    echo "────────────────────────────────────────────────────────────────────"
+    echo ""
+    
+    # Check Job final status
+    local job_succeeded
+    job_succeeded=$(kubectl get job ${job_name} -n ${managed_namespace} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+    local job_failed
+    job_failed=$(kubectl get job ${job_name} -n ${managed_namespace} -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+    
+    # Cleanup
+    kubectl delete job ${job_name} -n ${managed_namespace} >/dev/null 2>&1 || true
+    
+    if [ "${job_succeeded}" = "True" ]; then
+        echo "✅ Pyxis is operational from cluster"
+        echo ""
+        return 0
+    elif [ "${job_failed}" = "True" ]; then
+        echo "❌ Pyxis verification Job failed"
+        echo ""
+        echo "This idempotency test REQUIRES Pyxis stage to be operational:"
+        echo "  • First release: Must write image metadata to Pyxis"
+        echo "  • Second release: Must query Pyxis for idempotency verification"
+        echo ""
+        log_error "Pyxis stage is unavailable. Idempotency test cannot proceed."
+    else
+        echo "❌ Pyxis verification Job timed out or did not complete"
+        echo ""
+        log_error "Pyxis pre-flight check did not complete. Cannot proceed."
+    fi
+}
+
+# Verify that create-pyxis-image task succeeded in first release
+# Args: $1 = release name
+# Returns: 0 if succeeded, 1 if failed
+verify_pyxis_write_succeeded() {
+    local release_name="$1"
+    
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Verifying Pyxis Write (create-pyxis-image task)"
+    echo "════════════════════════════════════════════════════════════════════"
+    
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || {
+        echo "⚠️  Warning: Could not get PipelineRun name"
+        return 0  # Don't fail test, just warn
+    }
+    
+    echo "PipelineRun: ${pipelinerun_name}"
+    
+    # Get create-pyxis-image TaskRun status
+    local taskrun_status
+    taskrun_status=$(kubectl get taskrun -n "${managed_namespace}" \
+        -l "tekton.dev/pipelineRun=${pipelinerun_name},tekton.dev/pipelineTask=create-pyxis-image" \
+        -o jsonpath='{.items[0].status.conditions[0].reason}' 2>/dev/null)
+    
+    if [ -z "${taskrun_status}" ]; then
+        echo "⚠️  Warning: create-pyxis-image task not found (may have been skipped)"
+        echo "This is unexpected - task should run for first release"
+        return 0  # Don't block, polling will reveal the truth
+    fi
+    
+    echo "create-pyxis-image status: ${taskrun_status}"
+    
+    # Check for retries
+    local retry_count
+    retry_count=$(kubectl get taskrun -n "${managed_namespace}" \
+        -l "tekton.dev/pipelineRun=${pipelinerun_name},tekton.dev/pipelineTask=create-pyxis-image" \
+        -o jsonpath='{.items[0].status.retriesStatus}' 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+    
+    if [ -n "${retry_count}" ] && [ "${retry_count}" -gt 0 ] 2>/dev/null; then
+        echo "⚠️  Task had ${retry_count} retries (Pyxis was flaky)"
+    fi
+    
+    if [ "${taskrun_status}" != "Succeeded" ]; then
+        echo ""
+        echo "❌ CRITICAL: create-pyxis-image task status: ${taskrun_status}"
+        echo ""
+        echo "This means the first release did NOT write to Pyxis!"
+        echo "Root cause: Pyxis was unavailable during first release execution"
+        echo ""
+        echo "The idempotency test will fail because:"
+        echo "  • First release: No data written to Pyxis"
+        echo "  • Second release: Queries Pyxis → finds nothing → pushes again"
+        echo ""
+        echo "This is NOT a propagation delay - it's a write failure."
+        echo ""
+        
+        # Show task logs for debugging
+        local taskrun_name
+        taskrun_name=$(kubectl get taskrun -n "${managed_namespace}" \
+            -l "tekton.dev/pipelineRun=${pipelinerun_name},tekton.dev/pipelineTask=create-pyxis-image" \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        
+        if [ -n "${taskrun_name}" ]; then
+            echo "TaskRun logs (last 50 lines):"
+            kubectl logs -n "${managed_namespace}" "${taskrun_name}" --tail=50 2>/dev/null || echo "(no logs available)"
+        fi
+        
+        echo ""
+        log_error "First release failed to write to Pyxis. Cannot test idempotency."
+    fi
+    
+    echo "✅ create-pyxis-image task succeeded (Pyxis write completed)"
+    echo ""
+    return 0
+}
+
+# Poll Pyxis until the image digest appears (or timeout) by running a Job in the cluster
+# This avoids local SSL/CA bundle issues and polls from the same network as pipeline tasks
+# STRATEGY: Try repository-based query first (faster indexing), fall back to digest query
+# Args: $1 = managed namespace, $2 = component name, $3 = image digest
+# Returns: 0 if found, 1 if timeout
+wait_for_pyxis_indexing_from_cluster() {
+    local managed_namespace="$1"
+    local component_name="$2"
+    local digest="$3"
+    local max_wait_seconds="${IDEMPOTENT_WAIT_SECONDS:-60}"
+    local pyxis_secret_name="pyxis-${component_name}"
+    local job_name="pyxis-poll-${uuid}"
+    
+    # The Pyxis repositories.repository field uses the short path form of the registry URL.
+    # E.g. quay.io/redhat-pending/rhtap----rh-advisories-component → rhtap/rh-advisories-component
+    # (Confirmed by inspecting actual Pyxis stage records, March 2026)
+    local repository_name="rhtap/rh-advisories-component"
+    
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Polling Pyxis for Image Indexing (from cluster)"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "Image digest: ${digest}"
+    echo "Repository: ${repository_name}"
+    echo "Max wait time: ${max_wait_seconds}s"
+    echo "Poll interval: 30s"
+    echo ""
+    echo "Strategy: Try repository query first (faster), fall back to digest query"
+    echo ""
+    
+    # URL-encode both filters (use image_id to match filter task and Pyxis API)
+    local digest_filter="image_id==${digest}"
+    local repo_filter="repositories.repository==${repository_name}"
+    
+    local digest_filter_encoded
+    local repo_filter_encoded
+    digest_filter_encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${digest_filter}', safe=''))" 2>/dev/null)
+    repo_filter_encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${repo_filter}', safe=''))" 2>/dev/null)
+    
+    if [ -z "${digest_filter_encoded}" ] || [ -z "${repo_filter_encoded}" ]; then
+        echo "⚠️  Warning: Could not URL-encode filters. Using fixed wait."
+        echo "Waiting ${max_wait_seconds}s for Pyxis propagation..."
+        sleep "${max_wait_seconds}"
+        return 0
+    fi
+    
+    local max_job_attempts=2
+    local job_attempt=0
+    local job_created=false
+    
+    while [ $job_attempt -lt $max_job_attempts ]; do
+        job_attempt=$((job_attempt + 1))
+        echo "Creating polling Job (attempt $job_attempt/$max_job_attempts)..."
+        
+        # Create Job that polls Pyxis FROM the cluster
+        if cat <<EOF | kubectl apply -f - 2>&1
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${managed_namespace}
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 0
+  activeDeadlineSeconds: $((max_wait_seconds + 60))
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: poll
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set +e
+          
+          # Verify credentials exist
+          if [ ! -f /etc/pyxis/cert ] || [ ! -f /etc/pyxis/key ]; then
+            echo "❌ ERROR: Pyxis credentials not mounted"
+            exit 1
+          fi
+          
+          echo "════════════════════════════════════════════════════════════════════"
+          echo "Polling Pyxis from cluster network"
+          echo "════════════════════════════════════════════════════════════════════"
+          echo "Digest: ${digest}"
+          echo "Repository: ${repository_name}"
+          echo ""
+          
+          # Configure CA bundle
+          if [ -f /mnt/trusted-ca/ca-bundle.crt ]; then
+            CA_ARGS="--cacert /mnt/trusted-ca/ca-bundle.crt"
+          else
+            CA_ARGS=""
+          fi
+          
+          max_wait=${max_wait_seconds}
+          poll_interval=30
+          elapsed=0
+          pyxis_base_url="https://pyxis.preprod.api.redhat.com/v1/images"
+          
+          # Query function - checks if image found with complete RPM data.
+          # For image_id queries: also requires rpm_manifest.rpms to be non-empty,
+          # matching the filter task's completeness check (push-rpm-data-to-pyxis done).
+          # For repository queries: any image in the repo is enough (existence check).
+          check_image() {
+            local query_name="\$1"
+            local query_url="\$2"
+            local require_rpms="\${3:-false}"
+
+            local response=\$(mktemp)
+            local http_code
+            http_code=\$(curl -s -o "\$response" -w "%{http_code}" --max-time 15 \
+              \$CA_ARGS --cert /etc/pyxis/cert --key /etc/pyxis/key "\${query_url}" 2>/dev/null || echo "000")
+
+            if [ "\${http_code}" != "200" ]; then
+              echo "  ⏳ \${query_name}: Not yet (HTTP \${http_code})"
+              rm -f "\$response"
+              return 1
+            fi
+
+            local image_count
+            image_count=\$(cat "\$response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('data',[])))" 2>/dev/null || echo "0")
+
+            if [ "\${image_count}" -lt 1 ] 2>/dev/null; then
+              echo "  ⏳ \${query_name}: Not yet (no records)"
+              rm -f "\$response"
+              return 1
+            fi
+
+            if [ "\${require_rpms}" = "true" ]; then
+              local rpm_count
+              rpm_count=\$(cat "\$response" | python3 -c "import sys, json; d=json.load(sys.stdin); rpms=(d.get('data') or [{}])[0].get('rpm_manifest',{}).get('rpms') or []; print(len(rpms))" 2>/dev/null || echo "0")
+              if [ "\${rpm_count}" -lt 1 ] 2>/dev/null; then
+                echo "  ⏳ \${query_name}: Image found but rpm_manifest.rpms empty (push-rpm-data-to-pyxis pending)"
+                rm -f "\$response"
+                return 1
+              fi
+              echo "  ✅ \${query_name}: Found with RPM data (\${rpm_count} rpms)!"
+            else
+              echo "  ✅ \${query_name}: Found!"
+            fi
+            rm -f "\$response"
+            return 0
+          }
+          
+          while [ \$elapsed -lt \$max_wait ]; do
+            echo ""
+            echo "[\${elapsed}s / \${max_wait}s] Checking Pyxis..."
+
+            # Primary: image_id query with RPM data check
+            # Mirrors exactly what the filter task requires: image found AND rpm_manifest.rpms non-empty
+            if check_image "image_id query (with RPM data)" "\${pyxis_base_url}?filter=${digest_filter_encoded}" "true"; then
+              echo ""
+              echo "✅ Image IS in Pyxis (found via image_id) with RPM data — filter task will skip this component"
+              exit 0
+            fi
+
+            # Fallback: repository query (existence only — useful if rpm_manifest write is lagging)
+            if check_image "Repository query (existence)" "\${pyxis_base_url}?filter=${repo_filter_encoded}&page_size=50" "false"; then
+              echo ""
+              echo "⚠️  Image found in repository but rpm_manifest.rpms not yet populated — continuing to wait"
+            fi
+            
+            sleep \$poll_interval
+            elapsed=\$((elapsed + poll_interval))
+          done
+          
+          echo ""
+          echo "❌ TIMEOUT: Image not indexed after \${max_wait}s"
+          echo ""
+          echo "Tried both:"
+          echo "  1. image_id query (primary):  image_id==${digest} + rpm_manifest.rpms non-empty"
+          echo "  2. Repository query (fallback): repositories.repository==${repository_name}"
+          echo ""
+          echo "After \$((max_wait / poll_interval)) poll cycles (every \${poll_interval}s)"
+          echo ""
+          echo "Possible causes:"
+          echo "  • Pyxis stage indexing is delayed (wait longer with IDEMPOTENT_WAIT_SECONDS)"
+          echo "  • Image write to Pyxis failed"
+          echo "  • Pyxis stage has a systemic issue"
+          exit 1
+        volumeMounts:
+        - name: pyxis-secret
+          mountPath: /etc/pyxis
+          readOnly: true
+        - name: trusted-ca
+          mountPath: /mnt/trusted-ca
+          readOnly: true
+      volumes:
+      - name: pyxis-secret
+        secret:
+          secretName: ${pyxis_secret_name}
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
+          optional: true
+EOF
+        then
+            job_created=true
+            
+            # Check for FailedCreate events
+            sleep 2
+            local failed_create
+            failed_create=$(kubectl get events -n ${managed_namespace} --field-selector involvedObject.name=${job_name},reason=FailedCreate -o jsonpath='{.items[0].message}' 2>/dev/null)
+            
+            if [ -n "${failed_create}" ]; then
+                echo "⚠️  Job creation failed: ${failed_create}"
+                kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+                job_created=false
+                if [ $job_attempt -lt $max_job_attempts ]; then
+                    echo "Retrying in 3s..."
+                    sleep 3
+                fi
+            else
+                break
+            fi
+        else
+            echo "⚠️  kubectl apply failed"
+            if [ $job_attempt -lt $max_job_attempts ]; then
+                echo "Retrying in 3s..."
+                sleep 3
+            fi
+        fi
+    done
+    
+    if [ "$job_created" = "false" ]; then
+        echo "❌ ERROR: Failed to create polling Job after $max_job_attempts attempts"
+        echo "⚠️  Falling back to fixed wait time: ${max_wait_seconds}s"
+        sleep "${max_wait_seconds}"
+        return 0
+    fi
+    
+    # Wait for Pod to start (max 60s, increased from 30s)
+    echo "Waiting for polling Pod to start..."
+    local wait_count=0
+    local pod_name=""
+    while [ $wait_count -lt 60 ]; do
+        pod_name=$(kubectl get pods -n ${managed_namespace} -l job-name=${job_name} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -n "${pod_name}" ]; then
+            break
+        fi
+        sleep 1
+        wait_count=$((wait_count + 1))
+    done
+    
+    if [ -z "${pod_name}" ]; then
+        echo "❌ ERROR: Polling Pod did not start within 60s"
+        echo "⚠️  Falling back to fixed wait time: ${max_wait_seconds}s"
+        kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+        sleep "${max_wait_seconds}"
+        return 0
+    fi
+    
+    echo "✅ Polling Pod started: ${pod_name}"
+    
+    # Check for Pod startup failures
+    local pod_phase
+    pod_phase=$(kubectl get pod ${pod_name} -n ${managed_namespace} -o jsonpath='{.status.phase}' 2>/dev/null)
+    
+    if [ "${pod_phase}" = "Failed" ]; then
+        echo "❌ ERROR: Polling Pod failed to start"
+        kubectl describe pod ${pod_name} -n ${managed_namespace} | grep -A 10 "Events:"
+        echo "⚠️  Falling back to fixed wait time: ${max_wait_seconds}s"
+        kubectl delete job ${job_name} -n ${managed_namespace} 2>/dev/null || true
+        sleep "${max_wait_seconds}"
+        return 0
+    fi
+    
+    # Wait for Job to complete (max: activeDeadlineSeconds)
+    local total_timeout=$((max_wait_seconds + 90))
+    echo "Polling Pyxis (max ${total_timeout}s)..."
+    echo ""
+    
+    if ! kubectl wait --for=condition=complete job/${job_name} -n ${managed_namespace} --timeout=${total_timeout}s 2>/dev/null; then
+        echo "⚠️  Polling Job did not complete in time"
+    fi
+    
+    # Check Job final status FIRST (before logs, in case ttl cleanup happens)
+    local job_succeeded
+    job_succeeded=$(kubectl get job ${job_name} -n ${managed_namespace} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+    local job_failed
+    job_failed=$(kubectl get job ${job_name} -n ${managed_namespace} -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+    
+    # Get logs (Pod might be gone if ttl cleanup happened)
+    echo "────────────────────────────────────────────────────────────────────"
+    if kubectl get pod ${pod_name} -n ${managed_namespace} &>/dev/null; then
+        kubectl logs ${pod_name} -n ${managed_namespace} 2>/dev/null || echo "(no logs available)"
+    else
+        echo "(no logs available - Pod already cleaned up by ttlSecondsAfterFinished)"
+        if [ "${job_failed}" = "True" ]; then
+            echo ""
+            echo "Job failed. Reason:"
+            kubectl get job ${job_name} -n ${managed_namespace} -o jsonpath='{.status.conditions[?(@.type=="Failed")].message}' 2>/dev/null || echo "(unknown)"
+        fi
+    fi
+    echo "────────────────────────────────────────────────────────────────────"
+    echo ""
+    
+    # Cleanup
+    kubectl delete job ${job_name} -n ${managed_namespace} >/dev/null 2>&1 || true
+    
+    if [ "${job_succeeded}" = "True" ]; then
+        echo "✅ Image indexed in Pyxis"
+        echo ""
+        return 0
+    elif [ "${job_failed}" = "True" ]; then
+        echo "❌ Pyxis indexing timeout (>${max_wait_seconds}s)"
+        echo ""
+        echo "Increase wait time: export IDEMPOTENT_WAIT_SECONDS=300"
+        echo ""
+        return 1
+    else
+        echo "❌ Pyxis polling Job timed out or did not complete"
+        echo ""
+        return 1
+    fi
+}
+
+verify_release_contents() {
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Idempotent Release Test - Phase 1: First Release Verification"
+    echo "════════════════════════════════════════════════════════════════════"
+    
+    # Note: Pre-flight check already ran in test_setup() before test started
+    # Pyxis availability was verified from the cluster
+
+    local first_release_name
+    first_release_name=$(echo "${RELEASE_NAMES}" | awk '{print $1}')
+
+    echo "First release: ${first_release_name}"
+
+    echo "Checking if first release pushed components..."
+    if were_all_components_filtered "${first_release_name}"; then
+        log_error "First release should NOT have filtered components, but push-snapshot was skipped"
+    fi
+    echo "✅ First release pushed components (expected behavior)"
+
+    if ! verify_single_release "${first_release_name}"; then
+        log_error "First release verification failed"
+    fi
+    
+    # CRITICAL: Verify that create-pyxis-image task actually succeeded
+    # If it failed, the first release didn't write to Pyxis, making idempotency test invalid
+    verify_pyxis_write_succeeded "${first_release_name}"
+
+    local first_release_json
+    first_release_json=$(get_release_json "${first_release_name}")
+    local snapshot_name
+    snapshot_name=$(jq -r '.spec.snapshot' <<< "${first_release_json}")
+
+    if [ -z "${snapshot_name}" ] || [ "${snapshot_name}" == "null" ]; then
+        log_error "Could not get snapshot name from first release"
+    fi
+    echo "Using snapshot: ${snapshot_name}"
+    
+    # Extract image digest for Pyxis polling
+    local image_digest
+    image_digest=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${first_release_json}")
+    
+    if [ -z "${image_digest}" ] || [ "${image_digest}" == "null" ]; then
+        echo "⚠️  Warning: Could not extract image digest from first release"
+        echo "Falling back to fixed wait time"
+        local wait_seconds="${IDEMPOTENT_WAIT_SECONDS:-60}"
+        echo "Waiting ${wait_seconds}s for Pyxis stage propagation..."
+        sleep "${wait_seconds}"
+    else
+        echo "Image digest to verify: ${image_digest}"
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Idempotent Release Test - Phase 2: Second Release (Idempotent)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # Poll Pyxis until image is indexed (or timeout)
+    # Run polling FROM CLUSTER to avoid local SSL/CA issues
+    if [ -n "${image_digest}" ] && [ "${image_digest}" != "null" ]; then
+        # Try polling - it will handle Pyxis unavailability internally
+        if ! wait_for_pyxis_indexing_from_cluster "${managed_namespace}" "${component_name}" "${image_digest}"; then
+            log_error "Pyxis indexing timeout. Cannot verify idempotency."
+        fi
+    else
+        # No digest: fall back to fixed wait
+        local wait_seconds="${IDEMPOTENT_WAIT_SECONDS:-60}"
+        echo "⚠️  Could not extract image digest, using fixed wait time (${wait_seconds}s)"
+        echo "Waiting for Pyxis indexing..."
+        sleep "${wait_seconds}"
+    fi
+
+    local second_release_name="idempotent-retry-${uuid}"
+    echo "Creating second release: ${second_release_name}"
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${second_release_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "idempotent-second-release"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    echo "Waiting for second release to complete..."
+    export RELEASE_NAME="${second_release_name}"
+    export RELEASE_NAMESPACE="${tenant_namespace}"
+    "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  Idempotent Release Test - Phase 3: Idempotent Behavior Verification"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # Get the second release's pipelinerun for detailed debugging
+    local second_pipelinerun_name
+    second_pipelinerun_name=$(get_pipelinerun_name_from_release "${second_release_name}")
+    
+    echo ""
+    echo "🔍 DEBUG: Second Release PipelineRun Details"
+    echo "   Release: ${second_release_name}"
+    echo "   PipelineRun: ${second_pipelinerun_name}"
+    echo ""
+    
+    # Show pipelinerun status
+    echo "📊 PipelineRun Status:"
+    kubectl get pipelinerun "${second_pipelinerun_name}" -n "${managed_namespace}" -o json | jq '{
+        status: .status.conditions[0].reason,
+        message: .status.conditions[0].message,
+        skippedTasks: [.status.skippedTasks[]?.name],
+        childReferences: [.status.childReferences[]? | {name: .name, pipelineTaskName: .pipelineTaskName}]
+    }'
+    
+    # Show skipped tasks explicitly
+    echo ""
+    echo "📋 Skipped Tasks:"
+    kubectl get pipelinerun "${second_pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath='{range .status.skippedTasks[*]}{.name}{"\n"}{end}' || echo "  (none)"
+    
+    # Check filter task logs
+    echo ""
+    echo "🔍 Filter Task Logs (filter-already-released-by-pyxis-and-file-updates):"
+    local filter_taskrun
+    filter_taskrun=$(kubectl get taskrun -n "${managed_namespace}" \
+        -l "tekton.dev/pipelineRun=${second_pipelinerun_name}" \
+        -l "tekton.dev/pipelineTask=filter-already-released-by-pyxis-and-file-updates" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || filter_taskrun=""
+    
+    if [ -n "${filter_taskrun}" ]; then
+        echo "   TaskRun: ${filter_taskrun}"
+        echo ""
+        echo "   Filter logs (last 100 lines):"
+        kubectl logs -n "${managed_namespace}" -l "tekton.dev/taskRun=${filter_taskrun}" -c step-filter-already-released-by-metadata --tail=100 2>/dev/null || echo "   (no logs available)"
+    else
+        echo "   ⚠️  No filter TaskRun found"
+    fi
+    
+    # Check if push-snapshot ran — use skippedTasks (authoritative) AND TaskRun existence (informational)
+    echo ""
+    echo "🔍 Push-Snapshot Task Status:"
+    local push_taskrun push_skipped
+    push_taskrun=$(kubectl get taskrun -n "${managed_namespace}" \
+        -l "tekton.dev/pipelineRun=${second_pipelinerun_name}" \
+        -l "tekton.dev/pipelineTask=push-snapshot" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || push_taskrun=""
+    push_skipped=$(kubectl get pipelinerun "${second_pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath="{.status.skippedTasks[?(@.name=='push-snapshot')].name}" 2>/dev/null || echo "")
+
+    if [ -n "${push_skipped}" ]; then
+        echo "   ✅ push-snapshot is in skippedTasks (task was correctly skipped)"
+        if [ -n "${push_taskrun}" ]; then
+            echo "   ⚠️  A TaskRun (${push_taskrun}) exists but task is marked skipped."
+            echo "      This can happen if the release had a prior failed attempt where push-snapshot ran."
+            echo "      The current PipelineRun (${second_pipelinerun_name}) correctly skipped it."
+        fi
+    else
+        if [ -n "${push_taskrun}" ]; then
+            echo "   ❌ push-snapshot TaskRun EXISTS: ${push_taskrun}"
+            echo "   This indicates the task was NOT skipped (idempotency failed)"
+        else
+            echo "   ✅ No push-snapshot TaskRun found and not in skippedTasks (unusual state)"
+        fi
+    fi
+
+    echo ""
+    echo "Checking if second release filtered all components..."
+    # Use second_pipelinerun_name (already resolved) for consistency — avoids stale re-lookup
+    if is_task_skipped_in_plr "${second_pipelinerun_name}" "push-snapshot"; then
+        echo "✅ Second release filtered all components (idempotent behavior confirmed)"
+    else
+        echo ""
+        echo "🔴 Debug: Filter failed to skip push-snapshot. To investigate:"
+        echo "  Run with: ./integration-tests/run-test.sh rh-push-to-registry-redhat-io-idempotent --skip-cleanup"
+        echo "  Then inspect the filter TaskRun logs for the second release's PipelineRun:"
+        echo "    kubectl get pipelinerun -n ${managed_namespace} -l \"release.appstudio.openshift.io/release=${second_release_name}\""
+        echo "    kubectl get taskrun -n ${managed_namespace} -l \"tekton.dev/pipelineRun=<pipelinerun-name>\" -l \"tekton.dev/pipelineTask=filter-already-released-by-pyxis-and-file-updates\" -o name"
+        echo "    kubectl logs -n ${managed_namespace} -l tekton.dev/taskRun=<filter-taskrun-name> -c step-filter-already-released-by-metadata --tail=100"
+        echo ""
+        echo "  Common causes: Pyxis stage propagation delay (try IDEMPOTENT_WAIT_SECONDS=300)"
+        echo ""
+        log_error "Second release should have filtered all components, but push-snapshot ran"
+    fi
+
+    echo ""
+    echo "Verifying artifact consistency..."
+    local second_release_json
+    second_release_json=$(get_release_json "${second_release_name}")
+
+    local artifacts_1 artifacts_2
+    artifacts_1=$(jq -S '.status.artifacts.images[0].shasum // "null"' <<< "${first_release_json}")
+    artifacts_2=$(jq -S '.status.artifacts.images[0]?.shasum // "null"' <<< "${second_release_json}")
+
+    if [ "${artifacts_2}" == "\"null\"" ] || [ "${artifacts_2}" == "null" ]; then
+        echo "✅ Second release has no artifacts (expected - all components filtered, push-snapshot skipped)"
+        echo "   First release pushed: ${artifacts_1}"
+        echo "   Second release skipped push (idempotent)"
+    elif [ "${artifacts_1}" == "${artifacts_2}" ]; then
+        echo "✅ Both releases report identical artifact digests"
+    else
+        echo "First release artifacts: ${artifacts_1}"
+        echo "Second release artifacts: ${artifacts_2}"
+        log_error "Releases report different artifacts: ${artifacts_1} vs ${artifacts_2}"
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  ✅ IDEMPOTENT RELEASE TEST PASSED (rh-push-to-registry-redhat-io)"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo ""
+    echo "Summary:"
+    echo "  • First release pushed 1 component (pyxis, signing)"
+    echo "  • Second release filtered component (Pyxis already had image)"
+    echo "  • Artifact consistency: Verified"
+    echo "  • Idempotent behavior: ✅ CONFIRMED"
+    echo ""
+}

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/vault/managed-secrets.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/vault/managed-secrets.yaml
@@ -1,0 +1,1 @@
+../../rh-push-to-registry-redhat-io/vault/managed-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io-idempotent/vault/tenant-secrets.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io-idempotent/vault/tenant-secrets.yaml
@@ -1,0 +1,1 @@
+../../rh-push-to-registry-redhat-io/vault/tenant-secrets.yaml

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/tenant/component.yaml
@@ -6,7 +6,9 @@ metadata:
     git-provider: github
     build.appstudio.openshift.io/request: configure-pac
     image.redhat.com/generate: '{"visibility": "public"}'
-    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-multi-platform-oci-ta", "bundle": "latest"}'
+    # Use single-platform build pipeline to avoid kueue admission policy requiring
+    # an invalid annotation key derived from PLATFORM values like "linux/x86_64".
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
   name: ${component_name}
   labels:
     originating-tool: "${originating_tool}"

--- a/pipelines/internal/check-file-updates/README.md
+++ b/pipelines/internal/check-file-updates/README.md
@@ -1,0 +1,16 @@
+# check-file-updates pipeline
+
+Internal pipeline to check whether fileUpdates changes are already complete for
+a given componentGroup and GitLab repository.
+
+This is intended to be triggered via InternalRequest from managed release tasks.
+
+## Parameters
+
+| Name                | Description                                                                           | Optional | Default value                                             |
+|---------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| upstream_repo       | Git repository (GitLab) where fileUpdates merge requests are created                  | No       | -                                                         |
+| componentGroup      | Component group being released (used to identify Konflux fileUpdates MRs)             | No       | -                                                         |
+| file_updates_secret | Secret containing GitLab host/access token used by internal services                  | Yes      | file-updates-secret                                       |
+| taskGitUrl          | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision     | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |

--- a/pipelines/internal/check-file-updates/check-file-updates.yaml
+++ b/pipelines/internal/check-file-updates/check-file-updates.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: check-file-updates
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Internal pipeline to check whether fileUpdates changes are already complete for
+    a given componentGroup and GitLab repository.
+
+    This is intended to be triggered via InternalRequest from managed release tasks.
+  params:
+    - name: upstream_repo
+      type: string
+      description: Git repository (GitLab) where fileUpdates merge requests are created
+    - name: componentGroup
+      type: string
+      description: Component group being released (used to identify Konflux fileUpdates MRs)
+    - name: file_updates_secret
+      type: string
+      description: Secret containing GitLab host/access token used by internal services
+      default: file-updates-secret
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: check-file-updates-task
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/check-file-updates-task/check-file-updates-task.yaml
+      params:
+        - name: upstream_repo
+          value: $(params.upstream_repo)
+        - name: componentGroup
+          value: $(params.componentGroup)
+        - name: file_updates_secret
+          value: $(params.file_updates_secret)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+  results:
+    - name: result
+      value: $(tasks.check-file-updates-task.results.result)
+    - name: file_updates_complete
+      value: $(tasks.check-file-updates-task.results.file_updates_complete)
+    - name: merge_request_url
+      value: $(tasks.check-file-updates-task.results.merge_request_url)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.check-file-updates-task.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.check-file-updates-task.results.internalRequestTaskRunName)

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -4,7 +4,9 @@ Tekton pipeline to release content to registry.redhat.io registry.
 
 This pipeline is idempotent: components that have already been fully released are
 automatically filtered out by verifying:
-- Pyxis metadata (container image entries with tags and RPM data)
+- Pyxis metadata: image record must have at least one repository with non-empty tags
+  and non-empty content_sets (RPM data). A digest-only or partial record does not
+  count as released, so reruns will still run push-rpm-data-to-pyxis if needed.
 - fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
 
 When all components are filtered, downstream release tasks are skipped (skip_release=true).

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -2,6 +2,14 @@
 
 Tekton pipeline to release content to registry.redhat.io registry.
 
+This pipeline is idempotent: components that have already been fully released are
+automatically filtered out by verifying:
+- Pyxis metadata (container image entries with tags and RPM data)
+- fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
+
+When all components are filtered, downstream release tasks are skipped (skip_release=true).
+This prevents redundant processing and allows safe re-runs of the same snapshot.
+
 ## Parameters
 
 | Name                            | Description                                                                                                                        | Optional | Default value                                             |

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -9,6 +9,14 @@ metadata:
 spec:
   description: |-
     Tekton pipeline to release content to registry.redhat.io registry.
+
+    This pipeline is idempotent: components that have already been fully released are
+    automatically filtered out by verifying:
+    - Pyxis metadata (container image entries with tags and RPM data)
+    - fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
+
+    When all components are filtered, downstream release tasks are skipped (skip_release=true).
+    This prevents redundant processing and allows safe re-runs of the same snapshot.
   params:
     - name: release
       type: string
@@ -290,8 +298,51 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - reduce-snapshot
+    - name: filter-already-released-by-pyxis-and-file-updates
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "$(tasks.collect-task-params.results.extractedValues[2])"
+        - name: pyxisServer
+          value: "$(tasks.collect-task-params.results.extractedValues[3])"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: orasOptions
+          value: "$(params.orasOptions)"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - apply-mapping
+        - reduce-snapshot
+        - collect-task-params
     - name: verify-conforma
       timeout: "4h00m0s"
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -318,11 +369,11 @@ spec:
         - name: WORKERS
           value: "$(tasks.collect-task-params.results.extractedValues[0])"
         - name: SOURCE_DATA_ARTIFACT
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
-        - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
         - collect-task-params
     - name: rh-sign-image-cosign
       timeout: "6h00m0s"
@@ -330,6 +381,9 @@ spec:
         - input: $(tasks.collect-task-params.results.extractedValues[1])
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -367,6 +421,9 @@ spec:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
           values: ["true"]
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -386,7 +443,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -400,6 +457,10 @@ spec:
     - name: rh-sign-image
       timeout: "6h00m0s"
       retries: 3
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -444,12 +505,16 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - verify-conforma
-        - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
         - publish-pyxis-repository
         - extract-requester-from-release
         - collect-task-params
     - name: create-pyxis-image
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -487,6 +552,10 @@ spec:
         - collect-task-params
     - name: publish-pyxis-repository
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -510,7 +579,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -522,8 +591,13 @@ spec:
       runAfter:
         - collect-task-params
         - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
     - name: push-rpm-data-to-pyxis
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -556,6 +630,10 @@ spec:
         - create-pyxis-image
         - collect-task-params
     - name: run-file-updates
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -570,7 +648,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -12,7 +12,9 @@ spec:
 
     This pipeline is idempotent: components that have already been fully released are
     automatically filtered out by verifying:
-    - Pyxis metadata (container image entries with tags and RPM data)
+    - Pyxis metadata: image record must have at least one repository with non-empty tags
+      and non-empty content_sets (RPM data). A digest-only or partial record does not
+      count as released, so reruns will still run push-rpm-data-to-pyxis if needed.
     - fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
 
     When all components are filtered, downstream release tasks are skipped (skip_release=true).
@@ -670,6 +672,10 @@ spec:
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
     - name: update-cr-status
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: resource
           value: $(params.release)

--- a/tasks/internal/check-file-updates-task/README.md
+++ b/tasks/internal/check-file-updates-task/README.md
@@ -1,0 +1,22 @@
+# check-file-updates-task
+
+Internal task to check whether Konflux `fileUpdates` changes are already complete for a
+given componentGroup and GitLab repository.
+
+This task is intentionally "best effort": on errors (missing credentials, API errors, invalid data),
+it returns file_updates_complete=false and result=Failure instead of failing the TaskRun. This enables
+managed pipelines to treat the check as incomplete and continue safely.
+
+## Parameters
+
+| Name                           | Description                                                               | Optional | Default value       |
+|--------------------------------|---------------------------------------------------------------------------|----------|---------------------|
+| upstream_repo                  | Git repository (GitLab) where fileUpdates merge requests are created      | No       | -                   |
+| componentGroup                 | Component group being released (used to identify Konflux fileUpdates MRs) | No       | -                   |
+| file_updates_secret            | Secret containing GitLab host/access token used by internal services      | Yes      | file-updates-secret |
+| apiRetryCount                  | Number of retries for GitLab API calls                                    | Yes      | 3                   |
+| apiConnectTimeout              | Connection timeout in seconds for GitLab API calls                        | Yes      | 10                  |
+| apiMaxTime                     | Maximum time in seconds for GitLab API calls                              | Yes      | 30                  |
+| caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca          |
+| caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt       |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                             | No       | -                   |

--- a/tasks/internal/check-file-updates-task/check-file-updates-task.yaml
+++ b/tasks/internal/check-file-updates-task/check-file-updates-task.yaml
@@ -1,0 +1,221 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-file-updates-task
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Internal task to check whether Konflux `fileUpdates` changes are already complete for a
+    given componentGroup and GitLab repository.
+
+    This task is intentionally "best effort": on errors (missing credentials, API errors, invalid data),
+    it returns file_updates_complete=false and result=Failure instead of failing the TaskRun. This enables
+    managed pipelines to treat the check as incomplete and continue safely.
+  params:
+    - name: upstream_repo
+      type: string
+      description: Git repository (GitLab) where fileUpdates merge requests are created
+    - name: componentGroup
+      type: string
+      description: Component group being released (used to identify Konflux fileUpdates MRs)
+    - name: file_updates_secret
+      type: string
+      description: Secret containing GitLab host/access token used by internal services
+      default: file-updates-secret
+    - name: apiRetryCount
+      type: string
+      description: Number of retries for GitLab API calls
+      default: "3"
+    - name: apiConnectTimeout
+      type: string
+      description: Connection timeout in seconds for GitLab API calls
+      default: "10"
+    - name: apiMaxTime
+      type: string
+      description: Maximum time in seconds for GitLab API calls
+      default: "30"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: internalRequestPipelineRunName
+      type: string
+      description: Name of the PipelineRun that called this task
+  results:
+    - name: result
+      type: string
+      description: Success if the check executed, Failure otherwise
+    - name: file_updates_complete
+      type: string
+      description: '"true" if latest matching fileUpdates MR is merged, otherwise "false"'
+    - name: merge_request_url
+      type: string
+      description: Web URL of the latest matching fileUpdates MR (may be empty)
+    - name: internalRequestPipelineRunName
+      type: string
+      description: Name of the PipelineRun that ran this task
+    - name: internalRequestTaskRunName
+      type: string
+      description: Name of the TaskRun that ran this task
+  volumes:
+    - name: file-updates-secret-vol
+      secret:
+        secretName: $(params.file_updates_secret)
+        defaultMode: 0444
+        optional: true
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    securityContext:
+      runAsUser: 1001
+    volumeMounts:
+      - name: file-updates-secret-vol
+        mountPath: /mnt/file-updates-secret
+        readOnly: true
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+  steps:
+    - name: check
+      image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 250m
+        requests:
+          memory: 256Mi
+          cpu: 250m
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Default results (best-effort: do not fail the TaskRun)
+        echo -n "Failure" > "$(results.result.path)"
+        echo -n "false" > "$(results.file_updates_complete.path)"
+        echo -n "" > "$(results.merge_request_url.path)"
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+        echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+        fail() {
+          local msg="${1:-unknown error}"
+          echo "ERROR: ${msg}"
+          exit 0
+        }
+
+        upstream_repo="$(params.upstream_repo)"
+        component_group="$(params.componentGroup)"
+
+        if [ -z "${upstream_repo}" ]; then
+          fail "upstream_repo param is required"
+        fi
+        if [ -z "${component_group}" ]; then
+          fail "componentGroup param is required"
+        fi
+
+        if [ ! -f /mnt/file-updates-secret/gitlab_host ] || [ ! -f /mnt/file-updates-secret/gitlab_access_token ]; then
+          fail "file updates secret missing required keys (gitlab_host, gitlab_access_token)"
+        fi
+
+        gitlab_host="$(tr -d '\n\r' < /mnt/file-updates-secret/gitlab_host)"
+        access_token="$(tr -d '\n\r' < /mnt/file-updates-secret/gitlab_access_token)"
+
+        if [ -z "${gitlab_host}" ] || [ -z "${access_token}" ]; then
+          fail "file updates secret contains empty gitlab_host or gitlab_access_token"
+        fi
+
+        # Use CA bundle if present (optional)
+        ca_bundle_path="/mnt/trusted-ca/ca-bundle.crt"
+        ca_bundle_args=()
+        if [ -f "${ca_bundle_path}" ]; then
+          ca_bundle_args=(--cacert "${ca_bundle_path}")
+        fi
+
+        # Parse <group>/<project> path from upstream_repo
+        project_path=""
+        if [[ "${upstream_repo}" =~ ^https?://[^/]+/(.+)$ ]]; then
+          project_path="${BASH_REMATCH[1]}"
+        elif [[ "${upstream_repo}" =~ ^git@[^:]+:(.+)$ ]]; then
+          project_path="${BASH_REMATCH[1]}"
+        else
+          fail "could not parse upstream_repo: ${upstream_repo}"
+        fi
+
+        project_path="${project_path%/}"
+        project_path="${project_path%.git}"
+        if [ -z "${project_path}" ]; then
+          fail "parsed project path is empty from upstream_repo: ${upstream_repo}"
+        fi
+
+        base_url="${gitlab_host}"
+        if ! [[ "${base_url}" =~ ^https?:// ]]; then
+          base_url="https://${base_url}"
+        fi
+        base_url="${base_url%/}"
+        gitlab_api_url="${base_url}/api/v4"
+
+        project_path_encoded="$(jq -sRr @uri <<< "${project_path}")"
+        search_encoded="$(jq -sRr @uri <<< "Konflux release")"
+
+        curl_config="$(mktemp)"
+        chmod "600" "${curl_config}"
+        printf '%s\n' "header = \"PRIVATE-TOKEN: ${access_token}\"" > "${curl_config}"
+
+        response_file="$(mktemp)"
+        mr_search_url="${gitlab_api_url}/projects/${project_path_encoded}/merge_requests"
+        mr_search_url="${mr_search_url}?state=all&search=${search_encoded}"
+        mr_search_url="${mr_search_url}&order_by=created_at&sort=desc&per_page=50"
+        http_code="$(
+          curl --retry "$(params.apiRetryCount)" --retry-all-errors \
+            --connect-timeout "$(params.apiConnectTimeout)" --max-time "$(params.apiMaxTime)" \
+            -sS "${ca_bundle_args[@]}" --config "${curl_config}" \
+            -o "${response_file}" -w "%{http_code}" \
+            "${mr_search_url}" \
+            2>/dev/null || echo "000"
+        )"
+
+        if [ "${http_code}" != "200" ]; then
+          fail "GitLab API query failed for ${project_path} (HTTP ${http_code})"
+        fi
+
+        # Find the latest MR matching this componentGroup and fileUpdates title pattern.
+        # process-file-updates-task creates titles like:
+        #   [Konflux release] <componentGroup>: fileUpdates changes <branch>
+        latest_mr="$(
+          jq -c --arg cg "${component_group}" '
+            map(
+              select((.title // "") | contains($cg))
+              | select((.title // "") | contains("fileUpdates changes"))
+            )
+            | .[0] // empty
+          ' "${response_file}" 2>/dev/null || true
+        )"
+
+        if [ -z "${latest_mr}" ]; then
+          echo "No matching fileUpdates MR found for componentGroup=${component_group}"
+          echo -n "Success" > "$(results.result.path)"
+          exit 0
+        fi
+
+        mr_state="$(jq -r '.state // ""' <<< "${latest_mr}" 2>/dev/null || echo "")"
+        mr_url="$(jq -r '.web_url // ""' <<< "${latest_mr}" 2>/dev/null || echo "")"
+        echo -n "${mr_url}" > "$(results.merge_request_url.path)"
+
+        if [ "${mr_state}" = "merged" ]; then
+          echo -n "true" > "$(results.file_updates_complete.path)"
+        else
+          echo -n "false" > "$(results.file_updates_complete.path)"
+        fi
+
+        echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/check-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/check-file-updates-task/tests/mocks.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# mocks to be injected into task step scripts
+# Mocks for the check-file-updates-task test. Sourced via BASH_ENV from the mounted
+# ConfigMap (file-updates-task-mocks); see pre-apply-task-hook.sh.
 
 function curl() {
   # Mock curl for GitLab API query

--- a/tasks/internal/check-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/check-file-updates-task/tests/mocks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mocks to be injected into task step scripts
+
+function curl() {
+  # Mock curl for GitLab API query
+  local output_file=""
+  local url=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o)
+        output_file="$2"
+        shift 2
+        ;;
+      -w|--retry|--connect-timeout|--max-time)
+        shift 2
+        ;;
+      --config|--cacert)
+        shift 2
+        ;;
+      -sS|--retry-all-errors|-s|-S)
+        shift 1
+        ;;
+      *)
+        if [[ ! "$1" =~ ^- ]]; then
+          url="$1"
+        fi
+        shift 1
+        ;;
+    esac
+  done
+
+  # component_group is set by the task script before invoking curl
+  local json_response="[]"
+  case "${component_group:-}" in
+    merged-app)
+      json_response='[{"title":"[Konflux release] merged-app: fileUpdates changes abc","state":"merged","web_url":"https://gitlab.example.com/merged"}]'
+      ;;
+    open-app)
+      json_response='[{"title":"[Konflux release] open-app: fileUpdates changes def","state":"opened","web_url":"https://gitlab.example.com/open"}]'
+      ;;
+    *)
+      json_response='[]'
+      ;;
+  esac
+
+  if [ -n "$output_file" ]; then
+    echo "$json_response" > "$output_file"
+  else
+    echo "$json_response"
+  fi
+
+  # Simulate curl -w "%{http_code}"
+  printf "%s" "200"
+}

--- a/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
@@ -17,8 +17,15 @@ if [ ! -f "${TASK_PATH}" ]; then
   exit 1
 fi
 
-# Add mocks to the beginning of the task step script (standard approach)
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+# Mount mocks via ConfigMap and source via BASH_ENV (avoids inlining mocks into the step script)
+MOCKS_CM_NAME="file-updates-task-mocks"
+MOCKS_MOUNT_PATH="/workspace/mocks"
+kubectl delete configmap "${MOCKS_CM_NAME}" --ignore-not-found
+kubectl create configmap "${MOCKS_CM_NAME}" --from-file=mocks.sh="${SCRIPT_DIR}/mocks.sh"
+
+yq -i '.spec.volumes += [{"name": "test-mocks", "configMap": {"name": "'"${MOCKS_CM_NAME}"'"}}]' "$TASK_PATH"
+yq -i '.spec.steps[0].volumeMounts += [{"name": "test-mocks", "mountPath": "'"${MOCKS_MOUNT_PATH}"'", "readOnly": true}]' "$TASK_PATH"
+yq -i '.spec.steps[0].env += [{"name": "BASH_ENV", "value": "'"${MOCKS_MOUNT_PATH}"'/mocks.sh"}]' "$TASK_PATH"
 
 # Create test secrets (delete first if they exist)
 kubectl delete secret file-updates-secret --ignore-not-found

--- a/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate required argument
+if [ $# -ne 1 ]; then
+  echo "Error: Missing required argument TASK_PATH" >&2
+  echo "Usage: $0 <path-to-task.yaml>" >&2
+  exit 1
+fi
+
+TASK_PATH="$1"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Validate TASK_PATH exists
+if [ ! -f "${TASK_PATH}" ]; then
+  echo "Error: Task file not found: ${TASK_PATH}" >&2
+  exit 1
+fi
+
+# Add mocks to the beginning of the task step script (standard approach)
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create test secrets (delete first if they exist)
+kubectl delete secret file-updates-secret --ignore-not-found
+kubectl create secret generic file-updates-secret \
+  --from-literal=gitlab_host="gitlab.example.com" \
+  --from-literal=gitlab_access_token="mock-token"

--- a/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-merged.yaml
+++ b/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-merged.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-file-updates-task-merged
+spec:
+  description: |
+    Verify check-file-updates-task returns complete=true when the latest matching MR is merged.
+  tasks:
+    - name: run-check
+      taskRef:
+        name: check-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://gitlab.example.com/group/project.git"
+        - name: componentGroup
+          value: "merged-app"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: internalRequestPipelineRunName
+          value: "test"
+    - name: verify
+      runAfter:
+        - run-check
+      params:
+        - name: result
+          value: "$(tasks.run-check.results.result)"
+        - name: complete
+          value: "$(tasks.run-check.results.file_updates_complete)"
+        - name: mr
+          value: "$(tasks.run-check.results.merge_request_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: complete
+            type: string
+          - name: mr
+            type: string
+        steps:
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [ "$(params.result)" != "Success" ]; then
+                echo "ERROR: expected result=Success, got: $(params.result)"
+                exit 1
+              fi
+
+              if [ "$(params.complete)" != "true" ]; then
+                echo "ERROR: expected file_updates_complete=true, got: $(params.complete)"
+                exit 1
+              fi
+
+              if [ -z "$(params.mr)" ]; then
+                echo "ERROR: expected merge_request_url to be set"
+                exit 1
+              fi

--- a/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-open.yaml
+++ b/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-open.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-file-updates-task-open
+spec:
+  description: |
+    Verify check-file-updates-task returns complete=false when the latest matching MR is not merged.
+  tasks:
+    - name: run-check
+      taskRef:
+        name: check-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://gitlab.example.com/group/project.git"
+        - name: componentGroup
+          value: "open-app"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: internalRequestPipelineRunName
+          value: "test"
+    - name: verify
+      runAfter:
+        - run-check
+      params:
+        - name: result
+          value: "$(tasks.run-check.results.result)"
+        - name: complete
+          value: "$(tasks.run-check.results.file_updates_complete)"
+        - name: mr
+          value: "$(tasks.run-check.results.merge_request_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: complete
+            type: string
+          - name: mr
+            type: string
+        steps:
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [ "$(params.result)" != "Success" ]; then
+                echo "ERROR: expected result=Success, got: $(params.result)"
+                exit 1
+              fi
+
+              if [ "$(params.complete)" != "false" ]; then
+                echo "ERROR: expected file_updates_complete=false, got: $(params.complete)"
+                exit 1
+              fi
+
+              if [ -z "$(params.mr)" ]; then
+                echo "ERROR: expected merge_request_url to be set"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
@@ -1,0 +1,45 @@
+# filter-already-released-by-pyxis-and-file-updates
+
+Tekton task to filter out images from a snapshot that have already been released.
+This task verifies:
+- Pyxis metadata (always required)
+- fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
+
+The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
+not by calling GitLab directly from this managed task.
+
+The task overwrites the original snapshot file in place with a filtered version
+containing only components that still need release work.
+
+This task expects a mapped snapshot (repositories/tags already resolved) from
+trusted artifacts.
+
+Fail-safe behavior: The task fails only if Pyxis credentials are missing or
+pyxisServer is invalid. For all other issues (API errors, missing data, internal
+check errors), components are kept and the pipeline proceeds.
+
+## Parameters
+
+| Name                    | Description                                                                                                                                                       | Optional | Default value                                             |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                                                                | No       | -                                                         |
+| dataPath                | Path to the JSON string of the merged data in the data workspace                                                                                                  | Yes      | ""                                                        |
+| request                 | Name of the internal pipeline used to check fileUpdates completion                                                                                                | Yes      | check-file-updates                                        |
+| requestTimeout          | InternalRequest timeout (seconds) for the fileUpdates completion check                                                                                            | Yes      | 300                                                       |
+| synchronously           | Whether to run internal requests synchronously or not                                                                                                             | Yes      | true                                                      |
+| pipelineRunUid          | The uid of the current PipelineRun. Used as a label value when creating internal requests                                                                         | No       | -                                                         |
+| pyxisSecret             | The kubernetes secret for Pyxis authentication (needs keys: cert, key)                                                                                            | Yes      | pyxis-secret                                              |
+| pyxisServer             | The Pyxis server: production, production-internal, stage-internal, or stage                                                                                       | Yes      | production                                                |
+| apiRetryCount           | Number of retries for API calls to Pyxis                                                                                                                          | Yes      | 3                                                         |
+| apiConnectTimeout       | Connection timeout in seconds for API calls to Pyxis                                                                                                              | Yes      | 10                                                        |
+| apiMaxTime              | Maximum time in seconds for API calls to Pyxis                                                                                                                    | Yes      | 30                                                        |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                                                             | Yes      | trusted-ca                                                |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                                                             | Yes      | ca-bundle.crt                                             |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored. Must be provided by the pipeline (e.g., quay.io/redhat-user-workloads/workspace/application/component) | Yes      | ""                                                        |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire                                        | Yes      | 1d                                                        |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                                                            | Yes      | ""                                                        |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                                                                   | Yes      | ""                                                        |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                                                               | Yes      | ""                                                        |
+| dataDir                 | The location where data will be stored                                                                                                                            | Yes      | /var/workdir/release                                      |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                             | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                    | No       | -                                                         |

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
@@ -2,7 +2,11 @@
 
 Tekton task to filter out images from a snapshot that have already been released.
 This task verifies:
-- Pyxis metadata (always required)
+- Pyxis metadata (always required): the image IS in Pyxis — found via image_id
+  (the manifest digest stored by create-pyxis-image). The query uses the Pyxis REST
+  API field `image_id`, NOT `docker_image_digest` (which does not exist in Pyxis records).
+  Additionally, rpm_manifest.rpms must be non-empty (populated by push-rpm-data-to-pyxis).
+  A record with no rpm_manifest or empty rpms does not count as a complete release.
 - fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
 
 The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
@@ -11,8 +15,13 @@ not by calling GitLab directly from this managed task.
 The task overwrites the original snapshot file in place with a filtered version
 containing only components that still need release work.
 
-This task expects a mapped snapshot (repositories/tags already resolved) from
-trusted artifacts.
+This task supports both Trusted Artifacts and PVC-based workflows (compliance):
+
+- **Trusted Artifacts**: Leave workspace `data` unbound; set `sourceDataArtifact` and use default
+  `dataDir` (/var/workdir/release). Snapshot/data are pulled into an emptyDir and results pushed to OCI.
+- **PVC-based**: Bind the optional workspace `data` to a PVC that already contains snapshot/data; set
+  `dataDir` to the workspace path (e.g. `/workspace/data/release`). Leave `sourceDataArtifact` empty;
+  `use-trusted-artifact` and `create-trusted-artifact` steps are skipped.
 
 Fail-safe behavior: The task fails only if Pyxis credentials are missing or
 pyxisServer is invalid. For all other issues (API errors, missing data, internal
@@ -26,7 +35,6 @@ check errors), components are kept and the pipeline proceeds.
 | dataPath                | Path to the JSON string of the merged data in the data workspace                                                                                                  | Yes      | ""                                                        |
 | request                 | Name of the internal pipeline used to check fileUpdates completion                                                                                                | Yes      | check-file-updates                                        |
 | requestTimeout          | InternalRequest timeout (seconds) for the fileUpdates completion check                                                                                            | Yes      | 300                                                       |
-| synchronously           | Whether to run internal requests synchronously or not                                                                                                             | Yes      | true                                                      |
 | pipelineRunUid          | The uid of the current PipelineRun. Used as a label value when creating internal requests                                                                         | No       | -                                                         |
 | pyxisSecret             | The kubernetes secret for Pyxis authentication (needs keys: cert, key)                                                                                            | Yes      | pyxis-secret                                              |
 | pyxisServer             | The Pyxis server: production, production-internal, stage-internal, or stage                                                                                       | Yes      | production                                                |
@@ -40,6 +48,6 @@ check errors), components are kept and the pipeline proceeds.
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                                                            | Yes      | ""                                                        |
 | orasOptions             | oras options to pass to Trusted Artifacts calls                                                                                                                   | Yes      | ""                                                        |
 | sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                                                               | Yes      | ""                                                        |
-| dataDir                 | The location where data will be stored                                                                                                                            | Yes      | /var/workdir/release                                      |
+| dataDir                 | The location where data will be stored. In Trusted Artifacts mode use default; in PVC mode set to the workspace path (e.g. /workspace/data/release)               | Yes      | /var/workdir/release                                      |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                             | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                    | No       | -                                                         |

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
@@ -1,0 +1,659 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-by-pyxis-and-file-updates
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task to filter out images from a snapshot that have already been released.
+    This task verifies:
+    - Pyxis metadata (always required)
+    - fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
+
+    The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
+    not by calling GitLab directly from this managed task.
+
+    The task overwrites the original snapshot file in place with a filtered version
+    containing only components that still need release work.
+
+    This task expects a mapped snapshot (repositories/tags already resolved) from
+    trusted artifacts.
+
+    Fail-safe behavior: The task fails only if Pyxis credentials are missing or
+    pyxisServer is invalid. For all other issues (API errors, missing data, internal
+    check errors), components are kept and the pipeline proceeds.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      type: string
+    - name: dataPath
+      type: string
+      description: Path to the JSON string of the merged data in the data workspace
+      default: ""
+    - name: request
+      type: string
+      description: Name of the internal pipeline used to check fileUpdates completion
+      default: "check-file-updates"
+    - name: requestTimeout
+      type: string
+      default: "300"
+      description: InternalRequest timeout (seconds) for the fileUpdates completion check
+    - name: synchronously
+      type: string
+      description: Whether to run internal requests synchronously or not
+      default: "true"
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current PipelineRun. Used as a label value when creating internal requests
+    - name: pyxisSecret
+      type: string
+      description: |-
+        The kubernetes secret for Pyxis authentication (needs keys: cert, key)
+      default: "pyxis-secret"
+    - name: pyxisServer
+      type: string
+      description: |-
+        The Pyxis server: production, production-internal, stage-internal, or stage
+      default: "production"
+    - name: apiRetryCount
+      type: string
+      description: Number of retries for API calls to Pyxis
+      default: "3"
+    - name: apiConnectTimeout
+      type: string
+      description: Connection timeout in seconds for API calls to Pyxis
+      default: "10"
+    - name: apiMaxTime
+      type: string
+      description: Maximum time in seconds for API calls to Pyxis
+      default: "30"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: ociStorage
+      description: |-
+        The OCI repository where the Trusted Artifacts are stored.
+        Must be provided by the pipeline (e.g., quay.io/redhat-user-workloads/workspace/application/component)
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: |-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  results:
+    - name: skip_release
+      description: Whether to skip release tasks (true if all components are already released)
+    - name: sourceDataArtifact
+      description: The location of the source data artifact in the OCI repository
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: pyxis-secret-vol
+      secret:
+        secretName: $(params.pyxisSecret)
+        defaultMode: 0444
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: ORAS_OPTIONS
+        value: $(params.orasOptions)
+      - name: TRUSTED_ARTIFACTS_DEBUG
+        value: $(params.trustedArtifactsDebug)
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          cpu: 30m
+          memory: 64Mi
+        requests:
+          cpu: 30m
+          memory: 64Mi
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+        - name: orasOptions
+          value: $(params.orasOptions)
+    - name: filter-already-released-by-metadata
+      image: quay.io/konflux-ci/release-service-utils@sha256:653b4782f0693c031a5d1327c026e6895d90b8126d51d8a3d07ffe940f6721fd
+      computeResources:
+        limits:
+          cpu: 250m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 1Gi
+      volumeMounts:
+        - name: pyxis-secret-vol
+          mountPath: /etc/pyxis-secrets
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        
+        echo "╔═══════════════════════════════════════════════════════════════════╗"
+        echo "║ Filter Already Released Components (Pyxis Check)                ║"
+        echo "╚═══════════════════════════════════════════════════════════════════╝"
+        # API call retry/timeout configuration (from task parameters)
+        API_RETRY_COUNT="$(params.apiRetryCount)"
+        API_CONNECT_TIMEOUT="$(params.apiConnectTimeout)"
+        API_MAX_TIME="$(params.apiMaxTime)"
+
+        # CA bundle configuration (use array to avoid word-splitting)
+        CA_BUNDLE_PATH="/mnt/trusted-ca/ca-bundle.crt"
+        if [ -f "${CA_BUNDLE_PATH}" ]; then
+          CA_BUNDLE_ARGS=(--cacert "${CA_BUNDLE_PATH}")
+        else
+          CA_BUNDLE_ARGS=()
+        fi
+
+        # Helper function for Pyxis API calls (certificate-based auth)
+        # Usage: http_get_pyxis <url> <output_file> <cert_path> <key_path>
+        # Returns: HTTP status code (always numeric, "000" on complete failure)
+        # SECURITY: Stderr redirected to /dev/null to prevent cert path leakage in error messages
+        http_get_pyxis() {
+          local url="$1"
+          local output_file="$2"
+          local cert_path="$3"
+          local key_path="$4"
+          local http_code
+          http_code=$(curl-with-retry --retry "${API_RETRY_COUNT}" --retry-all-errors \
+            --connect-timeout "${API_CONNECT_TIMEOUT}" --max-time "${API_MAX_TIME}" -sS \
+            "${CA_BUNDLE_ARGS[@]}" \
+            --cert "${cert_path}" --key "${key_path}" \
+            -o "${output_file}" -w "%{http_code}" "${url}" 2>/dev/null || echo "000")
+          # Ensure we always return a numeric code
+          if [[ "${http_code}" =~ ^[0-9]{3}$ ]]; then
+            echo "${http_code}"
+          else
+            echo "000"
+          fi
+        }
+
+        # Helper function to keep a component in the filtered list
+        # Usage: keep_component <component_json> <reason_message>
+        keep_component() {
+          local component_json="$1"
+          local reason="$2"
+          echo "${reason}"
+          FILTERED_COMPONENTS=$(jq --argjson comp "${component_json}" '. += [$comp]' <<< "${FILTERED_COMPONENTS}")
+          echo ""
+        }
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+
+        # Initialize results with defaults to prevent task failure on early exits
+        if [ -n "$(params.sourceDataArtifact)" ]; then
+          echo -n "$(params.sourceDataArtifact)" > "$(results.sourceDataArtifact.path)"
+        else
+          echo -n "" > "$(results.sourceDataArtifact.path)"
+        fi
+        echo -n "false" > "$(results.skip_release.path)"
+
+        if [ ! -f "${SNAPSHOT_FILE}" ]; then
+            echo "Error: Snapshot file not found: ${SNAPSHOT_FILE}"
+            exit 1
+        fi
+
+        # Check Pyxis credentials (required)
+        if [ ! -f /etc/pyxis-secrets/cert ] || [ ! -f /etc/pyxis-secrets/key ]; then
+          echo "Error: Pyxis credentials not available"
+          exit 1
+        fi
+
+        if [[ "$(params.pyxisServer)" == "production" ]]; then
+          PYXIS_URL="https://pyxis.api.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "stage" ]]; then
+          PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "production-internal" ]]; then
+          PYXIS_URL="https://pyxis.engineering.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "stage-internal" ]]; then
+          PYXIS_URL="https://pyxis.stage.engineering.redhat.com/"
+        else
+          echo "Invalid pyxisServer parameter. Allowed values: production, production-internal, stage-internal, stage"
+          exit 1
+        fi
+
+        # Validate snapshot JSON structure (work directly on file for better performance)
+        if ! jq -e '.' "${SNAPSHOT_FILE}" >/dev/null 2>&1; then
+          echo "Error: Invalid JSON in snapshot file"
+          exit 1
+        fi
+        
+        if ! jq -e '.components | type == "array"' "${SNAPSHOT_FILE}" >/dev/null 2>&1; then
+          echo "Error: Snapshot missing required 'components' array or it is not an array"
+          exit 1
+        fi
+        
+        COMPONENT_COUNT=$(jq '.components | length' "${SNAPSHOT_FILE}")
+
+        # Skip release if snapshot is empty
+        if [ "${COMPONENT_COUNT}" -eq 0 ]; then
+          echo "Snapshot has no components - skipping release"
+          echo -n "true" > "$(results.skip_release.path)"
+          # sourceDataArtifact already initialized at start
+          exit 0
+        fi
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "Starting filter check for ${COMPONENT_COUNT} component(s)"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        FILTERED_COMPONENTS='[]'
+        FILTERED_COUNT=0
+
+        # Check fileUpdates completion (if configured in data.json). This is required
+        # to consider a component "fully released" for idempotency.
+        FILE_UPDATES_COMPLETE="true"
+        FILE_UPDATES_REQUIRED="false"
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+        COMPONENT_GROUP=$(jq -r '.componentGroup // .application // ""' "${SNAPSHOT_FILE}")
+
+        if [ -n "$(params.dataPath)" ]; then
+          if [ ! -f "${DATA_FILE}" ]; then
+            echo "WARNING: dataPath provided but data file missing: ${DATA_FILE}"
+            FILE_UPDATES_REQUIRED="true"
+            FILE_UPDATES_COMPLETE="false"
+          elif ! jq -e '.' "${DATA_FILE}" >/dev/null 2>&1; then
+            echo "WARNING: Data file contains invalid JSON - preventing filtering"
+            FILE_UPDATES_REQUIRED="true"
+            FILE_UPDATES_COMPLETE="false"
+          else
+            FILE_UPDATES_LENGTH=$(jq '.fileUpdates // [] | length' "${DATA_FILE}" 2>/dev/null || echo "0")
+            if [ "${FILE_UPDATES_LENGTH}" -gt 0 ] 2>/dev/null; then
+              FILE_UPDATES_REQUIRED="true"
+
+              if [ -z "${COMPONENT_GROUP}" ] || [ "${COMPONENT_GROUP}" = "null" ]; then
+                echo "WARNING: Snapshot componentGroup is empty - cannot verify fileUpdates"
+                FILE_UPDATES_COMPLETE="false"
+              else
+                echo "Checking fileUpdates completion for ${FILE_UPDATES_LENGTH} repo(s)..."
+
+                TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
+                REQUEST_LABEL="internal-services.appstudio.openshift.io/request-id"
+                TASK_ID=$(context.taskRun.uid)
+                PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+                for ((fu=0; fu<FILE_UPDATES_LENGTH; fu++)); do
+                  item=$(jq -cr ".fileUpdates[$fu]" "${DATA_FILE}")
+                  upstream_repo=$(jq -r '.upstream_repo // .repo // ""' <<< "${item}")
+                  file_updates_secret=$(jq -r '.file_updates_secret // "file-updates-secret"' <<< "${item}")
+
+                  if [ -z "${upstream_repo}" ] || [ "${upstream_repo}" = "null" ]; then
+                    echo "WARNING: fileUpdates entry missing repo/upstream_repo (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  requestId="$(openssl rand -hex 12)"
+                  if ! internal-request --pipeline "$(params.request)" \
+                      -p upstream_repo="${upstream_repo}" \
+                      -p componentGroup="${COMPONENT_GROUP}" \
+                      -p file_updates_secret="${file_updates_secret}" \
+                      -p taskGitUrl="$(params.taskGitUrl)" \
+                      -p taskGitRevision="$(params.taskGitRevision)" \
+                      -s "$(params.synchronously)" \
+                      -t "$(params.requestTimeout)" \
+                      -l "${TASK_LABEL}=${TASK_ID}" \
+                      -l "${REQUEST_LABEL}=${requestId}" \
+                      -l "${PIPELINERUN_LABEL}=$(params.pipelineRunUid)"; then
+                    echo "WARNING: Failed to create InternalRequest for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  ir_selector="${PIPELINERUN_LABEL}=$(params.pipelineRunUid)"
+                  ir_selector="${ir_selector},${TASK_LABEL}=${TASK_ID}"
+                  ir_selector="${ir_selector},${REQUEST_LABEL}=${requestId}"
+                  IRjson=$(kubectl get internalrequest \
+                    -l "${ir_selector}" \
+                    -o jsonpath='{.items[0]}' \
+                    --sort-by=.metadata.creationTimestamp 2>/dev/null || true)
+
+                  if [ -z "${IRjson}" ]; then
+                    echo "WARNING: No InternalRequest found for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  results=$(jq -c '.status.results // empty' <<< "${IRjson}" 2>/dev/null || echo "")
+                  if [ -z "${results}" ]; then
+                    echo "WARNING: InternalRequest has no status.results for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  if [ "$(jq -r '.result // ""' <<< "${results}" 2>/dev/null || echo "")" != "Success" ]; then
+                    echo "WARNING: fileUpdates check did not succeed for ${upstream_repo}"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  file_updates_complete="$(
+                    jq -r '.file_updates_complete // "false"' <<< "${results}" 2>/dev/null || echo "false"
+                  )"
+                  if [ "${file_updates_complete}" != "true" ]; then
+                    echo "fileUpdates not complete for ${upstream_repo}"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+                done
+              fi
+            fi
+          fi
+        fi
+
+        if [ "${FILE_UPDATES_REQUIRED}" = "true" ]; then
+          echo "fileUpdates required: ${FILE_UPDATES_REQUIRED}, complete: ${FILE_UPDATES_COMPLETE}"
+        fi
+
+        # If fileUpdates are configured but not complete, we cannot consider any component
+        # "fully released" yet. Fail-safe: keep the snapshot unchanged and proceed.
+        if [ "${FILE_UPDATES_REQUIRED}" = "true" ] && [ "${FILE_UPDATES_COMPLETE}" != "true" ]; then
+          echo "fileUpdates are not complete - skipping filtering and passing snapshot unchanged."
+          exit 0
+        fi
+
+        # Create temp files once for component processing (reused in loop)
+        COMPONENT_AUTH_FILE=$(mktemp)
+        PYXIS_RESPONSE=$(mktemp)
+
+        for ((i=0; i<COMPONENT_COUNT; i++)); do
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "Processing component $((i+1))/${COMPONENT_COUNT}"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            COMPONENT=$(jq -c ".components[$i]" "${SNAPSHOT_FILE}")
+            COMPONENT_NAME=$(jq -r '.name' <<< "${COMPONENT}")
+            CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "${COMPONENT}")
+            echo "Component: ${COMPONENT_NAME}"
+            echo "Image: ${CONTAINER_IMAGE}"
+
+            # Validate component has required fields
+            if [ -z "${COMPONENT_NAME}" ] || [ "${COMPONENT_NAME}" = "null" ]; then
+              keep_component "${COMPONENT}" "Component at index $i: KEPT (missing or null name field)"
+              continue
+            fi
+
+            if [ -z "${CONTAINER_IMAGE}" ] || [ "${CONTAINER_IMAGE}" = "null" ]; then
+              keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (missing or null containerImage field)"
+              continue
+            fi
+
+            PYXIS_COMPLETE="false"
+            DIGEST=""
+            if [[ "${CONTAINER_IMAGE}" == *@sha256:* ]]; then
+              # Extract digest from image reference (after @)
+              RAW_DIGEST="${CONTAINER_IMAGE##*@}"
+              # Remove sha256: prefix if present, then validate and re-add
+              RAW_DIGEST="${RAW_DIGEST#sha256:}"
+              if [[ "${RAW_DIGEST}" =~ ^[a-fA-F0-9]{64}$ ]]; then
+                DIGEST="sha256:${RAW_DIGEST}"
+              else
+                echo "WARNING: Invalid digest in containerImage: ${CONTAINER_IMAGE}"
+                DIGEST=""
+              fi
+            else
+              # Resolve digest using oras (reuse temp file for auth config)
+              # Add timeout to prevent hanging on slow/broken registries
+              if ! timeout 30 select-oci-auth "${CONTAINER_IMAGE}" > "${COMPONENT_AUTH_FILE}" 2>/dev/null || \
+                 [ ! -s "${COMPONENT_AUTH_FILE}" ]; then
+                  echo '{}' > "${COMPONENT_AUTH_FILE}"
+              fi
+              
+              # Add timeout to prevent hanging on slow/broken registries
+              if ! RAW_DIGEST=$(timeout 60 oras resolve --registry-config "${COMPONENT_AUTH_FILE}" \
+                  "${CONTAINER_IMAGE}" 2>/dev/null); then
+                # oras resolve failed or timed out - cannot verify this component, keep it
+                keep_component "${COMPONENT}" \
+                  "Component ${COMPONENT_NAME}: KEPT (oras resolve failed or timed out for ${CONTAINER_IMAGE})"
+                continue
+              fi
+              
+              # Normalize digest: strip whitespace, remove any prefix, ensure sha256: format
+              RAW_DIGEST=$(echo "${RAW_DIGEST}" | tr -d '[:space:]')
+              # If it contains @, extract the part after @
+              if [[ "${RAW_DIGEST}" == *@* ]]; then
+                RAW_DIGEST="${RAW_DIGEST##*@}"
+              fi
+              # Remove sha256: prefix if present
+              RAW_DIGEST="${RAW_DIGEST#sha256:}"
+              
+              # Validate it looks like a sha256 hash (64 hex chars)
+              if ! [[ "${RAW_DIGEST}" =~ ^[a-fA-F0-9]{64}$ ]]; then
+                # Invalid digest format - cannot verify this component, keep it
+                keep_component "${COMPONENT}" \
+                  "Component ${COMPONENT_NAME}: KEPT (invalid digest format from oras: ${RAW_DIGEST})"
+                continue
+              fi
+              
+              DIGEST="sha256:${RAW_DIGEST}"
+            fi
+
+            # At this point, DIGEST is guaranteed to be valid (either from containerImage or oras)
+            if [ -z "${DIGEST}" ]; then
+              # This should never happen now, but keep as safety check
+              keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (empty digest - internal error)"
+              continue
+            fi
+            
+            # Encode the entire filter parameter value (including == operator)
+            FILTER_VALUE="docker_image_digest==${DIGEST}"
+            FILTER_ENCODED=$(jq -sRr @uri <<< "${FILTER_VALUE}")
+            PYXIS_QUERY_URL="${PYXIS_URL}v1/images?filter=${FILTER_ENCODED}"
+            echo "Querying Pyxis for ${COMPONENT_NAME}..."
+            # Reuse temp file for this API call (overwrites previous content)
+            PYXIS_HTTP_CODE=$(http_get_pyxis "${PYXIS_QUERY_URL}" "${PYXIS_RESPONSE}" \
+              /etc/pyxis-secrets/cert /etc/pyxis-secrets/key)
+            echo "Pyxis query returned HTTP ${PYXIS_HTTP_CODE}"
+
+            if [ "${PYXIS_HTTP_CODE}" != "200" ]; then
+              # SECURITY: Only log component name and HTTP code - NOT the digest, URL, or cert paths
+              echo "Pyxis query failed for ${COMPONENT_NAME} (HTTP ${PYXIS_HTTP_CODE})"
+              PYXIS_COMPLETE="false"
+            else
+              IMAGE_COUNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+              if [ "${IMAGE_COUNT}" -eq 0 ] 2>/dev/null; then
+                echo "No Pyxis entries found for ${COMPONENT_NAME}"
+                PYXIS_COMPLETE="false"
+              elif [ -z "${IMAGE_COUNT}" ]; then
+                echo "WARNING: Invalid Pyxis response for ${COMPONENT_NAME}"
+                PYXIS_COMPLETE="false"
+              else
+                # Extract expected tags as JSON array (normalize objects to strings)
+                EXPECTED_TAGS_JSON=$(jq -c \
+                  '[.repositories[]?.tags[]? | if type == "object" then .name else . end] | 
+                   sort | unique' \
+                  <<< "${COMPONENT}" 2>/dev/null || echo "[]")
+                EXPECTED_TAG_COUNT=$(jq 'length' <<< "${EXPECTED_TAGS_JSON}")
+                
+                if [ "${EXPECTED_TAG_COUNT}" -eq 0 ] 2>/dev/null; then
+                  echo "WARNING: No expected tags found for ${COMPONENT_NAME}"
+                  PYXIS_COMPLETE="false"
+                else
+                  # Extract Pyxis tags as JSON array (normalize objects to strings)
+                  PYXIS_TAGS_JSON=$(jq -c \
+                    '[.data[]?.repositories[]?.tags[]? | if type == "object" then .name else . end] | 
+                     sort | unique' \
+                    "${PYXIS_RESPONSE}" 2>/dev/null || echo "[]")
+                  
+                  # Compute missing tags: expected - pyxis (set difference)
+                  MISSING_TAGS_JSON=$(jq -c --argjson expected "${EXPECTED_TAGS_JSON}" \
+                    --argjson pyxis "${PYXIS_TAGS_JSON}" \
+                    -n '$expected - $pyxis' 2>/dev/null || echo "[]")
+                  MISSING_TAG_COUNT=$(jq 'length' <<< "${MISSING_TAGS_JSON}" 2>/dev/null || echo "1")
+                  
+                  if [ "${MISSING_TAG_COUNT}" -gt 0 ] 2>/dev/null; then
+                    echo "Pyxis missing tags for ${COMPONENT_NAME}: $(jq -r 'join(", ")' <<< "${MISSING_TAGS_JSON}")"
+                    PYXIS_COMPLETE="false"
+                  else
+                    # All tags present, check for RPM data
+                    HAS_RPM_DATA=$(jq -r '[.data[]?.repositories[]?.content_sets // [] | length] | max // 0' \
+                      "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+                    if [ "${HAS_RPM_DATA}" -gt 0 ] 2>/dev/null; then
+                      PYXIS_COMPLETE="true"
+                    else
+                      PYXIS_COMPLETE="false"
+                    fi
+                  fi
+                fi
+              fi
+            fi
+
+            ALL_CHECKS_PASSED="true"
+            if [ "${PYXIS_COMPLETE}" != "true" ]; then
+              ALL_CHECKS_PASSED="false"
+            fi
+            if [ "${FILE_UPDATES_REQUIRED}" = "true" ] && [ "${FILE_UPDATES_COMPLETE}" != "true" ]; then
+              ALL_CHECKS_PASSED="false"
+            fi
+
+            if [ "${ALL_CHECKS_PASSED}" == "true" ]; then
+                echo "Component ${COMPONENT_NAME}: FILTERED (Pyxis + fileUpdates complete)"
+                FILTERED_COUNT=$((FILTERED_COUNT + 1))
+                echo ""
+            else
+                if [ "${FILE_UPDATES_REQUIRED}" = "true" ] && [ "${FILE_UPDATES_COMPLETE}" != "true" ]; then
+                  keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (fileUpdates incomplete)"
+                else
+                  keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (Pyxis metadata incomplete)"
+                fi
+            fi
+        done
+
+        # Write filtered snapshot atomically using temp file
+        # Create temp file in same directory as snapshot to ensure atomic mv (same filesystem)
+        SNAPSHOT_DIR=$(dirname "${SNAPSHOT_FILE}")
+        
+        # Validate target directory before creating temp file
+        if [ ! -d "${SNAPSHOT_DIR}" ]; then
+          echo "Error: Snapshot directory does not exist: ${SNAPSHOT_DIR}"
+          exit 1
+        fi
+        if [ ! -w "${SNAPSHOT_DIR}" ]; then
+          echo "Error: Snapshot directory is not writable: ${SNAPSHOT_DIR}"
+          exit 1
+        fi
+        
+        TEMP_SNAPSHOT=$(mktemp "${SNAPSHOT_DIR}/.snapshot.XXXXXX")
+        
+        # Create filtered snapshot with error handling (work directly on file)
+        if ! jq --argjson comps "${FILTERED_COMPONENTS}" '.components = $comps' \
+          "${SNAPSHOT_FILE}" > "${TEMP_SNAPSHOT}"; then
+          echo "Error: Failed to create filtered snapshot with jq"
+          exit 1
+        fi
+        
+        # Validate temp file before moving
+        if [ ! -s "${TEMP_SNAPSHOT}" ]; then
+          echo "Error: Filtered snapshot file is empty"
+          exit 1
+        fi
+        
+        # Validate it's valid JSON
+        if ! jq -e '.' "${TEMP_SNAPSHOT}" >/dev/null 2>&1; then
+          echo "Error: Filtered snapshot is not valid JSON"
+          exit 1
+        fi
+        
+        # All checks passed, atomically replace the original
+        mv "${TEMP_SNAPSHOT}" "${SNAPSHOT_FILE}"
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "SUMMARY:"
+        echo "  Total components: ${COMPONENT_COUNT}"
+        echo "  Filtered (already released): ${FILTERED_COUNT}"
+        echo "  To be released: $((COMPONENT_COUNT - FILTERED_COUNT))"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Skip release if all components were filtered
+        if [ "${FILTERED_COUNT}" -eq "${COMPONENT_COUNT}" ]; then
+            echo -n "true" > "$(results.skip_release.path)"
+        else
+            echo -n "false" > "$(results.skip_release.path)"
+        fi
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          cpu: 250m
+          memory: 128Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+        - name: orasOptions
+          value: $(params.orasOptions)
+          

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
@@ -533,8 +533,56 @@ spec:
               IMAGE_COUNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
               echo "  Pyxis response: IMAGE_COUNT=${IMAGE_COUNT}"
               if [ "${IMAGE_COUNT}" -eq 0 ] 2>/dev/null; then
-                echo "No Pyxis entries found for ${COMPONENT_NAME}"
-                PYXIS_COMPLETE="false"
+                echo "No direct Pyxis entry found for ${COMPONENT_NAME} — trying manifest list resolution"
+                # The containerImage may be a manifest list (multi-arch OCI index).
+                # Pyxis stores per-arch image records by their individual arch digest,
+                # not by the manifest list digest. Resolve the manifest and query each arch.
+                # Use oras (with registry credentials) instead of anonymous curl so that
+                # private registries (e.g. quay.io/redhat-user-workloads-stage) are accessible.
+                ML_IMAGE_REF="${CONTAINER_IMAGE%@*}@${DIGEST}"
+                if ! timeout 30 select-oci-auth "${ML_IMAGE_REF}" > "${COMPONENT_AUTH_FILE}" 2>/dev/null || \
+                   [ ! -s "${COMPONENT_AUTH_FILE}" ]; then
+                  echo '{}' > "${COMPONENT_AUTH_FILE}"
+                fi
+                ML_MANIFEST=$(timeout 30 oras manifest fetch \
+                  --registry-config "${COMPONENT_AUTH_FILE}" \
+                  "${ML_IMAGE_REF}" 2>/dev/null || echo "{}")
+                ARCH_DIGESTS=$(echo "${ML_MANIFEST}" \
+                  | jq -r '.manifests[]?.digest // empty' 2>/dev/null || echo "")
+                if [ -n "${ARCH_DIGESTS}" ]; then
+                  echo "Manifest list detected — checking per-arch digests in Pyxis..."
+                  FOUND_ARCH="false"
+                  while IFS= read -r ARCH_D; do
+                    [ -z "${ARCH_D}" ] && continue
+                    ARCH_FILTER=$(printf '%s' "image_id==${ARCH_D}" | jq -sRr @uri)
+                    ARCH_HTTP=$(http_get_pyxis "${PYXIS_URL}v1/images?filter=${ARCH_FILTER}" \
+                      "${PYXIS_RESPONSE}" /etc/pyxis-secrets/cert /etc/pyxis-secrets/key)
+                    if [ "${ARCH_HTTP}" = "200" ]; then
+                      ARCH_CNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+                      if [ "${ARCH_CNT}" -gt 0 ] 2>/dev/null; then
+                        HAS_RPM_DATA=$(jq -r \
+                          '(.data[0].rpm_manifest.rpms // []) | length' \
+                          "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+                        if [ "${HAS_RPM_DATA}" -gt 0 ] 2>/dev/null; then
+                          echo "Arch ${ARCH_D}: found in Pyxis with ${HAS_RPM_DATA} rpms"
+                          FOUND_ARCH="true"
+                          break
+                        else
+                          echo "Arch ${ARCH_D}: found but rpm_manifest.rpms empty"
+                        fi
+                      fi
+                    fi
+                  done <<< "${ARCH_DIGESTS}"
+                  if [ "${FOUND_ARCH}" = "true" ]; then
+                    PYXIS_COMPLETE="true"
+                  else
+                    echo "No arch images found in Pyxis with RPM data for ${COMPONENT_NAME}"
+                    PYXIS_COMPLETE="false"
+                  fi
+                else
+                  echo "No Pyxis entries found for ${COMPONENT_NAME}"
+                  PYXIS_COMPLETE="false"
+                fi
               elif [ -z "${IMAGE_COUNT}" ]; then
                 echo "WARNING: Invalid Pyxis response for ${COMPONENT_NAME}"
                 PYXIS_COMPLETE="false"

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
@@ -10,7 +10,11 @@ spec:
   description: |-
     Tekton task to filter out images from a snapshot that have already been released.
     This task verifies:
-    - Pyxis metadata (always required)
+    - Pyxis metadata (always required): the image IS in Pyxis — found via image_id
+      (the manifest digest stored by create-pyxis-image). The query uses the Pyxis REST
+      API field `image_id`, NOT `docker_image_digest` (which does not exist in Pyxis records).
+      Additionally, rpm_manifest.rpms must be non-empty (populated by push-rpm-data-to-pyxis).
+      A record with no rpm_manifest or empty rpms does not count as a complete release.
     - fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
 
     The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
@@ -19,8 +23,13 @@ spec:
     The task overwrites the original snapshot file in place with a filtered version
     containing only components that still need release work.
 
-    This task expects a mapped snapshot (repositories/tags already resolved) from
-    trusted artifacts.
+    This task supports both Trusted Artifacts and PVC-based workflows (compliance):
+
+    - **Trusted Artifacts**: Leave workspace `data` unbound; set `sourceDataArtifact` and use default
+      `dataDir` (/var/workdir/release). Snapshot/data are pulled into an emptyDir and results pushed to OCI.
+    - **PVC-based**: Bind the optional workspace `data` to a PVC that already contains snapshot/data; set
+      `dataDir` to the workspace path (e.g. `/workspace/data/release`). Leave `sourceDataArtifact` empty;
+      `use-trusted-artifact` and `create-trusted-artifact` steps are skipped.
 
     Fail-safe behavior: The task fails only if Pyxis credentials are missing or
     pyxisServer is invalid. For all other issues (API errors, missing data, internal
@@ -41,10 +50,6 @@ spec:
       type: string
       default: "300"
       description: InternalRequest timeout (seconds) for the fileUpdates completion check
-    - name: synchronously
-      type: string
-      description: Whether to run internal requests synchronously or not
-      default: "true"
     - name: pipelineRunUid
       type: string
       description: The uid of the current PipelineRun. Used as a label value when creating internal requests
@@ -103,7 +108,9 @@ spec:
       description: Location of trusted artifacts to be used to populate data directory
       default: ""
     - name: dataDir
-      description: The location where data will be stored
+      description: |-
+        The location where data will be stored. In Trusted Artifacts mode use default;
+        in PVC mode set to the workspace path (e.g. /workspace/data/release)
       type: string
       default: /var/workdir/release
     - name: taskGitUrl
@@ -117,7 +124,13 @@ spec:
     - name: skip_release
       description: Whether to skip release tasks (true if all components are already released)
     - name: sourceDataArtifact
-      description: The location of the source data artifact in the OCI repository
+      description: The location of the source data artifact in the OCI repository (empty in PVC mode)
+  workspaces:
+    - name: data
+      optional: true
+      description: |
+        Optional. When bound (PVC-based workflow), snapshot/data are read from this workspace.
+        dataDir should point to the workspace path (e.g. /workspace/data/release).
   volumes:
     - name: workdir
       emptyDir: {}
@@ -150,6 +163,10 @@ spec:
       runAsUser: 1001
   steps:
     - name: use-trusted-artifact
+      when:
+        - input: $(params.sourceDataArtifact)
+          operator: notin
+          values: [""]
       computeResources:
         limits:
           cpu: 30m
@@ -215,7 +232,7 @@ spec:
           local cert_path="$3"
           local key_path="$4"
           local http_code
-          http_code=$(curl-with-retry --retry "${API_RETRY_COUNT}" --retry-all-errors \
+          http_code=$(curl --retry "${API_RETRY_COUNT}" --retry-all-errors \
             --connect-timeout "${API_CONNECT_TIMEOUT}" --max-time "${API_MAX_TIME}" -sS \
             "${CA_BUNDLE_ARGS[@]}" \
             --cert "${cert_path}" --key "${key_path}" \
@@ -351,7 +368,7 @@ spec:
                       -p file_updates_secret="${file_updates_secret}" \
                       -p taskGitUrl="$(params.taskGitUrl)" \
                       -p taskGitRevision="$(params.taskGitRevision)" \
-                      -s "$(params.synchronously)" \
+                      -s "true" \
                       -t "$(params.requestTimeout)" \
                       -l "${TASK_LABEL}=${TASK_ID}" \
                       -l "${REQUEST_LABEL}=${requestId}" \
@@ -495,11 +512,14 @@ spec:
               continue
             fi
             
-            # Encode the entire filter parameter value (including == operator)
-            FILTER_VALUE="docker_image_digest==${DIGEST}"
-            FILTER_ENCODED=$(jq -sRr @uri <<< "${FILTER_VALUE}")
+            # Query Pyxis by image_id (the manifest digest stored by create-pyxis-image).
+            # docker_image_digest is not a filterable field in the Pyxis API.
+            FILTER_VALUE="image_id==${DIGEST}"
+            FILTER_ENCODED=$(printf '%s' "${FILTER_VALUE}" | jq -sRr @uri)
             PYXIS_QUERY_URL="${PYXIS_URL}v1/images?filter=${FILTER_ENCODED}"
             echo "Querying Pyxis for ${COMPONENT_NAME}..."
+            echo "  Filter: ${FILTER_VALUE}"
+            echo "  Encoded: ${FILTER_ENCODED}"
             # Reuse temp file for this API call (overwrites previous content)
             PYXIS_HTTP_CODE=$(http_get_pyxis "${PYXIS_QUERY_URL}" "${PYXIS_RESPONSE}" \
               /etc/pyxis-secrets/cert /etc/pyxis-secrets/key)
@@ -511,6 +531,7 @@ spec:
               PYXIS_COMPLETE="false"
             else
               IMAGE_COUNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+              echo "  Pyxis response: IMAGE_COUNT=${IMAGE_COUNT}"
               if [ "${IMAGE_COUNT}" -eq 0 ] 2>/dev/null; then
                 echo "No Pyxis entries found for ${COMPONENT_NAME}"
                 PYXIS_COMPLETE="false"
@@ -518,53 +539,36 @@ spec:
                 echo "WARNING: Invalid Pyxis response for ${COMPONENT_NAME}"
                 PYXIS_COMPLETE="false"
               else
-                # Extract expected tags as JSON array (normalize objects to strings)
-                EXPECTED_TAGS_JSON=$(jq -c \
-                  '[.repositories[]?.tags[]? | if type == "object" then .name else . end] | 
-                   sort | unique' \
-                  <<< "${COMPONENT}" 2>/dev/null || echo "[]")
-                EXPECTED_TAG_COUNT=$(jq 'length' <<< "${EXPECTED_TAGS_JSON}")
-                
-                if [ "${EXPECTED_TAG_COUNT}" -eq 0 ] 2>/dev/null; then
-                  echo "WARNING: No expected tags found for ${COMPONENT_NAME}"
-                  PYXIS_COMPLETE="false"
+                # Require evidence of full release:
+                # rpm_manifest.rpms must be non-empty (populated by push-rpm-data-to-pyxis).
+                # A record with no rpm_manifest or empty rpms means push-rpm-data-to-pyxis
+                # has not yet completed, so keep the component for reprocessing.
+                HAS_RPM_DATA=$(jq -r \
+                  '(.data[0].rpm_manifest.rpms // []) | length' \
+                  "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+                if [ "${HAS_RPM_DATA}" -gt 0 ] 2>/dev/null; then
+                  echo "Image found in Pyxis for ${COMPONENT_NAME} with RPM data (${HAS_RPM_DATA} rpms)"
+                  PYXIS_COMPLETE="true"
                 else
-                  # Extract Pyxis tags as JSON array (normalize objects to strings)
-                  PYXIS_TAGS_JSON=$(jq -c \
-                    '[.data[]?.repositories[]?.tags[]? | if type == "object" then .name else . end] | 
-                     sort | unique' \
-                    "${PYXIS_RESPONSE}" 2>/dev/null || echo "[]")
-                  
-                  # Compute missing tags: expected - pyxis (set difference)
-                  MISSING_TAGS_JSON=$(jq -c --argjson expected "${EXPECTED_TAGS_JSON}" \
-                    --argjson pyxis "${PYXIS_TAGS_JSON}" \
-                    -n '$expected - $pyxis' 2>/dev/null || echo "[]")
-                  MISSING_TAG_COUNT=$(jq 'length' <<< "${MISSING_TAGS_JSON}" 2>/dev/null || echo "1")
-                  
-                  if [ "${MISSING_TAG_COUNT}" -gt 0 ] 2>/dev/null; then
-                    echo "Pyxis missing tags for ${COMPONENT_NAME}: $(jq -r 'join(", ")' <<< "${MISSING_TAGS_JSON}")"
-                    PYXIS_COMPLETE="false"
-                  else
-                    # All tags present, check for RPM data
-                    HAS_RPM_DATA=$(jq -r '[.data[]?.repositories[]?.content_sets // [] | length] | max // 0' \
-                      "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
-                    if [ "${HAS_RPM_DATA}" -gt 0 ] 2>/dev/null; then
-                      PYXIS_COMPLETE="true"
-                    else
-                      PYXIS_COMPLETE="false"
-                    fi
-                  fi
+                  echo "Pyxis record for ${COMPONENT_NAME} has no RPM data (push-rpm-data-to-pyxis incomplete)"
+                  PYXIS_COMPLETE="false"
                 fi
               fi
+              echo "  PYXIS_COMPLETE=${PYXIS_COMPLETE}"
             fi
 
             ALL_CHECKS_PASSED="true"
             if [ "${PYXIS_COMPLETE}" != "true" ]; then
               ALL_CHECKS_PASSED="false"
+              echo "  → Check failed: PYXIS_COMPLETE=${PYXIS_COMPLETE}"
             fi
             if [ "${FILE_UPDATES_REQUIRED}" = "true" ] && [ "${FILE_UPDATES_COMPLETE}" != "true" ]; then
               ALL_CHECKS_PASSED="false"
+              echo "  → Check failed: FILE_UPDATES_REQUIRED=${FILE_UPDATES_REQUIRED}," \
+                "FILE_UPDATES_COMPLETE=${FILE_UPDATES_COMPLETE}"
             fi
+            
+            echo "  Decision: ALL_CHECKS_PASSED=${ALL_CHECKS_PASSED}"
 
             if [ "${ALL_CHECKS_PASSED}" == "true" ]; then
                 echo "Component ${COMPONENT_NAME}: FILTERED (Pyxis + fileUpdates complete)"
@@ -631,6 +635,10 @@ spec:
             echo -n "false" > "$(results.skip_release.path)"
         fi
     - name: create-trusted-artifact
+      when:
+        - input: $(params.sourceDataArtifact)
+          operator: notin
+          values: [""]
       computeResources:
         limits:
           cpu: 250m

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mocks to be injected into task step scripts
+
+function select-oci-auth() {
+  # Return empty auth config (all registries are accessible in tests)
+  echo '{}'
+  return 0
+}
+
+function curl() {
+  # Mock curl for testing
+  local output_file=""
+  local url=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o)
+        output_file="$2"
+        shift 2
+        ;;
+      -w|--retry|--connect-timeout|--max-time)
+        shift 2
+        ;;
+      --config|--cert|--key|--cacert)
+        shift 2
+        ;;
+      -sS|--retry-all-errors|-s|-S)
+        shift 1
+        ;;
+      *)
+        # Last non-flag argument is the URL
+        if [[ ! "$1" =~ ^- ]]; then
+          url="$1"
+        fi
+        shift 1
+        ;;
+    esac
+  done
+
+  local json_response="[]"
+  case "$url" in
+    *"pyxis.api.redhat.com/v1/images?filter=docker_image_digest%3D%3Dsha256%3Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"*)
+      json_response='{"data":[{"repositories":[{"tags":["latest","v1"],"content_sets":["rhel-9-for-x86_64-appstream-rpms"]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=docker_image_digest%3D%3D"*)
+      json_response='{"data":[]}'
+      ;;
+  esac
+
+  if [ -n "$output_file" ]; then
+    echo "$json_response" > "$output_file"
+  else
+    echo "$json_response"
+  fi
+
+  printf "%s" "200"
+}
+
+function curl-with-retry() {
+  curl "$@"
+}
+
+function oras() {
+  if [[ "$1" != "resolve" ]]; then
+    echo "Error: only 'oras resolve' is mocked" >&2
+    return 1
+  fi
+  
+  # Extract image reference (last argument)
+  local image_ref="${*: -1}"
+  
+  case "$image_ref" in
+    *"@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      return 0
+      ;;
+    *)
+      # Default: return the digest from the reference
+      if [[ "$image_ref" =~ @(sha256:[a-f0-9]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+      fi
+      echo "Error: manifest unknown: manifest unknown" >&2
+      return 1
+      ;;
+  esac
+}
+
+function internal-request() {
+  # Mock internal-request for fileUpdates completion checks.
+  # The task retrieves the InternalRequest object via kubectl labels, so this only
+  # needs to return success.
+  echo "internalrequests.appstudio.redhat.com 'mock-ir' created"
+  return 0
+}
+
+function kubectl() {
+  # Mock only the InternalRequest lookup used by the filter task.
+  #
+  # Expected shape:
+  # kubectl get internalrequest -l ... -o jsonpath='{.items[0]}' --sort-by=...
+  if [ "${1:-}" = "get" ] && [ "${2:-}" = "internalrequest" ]; then
+    local complete="true"
+    if [ -n "${DATA_FILE:-}" ] && [ -f "${DATA_FILE}" ]; then
+      complete="$(
+        jq -r 'if has("mock_file_updates_complete") then .mock_file_updates_complete else true end' \
+          "${DATA_FILE}" 2>/dev/null || echo "true"
+      )"
+    fi
+
+    jq -nc --arg complete "${complete}" '
+      {
+        status: {
+          results: {
+            result: "Success",
+            file_updates_complete: ($complete == "true")
+          }
+        }
+      }
+    '
+    return 0
+  fi
+
+  echo "Error: unexpected kubectl call: $*" >&2
+  return 1
+}

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 # mocks to be injected into task step scripts
+#
+# Pyxis query strategy (confirmed against real Pyxis stage API, March 2026):
+# - The image IS in Pyxis — found via image_id (the manifest digest stored by create-pyxis-image).
+# - Query field: image_id == sha256:...  (NOT docker_image_digest — that field does not exist)
+# - Completeness signal: rpm_manifest.rpms must be non-empty (populated by push-rpm-data-to-pyxis)
+# - URL-encoded filter: image_id%3D%3Dsha256%3A...
 
 function select-oci-auth() {
   # Return empty auth config (all registries are accessible in tests)
@@ -40,11 +46,21 @@ function curl() {
   done
 
   local json_response="[]"
+  # Pyxis API: query by image_id (the manifest digest). Completeness check uses rpm_manifest.rpms.
   case "$url" in
-    *"pyxis.api.redhat.com/v1/images?filter=docker_image_digest%3D%3Dsha256%3Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"*)
-      json_response='{"data":[{"repositories":[{"tags":["latest","v1"],"content_sets":["rhel-9-for-x86_64-appstream-rpms"]}]}]}'
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"*)
+      # Full release: image_id found AND rpm_manifest.rpms non-empty → component filtered out
+      json_response='{"data":[{"image_id":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","rpm_manifest":{"rpms":[{"name":"bash"}]},"repositories":[{"tags":[{"name":"latest"},{"name":"v1"}]}]}]}'
       ;;
-    *"pyxis.api.redhat.com/v1/images?filter=docker_image_digest%3D%3D"*)
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Ab"*)
+      # Partial: image found but rpm_manifest.rpms empty → push-rpm-data-to-pyxis incomplete → keep
+      json_response='{"data":[{"image_id":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","rpm_manifest":{"rpms":[]},"repositories":[{"tags":[{"name":"latest"}]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Ac"*)
+      # Partial: image found but no rpm_manifest at all → push-rpm-data-to-pyxis never ran → keep
+      json_response='{"data":[{"image_id":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","repositories":[{"tags":[{"name":"latest"}]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3D"*)
       json_response='{"data":[]}'
       ;;
   esac
@@ -74,6 +90,14 @@ function oras() {
   case "$image_ref" in
     *"@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
       echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      return 0
+      ;;
+    *"@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+      echo "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      return 0
+      ;;
+    *"@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"*)
+      echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
       return 0
       ;;
     *)

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/pre-apply-task-hook.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate required argument
+if [ $# -ne 1 ]; then
+  echo "Error: Missing required argument TASK_PATH" >&2
+  echo "Usage: $0 <path-to-task.yaml>" >&2
+  exit 1
+fi
+
+TASK_PATH="$1"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Validate TASK_PATH exists
+if [ ! -f "${TASK_PATH}" ]; then
+  echo "Error: Task file not found: ${TASK_PATH}" >&2
+  exit 1
+fi
+
+# Add mocks to the beginning of the filter step script (standard approach)
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Create test secrets (delete first if they exist)
+kubectl delete secret pyxis --ignore-not-found
+kubectl create secret generic pyxis \
+  --from-literal=cert="mock-cert" \
+  --from-literal=key="mock-key"

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
@@ -1,0 +1,201 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-complete
+spec:
+  description: |
+    Verify the filter filters components when Pyxis and fileUpdates checks pass.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mock_file_updates_complete": true,
+                "fileUpdates": [
+                  {
+                    "repo": "https://gitlab.com/test/project.git"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected component to be filtered, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
@@ -5,7 +5,8 @@ metadata:
   name: test-filter-by-pyxis-file-updates-complete
 spec:
   description: |
-    Verify the filter filters components when Pyxis and fileUpdates checks pass.
+    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
+    AND fileUpdates are complete. The component must be FILTERED OUT (skip_release=true).
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-incomplete.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-incomplete.yaml
@@ -1,0 +1,201 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-incomplete
+spec:
+  description: |
+    Verify the filter does not filter components when fileUpdates are configured but incomplete.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mock_file_updates_complete": false,
+                "fileUpdates": [
+                  {
+                    "repo": "https://gitlab.com/test/project.git"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be kept, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
@@ -5,7 +5,8 @@ metadata:
   name: test-filter-by-pyxis-file-updates-no-fileupdates
 spec:
   description: |
-    Verify the filter does not fail when fileUpdates is missing.
+    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
+    and no fileUpdates are configured. The component must be FILTERED OUT (skip_release=true).
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
@@ -1,0 +1,199 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-no-fileupdates
+spec:
+  description: |
+    Verify the filter does not fail when fileUpdates is missing.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected all components to be filtered, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-no-rpm-manifest.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-no-rpm-manifest.yaml
@@ -2,34 +2,21 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-by-pyxis-file-updates-incomplete
+  name: test-filter-by-pyxis-incomplete-no-rpm-manifest
 spec:
   description: |
-    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
-    but fileUpdates are configured and NOT yet complete. The component must be KEPT
-    (skip_release=false) because the full release pipeline is not done.
+    When Pyxis returns an image with no rpm_manifest at all (push-rpm-data-to-pyxis
+    never ran), the component must be kept. skip_release must be false.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
-    - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
-      type: string
-      default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -67,36 +54,21 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eu
-
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "componentGroup": "test-app",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                    "repositories": [
-                      {
-                        "url": "quay.io/redhat-pending/comp1",
-                        "tags": ["latest", "v1"]
-                      }
-                    ]
+                    "containerImage": "quay.io/test/comp1@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    "repositories": [{ "url": "quay.io/redhat-pending/comp1", "tags": ["latest"] }]
                   }
                 ]
               }
               EOF
-
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
-              {
-                "mock_file_updates_complete": false,
-                "fileUpdates": [
-                  {
-                    "repo": "https://gitlab.com/test/project.git"
-                  }
-                ]
-              }
+              { "pyxis": { "secret": "pyxis", "server": "production" } }
               EOF
           - name: create-trusted-artifact
             ref:
@@ -183,21 +155,18 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
-          - name: check-filtered-snapshot
+          - name: check-component-kept
             image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eu
-
               FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-
               if [ "${COUNT}" -ne 1 ]; then
-                echo "ERROR: Expected component to be kept, found ${COUNT}"
+                echo "ERROR: Expected component to be kept (no rpm_manifest), found ${COUNT} components"
                 exit 1
               fi
-
-              if [ "$(params.skipRelease)" != "false" ]; then
-                echo "ERROR: Expected skip_release=false"
+              if [ "$(params.skipRelease)" = "true" ]; then
+                echo "ERROR: Expected skip_release=false when Pyxis record has no rpm_manifest"
                 exit 1
               fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-rpms-empty.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-rpms-empty.yaml
@@ -2,34 +2,22 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-by-pyxis-file-updates-incomplete
+  name: test-filter-by-pyxis-incomplete-rpms-empty
 spec:
   description: |
-    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
-    but fileUpdates are configured and NOT yet complete. The component must be KEPT
-    (skip_release=false) because the full release pipeline is not done.
+    The image IS in Pyxis — found via image_id — but rpm_manifest.rpms is empty
+    (push-rpm-data-to-pyxis ran but wrote no RPMs). The component must be KEPT
+    because the release is not complete. skip_release must be false.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
-    - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
-      type: string
-      default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -67,36 +55,21 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -eu
-
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "componentGroup": "test-app",
                 "components": [
                   {
                     "name": "comp1",
-                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                    "repositories": [
-                      {
-                        "url": "quay.io/redhat-pending/comp1",
-                        "tags": ["latest", "v1"]
-                      }
-                    ]
+                    "containerImage": "quay.io/test/comp1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "repositories": [{ "url": "quay.io/redhat-pending/comp1", "tags": ["latest"] }]
                   }
                 ]
               }
               EOF
-
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
-              {
-                "mock_file_updates_complete": false,
-                "fileUpdates": [
-                  {
-                    "repo": "https://gitlab.com/test/project.git"
-                  }
-                ]
-              }
+              { "pyxis": { "secret": "pyxis", "server": "production" } }
               EOF
           - name: create-trusted-artifact
             ref:
@@ -183,21 +156,18 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
-          - name: check-filtered-snapshot
+          - name: check-component-kept
             image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eu
-
               FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-
               if [ "${COUNT}" -ne 1 ]; then
-                echo "ERROR: Expected component to be kept, found ${COUNT}"
+                echo "ERROR: Expected component to be kept (empty rpm_manifest.rpms), found ${COUNT} components"
                 exit 1
               fi
-
-              if [ "$(params.skipRelease)" != "false" ]; then
-                echo "ERROR: Expected skip_release=false"
+              if [ "$(params.skipRelease)" = "true" ]; then
+                echo "ERROR: Expected skip_release=false when Pyxis record has empty rpm_manifest.rpms"
                 exit 1
               fi


### PR DESCRIPTION
## Describe your changes

- Added a new task filter-already-released-by-pyxis-and-file-updates to filter
  snapshot components based on Pyxis metadata completion and optional file-updates
  verification, with fail-safe behavior that keeps components on verification issues.
- Updated rh-push-to-registry-redhat-io to use the new task.

## Relevant Jira
[RELEASE-1265](https://issues.redhat.com/browse/RELEASE-1265)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


Assisted-by: Cursor
