### PR TITLE
feat: support ARCH variable in envfile for kernel modules

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -228,34 +228,84 @@ spec:
             fi
         }
 
+        # Function to get final architecture name from envfile
+        get_final_arch_name() {
+            (
+                local temp_dir="$1"
+                local platform_arch="$2"
+
+                if [ -f "$temp_dir/envfile" ]; then
+                    # shellcheck source=/dev/null
+                    . "$temp_dir/envfile"
+                    if [ -n "${ARCH:-}" ]; then
+                        echo "Using ARCH=$ARCH from envfile (platform: $platform_arch)" >&2
+                        echo "$ARCH"
+                        return
+                    fi
+                fi
+
+                echo "No ARCH variable in envfile, using platform architecture: $platform_arch" >&2
+                echo "$platform_arch"
+            )
+        }
+
         if [ "$arch_count" -eq 1 ]; then
             echo "Single architecture image, using standard extraction"
             # Extract the actual architecture name
-            actual_arch=$(jq -r '.platform.architecture' "$(params.dataDir)/architectures.json")
-            echo "Architecture: $actual_arch"
-            extract_single_arch "$source_image" "$(params.dataDir)/$SIGNED_KMODS_PATH/$actual_arch" "$actual_arch"
+            platform_arch=$(jq -r '.platform.architecture' "$(params.dataDir)/architectures.json")
+            echo "Platform architecture: $platform_arch"
+
+            # Extract to temporary directory first
+            temp_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/${platform_arch}"
+            extract_single_arch "$source_image" "$temp_dir" "$platform_arch"
+
+            # Get final architecture name from envfile
+            final_arch=$(get_final_arch_name "$temp_dir" "$platform_arch")
+
+            # Rename directory if ARCH differs from platform architecture
+            if [ "$final_arch" != "$platform_arch" ]; then
+                final_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/${final_arch}"
+                echo "Renaming directory from $platform_arch to $final_arch"
+                mv "$temp_dir" "$final_dir"
+            fi
+
+            echo "Final architecture: $final_arch"
         else
             echo "Multi-architecture image detected, processing each architecture separately"
 
             # Read architecture data and process each one
             arch_data=$(cat "$(params.dataDir)/architectures.json")
 
-            echo "$arch_data" | jq -c '.' | while IFS= read -r arch_info; do
+            # Process architectures using a while loop with process substitution
+            # to avoid subshell issues with pipes
+            while IFS= read -r arch_info; do
                 platform_arch=$(echo "$arch_info" | jq -r '.platform.architecture')
                 arch_digest=$(echo "$arch_info" | jq -r '.digest')
 
-                echo "Processing architecture: $platform_arch (digest: $arch_digest)"
+                echo "Processing platform architecture: $platform_arch (digest: $arch_digest)"
 
-                # Create architecture-specific directory
-                arch_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/$platform_arch"
+                # Extract to temporary directory first
+                temp_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/${platform_arch}"
 
                 # Extract for this specific architecture using manifest digest
                 # Extract the registry and repository from source_image (remove existing digest)
                 source_base=$(echo "$source_image" | cut -d'@' -f1)
                 arch_specific_image="$source_base@$arch_digest"
                 echo "Using architecture-specific image: $arch_specific_image"
-                extract_single_arch "$arch_specific_image" "$arch_dir" "$platform_arch"
-            done
+                extract_single_arch "$arch_specific_image" "$temp_dir" "$platform_arch"
+
+                # Get final architecture name from envfile
+                final_arch=$(get_final_arch_name "$temp_dir" "$platform_arch")
+
+                # Rename directory if ARCH differs from platform architecture
+                if [ "$final_arch" != "$platform_arch" ]; then
+                    final_dir="$(params.dataDir)/$SIGNED_KMODS_PATH/${final_arch}"
+                    echo "Renaming directory from $platform_arch to $final_arch"
+                    mv "$temp_dir" "$final_dir"
+                fi
+
+                echo "Final architecture: $final_arch"
+            done < <(echo "$arch_data" | jq -c '.')
 
             # Create a summary of what was extracted
             summary_file="$(params.dataDir)/$SIGNED_KMODS_PATH/extraction_summary.txt"

--- a/tasks/managed/extract-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/extract-oot-kmods/tests/mocks.sh
@@ -137,6 +137,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=x86_64" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -159,6 +160,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=aarch64-64k" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -187,6 +189,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=x86_64" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -209,6 +212,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=aarch64-64k" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -231,6 +235,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=x86_64" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -253,6 +258,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=aarch64-64k" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -319,6 +325,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=x86_64" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"
@@ -341,6 +348,7 @@ EOF
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
+      echo "ARCH=aarch64-64k" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
@@ -164,7 +164,8 @@ spec:
               fi
 
               # Check for architecture-specific directories
-              expected_archs=("amd64" "arm64")
+              # Note: These are the ARCH values from envfile, not platform.architecture
+              expected_archs=("x86_64" "aarch64-64k")
               for arch in "${expected_archs[@]}"; do
                 arch_dir="$SIGNED_KMODS_PATH/$arch"
                 if [ -d "$arch_dir" ]; then
@@ -179,16 +180,29 @@ spec:
                     exit 1
                   fi
 
