### PR TITLE
test: verify push-rpm-data-to-pyxis CPU limits in isolation

### DIFF
--- a/.github/scripts/tkn_check_compute_resources.sh
+++ b/.github/scripts/tkn_check_compute_resources.sh
@@ -30,12 +30,6 @@ for file in ${CHANGED_FILES}; do
     limits=$(yq '.limits' <<< "$compute_resources")
     requests=$(yq '.requests' <<< "$compute_resources")
 
-    # Ensure limits.cpu is not defined
-    if yq -e 'has("cpu")' <<< "$limits" > /dev/null 2>&1; then
-      echo "ERROR: $file step $step_name (index $i) has limits.cpu defined. This should not be set"
-      fail=1
-    fi
-
     # Ensure requests.cpu is defined
     if ! yq -e 'has("cpu")' <<< "$requests" > /dev/null 2>&1; then
       echo "ERROR: $file step $step_name (index $i) does not have requests.cpu defined"
@@ -55,9 +49,9 @@ for file in ${CHANGED_FILES}; do
       echo "ERROR: $file step $step_name (index $i) computeResources has extra or missing keys"
       fail=1
     else
-      # Check that limits only has memory and requests only has cpu and memory (order-agnostic)
-      if ! yq -e 'keys | contains(["memory"]) and length == 1' <<< "$limits" > /dev/null 2>&1; then
-        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory"
+      # Check that limits only has memory and/or cpu, requests only has cpu and memory (order-agnostic)
+      if ! yq -e 'keys - ["cpu","memory"] | length == 0' <<< "$limits" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory and cpu"
         fail=1
       fi
       if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$requests" > /dev/null 2>&1; then

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -108,6 +108,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -131,9 +132,10 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '2'
         requests:
           memory: 1Gi
-          cpu: 500m
+          cpu: '2'
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -303,9 +305,10 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '2'
         requests:
           memory: 1Gi
-          cpu: '1'
+          cpu: '2'
       volumeMounts:
         - name: pyxis-secret-vol
           mountPath: "/etc/secrets"
@@ -426,6 +429,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -129,13 +129,14 @@ spec:
     - name: download-sbom-files
       image:
         quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      # CPU: Analysis showed 95th percentile ~2 cores, but CI Kind cluster limits to 1
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '2'
+          cpu: '1'
         requests:
           memory: 1Gi
-          cpu: '2'
+          cpu: '1'
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -302,13 +303,14 @@ spec:
     - name: push-rpm-data-to-pyxis
       image:
         quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      # CPU: Analysis showed 95th percentile ~2 cores, but CI Kind cluster limits to 1
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '2'
+          cpu: '1'
         requests:
           memory: 1Gi
-          cpu: '2'
+          cpu: '1'
       volumeMounts:
         - name: pyxis-secret-vol
           mountPath: "/etc/secrets"


### PR DESCRIPTION
Testing if this single task passes CI when not competing with 283 other tests.

Changes:
- Added limits.cpu = requests.cpu for all steps
- Increased download-sbom-files CPU: 500m -> 2 cores
- Increased push-rpm-data-to-pyxis CPU: 1 -> 2 cores
- Updated CI script to allow limits.cpu

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
