### PR TITLE
fix: support nested .ko files in checksum generation

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -516,10 +516,11 @@ spec:
                 # Generate checksums
                 echo "Generating checksums for $arch_subdir_name .ko files..."
                 cd "$arch_dir"
-                if ls ./*.ko >/dev/null 2>&1; then
-                    sha256sum ./*.ko > "signed_kmods_checksums_${arch_subdir_name}.txt"
+                sigkmod_file="signed_kmods_checksums_${arch_subdir_name}.txt"
+                find . -name "*.ko" -type f -exec sha256sum {} \; > "${sigkmod_file}"
+                if [ "$(wc -l < "${sigkmod_file}")" -ne 0 ]; then
                     echo "Generated checksums for $arch_subdir_name:"
-                    cat "signed_kmods_checksums_${arch_subdir_name}.txt"
+                    cat "${sigkmod_file}"
                 else
                     echo "ERROR: No .ko files found after signing process"
                     exit 1
@@ -624,11 +625,12 @@ spec:
 
             # Generate checksums for signed .ko files
             echo "Generating checksums for signed .ko files..."
-            if ls "${SIGNED_KMODS_PATH}"/*.ko >/dev/null 2>&1; then
-                cd "${SIGNED_KMODS_PATH}"
-                sha256sum ./*.ko > signed_kmods_checksums.txt
+            cd "${SIGNED_KMODS_PATH}"
+            sigkmod_file="signed_kmods_checksums.txt"
+            find . -name "*.ko" -type f -exec sha256sum {} \; > "${sigkmod_file}"
+            if [ "$(wc -l < "${sigkmod_file}")" -ne 0 ]; then
                 echo "Generated checksums:"
-                cat signed_kmods_checksums.txt
+                cat "${sigkmod_file}"
             else
                 echo "ERROR: No .ko files found after signing process"
                 exit 1


### PR DESCRIPTION
The checksum generation for signed kernel modules was using `ls ./*.ko` which only finds .ko files in the root directory. This fails for projects like NVIDIA Jetson and Bluefield that have nested module structures (e.g., hwpm/drivers/tegra/hwpm/nvhwpm.ko).

Changed to use `find . -name "*.ko" -type f` to recursively locate and checksum all .ko files regardless of directory structure. This fix applies to both the single-arch subdirectory logic and the fallback case.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
