### PR TITLE
refactor(RELEASE-2009): convert e2e test to python

### DIFF
--- a/integration-tests/docs/python-e2e-spike-summary.md
+++ b/integration-tests/docs/python-e2e-spike-summary.md
@@ -1,0 +1,156 @@
+# Python E2E Testing Spike Summary
+
+## Overview
+
+This document summarizes findings from implementing a Python-based E2E testing solution for the release-service-catalog, migrating the existing `integration-tests/e2e` bash test as a proof of concept.
+
+## Framework Selection
+
+### Chosen Stack
+
+| Component | Library | Purpose |
+|-----------|---------|---------|
+| Test Framework | **pytest** | Industry standard, excellent fixture system, rich plugin ecosystem |
+| Async Support | **pytest-asyncio** | Native async/await for concurrent K8s operations |
+| Kubernetes | **kubernetes (official client)** | Direct API access for status monitoring |
+| GitHub API | **PyGithub** | Official GitHub library for repo/PR operations |
+| Configuration | **pydantic-settings** | Type-safe config with environment variable loading |
+| Retries | **tenacity** | Robust retry logic with exponential backoff |
+
+### Why pytest?
+
+- **Fixtures**: Session-scoped fixtures naturally map to test lifecycle (setup → test → cleanup)
+- **Async support**: `pytest-asyncio` enables concurrent waits (e.g., multiple Releases)
+- **CI integration**: Native JUnit XML output, easy integration with Tekton tasks
+- **Extensibility**: Plugin ecosystem for timeouts, coverage, parallel execution
+
+### Alternatives Considered
+
+| Framework | Verdict |
+|-----------|---------|
+| `behave` (BDD) | Overkill for our needs; Gherkin adds overhead without clear benefit |
+| `pytest-operator` | Designed for Juju/Charmed operators, not Tekton |
+| `robot framework` | Keyword-driven approach less suitable for infrastructure tests |
+
+## Architecture
+
+```
+integration-tests/
+├── pylib/                    # Shared Python library
+│   ├── config.py             # Base configuration class
+│   ├── conftest_base.py      # Generic pytest fixtures
+│   ├── github.py             # GitHub API client
+│   ├── kubernetes.py         # Kubernetes client + status monitoring
+│   ├── resources.py          # Kustomize + resource management
+│   ├── runner.py             # Test runner utilities
+│   ├── utils.py              # Logging, retries, shell commands
+│   ├── vault.py              # Ansible Vault decryption
+│   └── requirements.txt      # Python dependencies
+│
+├── e2e/                      # Migrated test suite
+│   ├── conftest.py           # Imports generic fixtures, defines test_config
+│   ├── lib/config.py         # E2E-specific configuration
+│   ├── run_test.py           # Entry point (replaces test.sh)
+│   ├── test_e2e.py           # Actual test assertions
+│   ├── test.env              # Resource names (unchanged from bash)
+│   └── resources/            # Kustomize overlays (unchanged)
+│
+└── <other-suites>/           # Future migrations (same pattern)
+```
+
+## Key Capabilities
+
+### 1. Kubernetes/Tekton Interaction
+
+```python
+# Direct API access for status monitoring
+k8s_client = KubernetesClient()
+status = await k8s_client.wait_for_release_completion(name, namespace, timeout=1800)
+
+# kubectl for YAML operations (simpler than native client for CRDs)
+await k8s_client.kubectl_yaml("create", yaml_content, namespace)
+```
+
+**Approach**: Hybrid - use `kubectl` for apply/create/delete (handles CRDs without schema), official client for status polling.
+
+### 2. Resource Management
+
+- **Kustomize**: Existing overlays work unchanged
+- **Variable substitution**: Python `re.sub` replaces `envsubst`
+- **Cleanup**: Fixture finalizers ensure cleanup even on test failure
+
+### 3. Test Environment
+
+- **Configuration**: Pydantic models with environment variable loading
+- **Secrets**: Ansible Vault decryption (unchanged from bash)
+- **Isolation**: UUID-based resource naming prevents collisions
+
+### 4. GitHub Integration
+
+```python
+github_client = GitHubClient(token)
+await copy_branch_to_repo(source_repo, target_repo, branch)
+pr = await github_client.create_pull_request(repo, title, head, base)
+result = await github_client.merge_pull_request(repo, pr_number)
+```
+
+## Comparison: Bash vs Python
+
+| Aspect | Bash | Python |
+|--------|------|--------|
+| **Readability** | Scripts grow unwieldy | Clear structure, type hints |
+| **Error handling** | `set -e` + manual checks | Exceptions, structured errors |
+| **Async operations** | Background jobs, `wait` | Native async/await |
+| **Test reporting** | Manual output parsing | JUnit XML, pytest plugins |
+| **Debugging** | echo statements | IDE debugging, stack traces |
+| **Reusability** | Source scripts | Import modules |
+| **Dependencies** | System tools | pip + venv |
+
+## Trade-offs
+
+### Advantages of Python
+
+1. **Maintainability**: Type hints, IDE support, clear structure
+2. **Concurrent waits**: `asyncio.gather()` for multiple Releases
+3. **Better error messages**: Stack traces with context
+4. **Fixture system**: Declarative setup/teardown with dependency injection
+5. **Extensibility**: Easy to add new assertions, reporters
+
+### Disadvantages
+
+1. **venv management**: Additional setup step vs bash
+2. **Debugging async**: Async stack traces can be confusing
+
+## Recommendations
+
+### Phase 1: Stabilize e2e Migration
+- [x] Complete e2e migration (done in this spike)
+- [ ] Run in CI alongside bash version to validate parity
+- [ ] Document any behavioral differences
+
+### Phase 2: Migrate Additional Suites
+
+### Phase 3: Deprecate Bash
+- Remove bash versions once Python equivalents are validated
+- Keep `lib/test-functions.sh` for any remaining bash utilities
+
+### Not Recommended
+- Using native Python K8s client for CRD YAML operations (kubectl is simpler)
+- Adding BDD/Gherkin layer (unnecessary complexity)
+
+## Files Created/Modified
+
+### New Files (pylib/)
+- `config.py`, `conftest_base.py`, `github.py`, `kubernetes.py`
+- `resources.py`, `runner.py`, `utils.py`, `vault.py`
+- `requirements.txt`, `pytest.ini`, `__init__.py`
+
+### New Files (e2e/)
+- `conftest.py`, `lib/config.py`, `run_test.py`, `test_e2e.py`
+- `lib/__init__.py`, `__init__.py`
+
+### Unchanged
+- `test.env`, `resources/` directory, `vault/` directory
+
+### Can Be Removed (after validation)
+- `test.sh` (replaced by `run_test.py`)

--- a/integration-tests/e2e/README.md
+++ b/integration-tests/e2e/README.md
@@ -1,13 +1,29 @@
-# simple e2e test
+# Simple E2E Test
+
 ## Setup
+
 ### Dependencies
+
 * GitHub repo: https://github.com/hacbs-release-tests/e2e-base
 * GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
 * The password to the vault files. (Contact a member of the Release team should you want to run this
   test suite.)
 * Access to the target cluster and tenant and managed namespaces
   * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
+
+### Python Requirements
+
+```bash
+# Create and activate a virtual environment (recommended)
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies from the shared library
+pip install -r ../pylib/requirements.txt
+```
+
 ### Required Environment Variables
+
 - GITHUB_TOKEN
   - The GitHub personal access token needed for repo operations
   - The repo in question can be located in [test.env](test.env)
@@ -20,28 +36,49 @@
 - RELEASE_CATALOG_GIT_REVISION
   - The release service catalog revision to use in the RPA
   - This is provided when testing PRs
+
 ### Optional Environment Variables
+
 - KUBECONFIG
   - The KUBECONFIG file to used to login to the target cluster
-  - This is provided when testing PRs 
+  - This is provided when testing PRs
+
 ### Test Properties
+
 #### [test.env](test.env)
+
 - This file contains resource names and configuration values needed for testing.
 - Since this test requires internal services, the tenant and managed namespaces
   should remain as-is.
-#### [test.sh](test.sh)
-- This file contains specific variables and functions needed for the test.
+
+#### [lib/config.py](lib/config.py)
+
+- This file contains test-specific Python configuration that extends the base config.
+
 ### Test Functions
-#### [lib/test-functions.sh](../lib/test-functions.sh)
-- This file contains re-usable functions for tests
+
+#### [../pylib/](../pylib/)
+
+- This directory contains re-usable Python functions for tests.
+
 ### Secrets
+
 - Secrets needed for testing are stored in ansible vault files.
   - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
   - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
 - The secrets required are contained in the files above.
-### Running the test
 
