### PR TITLE
chore: tweak pubtools-sign timeouts

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -197,7 +197,7 @@ spec:
           topic_listen_to: queue://Consumer.${creator}.${requester}-{task_id}.${umb_listen_topic}
           environment: prod
           service: ${umb_client_name}
-          timeout: 120
+          timeout: 40
           retries: 2
           send_retries: 2
           message_id_key: request_id
@@ -211,7 +211,7 @@ spec:
           topic_listen_to: queue://Consumer.${creator}.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
           environment: prod
           service: ${umb_client_name}
-          timeout: 600
+          timeout: 200
           retries: 2
           send_retries: 2
           message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -168,7 +168,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 120
+                timeout: 40
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -182,7 +182,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.test-user-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 600
+                timeout: 200
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
@@ -198,7 +198,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 120
+                timeout: 40
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -212,7 +212,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 600
+                timeout: 200
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
@@ -139,7 +139,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_listen_topic}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 120
+                timeout: 40
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id
@@ -153,7 +153,7 @@ spec:
                 topic_listen_to: queue://Consumer.test-mock.${requester}-{task_id}.${umb_batch_listen_topic}.{task_id}
                 environment: prod
                 service: ${umb_client_name}
-                timeout: 600
+                timeout: 200
                 retries: 2
                 send_retries: 2
                 message_id_key: request_id


### PR DESCRIPTION
## Describe your changes

We recently increased the timeouts here:
https://github.com/konflux-ci/release-service-catalog/pull/1859

But I just learned that the full timeout is effectively timeout*(retries+1) - retries means retries for the listening part. And so after the timeout is reached, it will reconnect again and wait again.

So if we want to give it 10 minutes of waiting for signing response in batch signing in total, the timeout value should be divided by the number of attempts.

Before this change, pubtools-sign would wait up to 30 minutes and the whole pipeline has a timeout of 25 minutes.

Slack: https://redhat-internal.slack.com/archives/C06A2R1CF6Z/p1769430235573489?thread_ts=1766149929.662589&cid=C06A2R1CF6Z

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
