### PR TITLE
feat(MMENG-4518): create release-to-nrrc release pipeline

### DIFF
--- a/pipelines/managed/release-to-nrrc/README.md
+++ b/pipelines/managed/release-to-nrrc/README.md
@@ -1,0 +1,30 @@
+# release-to-nrrc pipeline
+
+Tekton release pipeline to release npm artifacts built through Middleware
+product in Konflux. The artifacts will be released to npm.registry.redhat.com.
+
+## Important Note on Idempotency
+
+Charon (the NRRC publishing tool) has no mechanism for detecting that a npm tarball was already published. 
+Thus, when rerunning this pipeline with the same release, no artifacts will be filtered out and all will
+be passed to the conforma check and other release tasks. This means the pipeline will re-process all 
+artifacts on every run, but Charon itself handles duplicate publications appropriately at the NRRC level.
+
+## Parameters
+
+| Name                            | Description                                                                                                                        | Optional | Default value                                             |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution                             | No       | -                                                         |
+| releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                                            | No       | -                                                         |
+| releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                                                   | No       | -                                                         |
+| releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                                                   | No       | -                                                         |
+| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                                               | No       | -                                                         |
+| enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                                                | No       | -                                                         |
+| enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
+| verify_ec_task_git_revision     | The git revision to be used when consuming the verify-conforma task                                                                | No       | -                                                         |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | Yes      | production                                                |
+| ociStorage                      | The OCI repository where the Trusted Artifacts are stored                                                                          | Yes      | quay.io/konflux-ci/release-service-trusted-artifacts      |
+| orasOptions                     | oras options to pass to Trusted Artifacts calls                                                                                    | Yes      | ""                                                        |
+| trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
+| dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |

--- a/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
+++ b/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
@@ -1,0 +1,309 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: release-to-nrrc
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton release pipeline to release npm artifacts built through Middleware
+    product in Konflux. The artifacts will be released to npm.registry.redhat.com.
+
+    ## Important Note on Idempotency
+    
+    Charon (the NRRC publishing tool) has no mechanism for detecting that a npm tarball was already published. 
+    Thus, when rerunning this pipeline with the same release, no artifacts will be filtered out and all will
+    be passed to the conforma check and other release tasks. This means the pipeline will re-process all 
+    artifacts on every run, but Charon itself handles duplicate publications appropriately at the NRRC level.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git revision to be used when consuming the verify-conforma task
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: production
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "quay.io/konflux-ci/release-service-trusted-artifacts"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      # to avoid tar extraction errors, we need to specify a subdirectory
+      # inside the volume.
+      default: "/var/workdir/release"
+  tasks:
+    - name: verify-access-to-resources
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: requireInternalServices
+          value: "false"
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - verify-access-to-resources
+    - name: collect-task-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-task-params/collect-task-params.yaml
+      params:
+        - name: dataDir
+          value: "$(params.dataDir)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: keysToExtract
+          value: |
+            [
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"}
+            ]
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+      runAfter:
+        - collect-data
+    - name: check-data-keys
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: schema
+          value: $(params.taskGitUrl)/raw/$(params.taskGitRevision)/schema/dataKeys.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "nrrc", "dynamic": false}
+            ]
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/check-data-keys/check-data-keys.yaml
+        resolver: git
+      runAfter:
+        - collect-data
+    - name: verify-conforma
+      timeout: "4h00m0s"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/conforma/cli
+          - name: revision
+            value: "$(params.verify_ec_task_git_revision)"
+          - name: pathInRepo
+            value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
+      params:
+        - name: SNAPSHOT_FILENAME
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          # only set to false for development
+          value: "true"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: WORKERS
+          value: "$(tasks.collect-task-params.results.extractedValues[0])"
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: TRUSTED_ARTIFACTS_DEBUG
+          value: "$(params.trustedArtifactsDebug)"
+      runAfter:
+        - check-data-keys
+        - collect-task-params
+    - name: collect-charon-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-charon-params/collect-charon-params.yaml
+      params:
+        - name: dataJsonPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: releasePath
+          value: "$(tasks.collect-data.results.release)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - verify-conforma
+    - name: publish-to-nrrc
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/publish-to-nrrc/publish-to-nrrc.yaml
+      params:
+        - name: charonParamFilePath
+          value: "$(tasks.collect-charon-params.results.charonParamFilePath)"
+        - name: charonConfigFilePath
+          value: "$(tasks.collect-charon-params.results.charonConfigFilePath)"
+        - name: charonAWSSecret
+          value: "$(tasks.collect-charon-params.results.charonAWSSecret)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-charon-params.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - collect-charon-params
+  finally:
+    - name: cleanup-internal-requests
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -21,6 +21,7 @@
               "fbc",
               "sign",
               "mrrc",