-```shell
+## Running the Test
+
+### Using Python (Recommended)
+
+```bash
+./run_test.py
+```
+
+### Using Bash (Legacy)
+
+```bash
 ../run-test.sh e2e
 ```
 
@@ -50,20 +87,22 @@
 There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
 after a test has ended.
 
-### Maintenance
+## Maintenance
+
 - Should you require to add or update a secret, follow these steps:
-```shell
+
+```bash
 ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" --vault-password-file <vault password file>
 ```
 
-```shell
+```bash
 vi /tmp/tenant-secrets.yaml
 ```
 
-```shell
+```bash
 ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" --vault-password-file <vault password file>
 ```
 
-```shell
+```bash
 rm /tmp/tenant-secrets.yaml
 ```

--- a/integration-tests/e2e/__init__.py
+++ b/integration-tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test suite for Release Service Catalog."""

--- a/integration-tests/e2e/conftest.py
+++ b/integration-tests/e2e/conftest.py
@@ -1,0 +1,43 @@
+"""
+Pytest configuration for E2E tests.
+
+Imports generic fixtures from the shared library and adds e2e-specific config.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add integration-tests directory to path
+suite_dir_path = Path(__file__).parent
+integration_tests_dir = suite_dir_path.parent
+sys.path.insert(0, str(integration_tests_dir))
+
+# Import all generic fixtures from shared library
+from pylib.conftest_base import *  # noqa: F401, F403
+
+# Import e2e-specific config
+from e2e.lib.config import E2EConfig
+
+from pylib.utils import log_info
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Log when test session starts."""
+    log_info("Starting E2E test session...")
+
+
+@pytest.fixture(scope="session")
+def suite_dir() -> Path:
+    """Return the path to the e2e test suite directory."""
+    return Path(__file__).parent
+
+
+@pytest.fixture(scope="session")
+def test_config(suite_dir: Path, skip_cleanup: bool) -> E2EConfig:
+    """Load e2e test configuration."""
+    config = E2EConfig.from_test_env(suite_dir)
+    config.cleanup = not skip_cleanup
+    log_info(f"E2E test configuration loaded with UUID: {config.uuid}")
+    return config

--- a/integration-tests/e2e/lib/__init__.py
+++ b/integration-tests/e2e/lib/__init__.py
@@ -1,0 +1,9 @@
+"""
+E2E Test-Specific Library
+
+This module extends the shared library with e2e-specific configuration.
+"""
+
+from .config import E2EConfig
+
+__all__ = ["E2EConfig"]

--- a/integration-tests/e2e/lib/config.py
+++ b/integration-tests/e2e/lib/config.py
@@ -1,0 +1,33 @@
+"""
+E2E Test Configuration.
+
+Extends the base configuration with e2e-specific settings.
+"""
+
+import sys
+from pathlib import Path
+
+# Add integration-tests directory to path
+integration_tests_dir = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(integration_tests_dir))
+
+from pylib.config import TestConfigBase
+
+
+class E2EConfig(TestConfigBase):
+    """
+    E2E test configuration.
+
+    This simple test just verifies the basic release workflow works.
+    """
+
+    # E2E-specific defaults
+    originating_tool: str = "simple-e2e-test"
+    component_type: str = "simple-e2e"
+    component_base_branch: str = "simple-e2e-base"
+    component_base_repo_name: str = "hacbs-release-tests/e2e-base"
+
+    @property
+    def application_name(self) -> str:
+        """Application name - matches bash test.env pattern."""
+        return f"e2e-app-{self.uuid}"

--- a/integration-tests/e2e/run_test.py
+++ b/integration-tests/e2e/run_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+E2E Test Runner
+
+Usage:
+    ./run_test.py                    # Run the test
+    ./run_test.py --skip-cleanup     # Skip cleanup after test
+    ./run_test.py -v                 # Verbose output
+"""
+
+import sys
+from pathlib import Path
+
+# Add integration-tests directory to path for pylib imports
+script_dir = Path(__file__).parent
+integration_tests_dir = script_dir.parent
+sys.path.insert(0, str(integration_tests_dir))
+
+from pylib.runner import check_environment, create_argument_parser, run_pytest
+
+
+def main() -> int:
+    parser = create_argument_parser("Run E2E test for Release Service Catalog")
+    args = parser.parse_args()
+
+    if not check_environment():
+        return 1
+
+    return run_pytest(
+        test_file=script_dir / "test_e2e.py",
+        suite_dir=script_dir,
+        skip_cleanup=args.skip_cleanup,
+        verbose=args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integration-tests/e2e/test_e2e.py
+++ b/integration-tests/e2e/test_e2e.py
@@ -1,0 +1,84 @@
+"""
+E2E Test for Release Service Catalog
+
+This test verifies the complete release workflow:
+1. Create GitHub repository from template
+2. Create Kubernetes resources (Application, Component, ReleasePlan, etc.)
+3. Wait for Component initialization (PAC creates PR)
+4. Merge the PR to trigger build
+5. Wait for PipelineRun to complete
+6. Wait for Release to be created and complete
+7. Verify Release contents
+
+Usage:
+    ./run_test.py
+    ./run_test.py --skip-cleanup  # Keep resources for debugging
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add integration-tests directory to path
+integration_tests_dir = Path(__file__).parent.parent
+sys.path.insert(0, str(integration_tests_dir))
+
+from pylib.kubernetes import KubernetesClient
+from pylib.utils import log_info
+
+# Import e2e config
+from e2e.lib.config import E2EConfig
+
+
+@pytest.mark.asyncio
+async def test_e2e_release(
+    k8s_client: KubernetesClient,
+    test_config: E2EConfig,
+    completed_releases: list[str],
+) -> None:
+    """
+    End-to-end test for the simple release pipeline.
+
+    This test relies on fixtures to perform the setup steps:
+    - Create GitHub repository
+    - Create Kubernetes resources
+    - Wait for component initialization
+    - Merge PR
+    - Wait for PipelineRun completion
+    - Wait for Release completion
+
+    The test then verifies the Release contents are correct.
+    """
+    log_info("Verifying release contents...")
+
+    assert completed_releases, "No releases were created"
+
+    for release_name in completed_releases:
+        log_info(f"Verifying Release {release_name} in namespace {test_config.tenant_namespace}")
+
+        release = await k8s_client.get_release(
+            release_name,
+            test_config.tenant_namespace,
+        )
+
+        assert release is not None, f"Release {release_name} not found"
+
+        # Verify release succeeded
+        status = await k8s_client.get_release_status(
+            release_name,
+            test_config.tenant_namespace,
+        )
+
+        assert status.succeeded, (
+            f"Release {release_name} failed: {status.reason} - {status.message}"
+        )
+
+        # Log release details
+        release_json = json.dumps(release, indent=2)
+        log_info(f"Release JSON: {release_json}")
+
+        log_info(f"✅ All release checks passed for {release_name}")
+
+    log_info("✅ Success!")

--- a/integration-tests/pylib/__init__.py
+++ b/integration-tests/pylib/__init__.py
@@ -1,0 +1,56 @@
+"""
+Shared Python Library for Integration Tests
+
+This module provides reusable utilities for all integration test suites:
+- Kubernetes client operations
+- GitHub API interactions
+- Secret management
+- Resource building and management
+- Logging and retry utilities
+- Reusable pytest fixtures
+
+Usage:
+    from pylib import KubernetesClient, GitHubClient, TestConfigBase
+
+For fixtures in conftest.py:
+    from pylib.conftest_base import *  # Import all generic fixtures
+"""
+
+from .config import TestConfigBase
+from .github import GitHubClient, copy_branch_to_repo, delete_repository
+from .kubernetes import KubernetesClient, ResourceStatus
+from .resources import ResourceManager, build_kustomize_resources
+from .vault import cleanup_decrypted_secrets, decrypt_secrets
+from .utils import (
+    log_error,
+    log_info,
+    log_warning,
+    run_command,
+    run_with_retry,
+    wait_for_condition,
+)
+
+__all__ = [
+    # Config
+    "TestConfigBase",
+    # Kubernetes
+    "KubernetesClient",
+    "ResourceStatus",
+    # GitHub
+    "GitHubClient",
+    "copy_branch_to_repo",
+    "delete_repository",
+    # Resources
+    "ResourceManager",
+    "build_kustomize_resources",
+    # Secrets
+    "decrypt_secrets",
+    "cleanup_decrypted_secrets",
+    # Utils
+    "log_info",
+    "log_error",
+    "log_warning",
+    "wait_for_condition",
+    "run_command",
+    "run_with_retry",
+]

--- a/integration-tests/pylib/config.py
+++ b/integration-tests/pylib/config.py
@@ -1,0 +1,193 @@
+"""
+Base test configuration management.
+
+Provides a base configuration class that test suites can extend
+with their specific settings.
+"""
+
+import os
+import secrets
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+def generate_uuid() -> str:
+    """Generate an 8-character hex UUID."""
+    return secrets.token_hex(4)
+
+
+class TestConfigBase(BaseSettings):
+    """
+    Base test configuration loaded from environment variables.
+
+    Test suites should subclass this and add their specific configuration.
+
+    Example:
+        class FBCReleaseConfig(TestConfigBase):
+            # FBC-specific settings
+            fbc_fragment_image: str = "quay.io/..."
+            target_index: str = "..."
+    """
+
+    # Generated at runtime
+    uuid: str = Field(default_factory=generate_uuid)
+
+    # Core environment variables (required for all tests)
+    github_token: str = Field(alias="GITHUB_TOKEN")
+    vault_password_file: str = Field(alias="VAULT_PASSWORD_FILE")
+    release_catalog_git_url: str = Field(alias="RELEASE_CATALOG_GIT_URL")
+    release_catalog_git_revision: str = Field(alias="RELEASE_CATALOG_GIT_REVISION")
+
+    # Optional environment variables
+    kubeconfig: Optional[str] = Field(default=None, alias="KUBECONFIG")
+    pr_number: Optional[str] = Field(default=None, alias="PR_NUMBER")
+
+    # Common test configuration with sensible defaults
+    originating_tool: str = "integration-test"
+    tenant_namespace: str = "dev-release-team-tenant"
+    managed_namespace: str = "managed-release-team-tenant"
+
+    # Component configuration (can be overridden by subclasses)
+    component_type: str = "test"
+    component_github_org: str = "hacbs-release-tests"
+    component_base_branch: str = "main"
+    component_base_repo_name: str = ""
+
+    # Runtime options
+    cleanup: bool = True
+    no_cve: bool = True  # Default to skipping CVE; tests that need CVE set this to False
+
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
+
+    @property
+    def application_name(self) -> str:
+        """Application name with UUID suffix."""
+        return f"{self.component_type}-app-{self.uuid}"
+
+    @property
+    def component_name(self) -> str:
+        """Component name with UUID suffix."""
+        return f"{self.component_type}-{self.uuid}"
+
+    @property
+    def component_branch(self) -> str:
+        """Branch name for the component (defaults to component_name)."""
+        return self.component_name
+
+    @property
+    def appstudio_component_branch(self) -> str:
+        """The branch name that AppStudio/Konflux creates."""
+        return f"appstudio-{self.component_name}"
+
+    @property
+    def component_repo_name(self) -> str:
+        """Full GitHub repository name (org/repo)."""
+        return f"{self.component_github_org}/{self.component_name}"
+
+    @property
+    def component_git_url(self) -> str:
+        """HTTPS URL to the component repository."""
+        return f"https://github.com/{self.component_repo_name}"
+
+    @property
+    def tenant_sa_name(self) -> str:
+        """Service account name in tenant namespace."""
+        return f"{self.component_type}-sa-{self.uuid}"
+
+    @property
+    def managed_sa_name(self) -> str:
+        """Service account name in managed namespace."""
+        return f"{self.component_type}-sa-{self.uuid}"
+
+    @property
+    def release_plan_name(self) -> str:
+        """ReleasePlan name."""
+        return f"{self.component_type}-rp-{self.uuid}"
+
+    @property
+    def release_plan_admission_name(self) -> str:
+        """ReleasePlanAdmission name."""
+        return f"{self.component_type}-rpa-{self.uuid}"
+
+    def get_env_dict(self) -> dict[str, str]:
+        """
+        Return environment variables for use with envsubst/kustomize.
+
+        Subclasses can override to add additional variables.
+        """
+        return {
+            "uuid": self.uuid,
+            "originating_tool": self.originating_tool,
+            "tenant_namespace": self.tenant_namespace,
+            "managed_namespace": self.managed_namespace,
+            "application_name": self.application_name,
+            "component_type": self.component_type,
+            "component_name": self.component_name,
+            "component_branch": self.component_branch,
+            "appstudio_component_branch": self.appstudio_component_branch,
+            "component_github_org": self.component_github_org,
+            "component_base_branch": self.component_base_branch,
+            "component_repo_name": self.component_repo_name,
+            "component_base_repo_name": self.component_base_repo_name,
+            "component_git_url": self.component_git_url,
+            "tenant_sa_name": self.tenant_sa_name,
+            "managed_sa_name": self.managed_sa_name,
+            "release_plan_name": self.release_plan_name,
+            "release_plan_admission_name": self.release_plan_admission_name,
+            "RELEASE_CATALOG_GIT_URL": self.release_catalog_git_url,
+            "RELEASE_CATALOG_GIT_REVISION": self.release_catalog_git_revision,
+        }
+
+    @classmethod
+    def load_test_env(cls, suite_dir: Path) -> None:
+        """
+        Source a bash test.env file and export its variables.
+
+        This provides compatibility with existing bash-based test.env files.
+        Call this before creating the config instance.
+
+        Args:
+            suite_dir: Path to the test suite directory containing test.env.
+        """
+        test_env_file = suite_dir / "test.env"
+
+        if test_env_file.exists():
+            # Source the bash test.env and extract exported variables
+            # This handles bash variable expansion like ${uuid:-"..."}
+            cmd = f"set -a && source {test_env_file} && env"
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
+                executable="/bin/bash",
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if "=" in line:
+                        key, _, value = line.partition("=")
+                        # Only set if not already in environment
+                        if key not in os.environ:
+                            os.environ[key] = value
+
+    @classmethod
+    def from_test_env(cls, suite_dir: Path) -> "TestConfigBase":
+        """
+        Load configuration, sourcing test.env shell variables first.
+
+        Args:
+            suite_dir: Path to the test suite directory.
+
+        Returns:
+            Configured instance.
+        """
+        cls.load_test_env(suite_dir)
+        return cls()

--- a/integration-tests/pylib/conftest_base.py
+++ b/integration-tests/pylib/conftest_base.py
@@ -1,0 +1,289 @@
+"""
+Base pytest configuration and fixtures for integration tests.
+
+This module provides generic fixtures that can be used by any test suite.
+Test suites should import these and add their own test_config fixture.
+
+Usage in a test suite's conftest.py:
+
+    from pylib.conftest_base import *  # Import all generic fixtures
+    from my_suite.lib.config import MyTestConfig
+
+    @pytest.fixture(scope="session")
+    def test_config(suite_dir: Path, skip_cleanup: bool) -> MyTestConfig:
+        config = MyTestConfig.from_test_env(suite_dir)
+        config.cleanup = not skip_cleanup
+        return config
+"""
+
+import asyncio
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+
+from .config import TestConfigBase
+from .github import GitHubClient, copy_branch_to_repo, delete_repository
+from .kubernetes import KubernetesClient
+from .resources import ResourceManager
+from .vault import cleanup_decrypted_secrets, decrypt_secrets
+from .utils import log_error, log_info, log_warning
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add custom command line options."""
+    parser.addoption(
+        "--skip-cleanup",
+        action="store_true",
+        default=False,
+        help="Skip cleanup of resources after test",
+    )
+
+
+@pytest.fixture(scope="session")
+def suite_dir() -> Path:
+    """
+    Return the path to the test suite directory.
+    
+    Override this in your conftest.py if needed.
+    """
+    # This will be overridden by each test suite
+    raise NotImplementedError("suite_dir fixture must be defined in test suite conftest.py")
+
+
+@pytest.fixture(scope="session")
+def scripts_dir(suite_dir: Path) -> Path:
+    """Return the path to the scripts directory."""
+    return suite_dir.parent / "scripts"
+
+
+@pytest.fixture(scope="session")
+def skip_cleanup(request: pytest.FixtureRequest) -> bool:
+    """Return whether to skip cleanup."""
+    return request.config.getoption("--skip-cleanup")
+
+
+@pytest.fixture(scope="session")
+def k8s_client(test_config: TestConfigBase) -> KubernetesClient:
+    """Create a Kubernetes client."""
+    return KubernetesClient(kubeconfig=test_config.kubeconfig)
+
+
+@pytest.fixture(scope="session")
+def github_client(test_config: TestConfigBase) -> GitHubClient:
+    """Create a GitHub client."""
+    return GitHubClient(token=test_config.github_token)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def decrypted_secrets(
+    suite_dir: Path,
+    test_config: TestConfigBase,
+    skip_cleanup: bool,
+) -> AsyncGenerator[None, None]:
+    """Decrypt secrets before tests and optionally clean up after."""
+    await decrypt_secrets(suite_dir, test_config.vault_password_file)
+    yield
+    if not skip_cleanup:
+        await cleanup_decrypted_secrets(suite_dir)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def github_repository(
+    test_config: TestConfigBase,
+    scripts_dir: Path,
+    skip_cleanup: bool,
+) -> AsyncGenerator[str, None]:
+    """Create the GitHub repository for testing."""
+    repo_name = test_config.component_repo_name
+
+    log_info(f"Creating repository {repo_name}")
+    await copy_branch_to_repo(
+        test_config.component_base_repo_name,
+        test_config.component_base_branch,
+        repo_name,
+        test_config.component_branch,
+        str(scripts_dir),
+    )
+
+    yield repo_name
+
+    if not skip_cleanup:
+        log_info(f"Cleaning up repository {repo_name}")
+        await delete_repository(repo_name, str(scripts_dir))
+
+
+@pytest_asyncio.fixture(scope="session")
+async def verified_namespaces(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+) -> None:
+    """Verify that required namespaces exist."""
+    for ns in [test_config.tenant_namespace, test_config.managed_namespace]:
+        if not await k8s_client.namespace_exists(ns):
+            raise RuntimeError(f"Required namespace {ns} does not exist")
+        log_info(f"Verified namespace exists: {ns}")
+
+    await k8s_client.set_current_namespace(test_config.tenant_namespace)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def kubernetes_resources(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    suite_dir: Path,
+    decrypted_secrets: None,
+    verified_namespaces: None,
+    skip_cleanup: bool,
+) -> AsyncGenerator[ResourceManager, None]:
+    """Create Kubernetes resources for testing."""
+    resource_manager = ResourceManager(k8s_client, test_config, suite_dir)
+
+    await resource_manager.create_resources()
+
+    yield resource_manager
+
+    if not skip_cleanup:
+        log_info("Cleaning up Kubernetes resources")
+        await resource_manager.cleanup_resources()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def initialized_component(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    github_repository: str,
+    kubernetes_resources: ResourceManager,
+) -> tuple[str, int]:
+    """Wait for the component to be initialized. Returns (pr_url, pr_number)."""
+    pr_url = await k8s_client.wait_for_component_initialization(
+        test_config.component_name,
+        test_config.tenant_namespace,
+        timeout_seconds=600,
+    )
+
+    pr_number = int(pr_url.split("/")[-1])
+    return pr_url, pr_number
+
+
+@pytest_asyncio.fixture(scope="session")
+async def merged_pr(
+    github_client: GitHubClient,
+    test_config: TestConfigBase,
+    initialized_component: tuple[str, int],
+) -> str:
+    """Merge the component PR. Returns the merge commit SHA."""
+    pr_url, pr_number = initialized_component
+
+    # Use CVE message if configured
+    commit_message = "e2e test"
+    if hasattr(test_config, 'no_cve') and not test_config.no_cve:
+        commit_message = "This fixes CVE-2024-8260"
+
+    result = await github_client.merge_pr(
+        test_config.component_repo_name,
+        pr_number,
+        commit_title="e2e test",
+        commit_message=commit_message,
+    )
+
+    if not result.merged:
+        raise RuntimeError(f"Failed to merge PR: {result.message}")
+
+    return result.sha
+
+
+@pytest_asyncio.fixture(scope="session")
+async def pipelinerun(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    merged_pr: str,
+) -> str:
+    """Wait for the PipelineRun to appear. Returns the PipelineRun name."""
+    return await k8s_client.wait_for_pipelinerun(
+        merged_pr,
+        test_config.tenant_namespace,
+        timeout_seconds=300,
+    )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def completed_pipelinerun(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    pipelinerun: str,
+) -> str:
+    """Wait for the PipelineRun to complete."""
+    status = await k8s_client.wait_for_pipelinerun_completion(
+        pipelinerun,
+        test_config.tenant_namespace,
+        timeout_seconds=1800,
+    )
+
+    if not status.succeeded:
+        log_warning(f"PipelineRun {pipelinerun} failed, attempting retry...")
+        await k8s_client.trigger_component_rebuild(
+            test_config.component_name,
+            test_config.tenant_namespace,
+        )
+
+        raise RuntimeError(
+            f"PipelineRun failed: {status.reason} - {status.message}"
+        )
+
+    return pipelinerun
+
+
+@pytest_asyncio.fixture(scope="session")
+async def releases(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    completed_pipelinerun: str,
+) -> list[str]:
+    """Wait for Releases to be created. Returns list of Release names."""
+    return await k8s_client.wait_for_releases(
+        completed_pipelinerun,
+        test_config.tenant_namespace,
+        timeout_seconds=300,
+    )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def completed_releases(
+    k8s_client: KubernetesClient,
+    test_config: TestConfigBase,
+    releases: list[str],
+) -> list[str]:
+    """Wait for all Releases to complete."""
+    tasks = [
+        k8s_client.wait_for_release_completion(
+            release_name,
+            test_config.tenant_namespace,
+            timeout_seconds=1800,
+        )
+        for release_name in releases
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    failed = []
+    succeeded_releases = []
+    for release_name, result in zip(releases, results):
+        if isinstance(result, Exception):
+            log_error(f"Release {release_name} failed with exception: {result}")
+            failed.append(release_name)
+        elif result.succeeded is None:
+            log_error(f"Release {release_name} status unknown (still running?)")
+            failed.append(release_name)
+        elif not result.succeeded:
+            log_error(f"Release {release_name} failed: {result.reason} - {result.message}")
+            failed.append(release_name)
+        else:
+            log_info(f"Release {release_name} completed successfully")
+            succeeded_releases.append(release_name)
+
+    if failed:
+        raise RuntimeError(f"Releases failed: {', '.join(failed)}")
+
+    return succeeded_releases

--- a/integration-tests/pylib/github.py
+++ b/integration-tests/pylib/github.py
@@ -1,0 +1,165 @@
+"""
+GitHub API client for integration tests.
+
+Provides async methods for GitHub repository and PR operations using PyGithub.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from github import Auth, Github
+from github.GithubException import GithubException
+
+from .utils import log_error, log_info, log_warning, run_command, run_with_retry
+
+
+@dataclass
+class MergeResult:
+    """Result of a PR merge operation."""
+
+    sha: str
+    merged: bool
+    message: str
+
+
+class GitHubClient:
+    """
+    Async GitHub API client using PyGithub.
+
+    Provides methods for:
+    - Repository operations (get, delete, create from template)
+    - Pull request operations (get, merge)
+    - Release verification
+    """
+
+    def __init__(self, token: str):
+        """Initialize the GitHub client."""
+        self.gh = Github(auth=Auth.Token(token))
+
+    async def get_repo(self, repo_name: str) -> dict | None:
+        """Get repository information."""
+        try:
+            repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+            return {"full_name": repo.full_name, "html_url": repo.html_url}
+        except GithubException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def delete_repo(self, repo_name: str) -> bool:
+        """Delete a repository."""
+        try:
+            repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+            await asyncio.to_thread(repo.delete)
+            log_info(f"Deleted repository: {repo_name}")
+            return True
+        except GithubException as e:
+            if e.status == 404:
+                log_warning(f"Repository {repo_name} not found (already deleted?)")
+                return False
+            raise
+
+    async def create_repo_from_template(
+        self,
+        template_repo: str,
+        new_repo_name: str,
+        owner: str,
+        private: bool = False,
+    ) -> dict:
+        """Create a repository from a template."""
+        template = await asyncio.to_thread(self.gh.get_repo, template_repo)
+        repo = await asyncio.to_thread(
+            template.create_repo_from_template, new_repo_name, private=private
+        )
+        return {"full_name": repo.full_name, "html_url": repo.html_url}
+
+    async def get_pr(self, repo_name: str, pr_number: int) -> dict | None:
+        """Get pull request information."""
+        try:
+            repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+            pr = await asyncio.to_thread(repo.get_pull, pr_number)
+            return {"number": pr.number, "state": pr.state, "merged": pr.merged}
+        except GithubException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def merge_pr(
+        self,
+        repo_name: str,
+        pr_number: int,
+        commit_title: str = "e2e test",
+        commit_message: str = "e2e test",
+    ) -> MergeResult:
+        """Merge a pull request with retry logic."""
+
+        async def do_merge() -> MergeResult:
+            repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+            pr = await asyncio.to_thread(repo.get_pull, pr_number)
+            result = await asyncio.to_thread(
+                pr.merge, commit_title=commit_title, commit_message=commit_message
+            )
+            return MergeResult(
+                sha=result.sha or "",
+                merged=result.merged,
+                message=result.message or "",
+            )
+
+        result = await run_with_retry(
+            do_merge,
+            max_attempts=3,
+            delay_seconds=5,
+            description=f"Merge PR #{pr_number} in {repo_name}",
+        )
+
+        if result.merged:
+            log_info(f"Merged PR #{pr_number} in {repo_name}, SHA: {result.sha[:8]}")
+        else:
+            log_error(f"Failed to merge PR #{pr_number}: {result.message}")
+
+        return result
+
+    async def add_comment(self, repo_name: str, pr_number: int, body: str) -> None:
+        """Add a comment to a pull request."""
+        repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+        issue = await asyncio.to_thread(repo.get_issue, pr_number)
+        await asyncio.to_thread(issue.create_comment, body)
+
+    async def get_release(self, repo_name: str, tag: str) -> dict | None:
+        """Get a GitHub release by tag."""
+        try:
+            repo = await asyncio.to_thread(self.gh.get_repo, repo_name)
+            release = await asyncio.to_thread(repo.get_release, tag)
+            return {"tag_name": release.tag_name, "html_url": release.html_url}
+        except GithubException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def release_exists(self, repo_name: str, tag: str) -> bool:
+        """Check if a GitHub release with the given tag exists."""
+        return await self.get_release(repo_name, tag) is not None
+
+
+# Script-based Operations (for compatibility with existing bash scripts)
+
+
+async def copy_branch_to_repo(
+    base_repo: str,
+    base_branch: str,
+    new_repo: str,
+    new_branch: str,
+    scripts_dir: str,
+) -> None:
+    """Copy a branch from one repo to a new repo using bash script."""
+    script_path = Path(scripts_dir) / "copy-branch-to-repo-git.sh"
+    await run_command([str(script_path), base_repo, base_branch, new_repo, new_branch])
+    log_info(f"Created {new_repo}:{new_branch} from {base_repo}:{base_branch}")
+
+
+async def delete_repository(repo_name: str, scripts_dir: str) -> None:
+    """Delete a GitHub repository using the bash script."""
+    script_path = Path(scripts_dir) / "delete-repository.sh"
+    await run_command([str(script_path), repo_name], check=False)
+    log_info(f"Deleted repository: {repo_name}")

--- a/integration-tests/pylib/kubernetes.py
+++ b/integration-tests/pylib/kubernetes.py
@@ -1,0 +1,634 @@
+"""
+Kubernetes client wrapper for integration tests.
+
+Provides async-friendly methods for common Kubernetes operations
+used in release pipeline testing.
+"""
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kubernetes import client, config
+from kubernetes.client.exceptions import ApiException
+
+from .utils import log_error, log_info, log_warning, wait_for_condition
+
+
+@dataclass
+class ResourceStatus:
+    """Status of a Kubernetes custom resource (PipelineRun, Release, etc.)."""
+
+    name: str
+    namespace: str
+    succeeded: bool | None  # None = still running
+    reason: str
+    message: str
+
+
+class KubernetesClient:
+    """
+    Kubernetes client for integration test operations.
+
+    Provides async wrappers around common K8s operations for:
+    - Namespace verification
+    - Component management
+    - PipelineRun monitoring
+    - Release monitoring
+    - Resource CRUD operations
+    """
+
+    def __init__(self, kubeconfig: str | None = None):
+        """
+        Initialize the Kubernetes client.
+
+        Args:
+            kubeconfig: Optional path to kubeconfig file.
+        """
+        if kubeconfig:
+            config.load_kube_config(config_file=kubeconfig)
+        else:
+            try:
+                config.load_incluster_config()
+            except config.ConfigException:
+                config.load_kube_config()
+
+        self.core_v1 = client.CoreV1Api()
+        self.custom_objects = client.CustomObjectsApi()
+        self.apps_v1 = client.AppsV1Api()
+
+    # -------------------------------------------------------------------------
+    # Namespace Operations
+    # -------------------------------------------------------------------------
+
+    async def namespace_exists(self, namespace: str) -> bool:
+        """Check if a namespace exists."""
+        try:
+            await asyncio.to_thread(self.core_v1.read_namespace, namespace)
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                return False
+            raise
+
+    async def set_current_namespace(self, namespace: str) -> None:
+        """Set the current namespace context."""
+        contexts, active_context = config.list_kube_config_contexts()
+        if active_context:
+            active_context["context"]["namespace"] = namespace
+            log_info(f"Set current namespace to {namespace}")
+
+    # -------------------------------------------------------------------------
+    # YAML Resource Operations
+    # -------------------------------------------------------------------------
+
+    async def kubectl_yaml(
+        self, action: str, yaml_content: str, namespace: str
+    ) -> None:
+        """
+        Run a kubectl action on YAML content.
+
+        Args:
+            action: One of "apply", "create", or "delete".
+            yaml_content: The YAML content to act on.
+            namespace: Target namespace.
+        """
+        import tempfile
+
+        import yaml as pyyaml
+
+        from .utils import run_command
+
+        # Parse YAML to list resources being acted on
+        resources = []
+        for doc in pyyaml.safe_load_all(yaml_content):
+            if doc:
+                kind = doc.get("kind", "Unknown")
+                name = doc.get("metadata", {}).get("name", "unknown")
+                resources.append(f"{kind}/{name}")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            check = action != "delete"  # Don't fail on delete errors
+            await run_command(
+                ["kubectl", action, "-f", temp_path, "-n", namespace],
+                check=check,
+            )
+            past_tense = {"apply": "Applied", "create": "Created", "delete": "Deleted"}
+            action_word = past_tense.get(action, action)
+            for resource in resources:
+                log_info(f"{action_word} {resource} in {namespace}")
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    # -------------------------------------------------------------------------
+    # Component Operations
+    # -------------------------------------------------------------------------
+
+    async def get_component(self, name: str, namespace: str) -> dict[str, Any] | None:
+        """Get an AppStudio Component custom resource."""
+        try:
+            result = await asyncio.to_thread(
+                self.custom_objects.get_namespaced_custom_object,
+                group="appstudio.redhat.com",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="components",
+                name=name,
+            )
+            return result
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def get_component_pr_url(self, name: str, namespace: str) -> str | None:
+        """
+        Get the PR URL from a Component's annotations.
+
+        Returns the merge-url from build.appstudio.openshift.io/status annotation.
+        """
+        component = await self.get_component(name, namespace)
+        if not component:
+            return None
+
+        annotations = component.get("metadata", {}).get("annotations", {})
+        status_json = annotations.get("build.appstudio.openshift.io/status", "")
+
+        if not status_json:
+            return None
+
+        try:
+            status = json.loads(status_json)
+            return status.get("pac", {}).get("merge-url")
+        except json.JSONDecodeError:
+            log_warning(f"Failed to parse component status JSON: {status_json}")
+            return None
+
+    async def wait_for_component_initialization(
+        self,
+        name: str,
+        namespace: str,
+        timeout_seconds: int = 600,
+    ) -> str:
+        """
+        Wait for a Component to be initialized and return its PR URL.
+
+        Args:
+            name: Component name.
+            namespace: Namespace.
+            timeout_seconds: Maximum time to wait.
+
+        Returns:
+            The PR URL for the component.
+
+        Raises:
+            TimeoutError: If component doesn't initialize in time.
+        """
+
+        async def check_initialized() -> str | None:
+            return await self.get_component_pr_url(name, namespace)
+
+        pr_url = await wait_for_condition(
+            check_initialized,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=10,
+            description=f"Component {name} initialization",
+        )
+
+        log_info(f"Component {name} initialized with PR: {pr_url}")
+        return pr_url
+
+    async def annotate_component(
+        self, name: str, namespace: str, annotation: str, value: str
+    ) -> None:
+        """Add an annotation to a Component."""
+        from .utils import run_command
+
+        await run_command(
+            [
+                "kubectl",
+                "annotate",
+                f"components/{name}",
+                f"{annotation}={value}",
+                "-n",
+                namespace,
+            ]
+        )
+        log_info(f"Annotated component {name} with {annotation}={value}")
+
+    async def trigger_component_rebuild(self, name: str, namespace: str) -> None:
+        """Trigger a rebuild for a Component."""
+        await self.annotate_component(
+            name,
+            namespace,
+            "build.appstudio.openshift.io/request",
+            "trigger-pac-build",
+        )
+
+    # -------------------------------------------------------------------------
+    # PipelineRun Operations
+    # -------------------------------------------------------------------------
+
+    async def get_pipelineruns_by_sha(
+        self, sha: str, namespace: str
+    ) -> list[dict[str, Any]]:
+        """Get PipelineRuns with a specific SHA label."""
+        result = await asyncio.to_thread(
+            self.custom_objects.list_namespaced_custom_object,
+            group="tekton.dev",
+            version="v1",
+            namespace=namespace,
+            plural="pipelineruns",
+            label_selector=f"pipelinesascode.tekton.dev/sha={sha}",
+        )
+        return result.get("items", [])
+
+    async def get_pipelineruns_by_label(
+        self, label_selector: str, namespace: str
+    ) -> list[dict[str, Any]]:
+        """Get PipelineRuns matching a label selector."""
+        result = await asyncio.to_thread(
+            self.custom_objects.list_namespaced_custom_object,
+            group="tekton.dev",
+            version="v1",
+            namespace=namespace,
+            plural="pipelineruns",
+            label_selector=label_selector,
+        )
+        return result.get("items", [])
+
+    async def wait_for_pipelinerun(
+        self,
+        sha: str,
+        namespace: str,
+        timeout_seconds: int = 300,
+    ) -> str:
+        """
+        Wait for a PipelineRun to appear for a given SHA.
+
+        Returns the PipelineRun name.
+        """
+
+        async def check_plr() -> str | None:
+            plrs = await self.get_pipelineruns_by_sha(sha, namespace)
+            for plr in plrs:
+                conditions = (
+                    plr.get("status", {}).get("conditions", [])
+                    if plr.get("status")
+                    else []
+                )
+                for cond in conditions:
+                    if cond.get("type") == "Succeeded" and cond.get("status") == "Unknown":
+                        return plr["metadata"]["name"]
+                if not conditions:
+                    return plr["metadata"]["name"]
+            return None
+
+        plr_name = await wait_for_condition(
+            check_plr,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=5,
+            description=f"PipelineRun for SHA {sha[:8]}",
+        )
+
+        log_info(f"Found PipelineRun: {plr_name}")
+        return plr_name
+
+    async def get_pipelinerun_status(
+        self, name: str, namespace: str
+    ) -> ResourceStatus:
+        """Get the status of a PipelineRun."""
+        result = await asyncio.to_thread(
+            self.custom_objects.get_namespaced_custom_object,
+            group="tekton.dev",
+            version="v1",
+            namespace=namespace,
+            plural="pipelineruns",
+            name=name,
+        )
+
+        conditions = result.get("status", {}).get("conditions", [])
+
+        succeeded = None
+        reason = ""
+        message = ""
+
+        for cond in conditions:
+            if cond.get("type") == "Succeeded":
+                status = cond.get("status")
+                if status == "True":
+                    succeeded = True
+                elif status == "False":
+                    succeeded = False
+                reason = cond.get("reason", "")
+                message = cond.get("message", "")
+                break
+
+        return ResourceStatus(
+            name=name,
+            namespace=namespace,
+            succeeded=succeeded,
+            reason=reason,
+            message=message,
+        )
+
+    async def wait_for_pipelinerun_completion(
+        self,
+        name: str,
+        namespace: str,
+        timeout_seconds: int = 1800,
+    ) -> ResourceStatus:
+        """Wait for a PipelineRun to complete. Returns the final status."""
+
+        async def check_completed() -> ResourceStatus | None:
+            status = await self.get_pipelinerun_status(name, namespace)
+            if status.succeeded is not None:
+                return status
+            print(f"PipelineRun {name}: {status.reason}")
+            return None
+
+        status = await wait_for_condition(
+            check_completed,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=10,
+            description=f"PipelineRun {name} completion",
+        )
+
+        if status.succeeded:
+            log_info(f"PipelineRun {name} succeeded")
+        else:
+            log_error(f"PipelineRun {name} failed: {status.message}")
+
+        return status
+
+    # -------------------------------------------------------------------------
+    # Release Operations
+    # -------------------------------------------------------------------------
+
+    async def get_releases_by_pipelinerun(
+        self, plr_name: str, namespace: str
+    ) -> list[dict[str, Any]]:
+        """Get Release resources associated with a PipelineRun."""
+        result = await asyncio.to_thread(
+            self.custom_objects.list_namespaced_custom_object,
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="releases",
+            label_selector=f"appstudio.openshift.io/build-pipelinerun={plr_name}",
+        )
+        return result.get("items", [])
+
+    async def wait_for_releases(
+        self,
+        plr_name: str,
+        namespace: str,
+        timeout_seconds: int = 300,
+    ) -> list[str]:
+        """Wait for Release resources to appear for a PipelineRun."""
+
+        async def check_releases() -> list[str] | None:
+            releases = await self.get_releases_by_pipelinerun(plr_name, namespace)
+            if releases:
+                return [r["metadata"]["name"] for r in releases]
+            return None
+
+        release_names = await wait_for_condition(
+            check_releases,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=5,
+            description=f"Releases for PipelineRun {plr_name}",
+        )
+
+        log_info(f"Found releases: {', '.join(release_names)}")
+        return release_names
+
+    async def get_release(self, name: str, namespace: str) -> dict[str, Any] | None:
+        """Get a Release custom resource."""
+        try:
+            result = await asyncio.to_thread(
+                self.custom_objects.get_namespaced_custom_object,
+                group="appstudio.redhat.com",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="releases",
+                name=name,
+            )
+            return result
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def get_release_status(self, name: str, namespace: str) -> ResourceStatus:
+        """Get the status of a Release."""
+        release = await self.get_release(name, namespace)
+        if not release:
+            raise ValueError(f"Release {name} not found in namespace {namespace}")
+
+        conditions = release.get("status", {}).get("conditions", [])
+
+        succeeded = None
+        reason = ""
+        message = ""
+
+        # Find the Released condition
+        for cond in conditions:
+            if cond.get("type") == "Released":
+                status_val = cond.get("status")
+                reason = cond.get("reason", "")
+                message = cond.get("message", "")
+
+                if status_val == "True":
+                    succeeded = True
+                elif status_val == "False":
+                    # Only treat as failed if reason indicates actual failure
+                    # "Progressing" means still in progress, not failed
+                    if reason in ("Progressing", "Running", "Pending"):
+                        succeeded = None  # Still in progress
+                    else:
+                        succeeded = False  # Actually failed
+                break
+
+        return ResourceStatus(
+            name=name,
+            namespace=namespace,
+            succeeded=succeeded,
+            reason=reason,
+            message=message,
+        )
+
+    async def wait_for_release_completion(
+        self,
+        name: str,
+        namespace: str,
+        timeout_seconds: int = 1800,
+    ) -> ResourceStatus:
+        """Wait for a Release to complete. Returns the final status."""
+
+        async def check_completed() -> ResourceStatus | None:
+            status = await self.get_release_status(name, namespace)
+            if status.succeeded is not None:
+                return status
+            print(f"Release {name}: {status.reason or 'waiting...'}")
+            return None
+
+        status = await wait_for_condition(
+            check_completed,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=10,
+            description=f"Release {name} completion",
+        )
+
+        if status.succeeded:
+            log_info(f"Release {name} completed: {status.reason}")
+        else:
+            log_error(f"Release {name} failed: {status.reason} - {status.message}")
+
+        return status
+
+    async def create_release(
+        self,
+        name: str,
+        namespace: str,
+        snapshot: str,
+        release_plan: str,
+    ) -> dict[str, Any]:
+        """
+        Create a Release custom resource.
+
+        Useful for tests that trigger manual releases.
+        """
+        release_manifest = {
+            "apiVersion": "appstudio.redhat.com/v1alpha1",
+            "kind": "Release",
+            "metadata": {
+                "name": name,
+                "namespace": namespace,
+            },
+            "spec": {
+                "snapshot": snapshot,
+                "releasePlan": release_plan,
+            },
+        }
+
+        result = await asyncio.to_thread(
+            self.custom_objects.create_namespaced_custom_object,
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="releases",
+            body=release_manifest,
+        )
+
+        log_info(f"Created Release {name} in namespace {namespace}")
+        return result
+
+    # -------------------------------------------------------------------------
+    # Snapshot Operations
+    # -------------------------------------------------------------------------
+
+    async def get_snapshots(
+        self, namespace: str, application: str
+    ) -> list[dict[str, Any]]:
+        """Get Snapshots for an application."""
+        result = await asyncio.to_thread(
+            self.custom_objects.list_namespaced_custom_object,
+            group="appstudio.redhat.com",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="snapshots",
+            label_selector=f"appstudio.openshift.io/application={application}",
+        )
+        return result.get("items", [])
+
+    async def get_snapshot_by_component_count(
+        self,
+        namespace: str,
+        application: str,
+        component_count: int,
+    ) -> dict[str, Any] | None:
+        """Get the most recent Snapshot with a specific number of components."""
+        snapshots = await self.get_snapshots(namespace, application)
+
+        # Sort by creation timestamp (newest first)
+        snapshots.sort(
+            key=lambda s: s.get("metadata", {}).get("creationTimestamp", ""),
+            reverse=True,
+        )
+
+        for snapshot in snapshots:
+            components = snapshot.get("spec", {}).get("components", [])
+            if len(components) == component_count:
+                return snapshot
+
+        return None
+
+    # -------------------------------------------------------------------------
+    # Utility Methods
+    # -------------------------------------------------------------------------
+
+    def get_console_url(self) -> str | None:
+        """
+        Get the console URL from the kubeconfig.
+
+        Derives the Konflux UI URL from the API server URL.
+        """
+        try:
+            contexts, active_context = config.list_kube_config_contexts()
+            if not active_context:
+                return None
+
+            # Get cluster server from current context
+            from .utils import run_command
+            import subprocess
+
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "config",
+                    "view",
+                    "--minify",
+                    "--output",
+                    "jsonpath={.clusters[*].cluster.server}",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                return None
+
+            server_url = result.stdout.strip()
+            # Transform api.xxx to konflux-ui.apps.xxx
+            console_url = server_url.replace("api.", "konflux-ui.apps.")
+            console_url = console_url.replace(":6443", "")
+            return console_url.rstrip("/")
+        except Exception:
+            return None
+
+    def get_pipelinerun_url(
+        self, namespace: str, application: str, plr_name: str
+    ) -> str | None:
+        """Get the console URL for a PipelineRun."""
+        console_url = self.get_console_url()
+        if not console_url:
+            return None
+        return f"{console_url}/ns/{namespace}/applications/{application}/pipelineruns/{plr_name}"
+
+    def get_release_url(
+        self, namespace: str, application: str, release_name: str
+    ) -> str | None:
+        """Get the console URL for a Release."""
+        console_url = self.get_console_url()
+        if not console_url:
+            return None
+        return f"{console_url}/ns/{namespace}/applications/{application}/releases/{release_name}"

--- a/integration-tests/pylib/pytest.ini
+++ b/integration-tests/pylib/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Required for pytest-asyncio
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session

--- a/integration-tests/pylib/requirements.txt
+++ b/integration-tests/pylib/requirements.txt
@@ -1,0 +1,26 @@
+# Python Integration Test Dependencies
+# Install with: pip install -r requirements.txt
+
+# Testing framework
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-timeout>=2.2.0
+
+# Kubernetes client
+kubernetes>=29.0.0
+
+# GitHub API client
+PyGithub>=2.1.0
+
+# Data validation
+pydantic>=2.5.0
+pydantic-settings>=2.1.0
+
+# Retry logic
+tenacity>=8.2.0
+
+# Environment management
+python-dotenv>=1.0.0
+
+# YAML processing
+PyYAML>=6.0.0

--- a/integration-tests/pylib/resources.py
+++ b/integration-tests/pylib/resources.py
@@ -1,0 +1,146 @@
+"""
+Kubernetes resource management for integration tests.
+
+Handles building and applying kustomize resources with variable substitution.
+"""
+
+import re
+from pathlib import Path
+
+from .config import TestConfigBase
+from .kubernetes import KubernetesClient
+from .utils import log_info, run_command
+
+
+def substitute_env_vars(content: str, env_vars: dict[str, str]) -> str:
+    """
+    Substitute environment variables in content.
+
+    Handles both $VAR and ${VAR} syntax, like envsubst.
+
+    Args:
+        content: String with variable references.
+        env_vars: Dictionary of variable names to values.
+
+    Returns:
+        String with variables substituted.
+    """
+    def replace_var(match: re.Match) -> str:
+        var_name = match.group(1) or match.group(2)
+        return env_vars.get(var_name, match.group(0))
+
+    # Match ${VAR} or $VAR (word characters only)
+    pattern = r'\$\{(\w+)\}|\$(\w+)'
+    return re.sub(pattern, replace_var, content)
+
+
+async def build_kustomize_resources(
+    resource_dir: Path,
+    env_vars: dict[str, str],
+) -> str:
+    """
+    Build kustomize resources with environment variable substitution.
+
+    Args:
+        resource_dir: Path to the kustomize directory.
+        env_vars: Environment variables to substitute.
+
+    Returns:
+        The processed YAML content.
+    """
+    # Run kustomize build
+    _, kustomize_output, _ = await run_command(
+        ["kustomize", "build", str(resource_dir)]
+    )
+
+    # Substitute environment variables (like envsubst)
+    return substitute_env_vars(kustomize_output, env_vars)
+
+
+class ResourceManager:
+    """
+    Manages Kubernetes resources for a test run.
+
+    Handles creation and cleanup of test resources using kustomize.
+    """
+
+    def __init__(
+        self,
+        k8s_client: KubernetesClient,
+        config: TestConfigBase,
+        suite_dir: Path,
+    ):
+        """
+        Initialize the resource manager.
+
+        Args:
+            k8s_client: Kubernetes client.
+            config: Test configuration.
+            suite_dir: Path to the test suite directory.
+        """
+        self.k8s = k8s_client
+        self.config = config
+        self.suite_dir = suite_dir
+        self.tenant_resources_yaml: str | None = None
+        self.managed_resources_yaml: str | None = None
+
+    async def create_resources(self) -> None:
+        """Create all Kubernetes resources for the test."""
+        env_vars = self.config.get_env_dict()
+
+        # Build and apply tenant resources
+        tenant_dir = self.suite_dir / "resources" / "tenant"
+        if tenant_dir.exists():
+            self.tenant_resources_yaml = await build_kustomize_resources(
+                tenant_dir, env_vars
+            )
+            await self.k8s.kubectl_yaml(
+                "create",
+                self.tenant_resources_yaml,
+                self.config.tenant_namespace,
+            )
+
+        # Build and apply managed resources
+        managed_dir = self.suite_dir / "resources" / "managed"
+        if managed_dir.exists():
+            self.managed_resources_yaml = await build_kustomize_resources(
+                managed_dir, env_vars
+            )
+            # Use apply to avoid conflicts when running tests in parallel
+            await self.k8s.kubectl_yaml(
+                "apply",
+                self.managed_resources_yaml,
+                self.config.managed_namespace,
+            )
+
+    async def cleanup_resources(self) -> None:
+        """Delete all Kubernetes resources created for the test."""
+        if self.tenant_resources_yaml:
+            await self.k8s.kubectl_yaml(
+                "delete",
+                self.tenant_resources_yaml,
+                self.config.tenant_namespace,
+            )
+
+        if self.managed_resources_yaml:
+            await self.k8s.kubectl_yaml(
+                "delete",
+                self.managed_resources_yaml,
+                self.config.managed_namespace,
+            )
+
+    async def save_resources_for_debug(self, output_dir: Path) -> None:
+        """Save the generated resources to files for debugging."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        if self.tenant_resources_yaml:
+            (output_dir / "tenant-resources.yaml").write_text(
+                self.tenant_resources_yaml
+            )
+
+        if self.managed_resources_yaml:
+            (output_dir / "managed-resources.yaml").write_text(
+                self.managed_resources_yaml
+            )
+
+        log_info(f"Saved resources to {output_dir}")

--- a/integration-tests/pylib/runner.py
+++ b/integration-tests/pylib/runner.py
@@ -1,0 +1,179 @@
+"""
+Test runner utilities.
+
+Common functions used by test runner scripts across all test suites.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+# Required environment variables for all tests
+REQUIRED_ENV_VARS = [
+    "GITHUB_TOKEN",
+    "VAULT_PASSWORD_FILE",
+    "RELEASE_CATALOG_GIT_URL",
+    "RELEASE_CATALOG_GIT_REVISION",
+]
+
+
+def check_required_env_vars(
+    additional_vars: list[str] | None = None,
+) -> list[str]:
+    """
+    Check for required environment variables and return missing ones.
+
+    Args:
+        additional_vars: Additional test-specific required variables.
+
+    Returns:
+        List of missing variable names.
+    """
+    required = REQUIRED_ENV_VARS.copy()
+    if additional_vars:
+        required.extend(additional_vars)
+
+    missing = []
+    for var in required:
+        if not os.environ.get(var):
+            missing.append(var)
+
+    return missing
+
+
+def check_vault_password_file() -> bool:
+    """
+    Check if the vault password file exists.
+
+    Returns:
+        True if file exists or VAULT_PASSWORD_FILE is not set, False otherwise.
+    """
+    vault_file = os.environ.get("VAULT_PASSWORD_FILE")
+    if vault_file and not Path(vault_file).exists():
+        print(f"❌ VAULT_PASSWORD_FILE points to non-existent file: {vault_file}")
+        return False
+    return True
+
+
+def check_environment(additional_vars: list[str] | None = None) -> bool:
+    """
+    Check all environment requirements.
+
+    Args:
+        additional_vars: Additional test-specific required variables.
+
+    Returns:
+        True if all checks pass, False otherwise.
+    """
+    print("🔍 Checking environment...")
+
+    missing_vars = check_required_env_vars(additional_vars)
+    if missing_vars:
+        print("❌ Missing required environment variables:")
+        for var in missing_vars:
+            print(f"   - {var}")
+        return False
+
+    if not check_vault_password_file():
+        return False
+
+    # Check for KUBECONFIG (optional, just informational)
+    kubeconfig = os.environ.get("KUBECONFIG")
+    if kubeconfig:
+        print(f"✅ Using KUBECONFIG: {kubeconfig}")
+    else:
+        print("⚠️  KUBECONFIG not set, using default kubectl config")
+
+    print("✅ Environment check passed")
+    return True
+
+
+def create_argument_parser(description: str) -> argparse.ArgumentParser:
+    """
+    Create a standard argument parser with common options.
+
+    Args:
+        description: Description for the test runner.
+
+    Returns:
+        Configured ArgumentParser.
+    """
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument(
+        "--skip-cleanup",
+        "-sc",
+        action="store_true",
+        help="Skip cleanup of resources after test",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+
+    return parser
+
+
+def run_pytest(
+    test_file: Path,
+    suite_dir: Path,
+    skip_cleanup: bool = False,
+    verbose: bool = False,
+    extra_args: list[str] | None = None,
+) -> int:
+    """
+    Run pytest for a test suite.
+
+    Args:
+        test_file: Path to the test file.
+        suite_dir: Path to the test suite directory.
+        skip_cleanup: Whether to skip cleanup.
+        verbose: Whether to enable verbose output.
+        extra_args: Additional pytest arguments.
+
+    Returns:
+        Exit code from pytest.
+    """
+    integration_tests_dir = suite_dir.parent
+    pytest_ini = integration_tests_dir / "pylib" / "pytest.ini"
+
+    pytest_args = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-s",  # Disable output capture - show logs immediately
+        "-c", str(pytest_ini),
+        str(test_file),
+    ]
+
+    if skip_cleanup:
+        pytest_args.append("--skip-cleanup")
+
+    if verbose:
+        pytest_args.append("-v")
+
+    if extra_args:
+        pytest_args.extend(extra_args)
+
+    print(f"\n🚀 Running: {' '.join(pytest_args)}\n")
+
+    # Add PYTHONPATH to include the shared library
+    env = os.environ.copy()
+    python_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{integration_tests_dir}:{python_path}" if python_path else str(integration_tests_dir)
+
+    # Run pytest
+    result = subprocess.run(pytest_args, cwd=suite_dir, env=env)
+
+    if result.returncode == 0:
+        print("\n✅ Test completed successfully")
+    else:
+        print(f"\n❌ Test failed with exit code {result.returncode}")
+
+    return result.returncode

--- a/integration-tests/pylib/utils.py
+++ b/integration-tests/pylib/utils.py
@@ -1,0 +1,153 @@
+"""
+Utility functions for logging and async operations.
+
+These utilities are shared across all integration test suites.
+"""
+
+import asyncio
+import os
+from typing import Awaitable, Callable, TypeVar
+
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_fixed,
+)
+
+T = TypeVar("T")
+
+
+def log_info(message: str) -> None:
+    """Log an info message."""
+    print(f"✅ {message}")
+
+
+def log_error(message: str) -> None:
+    """Log an error message."""
+    print(f"❌ error: {message}")
+
+
+def log_warning(message: str) -> None:
+    """Log a warning message."""
+    print(f"⚠️ Warning: {message}")
+
+
+async def wait_for_condition(
+    condition_func: Callable[[], Awaitable[T]],
+    timeout_seconds: int = 300,
+    interval_seconds: int = 5,
+    description: str = "condition",
+) -> T:
+    """
+    Wait for a condition to be met, with retries.
+
+    Args:
+        condition_func: Async function that returns a truthy value when condition is met,
+                       or raises an exception if it should retry.
+        timeout_seconds: Maximum time to wait.
+        interval_seconds: Time between retries.
+        description: Human-readable description for logging.
+
+    Returns:
+        The value returned by condition_func when it succeeds.
+
+    Raises:
+        TimeoutError: If the condition is not met within the timeout.
+    """
+    print(f"Waiting for {description} (timeout: {timeout_seconds}s)...")
+
+    try:
+        async for attempt in AsyncRetrying(
+            stop=stop_after_delay(timeout_seconds),
+            wait=wait_fixed(interval_seconds),
+            reraise=True,
+        ):
+            with attempt:
+                result = await condition_func()
+                if not result:
+                    raise ValueError(f"{description} not ready yet")
+                return result
+    except RetryError as e:
+        raise TimeoutError(
+            f"Timeout waiting for {description} after {timeout_seconds}s"
+        ) from e
+
+
+async def run_with_retry(
+    func: Callable[[], Awaitable[T]],
+    max_attempts: int = 3,
+    delay_seconds: int = 5,
+    description: str = "operation",
+) -> T:
+    """
+    Run an async function with retries.
+
+    Args:
+        func: Async function to run.
+        max_attempts: Maximum number of attempts.
+        delay_seconds: Delay between attempts.
+        description: Human-readable description for logging.
+
+    Returns:
+        The value returned by func when it succeeds.
+    """
+    try:
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(max_attempts),
+            wait=wait_fixed(delay_seconds),
+            reraise=True,
+        ):
+            with attempt:
+                print(
+                    f"{description} (attempt {attempt.retry_state.attempt_number}/{max_attempts})"
+                )
+                return await func()
+    except RetryError:
+        log_error(f"Failed {description} after {max_attempts} attempts")
+        raise
+
+
+async def run_command(
+    cmd: list[str],
+    check: bool = True,
+    capture_output: bool = True,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+) -> tuple[int, str, str]:
+    """
+    Run a shell command asynchronously.
+
+    Args:
+        cmd: Command and arguments as a list.
+        check: If True, raise exception on non-zero exit.
+        capture_output: If True, capture stdout/stderr.
+        env: Optional environment variables to add.
+        cwd: Optional working directory.
+
+    Returns:
+        Tuple of (return_code, stdout, stderr).
+    """
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE if capture_output else None,
+        stderr=asyncio.subprocess.PIPE if capture_output else None,
+        env=full_env,
+        cwd=cwd,
+    )
+
+    stdout_bytes, stderr_bytes = await process.communicate()
+    stdout = stdout_bytes.decode() if stdout_bytes else ""
+    stderr = stderr_bytes.decode() if stderr_bytes else ""
+
+    if check and process.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with code {process.returncode}: {stderr}"
+        )
+
+    return process.returncode, stdout, stderr

--- a/integration-tests/pylib/vault.py
+++ b/integration-tests/pylib/vault.py
@@ -1,0 +1,89 @@
+"""
+Secrets management for integration tests.
+
+Handles decryption of ansible-vault encrypted secrets.
+"""
+
+from pathlib import Path
+
+from .utils import log_info, run_command
+
+
+async def decrypt_secrets(suite_dir: Path, vault_password_file: str) -> None:
+    """
+    Decrypt ansible-vault secrets if they don't already exist.
+
+    Args:
+        suite_dir: Path to the test suite directory.
+        vault_password_file: Path to the vault password file.
+    """
+    tenant_secrets_dir = suite_dir / "resources" / "tenant" / "secrets"
+    managed_secrets_dir = suite_dir / "resources" / "managed" / "secrets"
+
+    tenant_secrets_dir.mkdir(parents=True, exist_ok=True)
+    managed_secrets_dir.mkdir(parents=True, exist_ok=True)
+
+    tenant_secrets_file = tenant_secrets_dir / "tenant-secrets.yaml"
+    managed_secrets_file = managed_secrets_dir / "managed-secrets.yaml"
+
+    vault_dir = suite_dir / "vault"
+
+    # Decrypt tenant secrets if needed
+    if not tenant_secrets_file.exists():
+        vault_file = vault_dir / "tenant-secrets.yaml"
+        if vault_file.exists():
+            log_info(f"Decrypting tenant secrets from {vault_file}")
+            await run_command(
+                [
+                    "ansible-vault",
+                    "decrypt",
+                    str(vault_file),
+                    "--output",
+                    str(tenant_secrets_file),
+                    "--vault-password-file",
+                    vault_password_file,
+                ]
+            )
+    else:
+        log_info("Tenant secrets already exist")
+
+    # Decrypt managed secrets if needed
+    if not managed_secrets_file.exists():
+        vault_file = vault_dir / "managed-secrets.yaml"
+        if vault_file.exists():
+            log_info(f"Decrypting managed secrets from {vault_file}")
+            await run_command(
+                [
+                    "ansible-vault",
+                    "decrypt",
+                    str(vault_file),
+                    "--output",
+                    str(managed_secrets_file),
+                    "--vault-password-file",
+                    vault_password_file,
+                ]
+            )
+    else:
+        log_info("Managed secrets already exist")
+
+    log_info("Secret decryption complete")
+
+
+async def cleanup_decrypted_secrets(suite_dir: Path) -> None:
+    """
+    Remove decrypted secrets files.
+
+    Args:
+        suite_dir: Path to the test suite directory.
+    """
+    tenant_secrets_file = (
+        suite_dir / "resources" / "tenant" / "secrets" / "tenant-secrets.yaml"
+    )
+    managed_secrets_file = (
+        suite_dir / "resources" / "managed" / "secrets" / "managed-secrets.yaml"
+    )
+
+    for secrets_file in [tenant_secrets_file, managed_secrets_file]:
+        if secrets_file.exists():
+            secrets_file.unlink()
+            log_info(f"Removed decrypted secrets: {secrets_file}")


### PR DESCRIPTION
This commit converts the e2e integration-test to use python instead of bash. It creates a lot of reusable functions in integration-tests/lib so that when future tests are also converted, less new code needs to be created.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
