### PR TITLE
fix(RELEASE-2184): use canonicalName for image PURL if available

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -267,6 +267,7 @@ spec:
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
+            canonical_name=$(jq -r '.canonicalName // empty' <<< "$component")
             image=$(jq -r '.containerImage' <<< "$component")
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"
@@ -317,8 +318,16 @@ spec:
                     arch=$(jq -r .platform.architecture <<< "${arch_json}")
                     digest=$(jq -r .digest <<< "${arch_json}")
                     containerImage="${deliveryRepo}@${digest}"
+        
+                    # Determine the name part of the PURL
+                    # If canonicalName is present, use it. Otherwise fallback to the last segment of the deliveryRepo
+                    purl_path="${deliveryRepo##*/}"
+                    if [[ -n "$canonical_name" ]]; then
+                        purl_path="${canonical_name}"
+                    fi
+
                     # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
-                    purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+                    purl="pkg:oci/${purl_path}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
 
                     uniqueTag=""
 


### PR DESCRIPTION
## Describe your changes

This commit updates the `populate-release-notes` task to prefer the component's `canonicalName` when generating the OCI Package URL (PURL) for release notes.

## Relevant Jira

RELESAE-2184

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
