### PR TITLE
fix: set correct path for tar.gz kmods

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -307,7 +307,8 @@ spec:
                             # Intentional client-side expansion: task_uid expands locally for unique remote directories
                             # shellcheck disable=SC2029
                             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                                "cd ~/${task_uid}/kmods/${arch_name} && tar -xzf ~/kmods_${arch_name}.tar.gz"
+                                "cd ~/${task_uid}/kmods/${arch_name} && \
+                                 tar -xzf ~/${task_uid}/kmods_${arch_name}.tar.gz"
 
                             # Cleanup local temp file
                             rm -f "$temp_tarball"
@@ -461,7 +462,7 @@ spec:
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                    "cd ~/${task_uid}/kmods && tar -xzf ~/kmods.tar.gz"
+                    "cd ~/${task_uid}/kmods && tar -xzf ~/${task_uid}/kmods.tar.gz"
 
                 # Cleanup local temp file
                 rm -f "$temp_tarball"
@@ -564,7 +565,7 @@ spec:
                 # Intentional client-side expansion: task_uid expands locally for unique remote directories
                 # shellcheck disable=SC2029
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
-                    "cd ~/${task_uid}/kmods && tar -xzf ~/kmods.tar.gz"
+                    "cd ~/${task_uid}/kmods && tar -xzf ~/${task_uid}/kmods.tar.gz"
 
                 # Cleanup local temp file
                 rm -f "$temp_tarball"


### PR DESCRIPTION
The path for the kmods tarball in the signing task is missing the  variable, so tar is not
found when script is trying to untar.

