### PR TITLE
fix(KONFLUX-11837): make sure the resolved index is published

### DIFF
--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -147,12 +147,18 @@ spec:
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         LENGTH="$(jq -r '.components | length' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
+        sourceIndex=()
         for((i=0; i<LENGTH; i++)); do
           targetIndex=$(jq -r --argjson i "$i" \
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          sourceIndex=$(jq -r  --argjson i "$i" \
-            '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")
+          sourceIndex+=("$(jq -r  --argjson i "$i" \
+            '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")")
+
+          # we need the resolved index_image as the published pub index might be replaced by another process,
+          # causing pyxis to fail, so we need to publish the resolved as the timestamped one.
+          sourceIndex+=("$(jq -r  --argjson i "$i" \
+            '.components[$i].index_image_resolved' "$(params.dataDir)/$(params.internalRequestResultsFile)")")
 
           buildTimestamp=$(jq -r --argjson i "$i" '.components[$i].completion_time' \
             "$(params.dataDir)/$(params.internalRequestResultsFile)")
@@ -171,11 +177,11 @@ spec:
           for((x=0; x<${#publishingImages[@]}; x++ )); do
               echo "=== Creating internal request to publish image:"
               echo ""
-              echo "- from: ${sourceIndex}"
+              echo "- from: ${sourceIndex[$x]}"
               echo "- to: ${publishingImages[$x]}"
 
               internal-request --pipeline "${request}" \
-                  -p sourceIndex="${sourceIndex}" \
+                  -p sourceIndex="${sourceIndex[$x]}" \
                   -p targetIndex="${publishingImages[$x]}" \
                   -p publishingCredentials="${credentials}" \
                   -p retries="$(params.retries)" \

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -189,13 +189,19 @@ spec:
                     exit 1
                   fi
 
-                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib:01" ]; then
+                  targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+                  expectedSourceIndex="redhat.com/rh-stage/iib:01"
+                  if [[ "$targetIndex" == *"2023-03-06T16:39:11.314092Z" ]]; then
+                      expectedSourceIndex="redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                  fi
+
+                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "$expectedSourceIndex" ]; then
                     echo "sourceIndex image does not match"
                     exit 1
                   fi
 
                   targetIndex=$(jq -r '.targetIndex' <<< "${params}")
-                  if [ $i = 0 ]; then
+                  if [ "$i" -eq 0 ]; then
                       if [ "$targetIndex" != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
                         echo "targetIndex image does not match"
                         exit 1


### PR DESCRIPTION
This PR changes the publish-index-image task to make sure the index_image_resolved image is published to the repo with its unique floating tag.

This is due to the fact that another process writing to the same OCP index might change the sha while the build is happening and a different sha is actually published.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
