### PR TITLE
fix: race condition in add-fbc-contribution parallel worker processing

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -452,28 +452,35 @@ spec:
                     pids=("${new_pids[@]}")
                 done
                 
-                local group_file="${groups_dir}/${ocp_version}.json"
+                # Capture loop variable in local variable to avoid race condition in background process
+                local current_ocp_version="$ocp_version"
+                local group_file="${groups_dir}/${current_ocp_version}.json"
+                
+                # Validate group file exists and is readable before launching worker
+                if [ ! -r "$group_file" ]; then
+                    echo "ERROR: Group file not found or not readable for OCP $current_ocp_version: $group_file"
+                    exit 1
+                fi
+                
                 launched_count=$((launched_count + 1))
-                echo "INFO: Launching worker $launched_count/$total_groups for OCP group: $ocp_version"
-
-                local group_components
-                group_components=$(cat "$group_file")
+                echo "INFO: Launching worker $launched_count/$total_groups for OCP group: $current_ocp_version"
 
                 (
-                    set -e
+                    set -euo pipefail
                     
-                    echo "INFO: [Parallel Worker $ocp_version] Starting processing"
+                    echo "INFO: [Parallel Worker $current_ocp_version] Starting processing"
                     
-                    process_ocp_group "$ocp_version" "$group_components"
+                    # Pass file path instead of content to avoid word-splitting issues
+                    process_ocp_group "$current_ocp_version" "$group_file"
                     
-                    echo "SUCCESS" > "${parallel_dir}/${ocp_version}.status"
-                    echo "INFO: [Parallel Worker $ocp_version] Completed successfully"
+                    echo "SUCCESS" > "${parallel_dir}/${current_ocp_version}.status"
+                    echo "INFO: [Parallel Worker $current_ocp_version] Completed successfully"
                 ) &
                 
                 local pid=$!
                 pids+=("$pid")
-                pid_to_ocp+=("$pid:$ocp_version")
-                echo "INFO: Launched worker for OCP $ocp_version (PID: $pid)" \
+                pid_to_ocp+=("$pid:$current_ocp_version")
+                echo "INFO: Launched worker for OCP $current_ocp_version (PID: $pid)" \
                      "[Active workers: ${#pids[@]}/$max_parallel_workers]"
             done
 
@@ -540,9 +547,16 @@ spec:
         # Process OCP group
         process_ocp_group() {
             local group_ocp_version="$1"
-            local group_components="$2"
+            local group_file="$2"
 
             echo "INFO: Processing OCP group $group_ocp_version"
+
+            # Read and validate group components JSON file
+            local group_components
+            if ! group_components=$(jq -c '.' "$group_file"); then
+                echo "ERROR: Failed to parse JSON from group file: $group_file"
+                exit 1
+            fi
 
             # Create per-worker results file to avoid concurrent write conflicts
             local worker_results_file="${parallel_dir}/${group_ocp_version}-results.json"
@@ -637,6 +651,11 @@ spec:
                 echo "Executing group batch $((batch_num + 1)): fromIndex=${from_index}" \
                     "(OCP: $group_ocp_version)"
 
+                # Define batch file paths
+                local batch_file_prefix
+                batch_file_prefix="$(params.dataDir)/ir-$(context.taskRun.uid)"
+                batch_file_prefix="${batch_file_prefix}-${group_ocp_version}-batch-$((batch_num + 1))"
+
                 # Get batch fragments
                 local batch_fragments
                 batch_fragments=$(get_batch_fragments "$batch_num")
@@ -660,12 +679,12 @@ spec:
                     --pipeline-timeout "${pipeline_timeout}" \
                     --task-timeout "${task_timeout}" \
                     -t "${request_timeout_seconds}" \
-                    | tee "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log"
+                    | tee "${batch_file_prefix}-output.log"
 
                 # Extract request name
                 local internalRequest
                 internalRequest=$(awk -F"'" '/created/ { print $2 }' \
-                    "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log")
+                    "${batch_file_prefix}-output.log")
 
                 # Validate internal request succeeded
                 local request_status
