### PR TITLE
fix: remove cgwSecret param from create-advisory task in pipelines

### DIFF
--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -181,8 +181,7 @@ spec:
             [
               {"resultIndex": 0, "key": ".mapping.cloudMarketplacesSecret"},
               {"resultIndex": 1, "key": ".mapping.cloudMarketplacesPrePush", "default": "false"},
-              {"resultIndex": 2, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"},
-              {"resultIndex": 3, "key": ".cgw.cgwSecret", "default": "publish-to-cgw-secret"}
+              {"resultIndex": 2, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -416,8 +415,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: cgwSecret
-          value: "$(tasks.collect-task-params.results.extractedValues[3])"
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -163,8 +163,7 @@ spec:
               {"resultIndex": 1, "key": ".pulp.secretName"},
               {"resultIndex": 2, "key": ".conforma.workerCount", "default": "4"},
               {"resultIndex": 3, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"},
-              {"resultIndex": 4, "key": ".cgw.cgwSecret", "default": "publish-to-cgw-secret"},
-              {"resultIndex": 5, "key": ".sign.cosignSecretName", "default": ""}
+              {"resultIndex": 4, "key": ".sign.cosignSecretName", "default": ""}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -660,8 +659,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: cgwSecret
-          value: "$(tasks.collect-task-params.results.extractedValues[4])"
       taskRef:
         params:
           - name: url

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -145,8 +145,7 @@ spec:
           value: |
             [
               {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
-              {"resultIndex": 1, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"},
-              {"resultIndex": 2, "key": ".cgw.cgwSecret", "default": "publish-to-cgw-secret"}
+              {"resultIndex": 1, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -566,8 +565,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: cgwSecret
-          value: "$(tasks.collect-task-params.results.extractedValues[2])"
       taskRef:
         resolver: "git"
         params:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -170,8 +170,7 @@ spec:
               {"resultIndex": 2, "key": ".pyxis.secret"},
               {"resultIndex": 3, "key": ".pyxis.server", "default": "production"},
               {"resultIndex": 4, "key": ".enforceContainerFirstSecurityLabels", "default": "false"},
-              {"resultIndex": 5, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"},
-              {"resultIndex": 6, "key": ".cgw.cgwSecret", "default": "publish-to-cgw-secret"}
+              {"resultIndex": 5, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -998,8 +997,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: cgwSecret
-          value: "$(tasks.collect-task-params.results.extractedValues[6])"
       taskRef:
         params:
           - name: url


### PR DESCRIPTION
The create-advisory task no longer accepts a cgwSecret parameter, but these 4 pipelines were still passing it. While this didn't break user functionality, it caused tektor validation errors.

Pipelines updated:
- push-rpms-to-pulp
- push-disk-images-to-marketplaces
- rh-advisories
- release-to-github

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
