### PR TITLE
feat(RELEASE-2112): add tags and expiration to oras pushes

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -576,7 +576,8 @@ spec:
           if [ -f "$COMPONENT_DIR/has_mac" ]; then
             pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Macos content for $COMPONENT_NAME to $(params.quayURL)..."
-            output=$(oras push "$(params.quayURL)/unsigned/${COMPONENT_NAME}" macos)
+            output=$(oras push --annotation=quay.expires-after=1d \
+              "$(params.quayURL)/unsigned/${COMPONENT_NAME}:$(context.taskRun.uid)-mac" macos)
             mac_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME mac content: $mac_digest"
             echo -n "$mac_digest" > "$COMPONENT_DIR/unsigned_mac_digest.txt"
@@ -589,7 +590,8 @@ spec:
           if [ -f "$COMPONENT_DIR/has_windows" ]; then
             pushd "$UNSIGNED_DIR" > /dev/null
             echo "Pushing unsigned Windows content for $COMPONENT_NAME to $(params.quayURL)..."
-            output=$(oras push "$(params.quayURL)/unsigned/${COMPONENT_NAME}" windows)
+            output=$(oras push --annotation=quay.expires-after=1d \
+              "$(params.quayURL)/unsigned/${COMPONENT_NAME}:$(context.taskRun.uid)-windows" windows)
             windows_digest=$(echo "$output" | grep 'Digest:' | awk '{print $2}')
             echo "Digest for $COMPONENT_NAME windows content: $windows_digest"
             echo -n "$windows_digest" > "$COMPONENT_DIR/unsigned_windows_digest.txt"
@@ -742,7 +744,7 @@ spec:
           set -x
 
           SIGNED_TAG="$(context.taskRun.uid)-mac"
-          PUSH_OUTPUT=\$(/usr/local/bin/oras push \
+          PUSH_OUTPUT=\$(/usr/local/bin/oras push --annotation=quay.expires-after=1d \
             "$QUAY_URL/signed/${COMPONENT_NAME}:\$SIGNED_TAG" macos)
           SIGNED_DIGEST=\$(echo "\$PUSH_OUTPUT" | grep 'Digest:' | awk '{print \$2}')
           echo -n "\$SIGNED_DIGEST" >> "$DIGEST_FILE"
@@ -896,7 +898,8 @@ spec:
           echo [%DATE% %TIME%] Signing of Windows binaries for ${COMPONENT_NAME} completed successfully
 
           cd unsigned
-          oras push $(params.quayURL)/signed/${COMPONENT_NAME}:$(context.taskRun.uid)-windows windows \
+          oras push --annotation=quay.expires-after=1d \
+            $(params.quayURL)/signed/${COMPONENT_NAME}:$(context.taskRun.uid)-windows windows \
           > oras_push_output.txt 2>&1
 
           for /f "tokens=2,3 delims=: " %%a in ('findstr "Digest:" oras_push_output.txt') do @echo %%a:%%b > digest.txt


### PR DESCRIPTION
Add unique tags and quay.expires-after=1d annotation to all oras push operations to prevent:
- Storage accumulation from orphaned OCI artifacts in Quay
- Race conditions when parallel PipelineRuns push to the same location

Changes:
- Unsigned Mac/Windows pushes now use :$(context.taskRun.uid) tag
- All pushes now include --annotation=quay.expires-after=1d

Artifacts are only needed temporarily during the signing workflow and will be automatically cleaned up by Quay after 1 day.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
