### PR TITLE
fix: enable recursion for oot kmods

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -191,17 +191,45 @@ spec:
 
             for LAYER in $(jq -r '.layers[].digest' "$tmp_dir/manifest.json"); do
                 LAYER=${LAYER#sha256:}
-                # Check if the archive contains the KMODS_PATH directory
-                if tar -tf "$tmp_dir/$LAYER" | grep -q "^${KMODS_PATH#/}/"; then
+                # Check if the archive contains the KMODS_PATH directory or .ko files within it
+                if tar -tf "$tmp_dir/$LAYER" | grep -E "^${KMODS_PATH#/}.*\.ko$" > /dev/null 2>&1; then
                     echo "Extracting $KMODS_PATH/ from $LAYER for $arch_name..."
                     tar -xf "$tmp_dir/$LAYER" -C "$tmp_dir" "${KMODS_PATH#/}" --no-same-owner
 
                     mkdir -p "$dest_dir"
-                    if ls "$tmp_dir$KMODS_PATH"/*.ko 1> /dev/null 2>&1; then
-                        cp -r "$tmp_dir$KMODS_PATH"/*.ko "$dest_dir/"
-                        extracted=true
-                        ko_count=$(find "$dest_dir" -name "*.ko" -type f | wc -l)
-                        echo "Extracted .ko files for $arch_name: $ko_count files"
+
+                    # Check if KMODS_PATH directory exists and extract recursively
+                    if [ -d "$tmp_dir$KMODS_PATH" ]; then
+                        cd "$tmp_dir$KMODS_PATH"
+
+                        # Find all .ko files recursively and preserve directory structure
+                        if find . -name "*.ko" -type f | head -1 | grep -q "."; then
+                            echo "Found .ko files in directory structure, extracting recursively..."
+
+                            # Copy entire directory structure containing .ko files
+                            find . -name "*.ko" -type f | while read -r ko_file; do
+                                ko_dir=$(dirname "$ko_file")
+                                mkdir -p "$dest_dir/$ko_dir"
+                                cp "$ko_file" "$dest_dir/$ko_file"
+                                echo "  Copied: $ko_file"
+                            done
+
+                            extracted=true
+                            ko_count=$(find "$dest_dir" -name "*.ko" -type f | wc -l)
+                            echo "Extracted .ko files for $arch_name: $ko_count files (recursive)"
+
+                            # List the directory structure for verification
+                            echo "Directory structure preserved:"
+                            find "$dest_dir" -name "*.ko" -type f | sort | head -20
+                            if [ "$(find "$dest_dir" -name "*.ko" -type f | wc -l)" -gt 20 ]; then
+                                echo "  ... (showing first 20 files)"
+                            fi
+                        else
+                            echo "No .ko files found in $KMODS_PATH directory structure"
+                        fi
+                        cd - > /dev/null
+                    else
+                        echo "$KMODS_PATH directory not found in layer"
                     fi
 
                     echo "Copying envfile to get versions data for $arch_name..."

--- a/tasks/managed/extract-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/extract-oot-kmods/tests/mocks.sh
@@ -80,6 +80,15 @@ skopeo() {
   # Write to workspace since the task runs there initially
   echo "$*" >> "$(params.dataDir)/mock_skopeo.txt"
 
+  # Extract tmp_dir from the "dir:" argument
+  local tmp_dir
+  for arg in "$@"; do
+    if [[ "$arg" == dir:* ]]; then
+      tmp_dir="${arg#dir:}"
+      break
+    fi
+  done
+
   case "$*" in
     "copy docker://quay.io/mock/image@sha256:dummy dir:"*)
       # Create a proper manifest.json with layers for single arch
@@ -94,12 +103,20 @@ EOF
       # Create a temporary directory to build the tar structure
       LAYER_BUILD_DIR=$(mktemp -d)
 
-      # Create the kmods directory structure with leading slash to match task expectation
+      # Create the kmods directory structure with nested subdirectories to test recursive extraction
       # Task looks for "^${KMODS_PATH#/}/" where KMODS_PATH=/kmods, so it looks for "^kmods/"
       mkdir -p "$LAYER_BUILD_DIR/kmods"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversA"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversB"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversB/submodule"
 
+      # Place .ko files in both top-level and subdirectories to test recursive extraction
       echo "mock-kmod1" > "$LAYER_BUILD_DIR/kmods/mod1.ko"
       echo "mock-kmod2" > "$LAYER_BUILD_DIR/kmods/mod2.ko"
+      echo "mock-driverA-kmod1" > "$LAYER_BUILD_DIR/kmods/driversA/driverA-mod1.ko"
+      echo "mock-driverA-kmod2" > "$LAYER_BUILD_DIR/kmods/driversA/driverA-mod2.ko"
+      echo "mock-driverB-kmod1" > "$LAYER_BUILD_DIR/kmods/driversB/driverB-mod1.ko"
+      echo "mock-driverB-submod" > "$LAYER_BUILD_DIR/kmods/driversB/submodule/submodule.ko"
 
       # The task expects envfile at $TMP_DIR$KMODS_PATH/../../envfile
       # For kmodsPath=/kmods, this resolves to $TMP_DIR/envfile
@@ -131,9 +148,13 @@ EOF
 
       LAYER_BUILD_DIR=$(mktemp -d)
       mkdir -p "$LAYER_BUILD_DIR/kmods"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversA"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversB"
 
       echo "amd64-kmod1" > "$LAYER_BUILD_DIR/kmods/amd64-mod1.ko"
       echo "amd64-kmod2" > "$LAYER_BUILD_DIR/kmods/amd64-mod2.ko"
+      echo "amd64-driverA-kmod" > "$LAYER_BUILD_DIR/kmods/driversA/amd64-driverA.ko"
+      echo "amd64-driverB-kmod" > "$LAYER_BUILD_DIR/kmods/driversB/amd64-driverB.ko"
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
@@ -154,9 +175,13 @@ EOF
 
       LAYER_BUILD_DIR=$(mktemp -d)
       mkdir -p "$LAYER_BUILD_DIR/kmods"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversA"
+      mkdir -p "$LAYER_BUILD_DIR/kmods/driversB"
 
       echo "arm64-kmod1" > "$LAYER_BUILD_DIR/kmods/arm64-mod1.ko"
       echo "arm64-kmod2" > "$LAYER_BUILD_DIR/kmods/arm64-mod2.ko"
+      echo "arm64-driverA-kmod" > "$LAYER_BUILD_DIR/kmods/driversA/arm64-driverA.ko"
+      echo "arm64-driverB-kmod" > "$LAYER_BUILD_DIR/kmods/driversB/arm64-driverB.ko"
       echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
@@ -259,50 +284,6 @@ EOF
       echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
       echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
       echo "ARCH=aarch64-64k" >> "$LAYER_BUILD_DIR/envfile"
-
-      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
-      rm -rf "$LAYER_BUILD_DIR"
-      ;;
-    "copy docker://quay.io/mock/multiarch@sha256:amd64digest123 dir:"*)
-      # Handle multiarch amd64 case
-      cat > "$tmp_dir/manifest.json" << 'EOF'
-{
-  "layers": [
-    {"digest": "sha256:amd64layer123"}
-  ]
-}
-EOF
-
-      LAYER_BUILD_DIR=$(mktemp -d)
-      mkdir -p "$LAYER_BUILD_DIR/kmods"
-
-      echo "amd64-kmod1" > "$LAYER_BUILD_DIR/kmods/amd64-mod1.ko"
-      echo "amd64-kmod2" > "$LAYER_BUILD_DIR/kmods/amd64-mod2.ko"
-      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
-      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
-      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
-
-      (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/amd64layer123" --transform 's,^\./kmods/,kmods/,' .)
-      rm -rf "$LAYER_BUILD_DIR"
-      ;;
-    "copy docker://quay.io/mock/multiarch@sha256:arm64digest456 dir:"*)
-      # Handle multiarch arm64 case
-      cat > "$tmp_dir/manifest.json" << 'EOF'
-{
-  "layers": [
-    {"digest": "sha256:arm64layer456"}
-  ]
-}
-EOF
-
-      LAYER_BUILD_DIR=$(mktemp -d)
-      mkdir -p "$LAYER_BUILD_DIR/kmods"
-
-      echo "arm64-kmod1" > "$LAYER_BUILD_DIR/kmods/arm64-mod1.ko"
-      echo "arm64-kmod2" > "$LAYER_BUILD_DIR/kmods/arm64-mod2.ko"
-      echo "DRIVER_VERSION=1.0.0" > "$LAYER_BUILD_DIR/envfile"
-      echo "DRIVER_VENDOR=test-vendor" >> "$LAYER_BUILD_DIR/envfile"
-      echo "KERNEL_VERSION=5.4.0" >> "$LAYER_BUILD_DIR/envfile"
 
       (cd "$LAYER_BUILD_DIR" && tar -cf "$tmp_dir/arm64layer456" --transform 's,^\./kmods/,kmods/,' .)
       rm -rf "$LAYER_BUILD_DIR"

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-from-image.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-from-image.yaml
@@ -129,24 +129,56 @@ spec:
                 if [ -d "$(params.dataDir)/signed-kmods" ]; then
                   echo "SUCCESS: Signed kmods directory was found in dataDir"
 
-                  # Check if any .ko files exist in the signed-kmods directory
-                  if ls "$(params.dataDir)/signed-kmods"/*.ko 1> /dev/null 2>&1; then
-                    echo "Kernel module files were extracted successfully"
-                    echo "Found files:"
-                    ls -la "$(params.dataDir)/signed-kmods"
-                  else
-                    echo "Warning: No .ko files found in signed-kmods directory"
-                    echo "Directory contents:"
-                    ls -la "$(params.dataDir)/signed-kmods" || echo "Directory does not exist or is empty"
-                  fi
+                  # Check for architecture-specific subdirectory structure
+                  arch_found=false
+                  for arch_dir in "$(params.dataDir)/signed-kmods"/*/; do
+                    if [ -d "$arch_dir" ]; then
+                      arch_name=$(basename "$arch_dir")
+                      echo "Found architecture directory: $arch_name"
+                      arch_found=true
 
-                  # Check if envfile was copied
-                  if [ -f "$(params.dataDir)/signed-kmods/envfile" ]; then
-                    echo "Environment file was copied successfully"
-                    cat "$(params.dataDir)/signed-kmods/envfile"
-                  else
-                    echo "Warning: envfile not found"
+                      # Check if any .ko files exist recursively in the architecture directory
+                      ko_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+                      if [ "$ko_count" -gt 0 ]; then
+                        echo "SUCCESS: Found $ko_count kernel module files in $arch_name (including subdirectories)"
+                        echo "Kernel module files were extracted successfully with recursive directory structure:"
+                        find "$arch_dir" -name "*.ko" -type f | sort | while read -r ko_file; do
+                          echo "  $ko_file"
+                        done
+
+                        # Verify we have files in subdirectories (testing recursive extraction)
+                        subdir_ko_count=$(find "$arch_dir" -mindepth 2 -name "*.ko" -type f | wc -l)
+                        if [ "$subdir_ko_count" -gt 0 ]; then
+                          echo "SUCCESS: Found $subdir_ko_count .ko files in subdirectories" \
+                               "(recursive extraction working)"
+                        else
+                          echo "INFO: All .ko files are in top-level directory"
+                        fi
+                      else
+                        echo "WARNING: No .ko files found in architecture directory $arch_name"
+                        echo "Directory contents:"
+                        ls -la "$arch_dir" || echo "Directory is empty"
+                      fi
+
+                      # Check if envfile was copied
+                      if [ -f "$arch_dir/envfile" ]; then
+                        echo "SUCCESS: Environment file was copied successfully for $arch_name"
+                        cat "$arch_dir/envfile"
+                      else
+                        echo "WARNING: envfile not found for $arch_name"
+                      fi
+                    fi
+                  done
+
+                  if [ "$arch_found" = false ]; then
+                    echo "ERROR: No architecture directories found in signed-kmods"
+                    echo "Contents of signed-kmods directory:"
+                    ls -la "$(params.dataDir)/signed-kmods" || echo "Directory is empty"
+                    exit 1
                   fi
+                else
+                  echo "ERROR: Signed kmods directory not found"
+                  exit 1
                 fi
       params:
         - name: dataDir

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-multiarch.yaml
@@ -171,10 +171,25 @@ spec:
                 if [ -d "$arch_dir" ]; then
                   echo "SUCCESS: Architecture directory found: $arch_dir"
 
-                  # Check for .ko files in this architecture
-                  if ls "$arch_dir"/*.ko 1> /dev/null 2>&1; then
-                    echo "SUCCESS: .ko files found in $arch:"
-                    ls -la "$arch_dir"/*.ko
+                  # Check for .ko files in this architecture (including subdirectories)
+                  ko_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+                  if [ "$ko_count" -gt 0 ]; then
+                    echo "SUCCESS: Found $ko_count .ko files in $arch (including subdirectories):"
+                    find "$arch_dir" -name "*.ko" -type f | sort | while read -r ko_file; do
+                      echo "  $ko_file"
+                    done
+
+                    # Verify recursive extraction worked by checking for files in subdirectories
+                    subdir_ko_count=$(find "$arch_dir" -mindepth 2 -name "*.ko" -type f | wc -l)
+                    if [ "$subdir_ko_count" -gt 0 ]; then
+                      echo "SUCCESS: Found $subdir_ko_count .ko files in subdirectories (recursive extraction working)"
+                      echo "Subdirectory .ko files:"
+                      find "$arch_dir" -mindepth 2 -name "*.ko" -type f | sort | while read -r subdir_ko; do
+                        echo "  $subdir_ko"
+                      done
+                    else
+                      echo "INFO: All .ko files are in top-level directory for $arch"
+                    fi
                   else
                     echo "ERROR: No .ko files found in $arch directory"
                     exit 1

--- a/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-recursive.yaml
+++ b/tasks/managed/extract-oot-kmods/tests/test-extract-kmods-recursive.yaml
@@ -1,0 +1,244 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-kmods-recursive
+spec:
+  description: >-
+    Test extracting kernel modules from container images with recursive directory structures.
+    This test specifically validates that .ko files in subdirectories are properly extracted
+    and that the directory hierarchy is preserved.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+    - name: taskGitUrl
+      type: string
+      description: The git repository URL for task and StepAction resolution
+      default: https://github.com/enriquebelarte/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The git revision for task and StepAction resolution
+      default: signed-kmods-release
+  tasks:
+    - name: setup
+      taskSpec:
+        params:
+          - name: dataDir
+            type: string
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Create the trusted artifacts data directory structure
+              mkdir -p "$(params.dataDir)"
+
+              echo "Recursive directory test setup completed - mocks will create nested structure"
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+
+    - name: run-task
+      taskRef:
+        name: extract-kmods-from-image
+      params:
+        - name: kmodsPath
+          value: /kmods
+        - name: signedKmodsPath
+          value: signed-kmods
+        - name: snapshot
+          value: my-recursive-snapshot
+        - name: snapshotPath
+          value: snapshot.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: ""
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - setup
+    - name: check-recursive-extraction
+      taskSpec:
+        params:
+          - name: dataDir
+            type: string
+          - name: ociStorage
+            type: string
+          - name: sourceDataArtifact
+            type: string
+            default: ""
+          - name: taskGitUrl
+            type: string
+          - name: taskGitRevision
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: "ORAS_OPTIONS"
+              value: "--insecure"
+            - name: "DEBUG"
+              value: ""
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: validate-recursive-structure
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "=== Recursive Directory Structure Test ==="
+
+              SIGNED_KMODS_PATH="$(params.dataDir)/signed-kmods"
+
+              # Find the architecture directory (should be only one for single-arch test)
+              arch_dir=""
+              for potential_arch_dir in "$SIGNED_KMODS_PATH"/*/; do
+                if [ -d "$potential_arch_dir" ]; then
+                  arch_dir="$potential_arch_dir"
+                  break
+                fi
+              done
+
+              if [ -z "$arch_dir" ]; then
+                echo "ERROR: No architecture directory found in $SIGNED_KMODS_PATH"
+                echo "Available contents:"
+                ls -la "$SIGNED_KMODS_PATH" || echo "Directory not found"
+                exit 1
+              fi
+
+              arch_name=$(basename "$arch_dir")
+              echo "SUCCESS: Found architecture directory: $arch_name"
+
+              # Count total .ko files recursively
+              total_ko_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+              if [ "$total_ko_count" -lt 1 ]; then
+                echo "ERROR: No .ko files found in $arch_name"
+                exit 1
+              fi
+
+              echo "SUCCESS: Found $total_ko_count total .ko files in $arch_name"
+
+              # Check for .ko files in top-level directory
+              top_level_ko_count=$(find "$arch_dir" -maxdepth 1 -name "*.ko" -type f | wc -l)
+              echo "Found $top_level_ko_count .ko files in top-level directory"
+
+              # Check for .ko files in subdirectories (this is the key test for recursive functionality)
+              subdir_ko_count=$(find "$arch_dir" -mindepth 2 -name "*.ko" -type f | wc -l)
+              if [ "$subdir_ko_count" -gt 0 ]; then
+                echo "SUCCESS: Found $subdir_ko_count .ko files in subdirectories - RECURSIVE EXTRACTION WORKING!"
+                echo "Subdirectory structure and .ko files:"
+                find "$arch_dir" -mindepth 2 -name "*.ko" -type f | sort | while read -r subdir_ko; do
+                  echo "  $subdir_ko"
+                done
+              else
+                echo "ERROR: No .ko files found in subdirectories - recursive extraction may not be working"
+                echo "All found .ko files:"
+                find "$arch_dir" -name "*.ko" -type f | sort
+                exit 1
+              fi
+
+              # Verify specific expected subdirectories were created based on mock data
+              expected_subdirs=("driversA" "driversB")
+              for expected_subdir in "${expected_subdirs[@]}"; do
+                subdir_path="$arch_dir/$expected_subdir"
+                if [ -d "$subdir_path" ]; then
+                  echo "SUCCESS: Expected subdirectory found: $expected_subdir"
+                  subdir_ko_files=$(find "$subdir_path" -name "*.ko" -type f | wc -l)
+                  if [ "$subdir_ko_files" -gt 0 ]; then
+                    echo "SUCCESS: Found $subdir_ko_files .ko files in $expected_subdir"
+                    find "$subdir_path" -name "*.ko" -type f | while read -r ko_file; do
+                      echo "  $ko_file"
+                    done
+                  else
+                    echo "WARNING: No .ko files found in $expected_subdir"
+                  fi
+                else
+                  echo "WARNING: Expected subdirectory not found: $expected_subdir"
+                fi
+              done
+
+              # Check for deeply nested structure (driversB/submodule)
+              deep_nested_path="$arch_dir/driversB/submodule"
+              if [ -d "$deep_nested_path" ]; then
+                echo "SUCCESS: Deeply nested directory found: driversB/submodule"
+                deep_ko_count=$(find "$deep_nested_path" -name "*.ko" -type f | wc -l)
+                if [ "$deep_ko_count" -gt 0 ]; then
+                  echo "SUCCESS: Found $deep_ko_count .ko files in deeply nested directory"
+                  find "$deep_nested_path" -name "*.ko" -type f | while read -r ko_file; do
+                    echo "  $ko_file"
+                  done
+                else
+                  echo "INFO: No .ko files found in deeply nested directory"
+                fi
+              else
+                echo "INFO: Deeply nested directory not found (may not be created by this test)"
+              fi
+
+              # Summary
+              echo "=== RECURSIVE EXTRACTION TEST SUMMARY ==="
+              echo "Total .ko files extracted: $total_ko_count"
+              echo "Top-level .ko files: $top_level_ko_count"
+              echo "Subdirectory .ko files: $subdir_ko_count"
+              echo "Directory structure preserved: $([ "$subdir_ko_count" -gt 0 ] && echo "YES" || echo "NO")"
+
+              if [ "$subdir_ko_count" -gt 0 ]; then
+                echo "SUCCESS: Recursive extraction test PASSED!"
+              else
+                echo "ERROR: Recursive extraction test FAILED!"
+                exit 1
+              fi
+      params:
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(tasks.run-task.results.sourceDataArtifact)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - run-task

--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -172,22 +172,34 @@ spec:
             AZURE_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}${arch_suffix}/"
             echo "Azure target path: ${ACCOUNT}/${CONTAINER}/${AZURE_TARGET_PATH}"
 
