### PR TITLE
feat(RELEASE-2035): add cpu limits to internal tasks

### DIFF
--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -56,6 +56,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m

--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -77,6 +77,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 200m
         requests:
           memory: 512Mi
           cpu: 200m

--- a/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
+++ b/tasks/internal/check-signing-certificates/check-signing-certificates.yaml
@@ -41,6 +41,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m

--- a/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
+++ b/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
@@ -48,6 +48,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 25m
         requests:
           memory: 64Mi
           cpu: 25m

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -70,6 +70,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 25m
         requests:
           memory: 64Mi
           cpu: 25m

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -66,6 +66,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -90,9 +90,10 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: '1'
         requests:
           memory: 256Mi
-          cpu: '1'  # 1 is the max allowed by at least the staging cluster
+          cpu: '1'
       volumeMounts:
         - name: advisory-secret
           mountPath: /mnt/advisory_secret

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -70,9 +70,10 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: '1'
         requests:
           memory: 256Mi
-          cpu: 500m
+          cpu: '1'
       volumeMounts:
         - name: advisory-secret
           mountPath: /mnt/advisory_secret

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -61,6 +61,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: '1'
         requests:
           memory: 128Mi
           cpu: '1'  # 1 is the max allowed by at least the staging cluster

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -84,6 +84,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -68,6 +68,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 400m
         requests:
           memory: 64Mi
           cpu: 400m

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -90,6 +90,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 450m
         requests:
           memory: 512Mi
           cpu: 450m

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -185,6 +185,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -406,9 +407,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: '1'
         requests:
           memory: 512Mi
-          cpu: 250m
+          cpu: '1'
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -605,6 +607,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -772,6 +775,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -935,6 +939,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -1146,6 +1151,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -1345,6 +1351,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -1673,6 +1680,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -66,6 +66,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m

--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -126,6 +126,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -150,6 +151,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -225,6 +227,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -257,6 +260,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -339,6 +343,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -402,6 +407,7 @@ spec:
       computeResources:
         limits:
           memory: 56Mi
+          cpu: 25m
         requests:
           memory: 56Mi
           cpu: 25m

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -102,6 +102,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: '1'
         requests:
           memory: 512Mi
           cpu: '1'
@@ -427,6 +428,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m


### PR DESCRIPTION
Set limits.cpu = requests.cpu for internal task steps to ensure predictable resource allocation.

Changes:
- Added CPU limits to 16 internal task files
- Increased requests for high-usage steps like create-advisory, filter-already-released-advisory-images

Part of the same effort as managed tasks PR, split for easier review and CI stability.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
