### PR TITLE
chore(RELEASE-2188): decrease chunk_size for batch signing

### DIFF
--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -216,7 +216,7 @@ spec:
           send_retries: 2
           message_id_key: request_id
           log_level: debug
-          chunk_size: 200
+          chunk_size: 100
         EOF
         echo "Using signing config:"
         cat "$(workspaces.data.path)/pubtools-sign-config.yaml"

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-2-references.yaml
@@ -187,7 +187,7 @@ spec:
                 send_retries: 2
                 message_id_key: request_id
                 log_level: debug
-                chunk_size: 200
+                chunk_size: 100
               EOF
               diff -Naur "/tmp/expected_config.yaml" "$(workspaces.data.path)/pubtools-sign-config.yaml"
 

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature-batch-signer.yaml
@@ -217,7 +217,7 @@ spec:
                 send_retries: 2
                 message_id_key: request_id
                 log_level: debug
-                chunk_size: 200
+                chunk_size: 100
               EOF
               diff -Naur "/tmp/expected_config.yaml" "$(workspaces.data.path)/pubtools-sign-config.yaml"
 

--- a/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/tests/test-request-and-upload-signature.yaml
@@ -158,7 +158,7 @@ spec:
                 send_retries: 2
                 message_id_key: request_id
                 log_level: debug
-                chunk_size: 200
+                chunk_size: 100
               EOF
               diff -Naur "/tmp/expected_config.yaml" "$(workspaces.data.path)/pubtools-sign-config.yaml"
 


### PR DESCRIPTION
## Describe your changes

In order to verify that the batch signing bug that caused incorrect signatures, we need a signing pipeline that will need more than one batches of signing within the internal request-and-upload-signatures task.

In our test, rh-sign-image would only request less than 200 signatures in a single IR, so we would never hit this scenario.

The reason is that the rh-sign-image caps the batch based on total string size - all references in a batch are capped at 16k chars. But out test is for stage releases
so each reference has an extra "stage." string which means that less references fit in a single batch...

So to help testing, let's reduce the number of requests that pubtools-sign sends at once: 200 -> 100

## Relevant Jira

RELEASE-2188

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
