### PR TITLE
chore: bot shouldn't repeat suggestions

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -35,4 +35,5 @@ commitable_code_suggestions = true
 num_code_suggestions_per_chunk = 3
 extra_instructions = """
 - Before suggesting a change, verify whether the PR/task already includes it (or equivalent logic). If it already exists, do not suggest it.
+- Do not repeat previously rejected suggestions in subsequent updates of the same PR if the thread was resolved without action.
 """


### PR DESCRIPTION
This commit updates the qodo review bot to not repeat a rejected suggestion when you update your PR. For example, it tells you to add a comment, you decide not to and resolve it, you update your PR in some other place, and it would open a new thread saying the same thing. This should stop that.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
