### PR TITLE
fix: strip architecture suffix from KERNEL_VERSION in push tasks

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -237,14 +237,20 @@ spec:
                 if [ -f "$temp_dir/envfile" ]; then
                     # shellcheck source=/dev/null
                     . "$temp_dir/envfile"
-                    if [ -n "${ARCH:-}" ]; then
+                    if [ -n "${ARCH:-}" ] && [ "$ARCH" != "MULTI_PLATFORM" ]; then
                         echo "Using ARCH=$ARCH from envfile (platform: $platform_arch)" >&2
                         echo "$ARCH"
                         return
+                    elif [ "${ARCH:-}" = "MULTI_PLATFORM" ]; then
+                        echo "ARCH=MULTI_PLATFORM in envfile, using platform architecture: $platform_arch" >&2
                     fi
                 fi
 
-                echo "No ARCH variable in envfile, using platform architecture: $platform_arch" >&2
+                if [ -z "${ARCH:-}" ]; then
+                    echo "No ARCH variable in envfile, using platform architecture: $platform_arch" >&2
+                else
+                    echo "Using platform architecture: $platform_arch" >&2
+                fi
                 echo "$platform_arch"
             )
         }

--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -149,13 +149,27 @@ spec:
                 return 1
             fi
 
-            # Use ARCH from envfile if available, otherwise fall back to directory name
-            local final_arch="${ARCH:-${arch_name}}"
+            # Strip architecture suffix from KERNEL_VERSION (e.g., .aarch64+64k, .x86_64)
+            KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+              sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+            echo "Original KERNEL_VERSION: $KERNEL_VERSION"
+            echo "Cleaned KERNEL_VERSION: $KERNEL_VERSION_CLEAN"
+
+            # Use ARCH from envfile if available and not MULTI_PLATFORM, otherwise fall back to directory name
+            if [ -n "${ARCH:-}" ] && [ "$ARCH" != "MULTI_PLATFORM" ]; then
+                local final_arch="$ARCH"
+                echo "Using architecture: $final_arch (from envfile ARCH variable)"
+            else
+                local final_arch="$arch_name"
+                if [ "${ARCH:-}" = "MULTI_PLATFORM" ]; then
+                    echo "Using architecture: $final_arch (ARCH=MULTI_PLATFORM, using directory name)"
+                else
+                    echo "Using architecture: $final_arch (from directory name)"
+                fi
+            fi
             local arch_suffix="/${final_arch}"
 
-            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
-
-            AZURE_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}/"
+            AZURE_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}${arch_suffix}/"
             echo "Azure target path: ${ACCOUNT}/${CONTAINER}/${AZURE_TARGET_PATH}"
 
             # Upload .ko files
@@ -219,7 +233,10 @@ spec:
                 if [ -n "$first_arch_dir" ] && [ -f "$first_arch_dir/envfile" ]; then
                     # shellcheck source=/dev/null
                     . "$first_arch_dir/envfile"
-                    summary_azure_path="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/multi-arch-summary/"
+                    # Strip architecture suffix from KERNEL_VERSION
+                    KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+                      sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+                    summary_azure_path="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}/multi-arch-summary/"
 
                     echo "Uploading multi-architecture summary to Azure: ${ACCOUNT}/${CONTAINER}/${summary_azure_path}"
                     az storage blob upload \

