### PR TITLE
fix: add sleep to kinit retry loops in koji tasks

### DIFF
--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -193,6 +193,9 @@ spec:
                 break
             fi
             TRIES=$((TRIES - 1))
+            if [ $TRIES -gt 0 ]; then
+                sleep 2
+            fi
         done
 
         USER_NAME=$(echo "$PRINCIPAL" | cut -d'@' -f1)

--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -202,6 +202,9 @@ spec:
                 break
             fi
             TRIES=$((TRIES - 1))
+            if [ $TRIES -gt 0 ]; then
+                sleep 2
+            fi
         done
 
         USER_NAME=$(echo "$PRINCIPAL" | cut -d'@' -f1)


### PR DESCRIPTION
The kinit retry loops in push-rpm-to-koji and promote-koji-draft-build were retrying immediately without delay, causing unnecessary load on authentication services. Added 2-second sleep between retry attempts.

## Describe your changes
### Summary
- Adds 2-second sleep between kinit authentication retry attempts
- Affects `push-rpm-to-koji` and `promote-koji-draft-build` tasks
- Prevents hammering auth service with immediate retries

### Changes
- Modified retry loop to include `sleep 2` between failed attempts
- No functional changes to retry count or error handling

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
