### PR TITLE
feat(HUM-304): filter already released rpms

### DIFF
--- a/tasks/managed/filter-already-released-advisory-rpms/README.md
+++ b/tasks/managed/filter-already-released-advisory-rpms/README.md
@@ -1,0 +1,31 @@
+# filter-already-released-advisory-rpms
+
+Filters RPMs already present in Pulp and reduces the snapshot to only components
+that still have RPMs to publish.
+
+The task:
+- pulls RPM files from each component's OCI artifact
+- queries Pulp to determine which RPMs already exist (by NEVRA + sha256)
+- writes the RPMs that still need publishing under `.components[].rpmsToPublish`
+- removes components with an empty `.rpmsToPublish` list
+- overwrites the snapshot file in-place
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value                |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|------------------------------|
+| snapshotPath            | Path to the JSON Snapshot spec in the data workspace                                                                       | No       | -                            |
+| PULP_DOMAIN             | The domain to use for Pulp operations                                                                                      | No       | -                            |
+| PULP_SECRET_NAME        | The name of the secret containing the Pulp cli.toml file. It must have the cli.toml key                                    | No       | -                            |
+| DEFAULT_EXCLUDES        | comma-delimited list of file patterns to exclude from consideration                                                        | Yes      | -debuginfo-, -debugsource-   |
+| DEFAULT_ARCHITECTURES   | Comma-delimited list of default architectures to use for noarch RPMs when no arch-specific RPMs are found                  | Yes      | x86_64,aarch64,s390x,ppc64le |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                        |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                           |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                           |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                           |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                           |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release         |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                            |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                            |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca                   |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt                |

