### PR TITLE
fix: update-infra-deployments safe encode

### DIFF
--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -291,10 +291,11 @@ spec:
                 now = int(time.time())
 
                 header_ = {"typ": "JWT", "alg": "RS256"}
-                header = base64.b64encode(json.dumps(header_).encode())
+                # JWT requires base64url encoding without padding
+                header = base64.urlsafe_b64encode(json.dumps(header_).encode()).rstrip(b'=')
 
                 payload_ = {"iat": now, "exp": now + expire_in, "iss": self.app_id}
-                payload = base64.b64encode(json.dumps(payload_).encode())
+                payload = base64.urlsafe_b64encode(json.dumps(payload_).encode()).rstrip(b'=')
 
                 header_payload = header + b"." + payload
                 proc = subprocess.run(
@@ -303,7 +304,7 @@ spec:
                     check=True,
                     stdout=subprocess.PIPE,
                 )
-                signature = base64.b64encode(proc.stdout)
+                signature = base64.urlsafe_b64encode(proc.stdout).rstrip(b'=')
 
                 token = header_payload + b"." + signature
                 return token.decode()


### PR DESCRIPTION
The update-infra-deployments task is now failing. Cursor says the standard base64 encoding uses + and / characters which can cause authentication failures, so this commit fixes that and includes padding.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
