### PR TITLE
fix(HUM-304): update schema for content type rpm

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -1849,6 +1849,11 @@
                       "required": [
                         "repositories"
                       ]
+                    },
+                    {
+                      "required": [
+                        "contentType"
+                      ]
                     }
                   ]
                 }


### PR DESCRIPTION
## Describe your changes
- we should be able to specify that a component is of `contentType = rpm` without having to specify image parameters
- Example:

```
data: 
  mapping: 
    components:
    - name: ${component_name}
    - contentType: rpm
```

## Relevant Jira
- HUM-340

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
