### PR TITLE
feat(RELEASE-2132): monitor memory usage in concurrent tasks

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -153,7 +153,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 3Gi
@@ -440,28 +440,56 @@ spec:
             fi
         done
 
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         SUCCESS=true
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
+        jobs_spawned=0
+        jobs_collected=0
 
-        # Process each digest group in parallel, but components within each group in series
-        for digest in "${!digest_groups[@]}"; do
-            echo "Starting parallel processing for components with digest: $digest"
-            # Limit batch size to concurrent limit
+        # Collect digest keys into indexed array for processing
+        digest_keys=("${!digest_groups[@]}")
+        total_digests=${#digest_keys[@]}
+
+        echo "Processing $total_digests digest groups in parallel..."
+
+        for digest in "${digest_keys[@]}"; do
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit before spawning
+            wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
                 wait -n || SUCCESS=false
+                jobs_collected=$((jobs_collected + 1))
             done
+
+            echo "Starting parallel processing for components with digest: $digest"
             # Use hex digest without sha256: prefix for filename consistency
             digest_filename="${digest#sha256:}"
             process_digest_group "$digest" "${digest_groups[$digest]}" \
               > "/tmp/component_group_${digest_filename}.out" \
               2> "/tmp/component_group_${digest_filename}.err" &
+            jobs_spawned=$((jobs_spawned + 1))
+
+            # Allow memory usage to stabilize every BURST_SIZE spawns.
+            if (( jobs_spawned % BURST_SIZE == 0 )); then
+                sleep $STABILIZATION_DELAY
+            fi
         done
 
-        # Wait for remaining processes to finish
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Wait for all remaining jobs - use counter to collect all exit codes
+        # in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
             wait -n || SUCCESS=false
+            jobs_collected=$((jobs_collected + 1))
         done
-        echo "All component processing jobs completed"
+        echo "All component processing jobs completed (spawned: $jobs_spawned, collected: $jobs_collected)"
 
         # Print outputs and errors for each component processing job
         for digest in "${!digest_groups[@]}"; do

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: pull-and-push-images-to-marketplaces
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 1Gi
@@ -163,6 +163,13 @@ spec:
         BASE_DIR="$(mktemp -d)"
         DISK_IMGS_DIR="${BASE_DIR}/starmap/CLOUD_IMAGES"
         mkdir -p "${DISK_IMGS_DIR}"
+
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
 
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
@@ -232,19 +239,32 @@ spec:
             echo "$RESOURCES_JSON" | yq -P -I 4 > "$DESTINATION/resources.yaml"
         }
 
-        # Process each component in parallel
-        for ((i = 0; i < NUM_COMPONENTS; i++)); do
-            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
-            # Limit batch size to concurrent limit
+        # Process each component in parallel with memory-aware job management
+        STABILIZATION_DELAY=2
+        jobs_spawned=0
+        jobs_collected=0
+        for (( i = 0; i < NUM_COMPONENTS; i++ )); do
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit before spawning
+            wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
                 wait -n
+                jobs_collected=$((jobs_collected + 1))
             done
+
+            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
             prepare_component "$COMPONENT" &
+            jobs_spawned=$((jobs_spawned + 1))
+
+            # Allow memory usage to stabilize before next spawn.
+            sleep $STABILIZATION_DELAY
         done
 
-        # Wait for remaining processes to finish
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Wait for all remaining jobs - use counter to collect all exit codes
+        # in case processes finished during a stabilization sleep
+        while (( jobs_collected < jobs_spawned )); do
             wait -n
+            jobs_collected=$((jobs_collected + 1))
         done
 
         # Change to the base directory

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -126,8 +126,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: download-sbom-files
-      image:
-        quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 1Gi
@@ -143,6 +142,12 @@ spec:
             echo "No valid pyxis file was provided."
             exit 1
         fi
+
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
 
         # Create a mapping of unique imageIds to their SBOM files for efficient download
         echo "Creating unique imageId mapping for efficient SBOM download..."
