### PR TITLE
refactor(RELEASE-2144): make idempotancy conditions explicit

### DIFF
--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -375,6 +375,9 @@ spec:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
           values: ["true"]
+        - input: "$(tasks.filter-already-released-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -410,6 +413,10 @@ spec:
         - collect-task-params
     - name: push-rpm-data-to-pyxis
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-images.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
## Describe your changes
Added `when: skip_release=false` condition to two tasks:
1. create-pyxis-image
2. push-rpm-data-to-pyxis

Currently these tasks skip implicitly (because upstream task results are missing). This change makes the skip behavior explicit and easier to understand.

## Relevant Jira
[RELEASE-2144](https://issues.redhat.com/browse/RELEASE-2144)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
