### PR TITLE
feat(RELEASE-2035): add cpu limits to heavy managed tasks

### DIFF
--- a/.github/scripts/tkn_check_compute_resources.sh
+++ b/.github/scripts/tkn_check_compute_resources.sh
@@ -44,14 +44,22 @@ for file in ${CHANGED_FILES}; do
       fail=1
     fi
 
+    # Ensure limits.cpu equals requests.cpu
+    limits_cpu=$(yq '.cpu' <<< "$limits")
+    requests_cpu=$(yq '.cpu' <<< "$requests")
+    if [[ "$limits_cpu" == "null" || "$requests_cpu" == "null" || "$limits_cpu" != "$requests_cpu" ]]; then
+      echo "ERROR: $file step $step_name (index $i) limits.cpu and requests.cpu must be defined and equal"
+      fail=1
+    fi
+
     # Check no other keys exist in computeResources (order-agnostic)
     if ! yq -e 'keys | contains(["limits","requests"]) and length == 2' <<< "$compute_resources" > /dev/null 2>&1; then
       echo "ERROR: $file step $step_name (index $i) computeResources has extra or missing keys"
       fail=1
     else
-      # Check that limits only has memory and/or cpu, requests only has cpu and memory (order-agnostic)
-      if ! yq -e 'keys - ["cpu","memory"] | length == 0' <<< "$limits" > /dev/null 2>&1; then
-        echo "ERROR: $file step $step_name (index $i) computeResources.limits has keys other than memory and cpu"
+      # Check that limits has exactly cpu and memory, requests only has cpu and memory (order-agnostic)
+      if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$limits" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits must have exactly cpu and memory"
         fail=1
       fi
       if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$requests" > /dev/null 2>&1; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,13 +114,17 @@ All steps in the [managed](tasks/managed) and [internal](tasks/internal) tasks h
 If you are contributing a new managed or internal task (or adding a step to an existing one), you must provide appropriate `computeResources`. If you do not do this, your PR will fail
 the linting check due to the check defined in [this script](.github/scripts/tkn_check_compute_resources.sh).
 
-When setting `computeResources`, you should set the `limits.memory` and `requests.memory` to the same value. No `limits.cpu` should be defined, but a `requests.cpu` should be.
-Here is an example
+When setting `computeResources`, you should set:
+- `limits.memory` and `requests.memory` to the same value
+- `limits.cpu` and `requests.cpu` to the same value
+
+Here is an example:
 ```yaml
 - name: my-new-step
   computeResources:
     limits:
       memory: 256Mi
+      cpu: 250m
     requests:
       memory: 256Mi
       cpu: 250m

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -148,6 +148,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -172,6 +173,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 200m
         requests:
           memory: 512Mi  # was exiting with code 137 when set to 256Mi
           cpu: 200m
@@ -945,6 +947,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -135,6 +135,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -157,6 +158,7 @@ spec:
       computeResources:
         limits:
           memory: 3Gi
+          cpu: '1'
         requests:
           memory: 3Gi
           cpu: '1'
@@ -539,6 +541,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -124,6 +124,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -146,6 +147,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -180,6 +182,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -244,6 +247,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -295,6 +299,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -336,6 +341,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -394,6 +400,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -108,6 +108,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -130,9 +131,10 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '1'
         requests:
           memory: 1Gi
-          cpu: 500m
+          cpu: '1'
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -322,6 +324,7 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
+          cpu: '1'
         requests:
           memory: 1Gi
           cpu: '1'
@@ -467,6 +470,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -119,6 +119,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -141,9 +142,10 @@ spec:
       computeResources:
         limits:
           memory: 2.5Gi
+          cpu: '2'
         requests:
           memory: 2.5Gi
-          cpu: "2"
+          cpu: '2'
       volumeMounts:
         - name: secret-vol
           mountPath: "/etc/secrets"
@@ -433,6 +435,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m


### PR DESCRIPTION
Split from #1734 - Tekton task tests were failing due to CI resource
constraints when running all tasks together, leading to separate PRs.

Set limits.cpu = requests.cpu for heavy managed task steps to ensure
predictable resource allocation.

Changes:
- Updated under-provisioned steps based on Prometheus data
  collected from 9 clusters (7 external + 2 internal)
- Added CPU limits to 5 heavy managed tasks: add-fbc-contribution,
  create-pyxis-image, publish-to-mrrc, push-rpm-data-to-pyxis,
  rh-sign-image-cosign

Collaborated with infra and perf teams who are working on
similar improvements in build-definitions (KONFLUX-6712).


## Describe your changes

## Relevant Jira

RELEASE-2035

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