--- a/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
@@ -45,12 +45,16 @@ function az() {
                     fi
 
                     COUNT_FILE="/var/workdir/upload_count.txt"
+                    UPLOAD_LOG="/var/workdir/upload_paths.log"
                     if [ ! -f "$COUNT_FILE" ]; then
                         echo 0 > "$COUNT_FILE"
                     fi
                     COUNT=$(cat "$COUNT_FILE")
 
                     echo "Mock az storage blob upload called (count=$COUNT) with: $*"
+
+                    # Log the upload path for verification
+                    echo "$*" >> "$UPLOAD_LOG"
 
                     # For multiarch, expect different upload patterns
                     # Check if this looks like a multiarch upload by looking for arch paths
@@ -131,5 +135,24 @@ check_upload_count() {
     else
         echo "ERROR: az blob upload was called $COUNT times, expected 4 (single arch) or 5+ (multiarch)"
         return 1
+    fi
+
+    # Verify kernel version cleaning: the test uses KERNEL_VERSION="6.5.0-az.x86_64"
+    # The task should strip the .x86_64 suffix, so upload paths should contain "6.5.0-az/" not "6.5.0-az.x86_64/"
+    UPLOAD_LOG="/var/workdir/upload_paths.log"
+    if [ -f "$UPLOAD_LOG" ]; then
+        echo ""
+        echo "Verifying KERNEL_VERSION architecture suffix was stripped..."
+        # Use grep -F for literal/fixed string matching (dots are literal, not regex)
+        if grep -F -q "6.5.0-az.x86_64" "$UPLOAD_LOG"; then
+            echo "ERROR: Found dirty kernel version (6.5.0-az.x86_64) in upload paths!"
+            echo "The .x86_64 suffix should have been stripped."
+            echo "Upload log:"
+            cat "$UPLOAD_LOG"
+            return 1
+        else
+            echo "SUCCESS: Kernel version architecture suffix was properly stripped"
+            echo "All uploads used cleaned path: 6.5.0-az (not 6.5.0-az.x86_64)"
+        fi
     fi
 }

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
@@ -8,10 +8,14 @@ mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
 echo "AZURE_SIGNED_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
 echo "AZURE_SIGNED_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
 
+# IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
+# This tests that the task properly strips the suffix when constructing upload paths
+# Expected: task strips .x86_64 to produce path mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/
+# NOT: mocked-vendor-azure/1.2.3-az/6.5.0-az.x86_64/x86_64/
 cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-azure"
 DRIVER_VERSION="1.2.3-az"
-KERNEL_VERSION="6.5.0-az"
+KERNEL_VERSION="6.5.0-az.x86_64"
 EOF
 
 # Create architecture-specific checksum file

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -150,13 +150,27 @@ spec:
                 return 1
             fi
 
-            # Use ARCH from envfile if available, otherwise fall back to directory name
-            local final_arch="${ARCH:-${arch_name}}"
+            # Strip architecture suffix from KERNEL_VERSION (e.g., .aarch64+64k, .x86_64)
+            KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+              sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+            echo "Original KERNEL_VERSION: $KERNEL_VERSION"
+            echo "Cleaned KERNEL_VERSION: $KERNEL_VERSION_CLEAN"
+
+            # Use ARCH from envfile if available and not MULTI_PLATFORM, otherwise fall back to directory name
+            if [ -n "${ARCH:-}" ] && [ "$ARCH" != "MULTI_PLATFORM" ]; then
+                local final_arch="$ARCH"
+                echo "Using architecture: $final_arch (from envfile ARCH variable)"
+            else
+                local final_arch="$arch_name"
+                if [ "${ARCH:-}" = "MULTI_PLATFORM" ]; then
+                    echo "Using architecture: $final_arch (ARCH=MULTI_PLATFORM, using directory name)"
+                else
+                    echo "Using architecture: $final_arch (from directory name)"
+                fi
+            fi
             local arch_suffix="/${final_arch}"
 
-            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
-
-            TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}"
+            TARGET_DIR="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}${arch_suffix}"
             echo "Target directory: $TARGET_DIR"
 
             git sparse-checkout add "$TARGET_DIR"
@@ -236,7 +250,10 @@ spec:
                 if [ -n "$first_arch_dir" ] && [ -f "$first_arch_dir/envfile" ]; then
                     # shellcheck source=/dev/null
                     . "$first_arch_dir/envfile"
-                    summary_target_dir="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/multi-arch-summary"
+                    # Strip architecture suffix from KERNEL_VERSION
+                    KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+                      sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+                    summary_target_dir="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}/multi-arch-summary"
 
                     echo "Creating multi-architecture summary in Git: ${summary_target_dir}"
                     git sparse-checkout add "$summary_target_dir"

--- a/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
@@ -18,9 +18,14 @@ git() {
         checkout)
             echo "Skipping git checkout: $*"
             ;;
-        
+
         add)
             echo "Mock git add: $*"
