### PR TITLE
fix: set correct path for signed kmods tar.gz

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -338,7 +338,7 @@ spec:
                             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
                                 "cd ~/${task_uid}/kmods/${arch_name} && \
                                  find . -name '*.ko' -type f | \
-                                 tar -czf ~/signed_${arch_name}.tar.gz --files-from=-"
+                                 tar -czf ~/${task_uid}/signed_${arch_name}.tar.gz --files-from=-"
 
                             # Copy back the tarball
                             scp "${SSH_OPTS[@]}" \
@@ -484,7 +484,7 @@ spec:
                 ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
                     "cd ~/${task_uid}/kmods && \
                      find . -name '*.ko' -type f | \
-                     tar -czf ~/signed_single.tar.gz --files-from=-"
+                     tar -czf ~/${task_uid}/signed_single.tar.gz --files-from=-"
 
                 # Copy back the tarball
                 scp "${SSH_OPTS[@]}" \
@@ -588,10 +588,12 @@ spec:
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
                 "cd ~/${task_uid}/kmods && \
                  find . -name '*.ko' -type f | \
-                 tar -czf ~/signed_fallback.tar.gz --files-from=-"
+                 tar -czf ~/${task_uid}/signed_fallback.tar.gz --files-from=-"
 
             # Copy back the tarball
-            if ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "test -f ~/signed_fallback.tar.gz"; then
+            # Intentional client-side expansion: task_uid expands locally for unique remote directories
+            # shellcheck disable=SC2029
+            if ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "test -f ~/${task_uid}/signed_fallback.tar.gz"; then
                 scp "${SSH_OPTS[@]}" \
                     "${signUser}@${signHost}:~/${task_uid}/signed_fallback.tar.gz" \
                     "$signed_tarball"


### PR DESCRIPTION
After commit 03b96867 fixed the extraction path for unsigned kmods tarballs, the signed kmods download still had the same issue.

The script creates signed tarballs at ~/${task_uid}/signed_*.tar.gz but was trying to download from ~/signed_*.tar.gz (missing task_uid).

This fix ensures signed tarball paths match their creation location in all three code paths: multi-arch, single-arch, and fallback.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
