### PR TITLE
fix: correct file copy path in push-oot-kmods-to-git task

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -177,13 +177,18 @@ spec:
                 echo "Copying .ko files with preserved directory structure for $arch_name..."
 
                 # Copy entire directory structure containing .ko files
-                cd "$source_dir"
-                find . -name "*.ko" -type f | while read -r ko_file; do
-                    ko_dir=$(dirname "$ko_file")
-                    mkdir -p "$TARGET_DIR/$ko_dir"
-                    cp "$ko_file" "$TARGET_DIR/$ko_file"
-                done
-                cd - > /dev/null
+                # Process files from source_dir and copy to TARGET_DIR using a subshell
+                # to avoid changing the current working directory
+                (
+                    cd "$source_dir"
+                    find . -name "*.ko" -type f | while read -r ko_file; do
+                        ko_dir=$(dirname "$ko_file")
+                        # Use absolute path by prepending the git work directory
+                        target_path="${GIT_WORK_DIR}/local-artifacts/$TARGET_DIR"
+                        mkdir -p "$target_path/$ko_dir"
+                        cp "$ko_file" "$target_path/$ko_file"
+                    done
+                )
                 ko_file_count=$(find "$TARGET_DIR" -name "*.ko" -type f | wc -l)
                 echo "Copied $ko_file_count .ko files for $arch_name (preserving directory structure)"
 


### PR DESCRIPTION
The push_arch_artifacts function was copying .ko files to the wrong location due to using relative paths after changing directories. This caused git push to report 0 files copied while S3 upload worked correctly.

Fixed by using a subshell with absolute paths via GIT_WORK_DIR variable, making behavior consistent with the push-oot-kmods-to-s3 task.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
