### PR TITLE
fix: don't run check-labels on non-images

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -467,6 +467,13 @@ spec:
                 "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 
+            # Add media type to component
+            if [ -n "$config_media_type" ]; then
+              jq --argjson i "$i" --arg media_type "$config_media_type" \
+                '.components[$i].metadata = (.components[$i].metadata // {}) * {media_type: $media_type}' \
+                "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
+            fi
+
             # Transform version to OCI tag format: replace + with _ (convention for OCI compliance)
             # Set default value if empty (common for regular container images without OCI annotations)
             oci_version="${oci_version_raw//+/_}"

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -185,3 +185,8 @@ spec:
               test "$(
                 jq -c '.components[0] | .metadata.annotations // []' < "$TEST_SNAPSHOT"
               )" == '[{"name":"org.opencontainers.image.created","value":"2024-07-29T02:17:29Z"}]'
+
+              echo "Test that component 0 has the correct media type"
+              test "$(
+                jq -r -c '.components[0] | .metadata.media_type // ""' < "$TEST_SNAPSHOT"
+              )" == 'application/vnd.oci.image.config.v1+json'

--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -135,6 +135,20 @@ spec:
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
 
+            # Fetch the media type of the artifact
+            media_type=$(jq -r '.metadata.media_type // null' <<< "$component")
+
+            # Standard config types are:
+            #   - application/vnd.oci.image.config.v1+json (OCI images)
+            #   - application/vnd.docker.container.image.v1+json (Docker images)
+            # All other artifacts (Helm charts, ML models, empty configs, etc.)
+            # don't have labels. Ignore this check for non-images
+            if [[ "$media_type" != "application/vnd.oci.image.config.v1+json" ]] && \
+               [[ "$media_type" != "application/vnd.docker.container.image.v1+json" ]]; then
+                echo "Skipping check for artifact '$name' of type '$media_type'"
+                continue
+            fi
+
             # Fetch the value of the 'name' label from the container's metadata
             name_label=$(jq -r '.metadata.labels? | .[] | select(.name == "name") | .value' <<< "$component" || true)
 
@@ -223,6 +237,20 @@ spec:
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
+
+            # Fetch the media type of the artifact
+            media_type=$(jq -r '.metadata.media_type // null' <<< "$component")
+
+            # Standard config types are:
+            #   - application/vnd.oci.image.config.v1+json (OCI images)
+            #   - application/vnd.docker.container.image.v1+json (Docker images)
+            # All other artifacts (Helm charts, ML models, empty configs, etc.)
+            # don't have labels. Ignore this check for non-images
+            if [[ "$media_type" != "application/vnd.oci.image.config.v1+json" ]] && \
+               [[ "$media_type" != "application/vnd.docker.container.image.v1+json" ]]; then
+                echo "Skipping check for artifact '$name' of type '$media_type'"
+                continue
+            fi
 
             # Fetch the value of the 'cpe' label from the component's metadata
             cpe_label=$(jq -r '.metadata.labels // [] | .[] | select(.name == "cpe")

--- a/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-canonical.yaml
@@ -70,6 +70,7 @@ spec:
                     "name": "comp1",
                     "canonicalName": "openshift-gitops-1/gitops-rhel8-operator",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-multiple-components.yaml
@@ -70,6 +70,7 @@ spec:
                     "name": "comp1",
                     "canonicalName": "openshift-gitops-1/gitops-rhel8-operator",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",
@@ -90,6 +91,7 @@ spec:
                     "name": "comp2",
                     "canonicalName": "openshift-gitops-2/gitops-rhel8-operator",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-canonical-fail.yaml
@@ -71,6 +71,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-label.yaml
@@ -70,6 +70,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-fail.yaml
@@ -72,6 +72,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-cpe-match-warning.yaml
@@ -70,6 +70,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-match-canonical-fail.yaml
@@ -72,6 +72,7 @@ spec:
                     "name": "comp1",
                     "canonicalName": "openshift-gitops-1/gitops-rhel8-operator",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-fail.yaml
@@ -71,6 +71,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-no-name-match-warning.yaml
@@ -69,6 +69,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",

--- a/tasks/managed/check-labels/tests/test-check-labels-non-image-success.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels-non-image-success.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-labels-non-image-success
+spec:
+  description: |
+    Run the check-labels task with a non-image OCI artifact, and ensure it passes
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "cpe": "cpe:/a:example:openstack:el8"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "metadata": {
+                      "media_type": "something weird, not an image"
+                    },
+                    "repositories": [
+                      {
+                        "rh-registry-repo": " registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-labels
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: enforce
+          value: "true"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/check-labels/tests/test-check-labels.yaml
+++ b/tasks/managed/check-labels/tests/test-check-labels.yaml
@@ -69,6 +69,7 @@ spec:
                   {
                     "name": "comp1",
                     "metadata": {
+                      "media_type": "application/vnd.oci.image.config.v1+json",
                       "labels": [
                         {
                           "name": "name",


### PR DESCRIPTION

## Describe your changes

This change makes the media type available via the metadata object and then uses it during the check labels task to skip checks for non-image OCI artifacts. 

We ship OCI artifacts via the rh-advisories pipeline, but they don't have labels and therefore will not pass the check-labels checks.

However, those tenants ship both OCI artifacts and normal images. We want to be able to enable the enforcement for them to cover their normal images while still letting their OCI artifacts pass.

## Relevant Jira
https://issues.redhat.com/browse/RELEASE-2186

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
