### PR TITLE
fix: fbc images copied to wrong version tag

### DIFF
--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -134,7 +134,7 @@ spec:
           cpu: 200m
       script: |
         #!/usr/bin/env bash
-        set -e
+        set -eo pipefail
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
@@ -147,17 +147,17 @@ spec:
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         LENGTH="$(jq -r '.components | length' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
-        sourceIndex=()
         for((i=0; i<LENGTH; i++)); do
           targetIndex=$(jq -r --argjson i "$i" \
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          sourceIndex+=("$(jq -r  --argjson i "$i" \
+          sourceImages=()
+          sourceImages+=("$(jq -r  --argjson i "$i" \
             '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")")
 
           # we need the resolved index_image as the published pub index might be replaced by another process,
           # causing pyxis to fail, so we need to publish the resolved as the timestamped one.
-          sourceIndex+=("$(jq -r  --argjson i "$i" \
+          sourceImages+=("$(jq -r  --argjson i "$i" \
             '.components[$i].index_image_resolved' "$(params.dataDir)/$(params.internalRequestResultsFile)")")
 
           buildTimestamp=$(jq -r --argjson i "$i" '.components[$i].completion_time' \
@@ -177,11 +177,11 @@ spec:
           for((x=0; x<${#publishingImages[@]}; x++ )); do
               echo "=== Creating internal request to publish image:"
               echo ""
-              echo "- from: ${sourceIndex[$x]}"
+              echo "- from: ${sourceImages[$x]}"
               echo "- to: ${publishingImages[$x]}"
 
               internal-request --pipeline "${request}" \
-                  -p sourceIndex="${sourceIndex[$x]}" \
+                  -p sourceIndex="${sourceImages[$x]}" \
                   -p targetIndex="${publishingImages[$x]}" \
                   -p publishingCredentials="${credentials}" \
                   -p retries="$(params.retries)" \

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-multiple-components.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-multiple-components.yaml
@@ -1,0 +1,249 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image-multiple-components
+spec:
+  description: Test that multiple components each use their correct source images
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "fbc": {
+                  "publishingCredentials": "test-credentials"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "index_image": {
+                  "target_index": "quay.io/redhat-prod/redhat----redhat-operator-index:v4.12"
+                },
+                "components": [
+                  {
+                    "fbc_fragment": "registry.io/image0@sha256:0000",
+                    "target_index": "quay.io/redhat-prod/redhat----redhat-operator-index:v4.12",
+                    "ocp_version": "v4.12",
+                    "index_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.12-tag",
+                    "index_image_resolved": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:aaa111",
+                    "completion_time": "1770154672",
+                    "iibLog": "v4.12 IIB Log"
+                  },
+                  {
+                    "fbc_fragment": "registry.io/image1@sha256:1111",
+                    "target_index": "quay.io/redhat-prod/redhat----redhat-operator-index:v4.16",
+                    "ocp_version": "v4.16",
+                    "index_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.16-tag",
+                    "index_image_resolved": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:bbb222",
+                    "completion_time": "1770154673",
+                    "iibLog": "v4.16 IIB Log"
+                  },
+                  {
+                    "fbc_fragment": "registry.io/image2@sha256:2222",
+                    "target_index": "quay.io/redhat-prod/redhat----redhat-operator-index:v4.18",
+                    "ocp_version": "v4.18",
+                    "index_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.18-tag",
+                    "index_image_resolved": "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:ccc333",
+                    "completion_time": "1770154674",
+                    "iibLog": "v4.18 IIB Log"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-index-image
+      params:
+        - name: buildTimestamp
+          value: 11111111111
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: retries
+          value: 2
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Get all internal requests sorted by creation time
+              internalRequests=$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+                -o json | jq '.items')
+
+              # We expect 6 internal requests total (2 per component: base tag + timestamped tag)
+              irCount=$(jq '. | length' <<< "${internalRequests}")
+              if [ "${irCount}" -ne 6 ]; then
+                  echo "Expected 6 internalrequests but found ${irCount}"
+                  exit 1
+              fi
+
+              # Define expected mappings: [sourceIndex, targetIndex]
+              # Component 0 (v4.12):
+              declare -A expected
+              expected[0]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.12-tag|quay.io/redhat-prod/redhat----redhat-operator-index:v4.12"
+              expected[1]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:aaa111|quay.io/redhat-prod/redhat----redhat-operator-index:v4.12-1770154672"
+              # Component 1 (v4.16):
+              expected[2]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.16-tag|quay.io/redhat-prod/redhat----redhat-operator-index:v4.16"
+              expected[3]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:bbb222|quay.io/redhat-prod/redhat----redhat-operator-index:v4.16-1770154673"
+              # Component 2 (v4.18):
+              expected[4]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.18-tag|quay.io/redhat-prod/redhat----redhat-operator-index:v4.18"
+              expected[5]="registry-proxy.engineering.redhat.com/rh-osbs/iib-pub@sha256:ccc333|quay.io/redhat-prod/redhat----redhat-operator-index:v4.18-1770154674"
+
+              # Verify each internal request
+              for((i=0; i<irCount; i++)); do
+                  params=$(jq -r ".[$i] | .spec.params" <<< "${internalRequests}")
+                  
+                  sourceIndex=$(jq -r '.sourceIndex' <<< "${params}")
+                  targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+                  
+                  expectedPair="${expected[$i]}"
+                  expectedSource="${expectedPair%%|*}"
+                  expectedTarget="${expectedPair##*|}"
+                  
+                  echo "=== Verifying InternalRequest $i ==="
+                  echo "Source: $sourceIndex (expected: $expectedSource)"
+                  echo "Target: $targetIndex (expected: $expectedTarget)"
+                  
+                  if [ "$sourceIndex" != "$expectedSource" ]; then
+                      echo "ERROR: sourceIndex mismatch for request $i"
+                      echo "  Expected: $expectedSource"
+                      echo "  Got: $sourceIndex"
+                      exit 1
+                  fi
+                  
+                  if [ "$targetIndex" != "$expectedTarget" ]; then
+                      echo "ERROR: targetIndex mismatch for request $i"
+                      echo "  Expected: $expectedTarget"
+                      echo "  Got: $targetIndex"
+                      exit 1
+                  fi
+                  
+                  echo "✓ InternalRequest $i is correct"
+              done
+
+              echo ""
+              echo "✅ All 6 InternalRequests have correct source and target images!"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
## Describe your changes
Fixes a critical bug where fbbc index images were being copied to incorrect ocp version tags, causing v4.18 images to be tagged as v4.12, v4.16, etc.

The `sourceIndex` array in `publish-index-image` task was declared globally and accumulated values across all component iterations. The inner loop used index `x` without accounting for previous iterations, causing each component to use images from the first component.

Resolved by changing from global `sourceIndex` to local `sourceImages` array that's created fresh for each component iteration, ensuring each OCP version gets its correct image.
+ dedicated unit-test was added

Related: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1770168286509869

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Cursor
