### PR TITLE
fix(RELEASE-2218): check all processes in rh-sign-image-cosign

### DIFF
--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -391,34 +391,41 @@ spec:
           for entry in filter(None, to_yield):
             print(' '.join(entry))
           print('---') # group separator
-        " | while read -r ENTRY; do
-          if [ "$ENTRY" = "---" ]; then
-            echo "... waiting for group to be signed ..."
-            # wait for group to finish
-            while (( ${RUNNING_JOBS@P} > 0 )); do
-              wait -n
+        " | {
+          SUCCESS=true
+          while read -r ENTRY; do
+            if [ "$ENTRY" = "---" ]; then
+              echo "... waiting for group to be signed ..."
+              # wait for group to finish
+              while (( ${RUNNING_JOBS@P} > 0 )); do
+                wait -n || SUCCESS=false
+              done
+              spawn_count=0
+              continue
+            fi
+            INTERNAL_REF=$(echo "$ENTRY" | cut -d' ' -f1)
+            PUBLIC_REF=$(echo "$ENTRY" | cut -d' ' -f2)
+            DIGEST=$(echo "$ENTRY" | cut -d' ' -f3)
+            TAG=$(echo "$ENTRY" | cut -d' ' -f4)
+            # This function is stored in the utils/memory-throttle.sh file
+            # Wait for memory and concurrent limit
+            wait_for_memory 80
+            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
+              wait -n || SUCCESS=false
             done
-            spawn_count=0
-            continue
-          fi
-          INTERNAL_REF=$(echo "$ENTRY" | cut -d' ' -f1)
-          PUBLIC_REF=$(echo "$ENTRY" | cut -d' ' -f2)
-          DIGEST=$(echo "$ENTRY" | cut -d' ' -f3)
-          TAG=$(echo "$ENTRY" | cut -d' ' -f4)
-          # This function is stored in the utils/memory-throttle.sh file
-          # Wait for memory and concurrent limit
-          wait_for_memory 80
-          while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
-            wait -n
-          done
-          check_and_sign "${PUBLIC_REF}:${TAG}" "${INTERNAL_REF}" "${DIGEST}" &
-          spawn_count=$((spawn_count + 1))
+            check_and_sign "${PUBLIC_REF}:${TAG}" "${INTERNAL_REF}" "${DIGEST}" &
+            spawn_count=$((spawn_count + 1))
 
-          # Allow memory usage to stabilize every BURST_SIZE spawns.
-          if (( spawn_count % BURST_SIZE == 0 )); then
-            sleep $STABILIZATION_DELAY
+            # Allow memory usage to stabilize every BURST_SIZE spawns.
+            if (( spawn_count % BURST_SIZE == 0 )); then
+              sleep $STABILIZATION_DELAY
+            fi
+          done
+          if [ "$SUCCESS" != true ]; then
+            echo "ERROR: One or more signing jobs failed"
+            exit 1
           fi
-        done
+        }
         # Note: The pipe runs the while loop in a subshell, but every group ends with "---"
         # which waits for all jobs in that group, so no jobs remain when the subshell exits.
         echo "done"

--- a/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image-cosign/tests/mocks.sh
@@ -153,8 +153,12 @@ function cosign () {
   # mock_cosign_success_calls file is expected to contain lines with "1" or "0" where
   # "1" means that the call should end successfully and "0" means that the call should end with an error
   # following command pops the first line from the file and stores it in successfull_run variable
-  successfull_run=$(sed -n '1p' $(params.dataDir)/mock_cosign_success_calls && \
-    sed -i '1d' $(params.dataDir)/mock_cosign_success_calls)
+  # Use flock to prevent race conditions when multiple parallel cosign calls access the file
+  successfull_run=$(
+    flock -x "$(params.dataDir)/mock_cosign_success_calls.lock" bash -c \
+      "sed -n '1p' '$(params.dataDir)/mock_cosign_success_calls' && \
+       sed -i '1d' '$(params.dataDir)/mock_cosign_success_calls'"
+  )
 
   if [ "$1" = "verify" ]; then
     mock_existing_sig_file=$(echo "${*: -1}" | tr "/" "-")


### PR DESCRIPTION
This commit updates the rh-sign-image-cosign task to check the return code of *all* processes started instead of just exiting when one fails (due to set -e). In practice, this only affects the unit test, as it relies on all the mock calls occurring. It also updates a race condition in the unit test mocks, ensuring that simultaneous calls can't use the same file.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
