### PR TITLE
chore: increase signing request timeout to 2 min

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -197,7 +197,7 @@ spec:
           topic_listen_to: queue://Consumer.${creator}.${requester}-{task_id}.${umb_listen_topic}
           environment: prod
           service: ${umb_client_name}
-          timeout: 60
+          timeout: 120
           retries: 2
           send_retries: 2
           message_id_key: request_id
@@ -211,7 +211,7 @@ spec:
           topic_listen_to: queue://Consumer.${creator}.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
           environment: prod
           service: ${umb_client_name}
-          timeout: 60
+          timeout: 600
           retries: 2
           send_retries: 2
           message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -168,7 +168,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 120
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -182,7 +182,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.test-user-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 600
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
@@ -198,7 +198,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 120
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -212,7 +212,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 600
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
@@ -139,7 +139,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 120
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -153,7 +153,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 60
+                timeout: 600
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id


### PR DESCRIPTION
## Describe your changes

There was another incident with UMB overload today and just recently the 99th percentile of messages
took 55 seconds to be delivered. While this is just a coincidence that this is close to our timeout of 60 seconds, it was suggested to us to increase
this time out a bit which could help with recovery when this happens.

Also, for batch signing, increase it to 10 minutes
as each batch will include multiple requests.

Slack discussion: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1769017900493399?thread_ts=1768893966.482959&cid=C04PZ7H0VA8

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