--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -1,0 +1,609 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-rpms
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Filters RPMs already present in Pulp and reduces the snapshot to only components
+    that still have RPMs to publish.
+
+    The task:
+    - pulls RPM files from each component's OCI artifact
+    - queries Pulp to determine which RPMs already exist (by NEVRA + sha256)
+    - writes the RPMs that still need publishing under `.components[].rpmsToPublish`
+    - removes components with an empty `.rpmsToPublish` list
+    - overwrites the snapshot file in-place
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON Snapshot spec in the data workspace
+    - name: PULP_DOMAIN
+      type: string
+      description: The domain to use for Pulp operations
+    - name: PULP_SECRET_NAME
+      type: string
+      description: >-
+        The name of the secret containing the Pulp cli.toml file. It must have the cli.toml key
+    - name: DEFAULT_EXCLUDES
+      type: string
+      description: comma-delimited list of file patterns to exclude from consideration
+      default: "-debuginfo-, -debugsource-"
+    - name: DEFAULT_ARCHITECTURES
+      type: string
+      description: >-
+        Comma-delimited list of default architectures to use for noarch RPMs when
+        no arch-specific RPMs are found
+      default: "x86_64,aarch64,s390x,ppc64le"
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+  results:
+    - name: skip_release
+      type: string
+      description: "true when all components had no RPMs to publish; otherwise false"
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: pulp-secret-name-vol
+      secret:
+        secretName: $(params.PULP_SECRET_NAME)
+        defaultMode: 0444
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    env:
+      # Ensure Tekton creds-init can copy registry creds to a writable $HOME (avoid /tekton/home permission warnings).
+      - name: HOME
+        value: /tmp
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: ORAS_OPTIONS
+        value: "$(params.orasOptions)"
+      - name: DEBUG
+        value: "$(params.trustedArtifactsDebug)"
+      - name: PULP_DOMAIN
+        value: "$(params.PULP_DOMAIN)"
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: filter
+      image: quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 350m
+      volumeMounts:
+        - name: pulp-secret-name-vol
+          mountPath: "/etc/secrets"
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        # Avoid leaking secrets from cli.toml via bash xtrace in task logs.
+        set +x
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        if [[ ! -f "${SNAPSHOT_FILE}" ]]; then
+          echo "Error: No valid snapshot file was provided at ${SNAPSHOT_FILE}" >&2
+          exit 1
+        fi
+
+        CONFIG_FILE_CONTENT="$(cat /etc/secrets/cli.toml || true)"
+        if [[ -z "${CONFIG_FILE_CONTENT}" ]]; then
+          echo "Error: Missing cli.toml in secret $(params.PULP_SECRET_NAME)" >&2
+          exit 1
+        fi
+        echo "${CONFIG_FILE_CONTENT:?}" > "/tmp/cli.toml"
+        export PULP_CONFIG_FILE="/tmp/cli.toml"
+
+        # Helpers to read cli.toml values (return empty string when not found)
+        toml_get_optional() {
+          local key="$1"
+          if [[ ! "${key}" =~ ^[A-Za-z0-9_]+$ ]]; then
+            echo "Error: Invalid cli.toml key '${key}'" >&2
+            return 1
+          fi
+          # Prevent leaking secret values from cli.toml in logs when xtrace is enabled.
+          local restore_xtrace=0
+          if [[ $- == *x* ]]; then
+            restore_xtrace=1
+            set +x
+          fi
+
+          local line current_table="" value=""
+          while IFS= read -r line || [[ -n "${line}" ]]; do
+            if [[ "${line}" =~ ^[[:space:]]*\\[([^]]+)\\][[:space:]]*$ ]]; then
+              current_table="${BASH_REMATCH[1]}"
+              continue
+            fi
+            if [[ "${line}" =~ ^[[:space:]]*# ]] || [[ "${line}" =~ ^[[:space:]]*$ ]]; then
+              continue
+            fi
+            if [[ -n "${current_table}" && "${current_table}" != "cli" ]]; then
+              continue
+            fi
+            if [[ "${line}" =~ ^[[:space:]]*${key}[[:space:]]*= ]]; then
+              if [[ "${line}" =~ \"([^\"]*)\" ]]; then
+                value="${BASH_REMATCH[1]}"
+                break
+              fi
+              if [[ "${line}" =~ \'([^\']*)\' ]]; then
+                value="${BASH_REMATCH[1]}"
+                break
+              fi
+              value=""
+              break
+            fi
+          done < "${PULP_CONFIG_FILE}"
+
+          if (( restore_xtrace )); then
+            set -x
+          fi
+
+          echo "${value}"
+          return 0
+        }
+
+        toml_get_required() {
+          local key="$1"
+          local value
+          value="$(toml_get_optional "${key}")"
+          if [[ -z "${value}" ]]; then
+            echo "Error: Missing required '${key}' in cli.toml" >&2
+            return 1
+          fi
+          echo "${value}"
+        }
+
+        # Extract credentials from cli.toml (support both top-level and [cli] table via toml_get_optional logic)
+        PULP_BASE_URL="$(toml_get_required "base_url" | sed 's:/*$::')" || exit 1
+        CLIENT_ID="$(toml_get_optional "client_id")"
+        CLIENT_SECRET="$(toml_get_optional "client_secret")"
+        PULP_USERNAME="$(toml_get_optional "username")"
+        PULP_PASSWORD="$(toml_get_optional "password")"
+        TOKEN_URL="https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+
+        AUTH_METHOD="unknown"
+        if [[ -n "${PULP_USERNAME}" && -n "${PULP_PASSWORD}" ]]; then
+          AUTH_METHOD="basic"
+        elif [[ -n "${CLIENT_ID}" && -n "${CLIENT_SECRET}" ]]; then
+          AUTH_METHOD="oauth2-bearer"
+        fi
+        echo "Auth method detected for Pulp API calls: ${AUTH_METHOD}"
+
+        # Re-enable xtrace for the non-secret portions of the task.
+        set -x
+
+        get_access_token() {
+          if [[ -z "${CLIENT_ID}" || -z "${CLIENT_SECRET}" ]]; then
+            echo "Error: client_id/client_secret not present in cli.toml; cannot use OAuth2 Bearer token flow" >&2
+            return 1
+          fi
+          local token
+          token=$(
+            set +x
+            curl --retry 3 -s -X POST "$TOKEN_URL" \
+              -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+              -d "grant_type=client_credentials" \
+              -d "scope=api.console" | jq -r '.access_token'
+          )
+          if [[ -z "$token" || "$token" == "null" ]]; then
+            echo "Error: Failed to get OAuth2 access token" >&2
+            return 1
+          fi
+          echo "$token"
+        }
+
+        get_auth_header() {
+          if [[ -n "${PULP_USERNAME}" && -n "${PULP_PASSWORD}" ]]; then
+            local basic
+            basic="$(printf '%s' "${PULP_USERNAME}:${PULP_PASSWORD}" | base64 -w0)"
+            echo "Authorization: Basic ${basic}"
+            return 0
+          fi
+          if [[ -n "${CLIENT_ID}" && -n "${CLIENT_SECRET}" ]]; then
+            local access_token
+            access_token="$(get_access_token)" || return 1
+            echo "Authorization: Bearer ${access_token}"
+            return 0
+          fi
+          echo "Error: No supported credentials found in cli.toml." >&2
+          echo "Provide either username/password or client_id/client_secret." >&2
+          return 1
+        }
+
+        # Parse NEVRA fields from an RPM file (RPM header is authoritative)
+        parse_nevra() {
+          local file_path="$1"
+          local q rc name epoch version release arch
+          set +e
+          q="$(rpm -qp --qf '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}\n' "${file_path}" 2>/dev/null)"
+          rc=$?
+          set -e
+          if [[ ${rc} -eq 0 && -n "${q}" ]]; then
+            IFS='|' read -r name epoch version release arch <<< "${q}"
+            if [[ -z "${epoch}" || "${epoch}" == "(none)" ]]; then
+              epoch="0"
+            fi
+            if [[ -n "${name}" && -n "${version}" && -n "${release}" && -n "${arch}" ]]; then
+              echo "${name}|${epoch}|${version}|${release}|${arch}"
+              return 0
+            fi
+          fi
+          echo "Error: Failed to parse NEVRA from RPM header for '${file_path}'" >&2
+          return 1
+        }
+
+        get_repo_latest_version_href() {
+          local repo_name="$1"
+          local auth_header repo_href
+          set +x
+          auth_header="$(get_auth_header)" || return 1
+          set -x
+          repo_href=$(
+            set +x
+            curl --retry 3 -s -H "${auth_header}" \
+              "${PULP_BASE_URL}/api/pulp/${PULP_DOMAIN}/api/v3/repositories/rpm/rpm/?name=${repo_name}" \
+              | jq -r '.results[0].pulp_href'
+          )
+          if [[ -z "$repo_href" || "$repo_href" == "null" ]]; then
+            echo "Error: Could not find repository href for ${repo_name}" >&2
+            return 1
+          fi
+          {
+            set +x
+            curl --retry 3 -s -H "${auth_header}" \
+              "${PULP_BASE_URL}${repo_href}" | jq -r '.latest_version_href'
+            set -x
+          }
+        }
+
+        # Returns: 0 exists+matches, 2 not found, 3 digest mismatch
+        check_rpm_exists_with_digest() {
+          local repo_name="$1"
+          local file_path="$2"
+
+          local nevra name epoch version release arch endpoint
+          if ! nevra="$(parse_nevra "${file_path}")"; then
+            echo "Error: Failed to parse NEVRA for '${file_path}'" >&2
+            return 1
+          fi
+          IFS='|' read -r name epoch version release arch <<< "${nevra}"
+
+          # Pulp's RPM content API supports querying SRPMs via the "packages" endpoint with arch=src.
+          # Some deployments do not expose a separate "srpms" endpoint (404).
+          endpoint="packages"
+          if [[ "${file_path}" == *.src.rpm ]]; then
+            # Some SRPMs report a non-src arch in the header; the Pulp API uses arch=src for SRPM queries.
+            arch="src"
+          fi
+
+          local local_sha
+          local_sha="$(sha256sum "${file_path}" | awk '{print $1}')"
+
+          local repo_version_href
+          repo_version_href="$(get_repo_latest_version_href "${repo_name}")" || return 1
+
+          local enc_repo_version enc_name enc_epoch enc_version enc_release enc_arch query_url
+          enc_repo_version="$(jq -rn --arg x "${repo_version_href}" '$x|@uri')"
+          enc_name="$(jq -rn --arg x "${name}" '$x|@uri')"
+          enc_epoch="$(jq -rn --arg x "${epoch}" '$x|@uri')"
+          enc_version="$(jq -rn --arg x "${version}" '$x|@uri')"
+          enc_release="$(jq -rn --arg x "${release}" '$x|@uri')"
+          if [[ "${endpoint}" == "packages" ]]; then
+            enc_arch="$(jq -rn --arg x "${arch}" '$x|@uri')"
+          else
+            enc_arch=""
+          fi
+          query_url="${PULP_BASE_URL}/api/pulp/${PULP_DOMAIN}/api/v3/content/rpm/${endpoint}/"
+          query_url+="?repository_version=${enc_repo_version}"
+          query_url+="&name=${enc_name}&epoch=${enc_epoch}"
+          query_url+="&version=${enc_version}&release=${enc_release}"
+          if [[ -n "${enc_arch}" ]]; then
+            query_url+="&arch=${enc_arch}"
+          fi
+
+          local auth_header response count
+          {
+            set +x
+            auth_header="$(get_auth_header)" || return 1
+            response="$(curl --retry 3 -sS --fail -H "${auth_header}" "${query_url}")" || {
+              local rc=$?
+              echo "Error: Pulp content query failed (curl rc=${rc})" >&2
+              echo "Query URL: ${query_url}" >&2
+              return 1
+            }
+            set -x
+          }
+          if ! count="$(jq -er '.count // 0' <<< "${response}" 2>/dev/null)"; then
+            echo "Error: Pulp content query returned non-JSON response" >&2
+            echo "Query URL: ${query_url}" >&2
+            echo "Response (first 200 bytes): $(printf '%s' "${response}" | head -c 200)" >&2
+            return 1
+          fi
+          if [[ "${count}" -eq 0 ]]; then
+            return 2
+          fi
+
+          local content_hrefs server_sha artifact_href content_json artifact_json
+          mapfile -t content_hrefs < <(jq -r '.results[].pulp_href' <<< "${response}" | sed '/^null$/d')
+          for chref in "${content_hrefs[@]}"; do
+            content_json="$(
+              set +x
+              curl --retry 3 -s -H "${auth_header}" "${PULP_BASE_URL}${chref}"
+            )"
+            artifact_href="$(jq -r '.artifact // empty' <<< "${content_json}")"
+            if [[ -z "${artifact_href}" || "${artifact_href}" == "null" ]]; then
+              artifact_href="$(jq -r '.artifacts[0] // empty' <<< "${content_json}")"
+            fi
+            if [[ -z "${artifact_href}" || "${artifact_href}" == "null" ]]; then
+              continue
+            fi
+            artifact_json="$(
+              set +x
+              curl --retry 3 -s -H "${auth_header}" "${PULP_BASE_URL}${artifact_href}"
+            )"
+            server_sha="$(jq -r '.sha256 // empty' <<< "${artifact_json}")"
+            if [[ -n "${server_sha}" && "${server_sha}" == "${local_sha}" ]]; then
+              return 0
+            fi
+          done
+          return 3
+        }
+
+        should_exclude_file() {
+          local filename="$1"
+          local patterns_csv="$2"
+          local should_exclude=false
+          local pattern
+          IFS=',' read -ra EXCLUDE_PATTERNS <<< "${patterns_csv}"
+          for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+            pattern="$(echo "${pattern}" | xargs)"
+            [[ -z "${pattern}" ]] && continue
+            if [[ "${filename}" == *"${pattern}"* ]]; then
+              should_exclude=true
+              break
+            fi
+          done
+          [[ "${should_exclude}" == "true" ]]
+        }
+
+        extract_arches_from_files() {
+          local -n files_ref=$1
+          local arches=()
+          local file arch
+          for file in "${files_ref[@]}"; do
+            if [[ "${file}" == *.src.rpm ]] || [[ "${file}" == *.noarch.rpm ]]; then
+              continue
+            fi
+            if [[ "${file}" =~ \\.([^.]+)\\.rpm$ ]]; then
+              arch="${BASH_REMATCH[1]}"
+              if [[ " ${arches[*]} " != *" ${arch} "* ]]; then
+                arches+=("${arch}")
+              fi
+            fi
+          done
+          printf '%s\n' "${arches[@]}"
+        }
+
+        echo "Filtering snapshot RPMs against Pulp..." >&2
+        tmp_out="$(mktemp)"
+        snapshot_json="$(jq '.' "${SNAPSHOT_FILE}")"
+
+        # Build new components array (avoid pipe-to-while subshell so failures abort the task).
+        while IFS= read -r component; do
+          image="$(jq -r '.containerImage' <<< "${component}")"
+          name="$(jq -r '.name' <<< "${component}")"
+          echo "Processing component '${name}' (${image})" >&2
+
+          workdir="$(mktemp -d)"
+          mkdir -p "${workdir}/files"
+          AUTHFILE="${workdir}/auth.json"
+
+          export AUTHFILE
+          # Keep stdout clean (it is consumed as JSON later). Auth/config output isn't needed on stdout here.
+          select-oci-auth "${image}" > "${AUTHFILE}"
+          # Ensure any oras output does not contaminate the JSON stream.
+          oras pull --registry-config "${AUTHFILE}" "${image}" -o "${workdir}/files" 1>&2
+
+          mapfile -t files < <(
+            set -euo pipefail
+            shopt -s nullglob
+            cd "${workdir}/files"
+            for f in *; do
+              [[ -f "${f}" ]] || continue
+              [[ "${f}" == *.rpm ]] || continue
+              if should_exclude_file "${f}" "$(params.DEFAULT_EXCLUDES)"; then
+                continue
+              fi
+              printf '%s\n' "${f}"
+            done
+          )
+
+          # Determine arches used for noarch targeting
+          mapfile -t ARCHES < <(extract_arches_from_files files)
+          if [[ ${#ARCHES[@]} -eq 0 ]]; then
+            IFS=',' read -ra ARCHES <<< "$(params.DEFAULT_ARCHITECTURES)"
+            for i in "${!ARCHES[@]}"; do
+              ARCHES[i]=$(echo "${ARCHES[i]}" | xargs)
+            done
+          fi
+
+          rpms_to_publish="[]"
+          for f in "${files[@]}"; do
+            file_abs="${workdir}/files/${f}"
+            local_sha="$(sha256sum "${file_abs}" | awk '{print $1}')"
+            nevra="$(parse_nevra "${file_abs}")"
+            IFS='|' read -r rpmname epoch version release arch <<< "${nevra}"
+
+            # Determine target repos
+            target_repos=()
+            if [[ "${f}" == *.src.rpm ]]; then
+              target_repos=("source")
+            elif [[ "${f}" == *.noarch.rpm ]]; then
+              target_repos=("${ARCHES[@]}")
+            else
+              target_repos=("${arch}")
+            fi
+
+            missing_repos=()
+            for repo in "${target_repos[@]}"; do
+              set +e
+              check_rpm_exists_with_digest "${repo}" "${file_abs}"
+              status=$?
+              set -e
+              if [[ ${status} -eq 0 ]]; then
+                continue
+              elif [[ ${status} -eq 2 ]]; then
+                missing_repos+=("${repo}")
+              elif [[ ${status} -eq 3 ]]; then
+                echo "Error: RPM exists with different digest in repo '${repo}': ${f}" >&2
+                exit 1
+              else
+                echo "Error: Failed to check existence/digest for ${f} in repo '${repo}' (rc=${status})" >&2
+                exit 1
+              fi
+            done
+
+            if [[ ${#missing_repos[@]} -eq 0 ]]; then
+              continue
+            fi
+
+            missing_repos_json="$(printf '%s\n' "${missing_repos[@]}" | jq -R . | jq -s .)"
+            rpms_to_publish="$(jq \
+              --arg rpm "${f}" \
+              --arg rpmname "${rpmname}" \
+              --arg arch "${arch}" \
+              --arg epoch "${epoch}" \
+              --arg version "${version}" \
+              --arg release "${release}" \
+              --arg sha256 "${local_sha}" \
+              --argjson targetRepos "${missing_repos_json}" \
+              '. + [{
+                rpm: $rpm,
+                rpmname: $rpmname,
+                arch: $arch,
+                epoch: $epoch,
+                version: $version,
+                release: $release,
+                sha256: $sha256,
+                targetRepos: $targetRepos
+              }]' <<< "${rpms_to_publish}")"
+          done
+
+          # Emit component only if there is something to publish
+          if [[ "$(jq 'length' <<< "${rpms_to_publish}")" -gt 0 ]]; then
+            jq --argjson rpmsToPublish "${rpms_to_publish}" '. + {rpmsToPublish: $rpmsToPublish}' <<< "${component}"
+          fi
+
+          rm -rf "${workdir}"
+        done < <(jq -c '.components[]' <<< "${snapshot_json}") | jq -s '{components: .}' > "${tmp_out}"
+
+        # Merge back into snapshot (preserve top-level fields, replace components)
+        jq --slurpfile new "${tmp_out}" '.components = $new[0].components' "${SNAPSHOT_FILE}" > "${SNAPSHOT_FILE}.tmp"
+        mv "${SNAPSHOT_FILE}.tmp" "${SNAPSHOT_FILE}"
+
+        if [[ "$(jq '.components | length' "${SNAPSHOT_FILE}")" -eq 0 ]]; then
+          echo -n "true" > "$(results.skip_release.path)"
+        else
+          echo -n "false" > "$(results.skip_release.path)"
+        fi
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -ex
+
+# Reuse the same mocks as push-rpms-to-pulp tests, since this task calls the same tools.
+# These mocks are injected into the task step script by pre-apply-task-hook.sh.
+
+UPLOAD_COUNTER=0
+UPLOAD_FAIL_ONCE_ENABLED=0
+UPLOAD_FAIL_ONCE_ENABLED_FILE="/tmp/mock_upload_failonce_enabled"
+UPLOAD_FAIL_ONCE_DONE_FILE="/tmp/mock_upload_failonce_done"
+CONTENT_EXISTS_MODE_FILE="/tmp/mock_content_exists_mode"
+
+function curl() {
+  local args="$*"
+
+  if [[ "$args" == *"sso.redhat.com"* ]]; then
+    echo "token_request" >> $(params.dataDir)/mock_sso.txt
+    echo '{"access_token": "mock-access-token", "expires_in": 3600}'
+  elif [[ "$args" == *"/api/pulp/mock/api/v3/repositories/rpm/rpm/"* ]] && [[ "$args" != *"name="* ]]; then
+    echo '{"latest_version_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/mock-repo-uuid/versions/1/"}'
+  elif [[ "$args" == *"/api/pulp/mock/api/v3/content/rpm/packages/mock-existing-uuid/"* ]]; then
+    echo '{"pulp_href": "/api/pulp/mock/api/v3/content/rpm/packages/mock-existing-uuid/", "artifact": "/api/pulp/mock/api/v3/artifacts/mock-artifact-uuid/"}'
+  elif [[ "$args" == *"/api/pulp/mock/api/v3/content/rpm/packages/mock-existing-uuid/"* ]]; then
+    echo '{"pulp_href": "/api/pulp/mock/api/v3/content/rpm/packages/mock-existing-uuid/", "artifact": "/api/pulp/mock/api/v3/artifacts/mock-artifact-uuid/"}'
+  elif [[ "$args" == *"/api/pulp/mock/api/v3/artifacts/"* ]]; then
+    echo '{"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}'
+  elif [[ "$args" == *"/content/rpm/packages/"* ]]; then
+    mode="none"
+    if [[ -f "${CONTENT_EXISTS_MODE_FILE}" ]]; then
+      mode="$(cat "${CONTENT_EXISTS_MODE_FILE}")"
+    fi
+    echo "content_query mode=${mode} url=${args}" >> $(params.dataDir)/mock_content_queries.txt
+    if [[ "${mode}" == "all" ]]; then
+      echo '{"count": 1, "results": [{"pulp_href": "/api/pulp/mock/api/v3/content/rpm/packages/mock-existing-uuid/", "artifact": "/api/pulp/mock/api/v3/artifacts/mock-artifact-uuid/"}]}'
+    else
+      echo '{"count": 0, "results": []}'
+    fi
+  elif [[ "$args" == *"repositories/rpm/rpm"* && "$args" == *"name="* ]]; then
+    if [[ "$args" == *"name=source"* ]]; then
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/source-uuid/"}]}'
+    elif [[ "$args" == *"name=x86_64"* ]]; then
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/x86_64-uuid/"}]}'
+    elif [[ "$args" == *"name=aarch64"* ]]; then
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/aarch64-uuid/"}]}'
+    elif [[ "$args" == *"name=ppc64le"* ]]; then
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/ppc64le-uuid/"}]}'
+    elif [[ "$args" == *"name=s390x"* ]]; then
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/s390x-uuid/"}]}'
+    else
+      echo '{"results": [{"pulp_href": "/api/pulp/mock/api/v3/repositories/rpm/rpm/default-uuid/"}]}'
+    fi
+  elif [[ "$args" == *"modify"* ]]; then
+    echo '{"task": "/api/pulp/mock/api/v3/tasks/mock-task-id/"}'
+  else
+    command curl "$@"
+  fi
+}
+
+function select-oci-auth() {
+  echo "Mock select-oci-auth called with: $*"
+  # The real helper writes registry credentials to $AUTHFILE; tests don't require it.
+  : > "${AUTHFILE}"
+}
+
+function oras() {
+  echo "Mock oras called with: $*"
+  echo $* >> $(params.dataDir)/mock_oras.txt
+  local args="$*"
+
+  if [[ "$*" == "pull --registry-config"* ]]; then
+    output_file_dir=""
+    echo "none" > "${CONTENT_EXISTS_MODE_FILE}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -o|--output)
+          output_file_dir="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    if [[ "$args" == *"quay.io/test/alreadyexists"* ]]; then
+      echo "all" > "${CONTENT_EXISTS_MODE_FILE}"
+    elif [[ "$args" == *"quay.io/test/digestmismatch"* ]]; then
+      echo "all" > "${CONTENT_EXISTS_MODE_FILE}"
+      printf '%s\n' "not-empty" > "${output_file_dir}/hello-2.12.1-6.fc44.x86_64.rpm"
+      mkdir -p "${output_file_dir}/logs"
+      touch "${output_file_dir}/logs/hello-2.12.1-6.fc44.x86_64.rpm.log"
+      return 0
+    fi
+
+    # Default: create empty RPM files
+    mkdir -p "${output_file_dir}"
+    touch "${output_file_dir}/hello-2.12.1-6.fc44.aarch64.rpm"
+    touch "${output_file_dir}/hello-2.12.1-6.fc44.ppc64le.rpm"
+    touch "${output_file_dir}/hello-2.12.1-6.fc44.s390x.rpm"
+    touch "${output_file_dir}/hello-2.12.1-6.fc44.src.rpm"
+    touch "${output_file_dir}/hello-2.12.1-6.fc44.x86_64.rpm"
+    touch "${output_file_dir}/hello-docs-2.12.1-6.fc44.noarch.rpm"
+    mkdir -p "${output_file_dir}/logs"
+    touch "${output_file_dir}/logs/hello-2.12.1-6.fc44.x86_64.rpm.log"
+    return 0
+  fi
+}
+
+# The unit tests create dummy RPM files (empty placeholders). The production task
+# parses NEVRA from the RPM header via `rpm -qp`, so we mock that behavior here.
+function rpm() {
+  # Only mock RPM header queries used by parse_nevra() (`rpm -qp --qf ... <file>`).
+  if [[ "${1-}" == "-qp" ]]; then
+    local file_path=""
+    local filename base nvra namever version_with_epoch name epoch version release arch
+
+    # Extract the RPM path from args (ignore query flags/format).
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -qp)
+          shift
+          ;;
+        --qf)
+          shift 2
+          ;;
+        *)
+          file_path="$1"
+          shift
+          ;;
+      esac
+    done
+
+    if [[ -z "${file_path}" ]]; then
+      echo "mock rpm: missing rpm file path" >&2
+      return 1
+    fi
+
+    filename="$(basename "${file_path}")"
+    base="${filename%.rpm}"
+    arch="${base##*.}"
+    nvra="${base%.*}"
+    release="${nvra##*-}"
+    namever="${nvra%-*}"
+    version_with_epoch="${namever##*-}"
+    name="${namever%-*}"
+    epoch="0"
+    if [[ "${version_with_epoch}" == *:* ]]; then
+      epoch="${version_with_epoch%%:*}"
+      version="${version_with_epoch#*:}"
+    else
+      version="${version_with_epoch}"
+    fi
+
+    printf '%s|%s|%s|%s|%s\n' "${name}" "${epoch}" "${version}" "${release}" "${arch}"
+    return 0
+  fi
+
+  command rpm "$@"
+}

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/pre-apply-task-hook.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script (step index 1 is the filter step)
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Create a dummy pulp secret (and delete it first if it exists)
+kubectl delete secret pulp-task-pulp-secret --ignore-not-found
+kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml='base_url = "https://dummy.com"
+client_id = "DUMMY"
+client_secret = "DUMMY"
+'

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-all-exists.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-all-exists.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-rpms-all-exists
+spec:
+  description: |
+    Run filter-already-released-advisory-rpms where all RPMs already exist
+    in Pulp and verify snapshot is reduced to 0 components.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/alreadyexists@sha256:12345",
+                    "name": "test"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-rpms
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: skip_release
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Check that skip_release is set to true when all RPMs already exist
+              if [ "$(params.skip_release)" != "true" ]; then
+                echo "skip_release should be true when all RPMs are already released"
+                exit 1
+              fi
+
+              snap="$(cat "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json")"
+              echo "$snap" | jq .
+              test "$(echo "$snap" | jq '.components | length')" = "0"
+      runAfter:
+        - run-task

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-basic.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-basic.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-rpms-basic
+spec:
+  description: |
+    Run filter-already-released-advisory-rpms where nothing exists in Pulp and verify rpmsToPublish is populated.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/happypath@sha256:12345",
+                    "name": "test"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-rpms
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              snap="$(cat "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json")"
+              echo "$snap" | jq .
+              # Should keep the component and attach rpmsToPublish with at least one entry
+              test "$(echo "$snap" | jq '.components | length')" = "1"
+              test "$(echo "$snap" | jq '.components[0].rpmsToPublish | length')" -gt 0
+      runAfter:
+        - run-task

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-digest-mismatch.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-digest-mismatch.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-rpms-digest-mismatch
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run filter-already-released-advisory-rpms where RPM exists in Pulp for the same NEVRA but digest differs.
+    The task should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/digestmismatch@sha256:12345",
+                    "name": "test"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-rpms
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup


### PR DESCRIPTION
## Describe your changes
- this task serves 2 functions.
  - The first is to actually filter already released rpms by checking for their existence in pulp.
  - The second is to produce a data set of rpms and their attributes that can be then provided to the populate release notes task

## Relevant Jira
- HUM-304

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