@@ -247,33 +252,48 @@ spec:
           task_urls+=("$CONTAINER_IMAGE")
         done
 
-        # Process downloads with continuous job management
-        N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
-        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        # Process downloads with memory-aware job management
+        N=$(params.concurrentLimit)
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
+        RUNNING_JOBS="\j"
         success=true
+        jobs_spawned=0
+        jobs_collected=0
         total=${#download_tasks[@]}
         echo "Starting SBOM download for $total unique images in total. " \
           "Up to $N images will be downloaded at once..."
 
         for (( idx=0; idx < total; idx++ )); do
+          # This function is stored in the utils/memory-throttle.sh file
+          # Wait for memory and concurrent limit before spawning
+          wait_for_memory 80
+          while (( ${RUNNING_JOBS@P} >= N )); do
+            wait -n || success=false
+            jobs_collected=$((jobs_collected + 1))
+          done
+
           PYXIS_IMAGE="${download_tasks[idx]}"
           IMAGEID="${task_images[idx]}"
           IMAGEURL="${task_urls[idx]}"
 
-          # Limit concurrent jobs to N
-          while (( ${RUNNING_JOBS@P} >= N )); do
-            wait -n || success=false
-          done
-
           echo "Starting download for IMAGE: $IMAGEID from URL: $IMAGEURL"
           download_sbom_for_image "$PYXIS_IMAGE" "$IMAGEURL" > "${IMAGEID}.download.out" 2>&1 &
+          jobs_spawned=$((jobs_spawned + 1))
+
+          # Allow memory usage to stabilize every BURST_SIZE spawns.
+          if (( jobs_spawned % BURST_SIZE == 0 )); then
+            sleep $STABILIZATION_DELAY
+          fi
         done
 
-        # Wait for remaining processes to finish
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Wait for all remaining jobs - use counter to collect all exit codes
+        # in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
           wait -n || success=false
+          jobs_collected=$((jobs_collected + 1))
         done
-        echo "All SBOM download jobs completed"
+        echo "All SBOM download jobs completed (spawned: $jobs_spawned, collected: $jobs_collected)"
 
         # Print outputs for all download jobs
         echo
@@ -298,8 +318,7 @@ spec:
           exit 1
         fi
     - name: push-rpm-data-to-pyxis
-      image:
-        quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 1Gi
@@ -369,14 +388,33 @@ spec:
         TOTAL_IMAGES_TO_PUSH=$(jq '. | length' "${ALL_IMAGES_FILE}")
         echo "Will push RPM data for $TOTAL_IMAGES_TO_PUSH total images"
 
-        N=$(params.concurrentLimit)  # The maximum number of images to be processed at once
-        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
+        N=$(params.concurrentLimit)
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
+        RUNNING_JOBS="\j"
         success=true
+        jobs_spawned=0
+        jobs_collected=0
         echo "Starting RPM data upload for $TOTAL_IMAGES_TO_PUSH images in total. " \
           "Up to $N images will be uploaded at once..."
 
-        for (( i=0; i < TOTAL_IMAGES_TO_PUSH; i++ )); do
-          IMAGE_DATA=$(jq -c --argjson i "$i" '.[$i]' "${ALL_IMAGES_FILE}")
+        for (( idx=0; idx < TOTAL_IMAGES_TO_PUSH; idx++ )); do
+          # This function is stored in the utils/memory-throttle.sh file
+          # Wait for memory and concurrent limit before spawning
+          wait_for_memory 80
+          while (( ${RUNNING_JOBS@P} >= N )); do
+            wait -n || success=false
+            jobs_collected=$((jobs_collected + 1))
+          done
+
+          IMAGE_DATA=$(jq -c --argjson i "$idx" '.[$i]' "${ALL_IMAGES_FILE}")
           IMAGEID=$(jq -r '.imageId' <<< "$IMAGE_DATA")
 
           # Find the corresponding SBOM file
@@ -393,20 +431,23 @@ spec:
             exit 1
           fi
 
-          # Limit concurrent jobs to N
-          while (( ${RUNNING_JOBS@P} >= N )); do
-            wait -n || success=false
-          done
-
           echo "Uploading RPM data to Pyxis for IMAGE: $IMAGEID with SBOM: $SBOM_FILE using script: upload_rpm_data"
           upload_rpm_data --retry --image-id "$IMAGEID" --sbom-path "$SBOM_FILE" --verbose > "${IMAGEID}.out" 2>&1 &
+          jobs_spawned=$((jobs_spawned + 1))
+
+          # Allow memory usage to stabilize every BURST_SIZE spawns.
+          if (( jobs_spawned % BURST_SIZE == 0 )); then
+            sleep $STABILIZATION_DELAY
+          fi
         done
 
-        # Wait for remaining processes to finish
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Wait for all remaining jobs - use counter to collect all exit codes
+        # in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
           wait -n || success=false
+          jobs_collected=$((jobs_collected + 1))
         done
-        echo "All RPM data upload jobs completed"
+        echo "All RPM data upload jobs completed (spawned: $jobs_spawned, collected: $jobs_collected)"
 
         # Print outputs for all upload jobs
         echo

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -120,7 +120,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 1Gi
@@ -304,15 +304,31 @@ spec:
         RESULTS_JSON_FILE=$(mktemp)
         echo '{"images":[]}' > "$RESULTS_JSON_FILE"
 
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
         RUNNING_JOBS="\j" # A Bash param for number of jobs running
         CONCURRENT_LIMIT=$(params.concurrentLimit)
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
         REQUEST_COUNT=0
         SUCCESS=true
+        jobs_spawned=0
+        jobs_collected=0
 
-        # Wait for a slot to open up in the concurrent limit
+        # Wait for a slot to open up in the concurrent limit and for memory to be available
         wait_for_slot () {
+          # This function is stored in the utils/memory-throttle.sh file
+          # First wait for memory to be available
+          wait_for_memory 80
+          # Then wait for concurrent limit
           while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
             wait -n || SUCCESS=false
+            jobs_collected=$((jobs_collected + 1))
           done
         }
 
@@ -417,6 +433,11 @@ spec:
                 "${repository_url}" "${source_tag}" "" > "$TMP_RESULTS_DIR/${name}-${source_tag}.out" 2>&1 &
               ((++REQUEST_COUNT))
               echo "Request Count: $REQUEST_COUNT"
+              jobs_spawned=$((jobs_spawned + 1))
+              # Allow memory usage to stabilize every BURST_SIZE spawns.
+              if (( jobs_spawned % BURST_SIZE == 0 )); then
+                sleep $STABILIZATION_DELAY
+              fi
             fi
 
             for tag in $(jq -r '.[]' <<< "$imageTags") ; do
@@ -426,6 +447,10 @@ spec:
               "$platform" > "$TMP_RESULTS_DIR/${name}-${tag}.out" 2>&1 &
               ((++REQUEST_COUNT))
               echo "Request Count: $REQUEST_COUNT"
+              jobs_spawned=$((jobs_spawned + 1))
+              if (( jobs_spawned % BURST_SIZE == 0 )); then
+                sleep $STABILIZATION_DELAY
+              fi
 
               # This variable will only exist if the above logic determined the source container should
               # be pushed for this component
@@ -435,6 +460,10 @@ spec:
                   "${repository_url}" "${tag}-source" "" > "$TMP_RESULTS_DIR/${name}-${tag}-source.out" 2>&1 &
                 ((++REQUEST_COUNT))
                 echo "Request Count: $REQUEST_COUNT"
+                jobs_spawned=$((jobs_spawned + 1))
+                if (( jobs_spawned % BURST_SIZE == 0 )); then
+                  sleep $STABILIZATION_DELAY
+                fi
               fi
             done
 
@@ -446,13 +475,19 @@ spec:
                 > "$TMP_RESULTS_DIR/${name}-migration-${migration_tag}.out" 2>&1 &
               ((++REQUEST_COUNT))
               echo "Request Count: $REQUEST_COUNT (migration artifact)"
+              jobs_spawned=$((jobs_spawned + 1))
+              if (( jobs_spawned % BURST_SIZE == 0 )); then
+                sleep $STABILIZATION_DELAY
+              fi
             fi
           done
         done
 
         echo "Waiting for all jobs to complete...."
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Use counter to collect all exit codes in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
           wait -n || SUCCESS=false
+          jobs_collected=$((jobs_collected + 1))
         done
 
         echo "Printing outputs for each push image"

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -137,7 +137,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 2.5Gi
@@ -188,7 +188,16 @@ spec:
         echo -n "${PUBLIC_KEY:?}" > "$PUBLIC_KEY_FILE"
         ls -ld "$PUBLIC_KEY_FILE"
 
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
 
         jobpid(){
             pid=$(cut -d' ' -f4 < /proc/self/stat)
@@ -363,6 +372,7 @@ spec:
                 done
             done
         done
+        spawn_count=0
         echo "${to_sign[@]}" | python3 -c "
         import sys
         from itertools import zip_longest
@@ -388,20 +398,29 @@ spec:
             while (( ${RUNNING_JOBS@P} > 0 )); do
               wait -n
             done
+            spawn_count=0
             continue
           fi
           INTERNAL_REF=$(echo "$ENTRY" | cut -d' ' -f1)
           PUBLIC_REF=$(echo "$ENTRY" | cut -d' ' -f2)
           DIGEST=$(echo "$ENTRY" | cut -d' ' -f3)
           TAG=$(echo "$ENTRY" | cut -d' ' -f4)
+          # This function is stored in the utils/memory-throttle.sh file
+          # Wait for memory and concurrent limit
+          wait_for_memory 80
           while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
             wait -n
           done
           check_and_sign "${PUBLIC_REF}:${TAG}" "${INTERNAL_REF}" "${DIGEST}" &
+          spawn_count=$((spawn_count + 1))
+
+          # Allow memory usage to stabilize every BURST_SIZE spawns.
+          if (( spawn_count % BURST_SIZE == 0 )); then
+            sleep $STABILIZATION_DELAY
+          fi
         done
-        while (( ${RUNNING_JOBS@P} > 0 )); do
-            wait -n
-        done
+        # Note: The pipe runs the while loop in a subshell, but every group ends with "---"
+        # which waits for all jobs in that group, so no jobs remain when the subshell exits.
         echo "done"
     - name: create-trusted-artifact
       computeResources:

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -152,7 +152,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 4Gi
@@ -174,9 +174,20 @@ spec:
 
         set -x
 
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         CONCURRENT_LIMIT=$(params.concurrentLimit)
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
         REQUEST_COUNT=0
+        jobs_spawned=0
+        jobs_collected=0
 
         SNAPSHOT_PATH=$(params.dataDir)/$(params.snapshotPath)
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
@@ -316,8 +327,12 @@ spec:
 
               # Start find_signatures jobs in parallel for manifest digests
               for manifest_digest in $manifest_digests; do
+                # This function is stored in the utils/memory-throttle.sh file
+                # Wait for memory and concurrent limit
+                wait_for_memory 80
                 while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
                   wait -n || FIND_SIGNATURES_SUCCESS=false
+                  jobs_collected=$((jobs_collected + 1))
                 done
 
                 echo "Starting find_signatures job for manifest digest: ${manifest_digest}"
@@ -331,12 +346,22 @@ spec:
                 > "/tmp/find_sig_${digest_filename}.out" \
                 2> "/tmp/find_sig_${digest_filename}.err" &
                 find_signatures_jobs+=($!)
+                jobs_spawned=$((jobs_spawned + 1))
+
+                # Allow memory usage to stabilize every BURST_SIZE spawns.
+                if (( jobs_spawned % BURST_SIZE == 0 )); then
+                  sleep $STABILIZATION_DELAY
+                fi
               done
 
               # Start find_signatures job for source container digest if it exists
               if [ "${sourceContainerDigest}" != "" ] ; then
+                # This function is stored in the utils/memory-throttle.sh file
+                # Wait for memory and concurrent limit
+                wait_for_memory 80
                 while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
                   wait -n || FIND_SIGNATURES_SUCCESS=false
+                  jobs_collected=$((jobs_collected + 1))
                 done
 
                 echo "Starting find_signatures job for source container digest: ${sourceContainerDigest}"
@@ -350,17 +375,25 @@ spec:
                 > "/tmp/find_sig_${digest_filename}.out" \
                 2> "/tmp/find_sig_${digest_filename}.err" &
                 find_signatures_jobs+=($!)
+                jobs_spawned=$((jobs_spawned + 1))
+
+                # Allow memory usage to stabilize every BURST_SIZE spawns
+                if (( jobs_spawned % BURST_SIZE == 0 )); then
+                  sleep $STABILIZATION_DELAY
+                fi
               fi
 
             done
         done
 
-        # Wait for all find_signatures jobs to complete
+        # Wait for all find_signatures jobs to complete - use counter to collect all exit codes
+        # in case processes finished during a burst sleep
         echo "Waiting for ${FIND_SIGNATURES_JOB_COUNT} find_signatures jobs to complete..."
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        while (( jobs_collected < jobs_spawned )); do
           wait -n || FIND_SIGNATURES_SUCCESS=false
+          jobs_collected=$((jobs_collected + 1))
         done
-        echo "All find_signatures jobs completed"
+        echo "All find_signatures jobs completed (spawned: $jobs_spawned, collected: $jobs_collected)"
 
         # Print outputs and errors for each find_signatures job
         for digest_filename in "${find_signatures_files[@]}"; do
@@ -489,6 +522,10 @@ spec:
           fi
         done
 
+        # Reset counters for signing phase
+        jobs_spawned=0
+        jobs_collected=0
+
         for keyset in "${!keys_to_ref_dig_map[@]}"; do
 
           references_batch=""
@@ -503,8 +540,12 @@ spec:
             new_references_batch="${references_batch}${reference} "
             new_digests_batch="${digests_batch}${digest} "
 
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit
+            wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
               wait -n
+              jobs_collected=$((jobs_collected + 1))
             done
 
             if [[ ${#new_references_batch} -gt $BATCH_LIMIT || ${#new_digests_batch} -gt $BATCH_LIMIT ]]; then
@@ -528,6 +569,13 @@ spec:
                 "${EXTRA_ARGS[@]}" -s true &
                 ((++REQUEST_COUNT))
                 echo "Request Count: $REQUEST_COUNT"
+                jobs_spawned=$((jobs_spawned + 1))
+
+                # Allow memory usage to stabilize every BURST_SIZE spawns
+                if (( jobs_spawned % BURST_SIZE == 0 )); then
+                  sleep $STABILIZATION_DELAY
+                fi
+
                 references_batch="${reference} "
                 digests_batch="${digest} "
             else
@@ -538,8 +586,12 @@ spec:
 
           done
           if [[ ${#references_batch} -gt 0 ]]; then
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit
+            wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
               wait -n
+              jobs_collected=$((jobs_collected + 1))
             done
 
             echo "🟢 Creating ${requestType} to sign images: ${references_batch}"
@@ -562,6 +614,12 @@ spec:
               "${EXTRA_ARGS[@]}" -s true &
               ((++REQUEST_COUNT))
               echo "Request Count: $REQUEST_COUNT"
+              jobs_spawned=$((jobs_spawned + 1))
+
+            # Allow memory usage to stabilize every BURST_SIZE spawns
+            if (( jobs_spawned % BURST_SIZE == 0 )); then
+              sleep $STABILIZATION_DELAY
+            fi
 
             # next batches consist of values which didn't fit in the previous batches
             references_batch="${to_sign_references[$i]} "
@@ -585,12 +643,15 @@ spec:
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
             "${EXTRA_ARGS[@]}" -s true &
+          jobs_spawned=$((jobs_spawned + 1))
           fi
         done
 
         echo "Waiting for remaining processes to finish..."
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Use counter to collect all exit codes in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
           wait -n
+          jobs_collected=$((jobs_collected + 1))
         done
         echo "done"
 

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -158,7 +158,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: sign-index-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
       computeResources:
         limits:
           memory: 1Gi
@@ -180,9 +180,20 @@ spec:
 
         set -x
 
+        # Initialize memory throttling
+        # This file is located at utils/memory-throttle.sh in the release-service-utils image
+        # shellcheck source=/dev/null
+        source memory-throttle.sh
+        # This function is stored in the utils/memory-throttle.sh file
+        log_memory_throttle_status 80
+
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         CONCURRENT_LIMIT=$(params.concurrentLimit)
+        BURST_SIZE=5
+        STABILIZATION_DELAY=2
         REQUEST_COUNT=0
+        jobs_spawned=0
+        jobs_collected=0
 
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
@@ -276,8 +287,12 @@ spec:
           # if batches are too big, send the request
           if [[ ${#new_references_batch} -gt $BATCH_LIMIT || ${#new_digests_batch} -gt $BATCH_LIMIT ]]; then
 
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit
+            wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
               wait -n
+              jobs_collected=$((jobs_collected + 1))
             done
 
             ${requestType} --pipeline "${request}" \
@@ -296,6 +311,12 @@ spec:
               "${EXTRA_ARGS[@]}" -s true &
               ((++REQUEST_COUNT))
               echo "Request Count: $REQUEST_COUNT"
+              jobs_spawned=$((jobs_spawned + 1))
+
+            # Allow memory usage to stabilize every BURST_SIZE spawns.
+            if (( jobs_spawned % BURST_SIZE == 0 )); then
+              sleep $STABILIZATION_DELAY
+            fi
 
             # next batches consist of values which didn't fit in the previous batches
             references_batch="${to_sign_references[$i]} "
@@ -311,8 +332,12 @@ spec:
 
         # Process the last batch
         if [[ ${#references_batch} -gt 0 ]]; then
+          # This function is stored in the utils/memory-throttle.sh file
+          # Wait for memory and concurrent limit
+          wait_for_memory 80
           while (( ${RUNNING_JOBS@P} >= "$CONCURRENT_LIMIT" )); do
             wait -n
+            jobs_collected=$((jobs_collected + 1))
           done
 
           ${requestType} \
@@ -330,11 +355,14 @@ spec:
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
             -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
             "${EXTRA_ARGS[@]}" -s true &
+          jobs_spawned=$((jobs_spawned + 1))
         fi
 
         echo "Waiting for remaining processes to finish..."
-        while (( ${RUNNING_JOBS@P} > 0 )); do
+        # Use counter to collect all exit codes in case processes finished during a burst sleep
+        while (( jobs_collected < jobs_spawned )); do
           wait -n
+          jobs_collected=$((jobs_collected + 1))
         done
 
         echo "done"


### PR DESCRIPTION
This commit updates tasks that spawn background processes in parallel. Instead of just spawning up to the concurrent limit, they will now use a script from release-service-utils that will monitor memory usage. If there is not at least 20% of total memory free, it will wait before spawning another background process. This should help to reduce the frequency at which we see OOMKills.

Finally, because it may take a few seconds for the memory to come under load when spawning a background process, tasks with a larger concurrentLimit will now spawn the processes in bursts. The goal is to spawn a fraction of the concurrent limit, sleep for a few seconds to let memory stabilize, then proceed.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
