### PR TITLE
docs: add note to integration-tests README.md

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -172,6 +172,13 @@ These integration tests are automatically executed in CI/CD pipelines:
 2. **Cluster Access** - Ensure KUBECONFIG is properly configured
 3. **Secret Errors** - Check vault password file exists and is correct
 4. **Resource Conflicts** - Use cleanup scripts to remove stale resources
+5. **PaC token unrecognizable error** - The following error:
+   ```bash
+   Initialization check attempt 6/60...
+   ⚠️ Warning: Could not get component PR from annotations: {"pac":{"state":"error","error-id":74,"error-message":"74: Access token is unrecognizable by GitHub"},"message":"done"}
+   ```
+   This is due to using a new GITHUB_TOKEN env variable but the old one being present in your tenant secrets file. Simply `rm resources/tenant/secrets/tenant-secrets.yaml`
+   in whatever test you are running so that a new secrets file will be generated for you with the proper secret
 
 ### Getting Help
 


### PR DESCRIPTION
This commit adds a note to the integration-tests/README.md that describes a PaC issue for an expired GITHUB_TOKEN and how to fix it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
