### PR TITLE
fix(RELEASE-2169): read tags from repository level in filter task

### DIFF
--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -192,7 +192,7 @@ spec:
                         jq -n \
                             --arg name "$COMPONENT_NAME" \
                             --arg ci "$containerImage" \
-                            --argjson tags "$(jq '.tags' <<< "$component")" \
+                            --argjson tags "$(jq --argjson i "$i" '.[$i].tags // null' <<< "$repositories")" \
                             --arg repo "$repo_url" \
                             '{
                               name: $name,

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-multi-repositories.yaml
@@ -80,15 +80,18 @@ spec:
                     "repositories": [
                       {
                         "url": "quay.io/redhat-pending/repo1",
-                        "rh-registry-repo": "quay.io/redhat-pending/repo1"
+                        "rh-registry-repo": "quay.io/redhat-pending/repo1",
+                        "tags": ["v1.0", "latest"]
                       },
                       {
                         "url": "quay.io/redhat-pending/repo2",
-                        "rh-registry-repo": "quay.io/redhat-pending/repo2"
+                        "rh-registry-repo": "quay.io/redhat-pending/repo2",
+                        "tags": ["v1.0", "latest"]
                       },
                       {
                         "url": "quay.io/redhat-pending/repo3",
-                        "rh-registry-repo": "quay.io/redhat-pending/repo3"
+                        "rh-registry-repo": "quay.io/redhat-pending/repo3",
+                        "tags": ["v1.0", "latest"]
                       }
                     ],
                     "containerImage": "quay.io/redhat-pending/repo1@sha256:abc123"
@@ -98,7 +101,8 @@ spec:
                     "repositories": [
                       {
                         "url": "quay.io/redhat-pending/repo4",
-                        "rh-registry-repo": "quay.io/redhat-pending/repo4"
+                        "rh-registry-repo": "quay.io/redhat-pending/repo4",
+                        "tags": ["v2.0"]
                       }
                     ],
                     "containerImage": "quay.io/redhat-pending/repo4@sha256:def456"
@@ -288,6 +292,13 @@ spec:
                 echo "Unexpected digest for single-repo-component in transformedSnapshot"
                 exit 1
               fi
+
+              # Verify tags are correctly read from repositories (not null)
+              echo "Checking multi-repo-component tags..."
+              test "$(echo "$multiRepoEntries" | head -1 | jq -c '.tags')" == '["v1.0","latest"]'
+
+              echo "Checking single-repo-component tags..."
+              test "$(jq -c '.tags' <<< "$singleRepoEntry")" == '["v2.0"]'
 
               # Check the origin parameter
               if [ "$(echo "$internalRequest" | jq -r '.spec.params.origin' )" != "dev" ]; then


### PR DESCRIPTION
## Describe your changes

The filter-already-released-advisory-images task was reading tags from the component level (.tags) which doesn't exist. Tags are set by apply-mapping at the repository level (.repositories[].tags).

This caused tags to always be null when passed to the internal filter task, which could lead to incorrect filtering behavior.

The fix reads tags from the correct path, matching the behavior of populate-release-notes task which correctly reads from repository level.

## Relevant Jira
RELEASE-2169
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