+
+            # Log the TARGET_DIR for verification
+            if [ -n "${KERNEL_VERSION:-}" ]; then
+                echo "KERNEL_VERSION=${KERNEL_VERSION}" >> /var/workdir/git_paths.log
+            fi
 
             # Check if this is a multi-arch build based on directory structure
             if [ -f "$(params.dataDir)/arch_count.txt" ]; then
@@ -87,4 +92,25 @@ git() {
             echo "Unknown subcommand: $1"
             ;;
     esac
+}
+
+check_git_paths() {
+    # Verify kernel version cleaning: the test uses KERNEL_VERSION="6.5.0.x86_64"
+    # The task should strip the .x86_64 suffix, so git paths should use "6.5.0" not "6.5.0.x86_64"
+    PATHS_LOG="/var/workdir/git_paths.log"
+    if [ -f "$PATHS_LOG" ]; then
+        echo ""
+        echo "Verifying KERNEL_VERSION architecture suffix was stripped..."
+        # Use grep -F for literal/fixed string matching (dots are literal, not regex)
+        if grep -F -q "6.5.0.x86_64" "$PATHS_LOG"; then
+            echo "ERROR: Found dirty kernel version (6.5.0.x86_64) in git paths!"
+            echo "The .x86_64 suffix should have been stripped."
+            echo "Paths log:"
+            cat "$PATHS_LOG"
+            exit 1
+        else
+            echo "SUCCESS: Kernel version architecture suffix was properly stripped"
+            echo "All git operations used cleaned KERNEL_VERSION: 6.5.0 (not 6.5.0.x86_64)"
+        fi
+    fi
 }

--- a/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
@@ -41,6 +41,11 @@ echo "Injecting mock/check scripts into spec.steps[1]..."
 MOCK_SCRIPT=$(cat "$SCRIPT_DIR/mocks.sh")
 ORIG_SCRIPT=$(yq '.spec.steps[1].script' "$TASK_PATH" | sed '1s|^#!/.*||')
 
+CHECK_SCRIPT="
+echo 'Running final mock assertions...'
+check_git_paths
+"
+
 cat > /tmp/injected-script.sh <<EOF
 #!/usr/bin/env bash
 # This is the new, combined script for testing
@@ -50,6 +55,9 @@ $MOCK_SCRIPT
 
 # --- Original Task Script (shebang removed) ---
 $ORIG_SCRIPT
+
+# --- Injected Check Script (runs assertions) ---
+$CHECK_SCRIPT
 EOF
 
 yq -i '.spec.steps[1].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
@@ -16,10 +16,14 @@ echo "Creating valid checksum file..."
 )
 
 echo "Creating envfile..."
+# IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
+# This tests that the task properly strips the suffix when constructing upload paths
+# Expected: task strips .x86_64 to produce path mocked-vendor/1.2.3/6.5.0/
+# NOT: mocked-vendor/1.2.3/6.5.0.x86_64/
 cat > "$KMODS_DIR/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor"
 DRIVER_VERSION="1.2.3"
-KERNEL_VERSION="6.5.0"
+KERNEL_VERSION="6.5.0.x86_64"
 EOF
 
 echo "Test data setup complete:"

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -132,13 +132,27 @@ spec:
                 return 1
             fi
 
-            # Use ARCH from envfile if available, otherwise fall back to directory name
-            local final_arch="${ARCH:-${arch_name}}"
+            # Strip architecture suffix from KERNEL_VERSION (e.g., .aarch64+64k, .x86_64)
+            KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+              sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+            echo "Original KERNEL_VERSION: $KERNEL_VERSION"
+            echo "Cleaned KERNEL_VERSION: $KERNEL_VERSION_CLEAN"
+
+            # Use ARCH from envfile if available and not MULTI_PLATFORM, otherwise fall back to directory name
+            if [ -n "${ARCH:-}" ] && [ "$ARCH" != "MULTI_PLATFORM" ]; then
+                local final_arch="$ARCH"
+                echo "Using architecture: $final_arch (from envfile ARCH variable)"
+            else
+                local final_arch="$arch_name"
+                if [ "${ARCH:-}" = "MULTI_PLATFORM" ]; then
+                    echo "Using architecture: $final_arch (ARCH=MULTI_PLATFORM, using directory name)"
+                else
+                    echo "Using architecture: $final_arch (from directory name)"
+                fi
+            fi
             local arch_suffix="/${final_arch}"
 