-            # Upload .ko files
-            if ls "$source_dir"/*.ko 1> /dev/null 2>&1; then
-                echo "Uploading .ko files for $arch_name"
-                for f in "$source_dir"/*.ko; do
-                    if [ -f "$f" ]; then
-                        BLOB_NAME="${AZURE_TARGET_PATH}$(basename "$f")"
-                        echo "Uploading ${f} to ${BLOB_NAME}..."
-                        az storage blob upload \
-                          --account-name "$ACCOUNT" \
-                          --container-name "$CONTAINER" \
-                          --name "$BLOB_NAME" \
-                          --file "$f" \
-                          --auth-mode login \
-                          --overwrite
-                    fi
+            # Upload .ko files (with recursive directory structure support)
+            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+                ko_file_count=$(find "$source_dir" -name "*.ko" -type f | wc -l)
+                echo "Uploading $ko_file_count .ko files for $arch_name (preserving directory structure)"
+
+                # Show directory structure being uploaded for verification
+                echo "Directory structure for $arch_name:"
+                find "$source_dir" -name "*.ko" -type f | sort | head -10 | sed 's|^|  |'
+                if [ "$(find "$source_dir" -name "*.ko" -type f | wc -l)" -gt 10 ]; then
+                    echo "  ... (showing first 10 files)"
+                fi
+
+                # Upload each .ko file preserving the directory structure
+                cd "$source_dir"
+                find . -name "*.ko" -type f | while read -r ko_file; do
+                    # Remove the leading "./" from the path and construct blob name
+                    relative_path="${ko_file#./}"
+                    BLOB_NAME="${AZURE_TARGET_PATH}${relative_path}"
+                    echo "Uploading ${ko_file} to ${BLOB_NAME}..."
+                    az storage blob upload \
+                      --account-name "$ACCOUNT" \
+                      --container-name "$CONTAINER" \
+                      --name "$BLOB_NAME" \
+                      --file "$ko_file" \
+                      --auth-mode login \
+                      --overwrite
                 done
+                cd - > /dev/null
             else
                 echo "WARNING: No .ko files found for architecture $arch_name"
                 return 1

--- a/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
@@ -69,16 +69,14 @@ function az() {
                         fi
                     else
                         # Single arch mode - now expects arch suffix (x86_64)
-                        if [ "$COUNT" -eq 0 ]; then
-                            if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod1.ko"* ]]; then
-                                echo "ERROR: First az blob upload call has wrong name param for mod1.ko"
-                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod1.ko"
-                                return 1
-                            fi
-                        elif [ "$COUNT" -eq 1 ]; then
-                             if [[ ! "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod2.ko"* ]]; then
-                                echo "ERROR: Second az blob upload call has wrong name param for mod2.ko"
-                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod2.ko"
+                        if [ "$COUNT" -le 1 ]; then
+                            # First two uploads should be .ko files (mod1.ko or mod2.ko, order doesn't matter)
+                            if [[ "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod1.ko"* ]] || [[ "$*" == *"--name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod2.ko"* ]]; then
+                                echo "Valid .ko file upload detected (upload #$COUNT)"
+                            else
+                                echo "ERROR: Upload #$COUNT should be mod1.ko or mod2.ko"
+                                echo "Expected: --name mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/mod[12].ko"
+                                echo "Got: $*"
                                 return 1
                             fi
                         elif [ "$COUNT" -eq 2 ]; then

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -172,10 +172,27 @@ spec:
             git checkout
             mkdir -p "$TARGET_DIR"
 
-            # Copy .ko files
-            if ls "$source_dir"/*.ko 1> /dev/null 2>&1; then
-                cp "$source_dir"/*.ko "$TARGET_DIR/"
-                echo "Copied .ko files for $arch_name"
+            # Copy .ko files (preserving directory structure)
+            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+                echo "Copying .ko files with preserved directory structure for $arch_name..."
+
+                # Copy entire directory structure containing .ko files
+                cd "$source_dir"
+                find . -name "*.ko" -type f | while read -r ko_file; do
+                    ko_dir=$(dirname "$ko_file")
+                    mkdir -p "$TARGET_DIR/$ko_dir"
+                    cp "$ko_file" "$TARGET_DIR/$ko_file"
+                done
+                cd - > /dev/null
+                ko_file_count=$(find "$TARGET_DIR" -name "*.ko" -type f | wc -l)
+                echo "Copied $ko_file_count .ko files for $arch_name (preserving directory structure)"
+
+                # Show directory structure for verification
+                echo "Directory structure copied for $arch_name:"
+                find "$TARGET_DIR" -name "*.ko" -type f | sort | head -10 | sed 's|^|  |'
+                if [ "$(find "$TARGET_DIR" -name "*.ko" -type f | wc -l)" -gt 10 ]; then
+                    echo "  ... (showing first 10 files)"
+                fi
             else
                 echo "WARNING: No .ko files found for $arch_name"
                 return 1

--- a/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/mocks.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -eux
 
 git() {

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
@@ -1,26 +1,38 @@
+#!/usr/bin/env bash
 set -x
 
 echo "Setting up test data for push-oot-kmods-to-git task..."
 
 KMODS_DIR="$(params.dataDir)/$(params.signedKmodsPath)"
 
-echo "Creating dummy signed kmods in dataDir..."
-mkdir -p "$KMODS_DIR"
-echo "SIGNED_MODULE1_CONTENT" > "$KMODS_DIR/mod1.ko"
-echo "SIGNED_MODULE2_CONTENT" > "$KMODS_DIR/mod2.ko"
+# Create arch_count.txt to indicate single-arch build with subdirectory structure
+echo "1" > "$(params.dataDir)/arch_count.txt"
+
+echo "Creating dummy signed kmods in dataDir with recursive architecture subdirectory structure..."
+ARCH_DIR="$KMODS_DIR/x86_64"
+mkdir -p "$ARCH_DIR"
+mkdir -p "$ARCH_DIR/driversA"
+mkdir -p "$ARCH_DIR/driversB"
+
+# Create .ko files in top-level and subdirectories to test recursive push
+echo "SIGNED_MODULE1_CONTENT" > "$ARCH_DIR/mod1.ko"
+echo "SIGNED_MODULE2_CONTENT" > "$ARCH_DIR/mod2.ko"
+echo "SIGNED_DRIVER_A_MODULE1" > "$ARCH_DIR/driversA/driverA-mod1.ko"
+echo "SIGNED_DRIVER_A_MODULE2" > "$ARCH_DIR/driversA/driverA-mod2.ko"
+echo "SIGNED_DRIVER_B_MODULE1" > "$ARCH_DIR/driversB/driverB-mod1.ko"
 
 echo "Creating valid checksum file..."
 (
-  cd "$KMODS_DIR"
-  sha256sum mod1.ko mod2.ko > signed_kmods_checksums.txt
+  cd "$ARCH_DIR" || exit
+  sha256sum mod1.ko mod2.ko driversA/driverA-mod1.ko driversA/driverA-mod2.ko driversB/driverB-mod1.ko > signed_kmods_checksums_x86_64.txt
 )
 
-echo "Creating envfile..."
+echo "Creating envfile in architecture directory..."
 # IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
 # This tests that the task properly strips the suffix when constructing upload paths
 # Expected: task strips .x86_64 to produce path mocked-vendor/1.2.3/6.5.0/
 # NOT: mocked-vendor/1.2.3/6.5.0.x86_64/
-cat > "$KMODS_DIR/envfile" << EOF
+cat > "$ARCH_DIR/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor"
 DRIVER_VERSION="1.2.3"
 KERNEL_VERSION="6.5.0.x86_64"
@@ -28,3 +40,5 @@ EOF
 
 echo "Test data setup complete:"
 ls -la "$KMODS_DIR"
+echo "Architecture directory structure:"
+find "$ARCH_DIR" -type f | sort

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -155,9 +155,18 @@ spec:
             S3_TARGET_PATH="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}${arch_suffix}/"
             echo "S3 target path: s3://$(params.s3Bucket)/${S3_TARGET_PATH}"
 
-            # Upload .ko files
-            if ls "$source_dir"/*.ko 1> /dev/null 2>&1; then
-                echo "Uploading .ko files for $arch_name"
+            # Upload .ko files (with recursive directory structure support)
+            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+                ko_file_count=$(find "$source_dir" -name "*.ko" -type f | wc -l)
+                echo "Uploading $ko_file_count .ko files for $arch_name (preserving directory structure)"
+
+                # Show directory structure being uploaded for verification
+                echo "Directory structure for $arch_name:"
+                find "$source_dir" -name "*.ko" -type f | sort | head -10 | sed 's|^|  |'
+                if [ "$(find "$source_dir" -name "*.ko" -type f | wc -l)" -gt 10 ]; then
+                    echo "  ... (showing first 10 files)"
+                fi
+
                 aws s3 cp \
                   "$source_dir" \
                   "s3://$(params.s3Bucket)/${S3_TARGET_PATH}" \

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -198,9 +198,12 @@ spec:
             REMOTE_DIR="$HOME/$TASK_UID/kmods"
         fi
 
-        # Check if any .ko files exist in the remote directory
-        if ls "$REMOTE_DIR"/*.ko 1> /dev/null 2>&1; then
-            for kmod in "$REMOTE_DIR"/*.ko; do
+        # Check if any .ko files exist in the remote directory (recursively)
+        if find "$REMOTE_DIR" -name "*.ko" -type f | head -1 | grep -q "."; then
+            echo "Remote: Found .ko files in directory structure, signing recursively..."
+
+            # Process each .ko file found recursively
+            find "$REMOTE_DIR" -name "*.ko" -type f | while read -r kmod; do
                 if [ -f "$kmod" ]; then
                     echo "Remote: Signing kernel module $kmod for $ARCH"
                     rh-signing-client --key "$KEY" --onbehalfof "${SIGNING_AUTHOR}" --lkmsign "$kmod"
@@ -212,6 +215,10 @@ spec:
                     echo "Remote: Skipping entry $kmod (not a regular file)"
                 fi
             done
+
+            # Count and report signed files
+            signed_count=$(find "$REMOTE_DIR" -name "*.ko" -type f | wc -l)
+            echo "Remote: Successfully signed $signed_count .ko files for $ARCH"
         else
             echo "Remote: ERROR: No .ko files found in $REMOTE_DIR for $ARCH"
             exit 1
@@ -257,12 +264,19 @@ spec:
                             cp "$arch_dir/envfile" "/tmp/envfile.backup.$arch_name"
                         fi
 
-                        # Verify we have .ko files to sign
+                        # Verify we have .ko files to sign (check recursively)
                         ko_files_found=false
-                        if ls "$arch_dir"/*.ko 1> /dev/null 2>&1; then
+                        if find "$arch_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
                             ko_files_found=true
                             ko_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
-                            echo "Found $ko_count .ko files to sign for $arch_name"
+                            echo "Found $ko_count .ko files to sign for $arch_name (recursive search)"
+
+                            # Show directory structure for verification
+                            echo "Directory structure for $arch_name:"
+                            find "$arch_dir" -name "*.ko" -type f | sort | head -10 | sed 's|^|  |'
+                            if [ "$(find "$arch_dir" -name "*.ko" -type f | wc -l)" -gt 10 ]; then
+                                echo "  ... (showing first 10 files)"
+                            fi
                         else
                             echo "WARNING: No .ko files found for architecture $arch_name, skipping"
                             continue
@@ -275,10 +289,29 @@ spec:
                             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
                                 "mkdir -p ~/${task_uid}/kmods/${arch_name}"
 
-                            # Copy unsigned kmods to signing server for this architecture
-                            echo "Copying unsigned .ko files to signing server for $arch_name..."
-                            scp "${SSH_OPTS[@]}" "$arch_dir"/*.ko \
-                                "${signUser}@${signHost}:~/${task_uid}/kmods/${arch_name}/"
+                            # Copy unsigned kmods to signing server for this architecture (preserving structure)
+                            echo "Copying directory structure with .ko files to signing server for $arch_name..."
+
+                            # Create a temporary tarball with the directory structure
+                            temp_tarball="/tmp/kmods_${arch_name}_${task_uid}.tar.gz"
+                            cd "$arch_dir"
+
+                            # Create tarball including all .ko files and their directory structure
+                            find . -name "*.ko" -type f | tar -czf "$temp_tarball" --files-from=-
+
+                            # Copy tarball to signing server
+                            scp "${SSH_OPTS[@]}" "$temp_tarball" \
+                                "${signUser}@${signHost}:~/${task_uid}/kmods_${arch_name}.tar.gz"
+
+                            # Extract on remote server preserving structure
+                            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                            # shellcheck disable=SC2029
+                            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                                "cd ~/${task_uid}/kmods/${arch_name} && tar -xzf ~/kmods_${arch_name}.tar.gz"
+
+                            # Cleanup local temp file
+                            rm -f "$temp_tarball"
+                            cd - > /dev/null
 
                             # Verify files were copied to remote server
                             echo "Verifying files on remote server for $arch_name..."
@@ -291,26 +324,40 @@ spec:
                             # Sign kmods for this architecture
                             sign_kmods_for_arch "$arch_name"
 
-                            # Copy back signed kmods to workspace
-                            # Remove unsigned files first to ensure complete replacement
-                            echo "Copying back signed .ko files for $arch_name..."
-                            rm -f "$arch_dir"/*.ko
-                            # Get list of .ko files from remote server and copy them individually
+                            # Copy back signed kmods to workspace (preserving directory structure)
+                            echo "Copying back signed .ko files with preserved structure for $arch_name..."
+
+                            # Remove all .ko files first to ensure complete replacement
+                            find "$arch_dir" -name "*.ko" -type f -delete
+
+                            # Create tarball on remote server with signed files and copy back
+                            signed_tarball="/tmp/signed_kmods_${arch_name}_${task_uid}.tar.gz"
                             # Intentional client-side expansion: task_uid expands locally for unique remote directories
                             # shellcheck disable=SC2029
-                            kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                                "cd ~/${task_uid}/kmods/${arch_name}/ && ls -1 *.ko 2>/dev/null || echo ''" )
-                            if [ -n "$kmod_files" ]; then
-                                echo "$kmod_files" | while IFS= read -r kmod_file; do
-                                    if [ -n "$kmod_file" ]; then
-                                        echo "Copying back signed file: $kmod_file"
-                                        scp "${SSH_OPTS[@]}" \
-                                            "${signUser}@${signHost}:~/${task_uid}/kmods/${arch_name}/$kmod_file" \
-                                            "$arch_dir/"
-                                    fi
-                                done
+                            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                                "cd ~/${task_uid}/kmods/${arch_name} && \
+                                 find . -name '*.ko' -type f | \
+                                 tar -czf ~/signed_${arch_name}.tar.gz --files-from=-"
+
+                            # Copy back the tarball
+                            scp "${SSH_OPTS[@]}" \
+                                "${signUser}@${signHost}:~/${task_uid}/signed_${arch_name}.tar.gz" \
+                                "$signed_tarball"
+
+                            # Extract to workspace preserving directory structure
+                            cd "$arch_dir"
+                            tar -xzf "$signed_tarball"
+                            cd - > /dev/null
+
+                            # Cleanup temp file
+                            rm -f "$signed_tarball"
+
+                            # Verify extraction worked
+                            signed_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+                            if [ "$signed_count" -gt 0 ]; then
+                                echo "Successfully copied back $signed_count signed .ko files for $arch_name"
                             else
-                                echo "WARNING: No .ko files found on remote server for $arch_name"
+                                echo "WARNING: No .ko files found after copy back for $arch_name"
                             fi
 
                             # Restore envfile
@@ -392,36 +439,71 @@ spec:
                     cp "$arch_dir/envfile" "/tmp/envfile.backup.$arch_subdir_name"
                 fi
 
-                # Copy unsigned kmods to signing server
+                # Copy unsigned kmods to signing server (preserving structure)
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/${task_uid}/kmods"
 
-                echo "Copying unsigned .ko files from $arch_subdir_name to signing server..."
-                scp "${SSH_OPTS[@]}" "$arch_dir"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
+                echo "Copying directory structure with .ko files from $arch_subdir_name to signing server..."
+
+                # Create a temporary tarball with the directory structure
+                temp_tarball="/tmp/kmods_single_${task_uid}.tar.gz"
+                cd "$arch_dir"
+
+                # Create tarball including all .ko files and their directory structure
+                find . -name "*.ko" -type f | tar -czf "$temp_tarball" --files-from=-
+
+                # Copy tarball to signing server
+                scp "${SSH_OPTS[@]}" "$temp_tarball" \
+                    "${signUser}@${signHost}:~/${task_uid}/kmods.tar.gz"
+
+                # Extract on remote server
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                    "cd ~/${task_uid}/kmods && tar -xzf ~/kmods.tar.gz"
+
+                # Cleanup local temp file
+                rm -f "$temp_tarball"
+                cd - > /dev/null
 
                 # Sign kmods
                 sign_kmods_for_arch "single"
 
-                # Copy back signed kmods to workspace
-                echo "Copying back signed .ko files for $arch_subdir_name..."
-                rm -f "$arch_dir"/*.ko
-                # Get list of .ko files from remote server and copy them individually
+                # Copy back signed kmods to workspace (preserving directory structure)
+                echo "Copying back signed .ko files with preserved structure for $arch_subdir_name..."
+
+                # Remove all .ko files first to ensure complete replacement
+                find "$arch_dir" -name "*.ko" -type f -delete
+
+                # Create tarball on remote server with signed files and copy back
+                signed_tarball="/tmp/signed_kmods_single_${task_uid}.tar.gz"
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
-                kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                    "cd ~/${task_uid}/kmods/ && ls -1 *.ko 2>/dev/null || echo ''" )
-                if [ -n "$kmod_files" ]; then
-                    echo "$kmod_files" | while IFS= read -r kmod_file; do
-                        if [ -n "$kmod_file" ]; then
-                            echo "Copying back signed file: $kmod_file"
-                            scp "${SSH_OPTS[@]}" \
-                                "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" \
-                                "$arch_dir/"
-                        fi
-                    done
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                    "cd ~/${task_uid}/kmods && \
+                     find . -name '*.ko' -type f | \
+                     tar -czf ~/signed_single.tar.gz --files-from=-"
+
+                # Copy back the tarball
+                scp "${SSH_OPTS[@]}" \
+                    "${signUser}@${signHost}:~/${task_uid}/signed_single.tar.gz" \
+                    "$signed_tarball"
+
+                # Extract to workspace preserving directory structure
+                cd "$arch_dir"
+                tar -xzf "$signed_tarball"
+                cd - > /dev/null
+
+                # Cleanup temp file
+                rm -f "$signed_tarball"
+
+                # Verify extraction worked
+                signed_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+                if [ "$signed_count" -gt 0 ]; then
+                    echo "Successfully copied back $signed_count signed .ko files for $arch_subdir_name"
                 else
-                    echo "ERROR: No .ko files found on remote server"
+                    echo "ERROR: No .ko files found after signing process"
                     exit 1
                 fi
 
@@ -461,33 +543,75 @@ spec:
                 cp envfile /tmp/envfile.backup
             fi
 
-            # Copy unsigned kmods to signing server
+            # Copy unsigned kmods to signing server (preserving structure if any)
             # Intentional client-side expansion: task_uid expands locally for unique remote directories
             # shellcheck disable=SC2029
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "mkdir -p ~/${task_uid}/kmods"
-            scp "${SSH_OPTS[@]}" "${SIGNED_KMODS_PATH}"/*.ko "${signUser}@${signHost}:~/${task_uid}/kmods/"
+
+            cd "$SIGNED_KMODS_PATH"
+            # Check if we have any .ko files in subdirectories or just in root
+            if find . -name "*.ko" -type f | head -1 | grep -q "."; then
+                echo "Creating tarball with directory structure for fallback case..."
+                # Create tarball including all .ko files and their directory structure
+                temp_tarball="/tmp/kmods_fallback_${task_uid}.tar.gz"
+                find . -name "*.ko" -type f | tar -czf "$temp_tarball" --files-from=-
+
+                # Copy tarball to signing server
+                scp "${SSH_OPTS[@]}" "$temp_tarball" \
+                    "${signUser}@${signHost}:~/${task_uid}/kmods.tar.gz"
+
+                # Extract on remote server
+                # Intentional client-side expansion: task_uid expands locally for unique remote directories
+                # shellcheck disable=SC2029
+                ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                    "cd ~/${task_uid}/kmods && tar -xzf ~/kmods.tar.gz"
+
+                # Cleanup local temp file
+                rm -f "$temp_tarball"
+            fi
+            cd - > /dev/null
 
             # Sign kmods
             sign_kmods_for_arch "single"
 
-            # Copy back signed kmods to workspace
-            echo "Copying back signed .ko files for fallback single architecture..."
-            rm -f "${SIGNED_KMODS_PATH}"/*.ko
-            # Get list of .ko files from remote server and copy them individually
+            # Copy back signed kmods to workspace (preserving structure)
+            echo "Copying back signed .ko files for fallback case with preserved structure..."
+
+            # Remove all .ko files first to ensure complete replacement
+            find "${SIGNED_KMODS_PATH}" -name "*.ko" -type f -delete
+
+            # Create tarball on remote server with signed files and copy back
+            signed_tarball="/tmp/signed_kmods_fallback_${task_uid}.tar.gz"
             # Intentional client-side expansion: task_uid expands locally for unique remote directories
             # shellcheck disable=SC2029
-            kmod_files=$(ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                "cd ~/${task_uid}/kmods/ && ls -1 *.ko 2>/dev/null || echo ''" )
-            if [ -n "$kmod_files" ]; then
-                echo "$kmod_files" | while IFS= read -r kmod_file; do
-                    if [ -n "$kmod_file" ]; then
-                        echo "Copying back signed file: $kmod_file"
-                        scp "${SSH_OPTS[@]}" \
-                            "${signUser}@${signHost}:~/${task_uid}/kmods/$kmod_file" "${SIGNED_KMODS_PATH}"/
-                    fi
-                done
+            ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
+                "cd ~/${task_uid}/kmods && \
+                 find . -name '*.ko' -type f | \
+                 tar -czf ~/signed_fallback.tar.gz --files-from=-"
+
+            # Copy back the tarball
+            if ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "test -f ~/signed_fallback.tar.gz"; then
+                scp "${SSH_OPTS[@]}" \
+                    "${signUser}@${signHost}:~/${task_uid}/signed_fallback.tar.gz" \
+                    "$signed_tarball"
+
+                # Extract to workspace preserving directory structure
+                cd "${SIGNED_KMODS_PATH}"
+                tar -xzf "$signed_tarball"
+                cd - > /dev/null
+
+                # Cleanup temp file
+                rm -f "$signed_tarball"
+
+                # Verify extraction worked
+                signed_count=$(find "${SIGNED_KMODS_PATH}" -name "*.ko" -type f | wc -l)
+                if [ "$signed_count" -gt 0 ]; then
+                    echo "Successfully copied back $signed_count signed .ko files for fallback case"
+                else
+                    echo "WARNING: No .ko files found after copy back for fallback case"
+                fi
             else
-                echo "WARNING: No .ko files found on remote server for fallback case"
+                echo "WARNING: No signed files tarball found on remote server for fallback case"
             fi
 
             # Restore envfile after signing process

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -40,20 +40,17 @@ function ssh() {
         echo "Mock ssh: Listing directory contents"
         return 0
       fi
-      # Handle ls commands for getting file lists (used for downloading)
-      if [[ "$*" == *"cd ~/"*"/kmods"* && "$*" == *"ls -1 *.ko"* ]]; then
-        echo "Mock ssh: Listing .ko files for download"
-        # Return the list of .ko files that should be available after signing
-        if [[ "$*" == *"/amd64/"* ]]; then
-          echo "amd64-mod1.ko"
-          echo "amd64-mod2.ko"
-        elif [[ "$*" == *"/arm64/"* ]]; then
-          echo "arm64-mod1.ko"
-          echo "arm64-mod2.ko"
-        else
-          echo "mod1.ko"
-          echo "mod2.ko"
-        fi
+      # Handle find commands for getting recursive file lists
+      if [[ "$*" == *"cd ~/"*"/kmods"* && "$*" == *"find . -name '*.ko' -type f"* ]]; then
+        echo "Mock ssh: Finding .ko files recursively for download"
+        # Return the recursive list of .ko files that should be available after signing
+        # Architecture is already captured in the directory path, so filenames don't need arch prefixes
+        echo "./mod1.ko"
+        echo "./mod2.ko"
+        echo "./driversA/driverA-mod1.ko"
+        echo "./driversA/driverA-mod2.ko"
+        echo "./driversB/driverB-mod1.ko"
+        echo "./driversB/submodule/submodule.ko"
         return 0
       fi
       ;;
@@ -77,6 +74,16 @@ function rm() {
     "-f "*signed-kmods*)
       /bin/rm "$@"
       ;;
+    "-f /tmp/"*".tar.gz")
+      # Handle cleanup of temporary tarball files from recursive implementation
+      echo "Mock rm: Cleaning up temporary tarball"
+      /bin/rm "$@"
+      ;;
+    "-rf /tmp/tmp."*)
+      # Handle cleanup of temporary directories created by mock scp
+      echo "Mock rm: Cleaning up temporary directory"
+      /bin/rm "$@"
+      ;;
     *)
       echo "Error: Unexpected rm parameters: $*"
       exit 1
@@ -91,7 +98,8 @@ function scp() {
 
   case "$*" in
     "-o UserKnownHostsFile=~/.ssh/known_hosts -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes"*)
-      local args=($*)
+      local args
+      read -ra args <<< "$*"
 
       # Determine if this is an upload or download operation
       # Upload: local files followed by remote destination (last arg contains @host:)
@@ -122,27 +130,60 @@ function scp() {
           echo "Mock scp: Download operation from $remote_source to $local_dest"
 
           # Extract filename from remote path
-          local filename=$(basename "${remote_source#*:}")
+          local filename
+          filename=$(basename "${remote_source#*:}")
 
-          # Create signed content based on architecture in path and filename
-          if [[ "$remote_source" == *"/amd64/"* ]]; then
-            echo "SIGNED_AMD64_MODULE" > "$local_dest/$filename"
-          elif [[ "$remote_source" == *"/arm64/"* ]]; then
-            echo "SIGNED_ARM64_MODULE" > "$local_dest/$filename"
-          else
-            # For single architecture, use filename to determine content
-            case "$filename" in
-              "mod1.ko")
-                echo "SIGNED_MODULE1" > "$local_dest/$filename"
-                ;;
-              "mod2.ko")
-                echo "SIGNED_MODULE2" > "$local_dest/$filename"
-                ;;
-              *)
-                echo "SIGNED_MODULE" > "$local_dest/$filename"
-                ;;
-            esac
+          # Handle tarball downloads for recursive directory structure
+          if [[ "$filename" == *.tar.gz ]]; then
+            echo "Mock scp: Downloading tarball with recursive structure"
+            # Create a temporary tarball with signed files that preserves directory structure
+            temp_extract_dir=$(mktemp -d)
+
+            # Create the directory structure with signed files
+            mkdir -p "$temp_extract_dir"
+            mkdir -p "$temp_extract_dir/driversA"
+            mkdir -p "$temp_extract_dir/driversB"
+            mkdir -p "$temp_extract_dir/driversB/submodule"
+
+            # Create signed files with original names (architecture already captured in path)
+            echo "SIGNED_MODULE1" > "$temp_extract_dir/mod1.ko"
+            echo "SIGNED_MODULE2" > "$temp_extract_dir/mod2.ko"
+            echo "SIGNED_DRIVER_A_MODULE1" > "$temp_extract_dir/driversA/driverA-mod1.ko"
+            echo "SIGNED_DRIVER_A_MODULE2" > "$temp_extract_dir/driversA/driverA-mod2.ko"
+            echo "SIGNED_DRIVER_B_MODULE1" > "$temp_extract_dir/driversB/driverB-mod1.ko"
+            echo "SIGNED_DRIVER_B_SUBMODULE" > "$temp_extract_dir/driversB/submodule/submodule.ko"
+
+            # Create the tarball
+            (cd "$temp_extract_dir" && tar -czf "$local_dest" .)
+            rm -rf "$temp_extract_dir"
+            echo "Mock scp: Created tarball with signed files at $local_dest"
+            return 0
           fi
+
+          # Handle individual file downloads - architecture is already captured in path
+          case "$filename" in
+            "mod1.ko")
+              echo "SIGNED_MODULE1" > "$local_dest/$filename"
+              ;;
+            "mod2.ko")
+              echo "SIGNED_MODULE2" > "$local_dest/$filename"
+              ;;
+            "driverA-mod1.ko")
+              echo "SIGNED_DRIVER_A_MODULE1" > "$local_dest/$filename"
+              ;;
+            "driverA-mod2.ko")
+              echo "SIGNED_DRIVER_A_MODULE2" > "$local_dest/$filename"
+              ;;
+            "driverB-mod1.ko")
+              echo "SIGNED_DRIVER_B_MODULE1" > "$local_dest/$filename"
+              ;;
+            "submodule.ko")
+              echo "SIGNED_DRIVER_B_SUBMODULE" > "$local_dest/$filename"
+              ;;
+            *)
+              echo "SIGNED_MODULE" > "$local_dest/$filename"
+              ;;
+          esac
           echo "Mock scp: Created signed file $local_dest/$filename"
         else
           echo "Mock scp: Unable to determine operation type"

--- a/tasks/managed/sign-oot-kmods/tests/test-setup.sh
+++ b/tasks/managed/sign-oot-kmods/tests/test-setup.sh
@@ -11,13 +11,22 @@ mkdir -p "$(params.dataDir)"
 # This triggers the new single-arch subdirectory logic instead of the fallback
 echo "1" > "$(params.dataDir)/arch_count.txt"
 
-# Create the signed kmods directory with architecture subdirectory structure
-# This matches the extract task output which always creates an arch subdirectory
-echo "Creating dummy kmods to be signed in dataDir with architecture subdirectory..."
+# Create the signed kmods directory with recursive architecture subdirectory structure
+# This matches the extract task output which creates recursive directory structures
+echo "Creating dummy kmods to be signed in dataDir with recursive architecture subdirectory structure..."
 ARCH_SUBDIR="x86_64"
 mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}"
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversA"
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversB"
+mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversB/submodule"
+
+# Create .ko files in top-level and subdirectories to test recursive signing
 echo "MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod1.ko"
 echo "MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/mod2.ko"
+echo "DRIVER_A_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversA/driverA-mod1.ko"
+echo "DRIVER_A_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversA/driverA-mod2.ko"
+echo "DRIVER_B_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversB/driverB-mod1.ko"
+echo "DRIVER_B_SUBMODULE" > "$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}/driversB/submodule/submodule.ko"
 
 echo "Test data setup complete:"
 echo "DataDir contents:"

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -135,18 +135,12 @@ spec:
                 exit 1
               fi
 
-              # Check that rm command was called to remove unsigned .ko files
+              # Check that rm command was called for cleanup (tarball and temp files)
               if [ -f "$RM_FILE" ]; then
                 echo "Mock rm file found: $RM_FILE"
                 echo "Contents:"
                 cat "$RM_FILE"
-
-                if grep -q '\.ko' "$RM_FILE"; then
-                  echo "SUCCESS: Found rm command with .ko files in $RM_FILE"
-                else
-                  echo "ERROR: rm command with .ko files not found in $RM_FILE"
-                  exit 1
-                fi
+                echo "SUCCESS: Found rm commands for cleanup operations"
               else
                 echo "ERROR: Mock rm file not found - rm command was not called"
                 exit 1
@@ -158,10 +152,12 @@ spec:
                 echo "Contents:"
                 cat "$SCP_FILE"
 
-                if grep -q 'mod1.ko' "$SCP_FILE" && grep -q 'mod2.ko' "$SCP_FILE"; then
-                  echo "SUCCESS: Found both mod1.ko and mod2.ko in $SCP_FILE"
+                # Check for tarball-based file transfers (new recursive implementation)
+                if grep -q 'kmods.tar.gz' "$SCP_FILE" && grep -q 'signed_single.tar.gz' "$SCP_FILE"; then
+                  echo "SUCCESS: Found tarball upload and download operations in $SCP_FILE"
                 else
-                  echo "ERROR: One or both .ko files not found in $SCP_FILE"
+                  echo "ERROR: Expected tarball upload (kmods.tar.gz) and download" \
+                       "(signed_single.tar.gz) not found in $SCP_FILE"
                   exit 1
                 fi
               else
@@ -180,6 +176,47 @@ spec:
                 fi
               else
                 echo "ERROR: mod1.ko not found after signing process in ${ARCH_SUBDIR}"
+                exit 1
+              fi
+
+              # Verify that subdirectory .ko files are also signed (testing recursive signing)
+              echo "Checking recursive directory structure and signed files..."
+              arch_dir="$(params.dataDir)/$(params.signedKmodsPath)/${ARCH_SUBDIR}"
+              signed_files_count=$(find "$arch_dir" -name "*.ko" -type f | wc -l)
+              echo "Total signed .ko files found: $signed_files_count"
+
+              if [ "$signed_files_count" -ge 6 ]; then
+                echo "SUCCESS: Expected number of .ko files found (at least 6 for recursive structure)"
+
+                # Check specific subdirectory files
+                subdir_files=(
+                  "driversA/driverA-mod1.ko"
+                  "driversA/driverA-mod2.ko"
+                  "driversB/driverB-mod1.ko"
+                  "driversB/submodule/submodule.ko"
+                )
+
+                for subdir_file in "${subdir_files[@]}"; do
+                  subdir_file_path="$arch_dir/$subdir_file"
+                  if [ -f "$subdir_file_path" ]; then
+                    content=$(cat "$subdir_file_path")
+                    if [[ "$content" == SIGNED_* ]]; then
+                      echo "SUCCESS: Subdirectory file $subdir_file contains signed content: $content"
+                    else
+                      echo "ERROR: Subdirectory file $subdir_file does not contain signed content, found: $content"
+                      exit 1
+                    fi
+                  else
+                    echo "ERROR: Expected subdirectory file not found: $subdir_file"
+                    exit 1
+                  fi
+                done
+
+                echo "SUCCESS: All subdirectory .ko files are properly signed - recursive signing working!"
+              else
+                echo "ERROR: Expected at least 6 .ko files but found only $signed_files_count"
+                echo "Found .ko files:"
+                find "$arch_dir" -name "*.ko" -type f
                 exit 1
               fi
 


### PR DESCRIPTION
Some vendors need their OOT kmods to be built in
different subdirectories so we have to support
recursion in all tasks used by push-oot-kmods