-                  # Check for envfile
+                  # Check for envfile and verify ARCH variable
                   if [ -f "$arch_dir/envfile" ]; then
                     echo "SUCCESS: envfile found for $arch"
                     cat "$arch_dir/envfile"
+
+                    # Verify ARCH variable matches expected value
+                    # shellcheck source=/dev/null
+                    . "$arch_dir/envfile"
+                    # shellcheck disable=SC2153
+                    if [ "${ARCH}" == "$arch" ]; then
+                      echo "SUCCESS: ARCH variable in envfile matches directory name: $arch"
+                    else
+                      echo "ERROR: ARCH variable mismatch. Expected: $arch, Got: ${ARCH}"
+                      exit 1
+                    fi
                   else
                     echo "ERROR: envfile not found for $arch"
                     exit 1
                   fi
                 else
                   echo "ERROR: Architecture directory not found: $arch_dir"
+                  echo "Available directories:"
+                  ls -la "$SIGNED_KMODS_PATH/" || echo "No directories found"
                   exit 1
                 fi
               done

--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -138,12 +138,9 @@ spec:
             local arch_name="$1"
             local source_dir="$2"
 
-            # Always include architecture suffix for consistent hierarchy
-            local arch_suffix="/${arch_name}"
+            echo "Processing Azure upload for architecture directory: $arch_name"
 
-            echo "Processing Azure upload for architecture: $arch_name"
-
-            # Read envfile to get version information
+            # Read envfile to get version information and ARCH override
             if [ -f "$source_dir/envfile" ]; then
                 # shellcheck source=/dev/null
                 . "$source_dir/envfile"
@@ -152,8 +149,14 @@ spec:
                 return 1
             fi
 
+            # Use ARCH from envfile if available, otherwise fall back to directory name
+            local final_arch="${ARCH:-${arch_name}}"
+            local arch_suffix="/${final_arch}"
+
+            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
+
             AZURE_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}/"
-            echo "Azure target path for $arch_name: ${ACCOUNT}/${CONTAINER}/${AZURE_TARGET_PATH}"
+            echo "Azure target path: ${ACCOUNT}/${CONTAINER}/${AZURE_TARGET_PATH}"
 
             # Upload .ko files
             if ls "$source_dir"/*.ko 1> /dev/null 2>&1; then

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -139,12 +139,9 @@ spec:
             local arch_name="$1"
             local source_dir="$2"
 
-            # Always include architecture suffix for consistent hierarchy
-            local arch_suffix="/${arch_name}"
+            echo "Processing artifacts for architecture directory: $arch_name"
 
-            echo "Processing artifacts for architecture: $arch_name"
-
-            # Read envfile to get version information
+            # Read envfile to get version information and ARCH override
             if [ -f "$source_dir/envfile" ]; then
                 # shellcheck source=/dev/null
                 . "$source_dir/envfile"
@@ -153,8 +150,14 @@ spec:
                 return 1
             fi
 
+            # Use ARCH from envfile if available, otherwise fall back to directory name
+            local final_arch="${ARCH:-${arch_name}}"
+            local arch_suffix="/${final_arch}"
+
+            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
+
             TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}"
-            echo "Target directory for $arch_name: $TARGET_DIR"
+            echo "Target directory: $TARGET_DIR"
 
             git sparse-checkout add "$TARGET_DIR"
             git checkout

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -121,12 +121,9 @@ spec:
             local arch_name="$1"
             local source_dir="$2"
 
-            # Always include architecture suffix for consistent hierarchy
-            local arch_suffix="/${arch_name}"
+            echo "Processing S3 upload for architecture directory: $arch_name"
 
-            echo "Processing S3 upload for architecture: $arch_name"
-
-            # Read envfile to get version information
+            # Read envfile to get version information and ARCH override
             if [ -f "$source_dir/envfile" ]; then
                 # shellcheck source=/dev/null
                 . "$source_dir/envfile"
@@ -135,8 +132,14 @@ spec:
                 return 1
             fi
 
+            # Use ARCH from envfile if available, otherwise fall back to directory name
+            local final_arch="${ARCH:-${arch_name}}"
+            local arch_suffix="/${final_arch}"
+
+            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
+
             S3_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}/"
-            echo "S3 target path for $arch_name: s3://$(params.s3Bucket)/${S3_TARGET_PATH}"
+            echo "S3 target path: s3://$(params.s3Bucket)/${S3_TARGET_PATH}"
 
             # Upload .ko files
             if ls "$source_dir"/*.ko 1> /dev/null 2>&1; then


### PR DESCRIPTION
Allow kernel module containerfiles to specify a custom ARCH value in their envfile to override the container manifest platform architecture. This enables differentiation between variants for the same platform architecture, such as standard 4k vs 64k page size aarch64 builds.

Changes:
- extract-oot-kmods: Read ARCH from envfile and rename directories
- push-oot-kmods-to-git/s3/azure: Use ARCH for upload paths
- Tests updated to verify ARCH override functionality
- Backward compatible: Falls back to platform.architecture if ARCH not present

Example use case:
- Standard aarch64: ARCH=arm64 (or omit for compatibility)
- 64k page aarch64: ARCH=aarch64-64k

This allows the same platform.architecture (arm64) to produce different upload paths based on kernel configuration differences.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
