### PR TITLE
fix(KFLUXSPRT-6742): enforce cpe label check

### DIFF
--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -228,9 +228,10 @@ spec:
             cpe_label=$(jq -r '.metadata.labels // [] | .[] | select(.name == "cpe")
                 | .value // empty' <<< "$component")
 
-            # Check if the label was found. If not, we skip the enforcement.
+            # Check if the label was found. It is always required.
             if [[ -z "$cpe_label" ]]; then
-              echo "Info: Component '$name' is missing the 'cpe' label. Skipping enforcement."
+              fail_or_warn "Component '$name' is missing the required container label" \
+                "'cpe' in its metadata."
               continue
             fi
 


### PR DESCRIPTION
Evaluate the missing "cpe" label and fail in case enforce is set to true.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
