### PR TITLE
fix(HUM-368): handle 504 errors

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -349,7 +349,7 @@ spec:
           # Build a printable command string for logging (no secrets included)
           local printable_cmd
           printable_cmd="pulp --config \"${PULP_CONFIG_FILE}\" --domain \"${PULP_DOMAIN}\" rpm content upload"
-          printable_cmd+=" --file \"${file_path}\" --relative-path \"${relpath}\""
+          printable_cmd+=" --chunk-size 20MB --file \"${file_path}\" --relative-path \"${relpath}\""
 
           for ((i=1; i<=attempts; i++)); do
             # For retries (i > 1) make it explicit which command is being retried
@@ -359,7 +359,7 @@ spec:
             fi
             set +e
             response=$(pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
-              --file "${file_path}" --relative-path "${relpath}")
+              --chunk-size 20MB --file "${file_path}" --relative-path "${relpath}")
             rc=$?
             set -e
 


### PR DESCRIPTION
## Describe your changes
- fix to better handle 504 errors. Example here: 

```
pulp --config /tmp/cli.toml --domain public-hummingbird rpm content upload --file dotnet-sdk-9.0-source-built-artifacts-9.0.113-3.hum1.aarch64.rpm --relative-path dotnet-sdk-9.0-source-built-artifacts-9.0.113-3.hum1.aarch64.rpm
.........................................................................................
..........................................................................
.....................................................................................
..............................................................................
.......................................................................
.........................................................................
.......................................................................
....................................................................................
........................................................................
.........................................................................
...............................................................................
......................................................................
........Upload complete.
Error: <html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```
- large files require the `--chunk-size 20MB` flag otherwise it may cause a gateway timeout.
 
- Tested using manual krw test: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/managed-release-team-tenant/applications/push-rpms-app-ca7aa6e0/pipelineruns/managed-zb5pm/logs?task=push-rpms-to-pulp

## Relevant Jira
- HUM-368

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
