### PR TITLE
feat(HUM-434): rpm advisories published officially

### DIFF
--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -163,7 +163,8 @@ spec:
               {"resultIndex": 1, "key": ".pulp.secretName"},
               {"resultIndex": 2, "key": ".conforma.workerCount", "default": "4"},
               {"resultIndex": 3, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"},
-              {"resultIndex": 4, "key": ".sign.cosignSecretName", "default": ""}
+              {"resultIndex": 4, "key": ".sign.cosignSecretName", "default": ""},
+              {"resultIndex": 5, "key": ".intention", "default": "staging"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -497,7 +498,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
         - name: cosignSecretName
-          value: "$(tasks.collect-task-params.results.extractedValues[5])"
+          value: "$(tasks.collect-task-params.results.extractedValues[4])"
         - name: attestationPubKey
           value: "$(params.conformaPubKey)"
       runAfter:
@@ -641,8 +642,7 @@ spec:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: environment
-          value: "stage"
-          # value: "$(tasks.set-advisory-severity.results.environment)"
+          value: "$(tasks.collect-task-params.results.extractedValues[5])"
         - name: resultsDirPath
           value: "$(tasks.collect-data.results.resultsDir)"
         - name: pipelineRunUid
@@ -680,10 +680,9 @@ spec:
         - input: "$(tasks.filter-already-released-advisory-rpms.results.skip_release)"
           operator: in
           values: ["false"]
-          # - input: "$(tasks.filter-already-released-advisory-rpms.results.environment)"
-        - input: "staging-changeme"
+        - input: "$(tasks.collect-task-params.results.extractedValues[5])"
           operator: in
-          values: ["production-changeme"]
+          values: ["production"]
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -471,10 +471,14 @@ spec:
         stagingSecretName="create-advisory-stage-secret"
         stagingErrataSecretName="errata-stage-service-account"
 
-        if [ "$content_type" = "image" ]; then
+        # See decision in https://issues.redhat.com/browse/HUM-434
+        # why we only publish image or rpm to main advisory repos
+        if [[ "$content_type" =~ ^(image|rpm)$ ]] ; then
+
           advisorySecretName="${prodSecretName}"
           errataSecretName="${prodErrataSecretName}"
-          if [ "$(params.environment)" == "stage" ]; then
+          # We allow "stage" or "staging" for the environment parameter
+          if [[ "$(params.environment)" =~ ^(stage|staging)$ ]]; then
             advisorySecretName="${stagingSecretName}"
             errataSecretName="${stagingErrataSecretName}"
           fi


### PR DESCRIPTION
## Describe your changes
- we now allow rpm advisories to be published officially in the main prod and staging advisory gitlab repos
- this feature can now be enabled since SDENGINE-233 is deployed to production.

## Relevant Jira
- HUM-434
- SDENGINE-223

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
