### PR TITLE
feat(check-labels): use canonicalName when provided for single repos

### DIFF
--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -150,34 +150,29 @@ spec:
 
             num_repos=$(jq '.repositories | length' <<< "$component")
 
-            if [[ "$num_repos" -eq 1 ]]; then
-                # --- SINGLE REPOSITORY LOGIC ---
-                # Must match the derived URL name. Component-level canonicalName is ignored.
+            # Require canonicalName when multiple repositories exist
+            if [[ "$num_repos" -gt 1 && -z "$canonical_name" ]]; then
+                fail_or_warn "Component '$name' has multiple repositories, but is missing the" \
+                    "component-level 'canonicalName'."
+                continue
+            fi
+
+            # Use canonicalName if present, otherwise derive from repository URL
+            if [[ -n "$canonical_name" ]]; then
+                expected_name="$canonical_name"
+            else
                 url=$(jq -r '.repositories[0]."rh-registry-repo" // empty' <<< "$component")
                 if [[ -z "$url" ]]; then
                     echo "Error: Component '$name' repositories[0].\"rh-registry-repo\" is missing" >&2
                     exit 1
                 fi
+                expected_name=$(derive_name_from_url "$url")
+            fi
 
-                derived_name=$(derive_name_from_url "$url")
-
-                if [[ "$name_label" != "$derived_name" ]]; then
-                    fail_or_warn "Component '$name' name label ('$name_label') does not match" \
-                        "derived name from URL ('$derived_name')"
-                fi
-            elif [[ "$num_repos" -gt 1 ]]; then
-                # --- MULTIPLE REPOSITORY LOGIC ---
-                # A component-level canonicalName is REQUIRED and must match the name label.
-                if [[ -z "$canonical_name" ]]; then
-                    fail_or_warn "Component '$name' has multiple repositories, but is missing the" \
-                        "component-level 'canonicalName'."
-                    continue
-                fi
-
-                if [[ "$name_label" != "$canonical_name" ]]; then
-                    fail_or_warn "Component '$name' name label ('$name_label') does not match" \
-                        "component-level canonicalName ('$canonical_name')"
-                fi
+            # Validate name label matches expected name
+            if [[ "$name_label" != "$expected_name" ]]; then
+                fail_or_warn "Component '$name' name label ('$name_label') does not match" \
+                    "expected name ('$expected_name')"
             fi
         done
     - name: enforce-cpe-label

--- a/tasks/managed/check-labels/tests/test-check-labels-single-repo-with-canonical.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-single-repo-with-canonical.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-labels-single-repo-with-canonical
+spec:
+  description: |
+    Run the check-labels task with a single repository but with canonicalName provided.
+    This should pass - canonicalName should be respected when provided, even with a single repo.
+    Use case: ubi9 (canonicalName) with single repo ubi9/ubi.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "cpe": "cpe:/a:example:openstack:el8"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "canonicalName": "ubi9",
+                    "metadata": {
+                      "labels": [
+                        {
+                          "name": "name",
+                          "value": "ubi9"
+                        },
+                        {
+                          "name": "cpe",
+                          "value": "cpe:/a:example:openstack:el8"
+                        }
+                      ]
+                    },
+                    "repositories": [
+                      {
+                        "rh-registry-repo": "registry.redhat.io/ubi9/ubi"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-labels
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: enforce
+          value: "true"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup


### PR DESCRIPTION
## Describe your changes
Allow components with a single repository to use canonicalName if provided, while only requiring it when multiple repositories exist. This supports use cases like ubi9 where canonicalName is "ubi9" but the repository is "ubi9/ubi" but also supports cases like openshift where the canonicalName is "openshift/some-repo" but the repository is "openshift4/some-repo".

Simplified validation logic to:
- Require canonicalName only when num_repos > 1
- Use canonicalName if present, otherwise derive from repository URL
- Single validation check for name label matching


## Relevant Jira

https://issues.redhat.com/browse/RELEASE-2185

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