@@ -695,7 +714,7 @@ spec:
                 fi
 
                 # Store results for this batch
-                echo "${results}" > "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-result.json"
+                echo "${results}" > "${batch_file_prefix}-result.json"
 
                 # Process results for each fragment in this batch
                 local decompressed_json_build_info
@@ -755,7 +774,8 @@ spec:
 
                     # Extract latest IIB index image for next batch (only when not overwriting)
                     if [ "${mustOverwriteFromIndexImage}" = "false" ]; then
-                        result_file="$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-result.json"
+                        result_file="$(params.dataDir)/ir-$(context.taskRun.uid)-${group_ocp_version}"
+                        result_file="${result_file}-batch-$((batch_num + 1))-result.json"
                         batch_results=$(cat "${result_file}")
                         group_latest_iib_index_image=$(jq -r '.jsonBuildInfo' <<< "${batch_results}" | \
                             base64 -d | gunzip | jq -r '.index_image')
@@ -795,7 +815,7 @@ spec:
                         # Add to successful batches and extract latest IIB index image (only when not overwriting)
                         group_successful_batches+=("$batch_num")
                         if [ "${mustOverwriteFromIndexImage}" = "false" ]; then
-                            result_file="$(params.dataDir)/ir-$(context.taskRun.uid)"
+                            result_file="$(params.dataDir)/ir-$(context.taskRun.uid)-${group_ocp_version}"
                             result_file+="-batch-$((batch_num + 1))-result.json"
                             batch_results=$(cat "${result_file}")
                             group_latest_iib_index_image=$(jq -r '.jsonBuildInfo' <<< "${batch_results}" | \
@@ -871,15 +891,26 @@ spec:
         fi
 
         # Get the final batch result for legacy compatibility (use last successful batch from any group)
-        # Find the most recent batch result file
-        latest_result_file=$(find "$(params.dataDir)" -name "ir-*-batch-*-result.json" \
+        # Find the most recent batch result file from current task run only
+        task_run_uid="$(context.taskRun.uid)"
+        latest_result_file=$(find "$(params.dataDir)" \
+            -name "ir-${task_run_uid}-*-batch-*-result.json" \
             -type f -exec ls -t {} + 2>/dev/null | head -1)
         if [[ -n "$latest_result_file" ]]; then
             results=$(cat "$latest_result_file")
-            # Extract batch number from filename for output log
-            batch_number=$(basename "$latest_result_file" | sed 's/.*-batch-\([0-9]*\)-result.json/\1/')
-            internalRequest=$(awk -F"'" '/created/ { print $2 }' \
-                "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-${batch_number}-output.log")
+            # Extract OCP version and batch number from filename with validation
+            # Expected format: ir-<uid>-v4.12-batch-1-result.json or ir-<uid>-4.12-batch-1-result.json
+            result_filename=$(basename "$latest_result_file")
+            if [[ "$result_filename" =~ ^ir-(.+)-(v?[0-9]+\.[0-9]+)-batch-([0-9]+)-result\.json$ ]]; then
+                result_ocp_version="${BASH_REMATCH[2]}"
+                result_batch_number="${BASH_REMATCH[3]}"
+                internalRequest=$(awk -F"'" '/created/ { print $2 }' \
+                    "$(params.dataDir)/ir-${task_run_uid}-${result_ocp_version}-batch-${result_batch_number}-output.log")
+            else
+                echo "ERROR: Result filename does not match expected format: $result_filename"
+                echo "Expected format: ir-<uid>-[v]<X.Y>-batch-<N>-result.json"
+                exit 1
+            fi
         else
             echo "ERROR: No batch result files found"
             exit 1

--- a/tasks/managed/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/managed/add-fbc-contribution/tests/mocks.sh
@@ -20,17 +20,43 @@ function internal-request() {
   # Use a unique temp file for each internal-request call to avoid race conditions in parallel execution
   local ir_output_file
   ir_output_file="$WORKDIR/ir-output-${PIPELINE_UID:-default}-$$.tmp"
-  /home/utils/internal-request "$@" -s false | tee "$ir_output_file"
-
-  sleep 1
   
-  # Extract the IR name from the captured output specific to this pipeline
+  # Count existing IRs before creating new one to track which one we created
+  local ir_count_before=0
+  if [ -n "$PIPELINE_UID" ]; then
+    ir_count_before=$(kubectl get internalrequest \
+      -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" \
+      --no-headers 2>/dev/null | wc -l)
+  fi
+  
+  /home/utils/internal-request "$@" -s false | tee "$ir_output_file"
+  
+  # Extract the IR name from the captured output
   IR_NAME=$(awk -F"'" '/created/ { print $2 }' "$ir_output_file")
   
   if [ -z "$IR_NAME" ]; then
-      # Fallback: try to find IR with matching pipeline UID label
+      # Poll for the new IR to appear (wait up to 10 seconds)
       if [ -n "$PIPELINE_UID" ]; then
-        IR_NAME=$(kubectl get internalrequest -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" --no-headers -o custom-columns=":metadata.name" --sort-by=.metadata.creationTimestamp | tail -1)
+        echo "Waiting for InternalRequest to be created for pipeline UID: ${PIPELINE_UID}..."
+        for attempt in {1..20}; do
+          sleep 0.5
+          local ir_count_after
+          ir_count_after=$(kubectl get internalrequest \
+            -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" \
+            --no-headers 2>/dev/null | wc -l)
+          
+          if [ "$ir_count_after" -gt "$ir_count_before" ]; then
+            # New IR appeared, get the most recent one for this pipeline
+            IR_NAME=$(kubectl get internalrequest \
+              -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" \
+              --no-headers -o custom-columns=":metadata.name" \
+              --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -1)
+            if [ -n "$IR_NAME" ]; then
+              echo "Found InternalRequest: $IR_NAME (attempt $attempt)"
+              break
+            fi
+          fi
+        done
       fi
       
       # Final fallback to the original method
@@ -52,9 +78,9 @@ function internal-request() {
   # The parameter comes in format: -p fbcFragments=["fail.io/image0@sha256:0000"]
   # Any image with "fail.io" in the registry/path will trigger a failure
   if [[ "$*" =~ fbcFragments=.*fail\.io ]]; then
-      set_ir_status $IR_NAME 1
+      set_ir_status "$IR_NAME" 1
   else
-      set_ir_status $IR_NAME 0
+      set_ir_status "$IR_NAME" 0
   fi
 }
 
@@ -63,6 +89,21 @@ function set_ir_status() {
     EXITCODE=$2
     local WORKDIR="${WORKDIR:-/var/workdir/release}"
     PATCH_FILE="$WORKDIR/${NAME}-patch.json"
+    
+    # Wait for the IR to actually exist before trying to patch it
+    echo "Waiting for InternalRequest $NAME to be created..."
+    for wait_attempt in {1..30}; do
+      if kubectl get internalrequest "$NAME" &>/dev/null; then
+        echo "InternalRequest $NAME found (attempt $wait_attempt)"
+        break
+      fi
+      if [ $wait_attempt -eq 30 ]; then
+        echo "ERROR: InternalRequest $NAME not found after 15 seconds"
+        kubectl get internalrequest --no-headers
+        return 1
+      fi
+      sleep 0.5
+    done
 
     # Determine condition status based on exit code - matches internal-services behavior
     if [ "${EXITCODE}" -eq 0 ]; then


### PR DESCRIPTION
## Describe your changes
Capture the loop variable $ocp_version in a local variable $current_ocp_version 
before spawning each background worker. This ensures each worker has its own 
immutable copy of the OCP version value that won't change when the parent loop 
continues iterating.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
