### PR TITLE
chore: add ROX_ENDPOINT to the run-collectors

### DIFF
--- a/pipelines/run-collectors/run-collectors.yaml
+++ b/pipelines/run-collectors/run-collectors.yaml
@@ -132,6 +132,8 @@ spec:
           value: $(tasks.collect-collectors-resources.results.previousRelease)
         - name: roxConfigDir
           value: $(tasks.collect-collectors-resources.results.roxConfigDir)
+        - name: roxCentralEndpoint
+          value: $(params.roxCentralEndpoint)
       workspaces:
         - name: data
           workspace: release-workspace

--- a/tasks/collectors/run-collectors/README.md
+++ b/tasks/collectors/run-collectors/README.md
@@ -9,15 +9,16 @@ This enables dynamic JQL queries without modifying ReleasePlan for each release 
 
 ## Parameters
 
-| Name                         | Description                                                                             | Optional | Default value |
-|------------------------------|-----------------------------------------------------------------------------------------|----------|---------------|
-| collectorsPath               | Path to the JSON string of the resource containing the collectors in the data workspace | No       | -             |
-| collectorsResourceType       | The type of resource that contains the collectors                                       | No       | -             |
-| resultsDir                   | The relative path in the workspace to save the collector results to                     | No       | -             |
-| collectorsRepository         | Git repository where the collectors will be defined                                     | No       | -             |
-| collectorsRepositoryRevision | Git repository revision                                                                 | Yes      | main          |
-| releasePath                  | Path to the json data file of the current in-progress Release                           | No       | -             |
-| previousReleasePath          | Path to the json data file of the previous successful Release prior to the current one  | No       | -             |
-| caTrustConfigMapName         | The name of the ConfigMap to read CA bundle data from                                   | Yes      | trusted-ca    |
-| caTrustConfigMapKey          | The name of the key in the ConfigMap that contains the CA bundle data                   | Yes      | ca-bundle.crt |
-| roxConfigDir                 | The relative path in the workspace to the roxctl configuration directory (optional)     | Yes      | ""            |
+| Name                         | Description                                                                             | Optional | Default value                                    |
+|------------------------------|-----------------------------------------------------------------------------------------|----------|--------------------------------------------------|
+| collectorsPath               | Path to the JSON string of the resource containing the collectors in the data workspace | No       | -                                                |
+| collectorsResourceType       | The type of resource that contains the collectors                                       | No       | -                                                |
+| resultsDir                   | The relative path in the workspace to save the collector results to                     | No       | -                                                |
+| collectorsRepository         | Git repository where the collectors will be defined                                     | No       | -                                                |
+| collectorsRepositoryRevision | Git repository revision                                                                 | Yes      | main                                             |
+| releasePath                  | Path to the json data file of the current in-progress Release                           | No       | -                                                |
+| previousReleasePath          | Path to the json data file of the previous successful Release prior to the current one  | No       | -                                                |
+| caTrustConfigMapName         | The name of the ConfigMap to read CA bundle data from                                   | Yes      | trusted-ca                                       |
+| caTrustConfigMapKey          | The name of the key in the ConfigMap that contains the CA bundle data                   | Yes      | ca-bundle.crt                                    |
+| roxConfigDir                 | The relative path in the workspace to the roxctl configuration directory (optional)     | Yes      | ""                                               |
+| roxCentralEndpoint           | The url for RHACS Central (optional, required for sbomdiff collector)                   | Yes      | https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com |

--- a/tasks/collectors/run-collectors/run-collectors.yaml
+++ b/tasks/collectors/run-collectors/run-collectors.yaml
@@ -51,6 +51,10 @@ spec:
       type: string
       description: The relative path in the workspace to the roxctl configuration directory (optional)
       default: ""
+    - name: roxCentralEndpoint
+      type: string
+      description: The url for RHACS Central (optional, required for sbomdiff collector)
+      default: https://acs-d4dgfbkto15c73biblcg.acs.rhcloud.com
   workspaces:
     - name: data
       description: Workspace where the CRs are stored
@@ -84,12 +88,18 @@ spec:
         RELEASE_FILE="$(workspaces.data.path)/$(params.releasePath)"
         PREVIOUS_RELEASE_FILE="$(workspaces.data.path)/$(params.previousReleasePath)"
 
-        # Set ROX_CONFIG_DIR if provided (for sbomdiff collector)
+        # Set ROX_CONFIG_DIR and ROX_ENDPOINT if provided (for sbomdiff collector)
         ROX_CONFIG_DIR_PARAM="$(params.roxConfigDir)"
         if [ -n "${ROX_CONFIG_DIR_PARAM}" ]; then
           ROX_CONFIG_DIR="$(workspaces.data.path)/${ROX_CONFIG_DIR_PARAM}"
           export ROX_CONFIG_DIR
           echo "ROX_CONFIG_DIR set to: ${ROX_CONFIG_DIR}"
+        fi
+
+        ROX_ENDPOINT_PARAM="$(params.roxCentralEndpoint)"
+        if [ -n "${ROX_ENDPOINT_PARAM}" ]; then
+          export ROX_ENDPOINT="${ROX_ENDPOINT_PARAM}"
+          echo "ROX_ENDPOINT set to: ${ROX_ENDPOINT}"
         fi
 
         # Interpolate template variables in a string using Release CR data


### PR DESCRIPTION
## Describe your changes

The run-collectors task is missing the ROX_ENDPOINT, failing the task when sbomdiff collector is enabled. This adds the parameter to the run-collectors task.

## Relevant Jira

CWFHEALTH-4628

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