-            echo "Using architecture: $final_arch (from ${ARCH:+envfile ARCH variable}${ARCH:-directory name})"
-
-            S3_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}${arch_suffix}/"
+            S3_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}${arch_suffix}/"
             echo "S3 target path: s3://$(params.s3Bucket)/${S3_TARGET_PATH}"
 
             # Upload .ko files
@@ -188,7 +202,10 @@ spec:
                 if [ -n "$first_arch_dir" ] && [ -f "$first_arch_dir/envfile" ]; then
                     # shellcheck source=/dev/null
                     . "$first_arch_dir/envfile"
-                    summary_s3_path="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION}/multi-arch-summary/"
+                    # Strip architecture suffix from KERNEL_VERSION
+                    KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
+                      sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
+                    summary_s3_path="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}/multi-arch-summary/"
 
                     echo "Uploading multi-architecture summary to s3://$(params.s3Bucket)/${summary_s3_path}"
                     aws s3 cp \

--- a/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
@@ -4,6 +4,9 @@ set -eux
 aws() {
     echo "Mock 'aws' called with: $*"
 
+    # Log the S3 target path for verification
+    echo "$*" >> /var/workdir/s3_upload_paths.log
+
     if [ "$1" != "s3" ] || [ "$2" != "cp" ]; then
         echo "ERROR: Mock aws called with wrong command ($1 $2)"
         exit 1
@@ -99,4 +102,23 @@ check_final_status() {
         exit 1
     fi
     echo "SUCCESS: Final check passed. AWS mock was validated."
+
+    # Verify kernel version cleaning: the test uses KERNEL_VERSION="6.5.0-s3.x86_64"
+    # The task should strip the .x86_64 suffix, so S3 paths should contain "6.5.0-s3/" not "6.5.0-s3.x86_64/"
+    UPLOAD_LOG="/var/workdir/s3_upload_paths.log"
+    if [ -f "$UPLOAD_LOG" ]; then
+        echo ""
+        echo "Verifying KERNEL_VERSION architecture suffix was stripped..."
+        # Use grep -F for literal/fixed string matching (dots are literal, not regex)
+        if grep -F -q "6.5.0-s3.x86_64" "$UPLOAD_LOG"; then
+            echo "ERROR: Found dirty kernel version (6.5.0-s3.x86_64) in S3 upload paths!"
+            echo "The .x86_64 suffix should have been stripped."
+            echo "Upload log:"
+            cat "$UPLOAD_LOG"
+            exit 1
+        else
+            echo "SUCCESS: Kernel version architecture suffix was properly stripped"
+            echo "All uploads used cleaned path: 6.5.0-s3 (not 6.5.0-s3.x86_64)"
+        fi
+    fi
 }

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
@@ -8,10 +8,14 @@ mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
 echo "S3_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
 echo "S3_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
 
+# IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
+# This tests that the task properly strips the suffix when constructing upload paths
+# Expected: task strips .x86_64 to produce path mocked-vendor-s3/1.2.3-s3/6.5.0-s3/x86_64/
+# NOT: mocked-vendor-s3/1.2.3-s3/6.5.0-s3.x86_64/x86_64/
 cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-s3"
 DRIVER_VERSION="1.2.3-s3"
-KERNEL_VERSION="6.5.0-s3"
+KERNEL_VERSION="6.5.0-s3.x86_64"
 EOF
 
 # Create architecture-specific checksum file


### PR DESCRIPTION
The KERNEL_VERSION variable in envfiles can contain architecture suffixes (e.g., 5.14.0-570.19.1.el9_6.aarch64+64k), which caused redundant architecture information in the target paths: nvidia/550.54.15/5.14.0-570.19.1.el9_6.aarch64+64k/aarch64

This change strips architecture suffixes (.x86_64, .aarch64, .ppc64le, .s390x and variants with +suffix) from KERNEL_VERSION before constructing target paths, resulting in cleaner paths: nvidia/550.54.15/5.14.0-570.19.1.el9_6/aarch64

Updated tasks:
- push-oot-kmods-to-git
- push-oot-kmods-to-s3
- push-oot-kmods-to-azure

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
