### PR TITLE
feat(RELEASE-2056): support flatpaks

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -300,6 +300,14 @@ spec:
                     echo "${repository/registry.stage.redhat.io/quay.io/redhat-pending}" \
                         | sed 's|/|----|g; s|quay.io----redhat-pending----|quay.io/redhat-pending/|'
                     ;;
+                flatpaks.registry.redhat.io/*)
+                    echo "${repository/flatpaks.registry.redhat.io/quay.io/rh-flatpaks-prod}" \
+                        | sed 's|/|----|g; s|quay.io----rh-flatpaks-prod----|quay.io/rh-flatpaks-prod/|'
+                    ;;
+                flatpaks.registry.stage.redhat.io/*)
+                    echo "${repository/flatpaks.registry.stage.redhat.io/quay.io/rh-flatpaks-stage}" \
+                        | sed 's|/|----|g; s|quay.io----rh-flatpaks-stage----|quay.io/rh-flatpaks-stage/|'
+                    ;;
                 *)
                     echo "$repository"
                     ;;
@@ -318,6 +326,16 @@ spec:
                     ;;
                 quay.io/redhat-pending/*)
                     repository="${repository//quay.io\/redhat-pending/registry.stage.redhat.io}"
+                    repository="${repository//----//}"
+                    echo "$repository"
+                    ;;
+                quay.io/rh-flatpaks-prod/*)
+                    repository="${repository//quay.io\/rh-flatpaks-prod/flatpaks.registry.redhat.io}"
+                    repository="${repository//----//}"
+                    echo "$repository"
+                    ;;
+                quay.io/rh-flatpaks-stage/*)
+                    repository="${repository//quay.io\/rh-flatpaks-stage/flatpaks.registry.stage.redhat.io}"
                     repository="${repository//----//}"
                     echo "$repository"
                     ;;
@@ -594,12 +612,18 @@ spec:
 
                 # This block is temporary to support both quay.io and registry.redhat.io
                 # It should be removed once all repositories are migrated to registry.redhat.io
-                if [[ "$url" == quay.io/redhat-prod/* || "$url" == quay.io/redhat-pending/* ]]; then
+                if [[ "$url" == quay.io/redhat-prod/* ||
+                  "$url" == quay.io/redhat-pending/* ||
+                  "$url" == quay.io/rh-flatpaks-prod/* ||
+                  "$url" == quay.io/rh-flatpaks-stage/* ]]; then
                     url=$(convert_to_registry "$url")
                 fi
 
                 # Convert to registry and quay format
-                if [[ "$url" == registry.redhat.io/* || "$url" == registry.stage.redhat.io/* ]]; then
+                if [[ "$url" == registry.redhat.io/* ||
+                  "$url" == registry.stage.redhat.io/* ||
+                  "$url" == flatpaks.registry.redhat.io/* ||
+                  "$url" == flatpaks.registry.stage.redhat.io/* ]]; then
                   rh_registry_repo=$url
                   registry_access_repo=$(convert_to_registry_access "$url")
                   url=$(convert_to_quay "$url")

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-flatpak-registries.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-flatpak-registries.yaml
@@ -1,0 +1,287 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-flatpak-registries
+spec:
+  description: |
+    Run the apply-mapping task with a snapshot.spec json containing some flatpak registry components.
+    Verify that the resulting json contains the expected transformations.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1",
+                      "repositories": [
+                        {
+                          "url": "flatpaks.registry.redhat.io/product-name/image1"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp2",
+                      "repositories": [
+                        {
+                          "url": "flatpaks.registry.redhat.io/product-name/image2"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp3",
+                      "repositories": [
+                        {
+                          "url": "flatpaks.registry.stage.redhat.io/product-name/image3"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp4",
+                      "repositories": [
+                        {
+                          "url": "flatpaks.registry.stage.redhat.io/product-name/image4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "imageurl1@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "myrev",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "imageurl2@sha256:789012",
+                    "source": {
+                      "git": {
+                        "revision": "myrev2",
+                        "url": "myurl2"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp3",
+                    "containerImage": "imageurl3@sha256:345678",
+                    "source": {
+                      "git": {
+                        "revision": "myrev3",
+                        "url": "myurl3"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp4",
+                    "containerImage": "imageurl4@sha256:456789",
+                    "source": {
+                      "git": {
+                        "revision": "myrev4",
+                        "url": "myurl4"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Test for comp1
+              echo Test that SNAPSHOT contains component comp1
+              test "$(jq -r '[ .components[] | select(.name=="comp1") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
+
+              echo Test that rh-registry-repo for comp1 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp1") | .repositories[0]."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                flatpaks.registry.redhat.io/product-name/image1
+
+              echo Test that registry-access-repo for comp1 is correctly undefined.
+              test "$(jq -r '.components[] | select(.name=="comp1") | .repositories[0]."registry-access-repo" // ""' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == ''
+
+              # Test for comp2
+              echo Test that SNAPSHOT contains component comp2
+              test "$(jq -r '[ .components[] | select(.name=="comp2") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
+
+              echo Test that rh-registry-repo for comp2 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repositories[0]."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                flatpaks.registry.redhat.io/product-name/image2
+
+              echo Test that url for comp2 is correctly set to quay format
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repositories[0].url' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                quay.io/rh-flatpaks-prod/product-name----image2
+
+              echo Test that registry-access-repo for comp2 is correctly undefined
+              test "$(jq -r '.components[] | select(.name=="comp2") | .repositories[0]."registry-access-repo" // ""' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == ''
+
+              # Test for comp3
+              echo Test that SNAPSHOT contains component comp3
+              test "$(jq -r '[ .components[] | select(.name=="comp3") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
+
+              echo Test that rh-registry-repo for comp3 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp3") | .repositories[0]."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                flatpaks.registry.stage.redhat.io/product-name/image3
+
+              echo Test that registry-access-repo for comp3 is correctly undefined
+              test "$(jq -r '.components[] | select(.name=="comp3") | .repositories[0]."registry-access-repo" // ""' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == ''
+
+              # Test for comp4
+              echo Test that SNAPSHOT contains component comp4
+              test "$(jq -r '[ .components[] | select(.name=="comp4") ] | length' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" -eq 1
+
+              echo Test that rh-registry-repo for comp4 is correctly set
+              test "$(jq -r '.components[] | select(.name=="comp4") | .repositories[0]."rh-registry-repo"' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                flatpaks.registry.stage.redhat.io/product-name/image4
+
+              echo Test that url for comp4 is correctly set to quay format
+              test "$(jq -r '.components[] | select(.name=="comp4") | .repositories[0].url' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == \
+                quay.io/rh-flatpaks-stage/product-name----image4
+
+              echo Test that registry-access-repo for comp4 is correctly undefined
+              test "$(jq -r '.components[] | select(.name=="comp4") | .repositories[0]."registry-access-repo" // ""' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json")" == ''

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -285,10 +285,10 @@ spec:
                     -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
 
                 # Determine the correct CATALOG_BASE_URL based on the repository prefix
-                if [[ "$REPOSITORY" == quay.io/redhat-prod/* ]]
+                if [[ "$REPOSITORY" == quay.io/redhat-prod/* || "$REPOSITORY" == quay.io/rh-flatpaks-prod/* ]]
                 then
                   CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
-                elif [[ "$REPOSITORY" == quay.io/redhat-pending/* ]]
+                elif [[ "$REPOSITORY" == quay.io/redhat-pending/* || "$REPOSITORY" == quay.io/rh-flatpaks-stage/* ]]
                 then
                   CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
                 else


### PR DESCRIPTION
## Describe your changes

This adds support for releasing to
flatpaks.registry.redhat.io . This support was previously in a custom rh-flatpaks branch.

This also includes a fix - in the rh-flatpaks branch, the comparison was done against $repository instead of $url.

This functionality was originally presented here: https://github.com/konflux-ci/release-service-catalog/pull/933

## Relevant Jira

RELEASE-2056

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
