### PR TITLE
fix: publishing to wrong targetIndex

### DIFF
--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -147,12 +147,11 @@ spec:
         pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
         LENGTH="$(jq -r '.components | length' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
-        sourceIndex=()
         for((i=0; i<LENGTH; i++)); do
           targetIndex=$(jq -r --argjson i "$i" \
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          sourceIndex+=("$(jq -r  --argjson i "$i" \
+          sourceIndex=("$(jq -r  --argjson i "$i" \
             '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")")
 
           # we need the resolved index_image as the published pub index might be replaced by another process,

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-multiple-targets.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-multiple-targets.yaml
@@ -1,0 +1,260 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image-multiple-images
+spec:
+  description: >-
+      Test creating a internal request to publish multiple images
+      to multiple repositories
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "fbc": {
+                  "publishingCredentials": "test-credentials"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "index_image": {
+                  "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                },
+                "components": [
+                  {
+                    "fbc_fragment": "registry.io/image0@sha256:0000",
+                    "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.12",
+                    "ocp_version": "v4.12",
+                    "index_image": "redhat.com/rh-stage/iib:01",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:v4.12abcdefghijk",
+                    "image_digests": [
+                      "quay.io/a",
+                      "quay.io/b"
+                    ],
+                    "completion_time": "1770199080",
+                    "iibLog": "Dummy IIB Log"
+                  },
+                  {
+                    "fbc_fragment": "registry.io/image0@sha256:0000",
+                    "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.13",
+                    "ocp_version": "v4.13",
+                    "index_image": "redhat.com/rh-stage/iib:01",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:v4.13abcdefghijk",
+                    "image_digests": [
+                      "quay.io/a",
+                      "quay.io/b"
+                    ],
+                    "completion_time": "1770199080",
+                    "iibLog": "Dummy IIB Log"
+                  },
+                  {
+                    "fbc_fragment": "registry.io/image0@sha256:0000",
+                    "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.14",
+                    "ocp_version": "v4.14",
+                    "index_image": "redhat.com/rh-stage/iib:01",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:v4.14abcdefghijk",
+                    "image_digests": [
+                      "quay.io/a",
+                      "quay.io/b"
+                    ],
+                    "completion_time": "1770199080",
+                    "iibLog": "Dummy IIB Log"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-index-image
+      params:
+        - name: buildTimestamp
+          value: 11111111111
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: retries
+          value: 2
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              internalRequests=$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers \
+              -o json | jq '.items')
+
+              irIndex=$(jq '. | length' <<< "${internalRequests}")
+              for((i=0; i<irIndex; i++)); do
+
+                  pipeline=$(jq -r ".[$i] | .spec.pipeline.pipelineRef.params[2].value" <<< "${internalRequests}")
+                  params=$(jq -r ".[$i] | .spec.params" <<< "${internalRequests}")
+
+                  if [ "$pipeline" != \
+                    "pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml" ]; then
+                    echo "pipeline does not match"
+                    exit 1
+                  fi
+
+                  if [ "$(jq -r '.retries' <<< "${params}")" != "2" ]; then
+                    echo "number of retries does not match"
+                    exit 1
+                  fi
+
+                  targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+                  expectedVersion="${targetIndex##*:}"
+                  expectedVersion="${expectedVersion%-*}"
+                  expectedSourceIndex="redhat.com/rh-stage/iib:01"
+                  if [[ "$targetIndex" == *"1770199080" ]]; then
+                      expectedSourceIndex="redhat.com/rh-stage/iib@sha256:${expectedVersion}abcdefghijk"
+                  fi
+
+                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "$expectedSourceIndex" ]; then
+                    echo "sourceIndex image does not match"
+                    exit 1
+                  fi
+
+                  targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+                  expectedTargetIndex="quay.io/scoheb/fbc-target-index-testing:${expectedVersion}"
+                  if [[ "$targetIndex" == *"1770199080" ]]; then
+                      expectedTargetIndex="quay.io/scoheb/fbc-target-index-testing:${expectedVersion}-1770199080"
+                  fi
+
+                  if [ "$targetIndex" != "$expectedTargetIndex" ]; then
+                    echo "targetIndex image does not match"
+                    exit 1
+                  fi
+
+                  if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
+                    echo "taskGitUrl image does not match"
+                    exit 1
+                  fi
+
+                  if [ "$(jq -r '.taskGitRevision' <<< "${params}")" != "main" ]; then
+                    echo "taskGitRevision image does not match"
+                    exit 1
+                  fi
+              done
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
this PR fixes the bug where the sourceIndex is
copied to the wrong target.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