+              "nrrc",
               "cgw",
               "jira",
               "infra",
@@ -870,6 +871,14 @@
           "type": "string",
           "description": "The k8s secret containing the aws credential for aws access"
         },
+        "packageType": {
+          "type": "string",
+          "enum": [
+            "maven",
+            "npm"
+          ],
+          "description": "The package type for the charon release"
+        },
         "signing": {
           "type": "object",
           "description": "The signing configuration through RADAS",
@@ -1409,6 +1418,44 @@
                 ]
               }
             }
+          },
+          "releaseNotes": {
+            "required": [
+              "product_name",
+              "product_version"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "charon"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "nrrc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "charon": {
+            "required": [
+              "environment",
+              "release",
+              "awsSecret",
+              "packageType",
+              "config"
+            ]
           },
           "releaseNotes": {
             "required": [

--- a/tasks/managed/collect-charon-params/collect-charon-params.yaml
+++ b/tasks/managed/collect-charon-params/collect-charon-params.yaml
@@ -148,7 +148,8 @@ spec:
 
         environment="$(jq -re '.charon.environment' "$DATA_FILE")"
         release="$(jq -re '.charon.release' "$DATA_FILE")"
-        target="$environment-maven-$release"
+        packageType="$(jq -re '.charon.packageType // "maven"' "$DATA_FILE")"
+        target="$environment-$packageType-$release"
         echo "export CHARON_TARGET=$target" >> "$CHARON_ENV_FILE_PATH"
 
         productName="$(jq -re '.releaseNotes.product_name' "$DATA_FILE")"
@@ -156,8 +157,10 @@ spec:
         echo "export CHARON_PRODUCT_NAME=\"$productName\"" >> "$CHARON_ENV_FILE_PATH"
         echo "export CHARON_PRODUCT_VERSION=\"$productVersion\"" >> "$CHARON_ENV_FILE_PATH"
 
-        sign_key="$(jq -re '.charon.signing.signKey' "$DATA_FILE")"
-        echo "export CHARON_SIGN_KEY=\"$sign_key\"" >> "$CHARON_ENV_FILE_PATH"
+        sign_key="$(jq -re '.charon.signing.signKey // ""' "$DATA_FILE")"
+        if [ "$sign_key" != "" ]; then
+          echo "export CHARON_SIGN_KEY=\"$sign_key\"" >> "$CHARON_ENV_FILE_PATH"
+        fi
 
         SNAPSHOT_PATH="$WORK_DIR/$(params.snapshotPath)"
         ociRegistries="$(jq -re '[.components[].containerImage] | join("%")' "$SNAPSHOT_PATH")"
@@ -166,7 +169,7 @@ spec:
         awsSecret="$(jq -re '.charon.awsSecret' "$DATA_FILE")"
         echo -n "$awsSecret" > "$(results.charonAWSSecret.path)"
 
-        sign_ca_secret="$(jq -re '.charon.signing.signCASecret' "$DATA_FILE")"
+        sign_ca_secret="$(jq -re '.charon.signing.signCASecret // ""' "$DATA_FILE")"
         echo -n "$sign_ca_secret" > "$(results.charonSignCASecret.path)"
 
         AUTHOR=$(jq -re '.status.attribution.author' "$WORK_DIR/$(params.releasePath)")

--- a/tasks/managed/publish-to-nrrc/README.md
+++ b/tasks/managed/publish-to-nrrc/README.md
@@ -1,0 +1,27 @@
+# publish-to-nrrc
+
+Tekton task that publishes the npm archives to NRRC(npm.registry.redhat.com)
+service. NRRC is used to host npm artifacts of Red Hat products.
+This task will work with [collect-charon-task](../collect-charon-params/README.md)
+together to do the NRRC publishment work.
+It accepts the `charon.env` file from the
+[collect-charon-task](../collect-charon-params/README.md)
+and use the variables in it as parameters for the NRRC publishing task.
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |
+| charonParamFilePath     | path of the env file for nrrc parameters to use                                                                            | No       | -                    |
+| charonConfigFilePath    | path of the charon config file for charon to consume                                                                       | No       | -                    |
+| charonAWSSecret         | the secret name for charon aws credential file                                                                             | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |

--- a/tasks/managed/publish-to-nrrc/publish-to-nrrc.yaml
+++ b/tasks/managed/publish-to-nrrc/publish-to-nrrc.yaml
@@ -1,0 +1,261 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-to-nrrc
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task that publishes the npm archives to NRRC(npm.registry.redhat.com)
+    service. NRRC is used to host npm artifacts of Red Hat products.
+    This task will work with [collect-charon-task](../collect-charon-params/README.md)
+    together to do the NRRC publishment work.
+    It accepts the `charon.env` file from the
+    [collect-charon-task](../collect-charon-params/README.md)
+    and use the variables in it as parameters for the NRRC publishing task.
+  params:
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: charonParamFilePath
+      description: path of the env file for nrrc parameters to use
+      type: string
+    - name: charonConfigFilePath
+      description: path of the charon config file for charon to consume
+      type: string
+    - name: charonAWSSecret
+      description: the secret name for charon aws credential file
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  results:
+    - name: sourceDataArtifact
+      type: string
+      description: Produced trusted data artifact
+  volumes:
+    - name: "charon-aws-vol"
+      secret:
+        secretName: "$(params.charonAWSSecret)"
+    - name: nrrc-workdir
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    # This is a workaround for a problem observed on Konflux clusters where the
+    # a step runs with root user causing a file or folder to not be readable
+    # in later steps. There might be solution coming related to the
+    # security context constraints on the cluster, but setting this explicitly here
+    # should probably be harmless either way.
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+          cpu: 30m
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: prepare-repo
+      image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 150m
+        requests:
+          memory: 256Mi
+          cpu: 150m
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        CHARON_FILE="$(params.dataDir)/$(params.charonParamFilePath)"
+        # shellcheck source=/dev/null
+        . "$CHARON_FILE"
+        repodir="/workdir/nrrc"
+        mkdir -p "$repodir"
+        shared_repo="$repodir"/shared
+        mkdir -p "$shared_repo"
+
+        IFS='%' read -ra ADDR <<< "$CHARON_OCI_REGISTRY"
+        for registry in "${ADDR[@]}"
+        do
+          echo "Downloading the npm archive from $registry"
+
+          # Extract the sha256 hash and get first 6 characters
+          hash_part="${registry#*@sha256:}"
+          short_hash="${hash_part:0:6}"
+
+          # Create subdirectory with short hash
+          subdir="$repodir/$short_hash"
+          mkdir -p "$subdir"
+
+          SOURCE_REPO=${registry%%@sha256:*}
+          AUTH_FILE=$(mktemp)
+          select-oci-auth "${SOURCE_REPO}" > "$AUTH_FILE"
+          oras pull --registry-config "$AUTH_FILE" "$registry" -o "$subdir"
+
+          while IFS= read -r -d '' "fi"
+          do
+            file_type=$(file -b "$fi")
+            if [[ "$file_type" =~ (gzip compressed data|POSIX tar archive) ]]
+            then
+              file_name=$(basename "$fi")
+              move_to="$shared_repo"/"$short_hash"_"$file_name"
+              if [[ -f "$move_to" ]]
+              then
+                echo "Warning: $move_to already exists, skipped"
+              else
+                mv "$fi" "$move_to"
+              fi
+            fi
+          done <   <(find "$subdir" -type f -print0)
+        done
+      volumeMounts:
+        - name: nrrc-workdir
+          mountPath: "/workdir"
+    - name: upload-npm-archive
+      image: quay.io/konflux-ci/charon@sha256:5b19341da3b441172a290831908c8783ea82225771030a6fdca16697f83f3143
+      computeResources:
+        limits:
+          memory: 512Mi
+          cpu: 250m
+        requests:
+          memory: 512Mi
+          cpu: 250m
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        CHARON_CFG_FILE="$(params.dataDir)/$(params.charonConfigFilePath)"
+        mkdir -p "/home/charon/.charon"
+        cp "$CHARON_CFG_FILE" /home/charon/.charon/charon.yaml
+
+        CHARON_FILE="$(params.dataDir)/$(params.charonParamFilePath)"
+        # shellcheck source=/dev/null
+        . "$CHARON_FILE"
+
+        target="$CHARON_TARGET"
+        productName="$CHARON_PRODUCT_NAME"
+        productVersion="$CHARON_PRODUCT_VERSION"
+
+        shared_repo="/workdir/nrrc/shared"
+
+        shopt -s nullglob
+        found_files=false
+        for archive in "$shared_repo"/*
+        do
+          if [[ -f "$archive" ]]
+          then
+            found_files=true
+            echo "Release $archive with $productName-$productVersion into $target"
+            charon upload -p "$productName" -v "$productVersion" -t "$target" "$archive"
+          fi
+        done
+
+        if [[ "$found_files" == "false" ]]
+        then
+          echo "No npm archive file found, will not publish."
+          exit 1
+        fi
+      volumeMounts:
+        - name: "charon-aws-vol"
+          mountPath: "/home/charon/.aws"
+        - name: nrrc-workdir
+          mountPath: "/workdir"
+        - name: trusted-ca
+          mountPath: /etc/ssl/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+          cpu: 250m
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/publish-to-nrrc/tests/mocks.sh
+++ b/tasks/managed/publish-to-nrrc/tests/mocks.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+
+function oras(){
+  echo Mock oras called with: "$*"
+  echo "$*" >> "$(params.dataDir)/mock_oras.txt"
+
+  if [[ "$*" == "pull --registry-config"* ]]
+  then
+    echo Mock oras called with: "$*"
+    echo "$4"
+    registry="$4"
+    hash=${registry##*@sha256:}
+    short_hash=${hash:0:6}
+    chmod 777 /workdir/nrrc/"$short_hash"
+    cd /workdir/nrrc/"$short_hash"
+    mkdir package
+    touch package/package.json
+    tar -zcvf test.tgz package/
+    rm -rf package
+    cd -
+  else
+    echo Mock oras called with: "$*"
+    echo Error: Unexpected call
+    exit 1
+  fi
+}
+
+function charon(){
+  echo Mock charon called with: "$*"
+  echo "$*" >> "$(params.dataDir)/mock_charon.txt"
+
+  if [ ! -f "$HOME/.charon/charon.yaml" ]
+  then
+    echo Error: Missing charon config file
+    exit 1
+  fi
+
+  if [[ "$*" != "sign -r "*" -p "*" -k "*" "*"" ]] && [[ "$*" != "upload -p "*" -v "*" -t "*" "*"" ]]
+  then
+    echo Mock charon called with: "$*"
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  # generate signing file to pass test
+  if [[ "$*" == "sign -r "*" -p "*" -k "*" "*"" ]]
+  then
+    echo Mock charon sign called with: "$*"
+    registry="$8"
+    hash=${registry##*@sha256:}
+    short_hash=${hash:0:6}
+    touch /workdir/nrrc/"$short_hash"/signing.json
+  fi
+
+  # will use testcert as a symbol for ca mounted test
+  if [[ "$*" == "sign -r "*" -p "*" -k \"testcert\" "*"" ]]
+  then
+    if [[ $(cat /etc/ssl/certs/ca-custom-bundle.crt) != "mycert" ]]
+    then
+      echo Custom certificate not mounted
+      return 1
+    fi
+  fi
+}
+
+function select-oci-auth() {
+  echo "$*" >> "$(params.dataDir)/mock_select-oci-auth.txt"
+}
+

--- a/tasks/managed/publish-to-nrrc/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-to-nrrc/tests/pre-apply-task-hook.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Create a dummy charon aws crendentials secret (and delete it first if it exists)
+aws_creds=$(cat <<- EOF
+[test]
+aws_user = test-user
+aws_access_key_id = justadummykey
+aws_secret_access_key = justadummyaccesskey
+region = us-east-1
+EOF
+)
+kubectl delete secret test-charon-aws-credentials --ignore-not-found
+kubectl create secret generic test-charon-aws-credentials --from-literal=credentials="$aws_creds"
+
+kubectl delete secret test-ca --ignore-not-found
+kubectl create secret generic test-ca \
+  --from-literal=client-key.pem="testkey" \
+  --from-literal=client-key.password="testpass" \
+  --from-literal=mrrc-signing.crt="testca"
+
+# Add mocks to the beginning of scripts
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-failure-no-charon-config.yaml
+++ b/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-failure-no-charon-config.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-nrrc-failure-no-charon-config
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-to-nrrc task without charon-config file
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon.env << EOF
+              export CHARON_OCI_REGISTRY=quay.io/testorg/test-prod.tgz@sha256:0b15aad24f1b847
+              export CHARON_TARGET=dev-npm-ga
+              export CHARON_PRODUCT_NAME="Test Product"
+              export CHARON_PRODUCT_VERSION=0.0.1
+              export CHARON_AUTHOR=testuser
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-to-nrrc
+      params:
+        - name: charonParamFilePath
+          value: $(context.pipelineRun.uid)/charon.env
+        - name: charonConfigFilePath
+          value: $(context.pipelineRun.uid)/charon-config.yaml
+        - name: charonAWSSecret
+          value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-failure-no-charon-file.yaml
+++ b/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-failure-no-charon-file.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-nrrc-failure-no-charon-file
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the publish-to-nrrc task without charon.env file
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
+              charon-config
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-to-nrrc
+      params:
+        - name: charonParamFilePath
+          value: $(context.pipelineRun.uid)/charon.env
+        - name: charonConfigFilePath
+          value: $(context.pipelineRun.uid)/charon-config.yaml
+        - name: charonAWSSecret
+          value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-mount-certs.yaml
+++ b/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-mount-certs.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-nrrc-mount-certs
+spec:
+  description: |
+    Run the publish-to-nrrc task with required parameters - a happy path scenario.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon.env << EOF
+              export CHARON_OCI_REGISTRY=quay.io/testorg/test-prod.tgz@sha256:0b15aad24f1b847
+              export CHARON_TARGET=dev-npm-ga
+              export CHARON_PRODUCT_NAME="Test Product"
+              export CHARON_PRODUCT_VERSION=0.0.1
+              export CHARON_AUTHOR=testuser
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
+              charon-config
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-to-nrrc
+      params:
+        - name: charonParamFilePath
+          value: $(context.pipelineRun.uid)/charon.env
+        - name: charonConfigFilePath
+          value: $(context.pipelineRun.uid)/charon-config.yaml
+        - name: charonAWSSecret
+          value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: caTrustConfigMapName
+          value: test-use-custom-ca-cert
+        - name: caTrustConfigMapKey
+          value: cert
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(< "$(params.dataDir)"/mock_oras.txt wc -l)" != 1 ]; then
+                echo Error: oras was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)"/mock_oras.txt
+                exit 1
+              fi
+
+              if [ "$(< "$(params.dataDir)"/mock_charon.txt wc -l)" != 1 ]; then
+                echo Error: charon was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)"/mock_charon.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-multiple-archives.yaml
+++ b/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc-multiple-archives.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-nrrc
+spec:
+  description: |
+    Run the publish-to-nrrc task with required parameters - a happy path scenario.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon.env << EOF
+              export CHARON_OCI_REGISTRY="quay.io/testorg/test-prod.tgz@sha256:0b15aad24f1b847\
+              %quay.io/testorg/test-prod.tgz@sha256:e400bc4b4398295"
+              export CHARON_TARGET=dev-npm-ga
+              export CHARON_PRODUCT_NAME="Test Product"
+              export CHARON_PRODUCT_VERSION=0.0.1
+              export CHARON_AUTHOR=testuser
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
+              charon-config
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-to-nrrc
+      params:
+        - name: charonParamFilePath
+          value: $(context.pipelineRun.uid)/charon.env
+        - name: charonConfigFilePath
+          value: $(context.pipelineRun.uid)/charon-config.yaml
+        - name: charonAWSSecret
+          value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(< "$(params.dataDir)"/mock_oras.txt wc -l)" != 2 ]; then
+                echo Error: oras was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)"/mock_oras.txt
+                exit 1
+              fi
+
+              if [ "$(< "$(params.dataDir)"/mock_charon.txt wc -l)" != 2 ]; then
+                echo Error: charon was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)"/mock_charon.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc.yaml
+++ b/tasks/managed/publish-to-nrrc/tests/test-publish-to-nrrc.yaml
@@ -1,0 +1,171 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-to-nrrc
+spec:
+  description: |
+    Run the publish-to-nrrc task with required parameters - a happy path scenario.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon.env << EOF
+              export CHARON_OCI_REGISTRY=quay.io/testorg/test-prod.tgz@sha256:0b15aad24f1b847
+              export CHARON_TARGET=dev-npm-ga
+              export CHARON_PRODUCT_NAME="Test Product"
+              export CHARON_PRODUCT_VERSION=0.0.1
+              export CHARON_AUTHOR=testuser
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/charon-config.yaml << EOF
+              charon-config
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-to-nrrc
+      params:
+        - name: charonParamFilePath
+          value: $(context.pipelineRun.uid)/charon.env
+        - name: charonConfigFilePath
+          value: $(context.pipelineRun.uid)/charon-config.yaml
+        - name: charonAWSSecret
+          value: test-charon-aws-credentials
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          # This is a workaround for a problem observed on Konflux clusters where the
+          # a step runs with root user causing a file or folder to not be readable
+          # in later steps. There might be solution coming related to the
+          # security context constraints on the cluster, but setting this explicitly here
+          # should probably be harmless either way.
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:454e457cdadd5892b31fe2b7d4911b3d3a761f5705bb0cd30f864be0a597594b
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$(< "$(params.dataDir)"/mock_oras.txt wc -l)" != 1 ]; then
+                echo Error: oras was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)"/mock_oras.txt
+                exit 1
+              fi
+
+              if [ "$(< "$(params.dataDir)"/mock_charon.txt wc -l)" != 1 ]; then
+                echo Error: charon was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)"/mock_charon.txt
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
  This new pipeline is used to publish npm archives from ASMW products
  to RedHat managed npm registry(npm.registry.redhat.com). It contains:

  * A new publish-to-nrrc task: which is used to do the real publishing work
  * A new release-to-nrrc pipeline: the release pipeline for the whole work

  This pipeline is using same collect-charon-params task for the params
  preparing work because it also uses the Charon tools to do the
  publishing.

Assisted-by: Claude

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
