### PR TITLE
chore: disable qodo auto-reviews. Manual only

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,17 +5,10 @@
 [github_app]
 # Ignore PRs opened by these authors.
 ignore_pr_authors = ["red-hat-konflux", "release-service-bot"]
-# Run review automatically when PRs are opened/reopened/ready.
-pr_commands = [
-  "/review",
-  "/improve",
-]
-# Run review automatically when new commits are pushed to an open PR.
-handle_push_trigger = true
-push_commands = [
-  "/review",
-  "/improve",
-]
+# Disable auto-run on PR open/reopen - only run when user explicitly comments /review
+pr_commands = []
+# Disable auto-run on push - only run when user explicitly comments /review
+handle_push_trigger = false
 
 [pr_reviewer]
 # Limit review feedback to 3 findings per PR.


### PR DESCRIPTION
Qodo can still review pr with /review cmd

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
