### PR TITLE
fix(KONFLUX-11897): handle leading 0 incrementer tags

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -187,14 +187,17 @@ spec:
             # Remove `{{ incrementer }}` placeholder to get the version prefix for regex pattern
             # shellcheck disable=SC2001
             version_prefix=$(echo "${tag_template}" | sed 's/{{ incrementer }}//g')
-            tag_pattern="^${version_prefix}[0-9]+$"  # Build regex pattern dynamically
+            # Match tags with 1–6 digit increments only. Ignore 7+ digit tags to avoid
+            # treating short commit SHAs as incrementer values
+            tag_pattern="^${version_prefix}[0-9]{1,6}$"
 
             # Extract the numeric part of existing tags and find the max increment
             max_increment=$(echo "${existing_tags}" | { grep -E "${tag_pattern}" || true; } \
             | sed -E "s/${version_prefix}//" | sort -nr | head -n1)
 
             # Calculate the next increment (default to 1 if max_increment is empty or unset)
-            increment=$((max_increment + 1))
+            # Use 10# to force decimal input preventing leading 0 from being treated as octal
+            increment=$((10#${max_increment:-0} + 1))
 
             # Substitute `{{ incrementer }}` in the tag template with the calculated increment
             tag="${tag_template//\{\{ incrementer \}\}/${increment}}"

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -46,6 +46,18 @@ function skopeo() {
       return
   fi
 
+  # 7 digit tags: ignored by {1,6} regex, incrementer starts at 1
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-leadingzero ]]; then
+      echo '{"Tags": ["v0.7.0-0760387", "v0.7.0-0760386"]}'
+      return
+  fi
+
+  # Leading 0 with invalid octal digit: 10# fix prevents octal error
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-octal ]]; then
+      echo '{"Tags": ["v1.0.0-08", "v1.0.0-07"]}'
+      return
+  fi
+
   # Raw manifest inspections (for annotations and config.mediaType) - these use the digest from get-image-architectures
   if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://quay.io/myorg/helm-chart"* ]]
   then

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -113,6 +113,28 @@ spec:
                           "url": "repo3a"
                         }
                       ]
+                    },
+                    {
+                      "name": "comp4-leadingzero",
+                      "repositories": [
+                        {
+                          "url": "repo-leadingzero",
+                          "tags": [
+                            "v0.7.0-{{ incrementer }}"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp5-octal",
+                      "repositories": [
+                        {
+                          "url": "repo-octal",
+                          "tags": [
+                            "v1.0.0-{{ incrementer }}"
+                          ]
+                        }
+                      ]
                     }
                   ],
                   "defaults": {
@@ -148,6 +170,26 @@ spec:
                     "name": "comp3",
                     "containerImage": "registry.io/image3@sha256:123456",
                     "repository": "repo3"
+                  },
+                  {
+                    "name": "comp4-leadingzero",
+                    "containerImage": "registry.io/image4@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp5-octal",
+                    "containerImage": "registry.io/image5@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
                   }
                 ]
               }
@@ -272,3 +314,15 @@ spec:
                 jq -r '.components[] | select(.name=="comp3") | .repositories[0].tags | length' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" -eq 1
+
+              echo Test that comp4 ignores 7 digit tags and starts at 1
+              test "$(
+                jq -c '.components[] | select(.name=="comp4-leadingzero").repositories[0].tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["defaultTag","v0.7.0-1"]'
+
+              echo Test that comp5 handles leading 0 with invalid octal
+              test "$(
+                jq -c '.components[] | select(.name=="comp5-octal").repositories[0].tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["defaultTag","v1.0.0-9"]'


### PR DESCRIPTION
## Describe your changes
* Use 10# prefix to force decimal input preventing leading zeros from being treated as octal.
* Limit incrementer regex to 1-6 digits ignoring 7+ digit tags.
## Relevant Jira
KONFLUX-11897
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
