### PR TITLE
feat(RELEASE-2137): implement a github action for detecting secret leaks

### DIFF
--- a/.github/scripts/check_secret_sensitive_data.sh
+++ b/.github/scripts/check_secret_sensitive_data.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+
+# Check that all kubectl create secret commands in pre-apply-task-hook.sh files
+# contain at least one SENSITIVE_DATA_ or sensitive-data- string
+#
+# This script ensures that test secrets are properly marked to prevent accidental
+# leakage of real credentials in CI/CD logs.
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration - Sensitive Data Prefix Rules
+# ============================================================================
+# Define the required prefixes for test secrets to prevent accidental
+# leakage of real credentials in CI/CD logs.
+#
+# To add a new allowed prefix:
+# 1. Add it to SENSITIVE_PREFIXES array
+# 2. The SENSITIVE_DATA_PATTERN will be automatically updated
+#
+readonly SENSITIVE_PREFIXES=(
+  "SENSITIVE_DATA_"   # Standard prefix for test data
+  "sensitive-data-"   # Alternative lowercase prefix
+)
+
+# Build regex pattern from prefixes array
+# Result: "(SENSITIVE_DATA_|sensitive-data-)"
+_build_pattern() {
+  local IFS="|"
+  echo "(${SENSITIVE_PREFIXES[*]})"
+}
+readonly SENSITIVE_DATA_PATTERN=$(_build_pattern)
+
+# File patterns
+readonly HOOK_FILE_PATTERN="pre-apply-task-hook\.sh$"
+readonly HOOK_DIR_PATTERN="*/tests/pre-apply-task-hook.sh"
+
+# Base64 detection threshold
+# Minimum length for base64-encoded strings to check for sensitive data.
+# Set to 20 to avoid false positives on short base64 strings that are unlikely
+# to be actual secrets (e.g., short encoded flags or simple values).
+# Adjust this if you need to detect shorter or longer base64-encoded secrets.
+readonly MIN_BASE64_LENGTH=20
+
+# Exit codes
+readonly EXIT_SUCCESS=0
+readonly EXIT_FAILURE=1
+
+# Counters
+fail_count=0
+check_count=0
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+# Clean command string for easier parsing
+# Joins multi-line commands into a single line while preserving backslashes in arguments
+# Note: The AWK extraction already handles line continuations, so we just normalize whitespace
+clean_command() {
+  local command="$1"
+  # Simply join lines and normalize spaces
+  # Do NOT remove backslashes - they may be part of valid arguments (e.g., "data=\"quoted\"")
+  echo "$command" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# Check if a string contains the sensitive data pattern
+has_sensitive_data() {
+  local text="$1"
+  echo "$text" | grep -qE "$SENSITIVE_DATA_PATTERN"
+}
+
+# Check if a string contains base64-encoded sensitive data
+has_base64_sensitive_data() {
+  local text="$1"
+  # Try to decode base64 values and check if they contain SENSITIVE_DATA
+  # This handles cases like: --from-literal=base64_keytab=U0VOU0lUSVZFX0RBVEFf...
+  if echo "$text" | grep -qE "=[A-Za-z0-9+/=]{${MIN_BASE64_LENGTH},}"; then
+    local encoded_values
+    encoded_values=$(echo "$text" | grep -oE "=[A-Za-z0-9+/=]{${MIN_BASE64_LENGTH},}" | sed 's/^=//')
+    for encoded in $encoded_values; do
+      if decoded=$(echo "$encoded" | base64 -d 2>/dev/null); then
+        if echo "$decoded" | grep -qE "$SENSITIVE_DATA_PATTERN"; then
+          return 0
+        fi
+      fi
+    done
+  fi
+  return 1
+}
+
+# Extract variable names from command
+extract_variable_names() {
+  local command="$1"
+  echo "$command" | grep -oE '\$\{?[A-Za-z_][A-Za-z0-9_]*\}?' | sed 's/[${}]//g' | sort -u
+}
+
+# Check if a variable definition contains sensitive data
+check_variable_definition() {
+  local file_content="$1"
+  local var_name="$2"
+
+  local var_def
+  var_def=$(echo "$file_content" | awk -v var="$var_name" '
+    $0 ~ "^"var"=" || $0 ~ "^"var"=\\$\\(" {
+      in_var=1
+      content=$0
+    }
+    in_var {
+      print content
+      # Check if this is a here-doc
+      if (content ~ /<</) {
+        # Extract heredoc delimiter dynamically
+        # Supports: <<EOF, <<-EOF, <<"EOF", <<'\''EOF'\'', etc.
+        delimiter = content
+        # Remove everything before <<
+        sub(/.*<<-?/, "", delimiter)
+        # Remove quotes (single or double)
+        gsub(/["'\'']/, "", delimiter)
+        # Remove everything after the delimiter (spaces, comments, etc.)
+        sub(/[[:space:]].*/, "", delimiter)
+        # Trim whitespace
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", delimiter)
+
+        # If we couldn'\''t extract a delimiter, use EOF as fallback
+        if (delimiter == "" || length(delimiter) > 50) {
+          delimiter = "EOF"
+        }
+
+        # Read heredoc content until we find the delimiter
+        getline
+        while ($0 !~ "^[[:space:]]*"delimiter"[[:space:]]*$") {
+          print $0
+          if (getline <= 0) break  # Prevent infinite loop on malformed heredoc
+        }
+        in_var=0
+        next
+      }
+      # Check if line continues
+      if (content ~ /\\$/) {
+        getline
+        content=$0
+        next
+      }
+      in_var=0
+    }
+  ')
+
+  [[ -n "$var_def" ]] && echo "$var_def" | grep -qE "$SENSITIVE_DATA_PATTERN"
+}
+
+# Extract kubectl secret commands from a file using AWK
+# Handles multi-line commands with proper quote tracking
+extract_kubectl_secrets() {
+  local file="$1"
+
+  awk '
+    # Skip comment lines
+    /^[[:space:]]*#/ {
+      next
+    }
+
+    /kubectl create secret/ {
+      in_secret=1
+      secret_cmd=$0
+      line_num=NR
+      # Track quote state
+      in_single_quote=0
+      in_double_quote=0
+      # Count quotes in current line using temporary copy to avoid mutating $0
+      temp_line = $0
+      num_single = gsub(/['"'"']/, "&", temp_line)
+      temp_line = $0
+      num_double = gsub(/"/, "&", temp_line)
+      # Update quote state based on count
+      if (num_single % 2 == 1) in_single_quote = !in_single_quote
+      if (num_double % 2 == 1) in_double_quote = !in_double_quote
+      next
+    }
+
+    in_secret {
+      # Count quotes in current line to track state using temporary copy to avoid mutating $0
+      temp_line = $0
+      num_single = gsub(/['"'"']/, "&", temp_line)
+      temp_line = $0
+      num_double = gsub(/"/, "&", temp_line)
+
+      # Update quote state
+      if (num_single % 2 == 1) in_single_quote = !in_single_quote
+      if (num_double % 2 == 1) in_double_quote = !in_double_quote
+
+      # Append current line to command
+      secret_cmd = secret_cmd "\n" $0
+
+      # Determine if command continues
+      # Command continues if:
+      # 1. Inside quotes (single or double)
+      # 2. Line ends with backslash
+      # 3. Line is indented (starts with space/tab)
+      if (in_single_quote || in_double_quote || $0 ~ /\\$/ || $0 ~ /^[[:space:]]/) {
+        next
+      } else {
+        # Command ended, print it with NUL delimiter
+        printf "%d:%s\0", line_num, secret_cmd
+        in_secret=0
+        secret_cmd=""
+        in_single_quote=0
+        in_double_quote=0
+      }
+    }
+
+    END {
+      # Print last command if file ends while in_secret
+      if (in_secret) {
+        printf "%d:%s\0", line_num, secret_cmd
+      }
+    }
+  ' "$file"
+}
+
+# Extract filenames from --from-file parameters
+extract_from_file_params() {
+  local clean_command="$1"
+
+  echo "$clean_command" | python3 -c '
+import shlex, sys, re
+
+input_text = sys.stdin.read()
+
+try:
+    # Try to parse using shlex for proper shell quoting handling
+    args = shlex.split(input_text)
+    for arg in args:
+        if arg.startswith("--from-file="):
+            value = arg[12:]  # Remove "--from-file="
+            # If format is key=filename, extract filename part
+            if "=" in value:
+                value = value.split("=", 1)[1]
+            print(value)
+except (ValueError, UnicodeDecodeError) as e:
+    # shlex.split() can fail on malformed shell syntax or encoding issues
+    # Fall back to simple regex extraction
+    sys.stderr.write(f"Warning: shlex parsing failed ({e}), using fallback regex extraction\n")
+    # Extract --from-file=value patterns using regex
+    for match in re.finditer(r"--from-file=([^\s]+)", input_text):
+        value = match.group(1)
+        # Remove quotes if present
+        value = value.strip("\"'\''")
+        # If format is key=filename, extract filename part
+        if "=" in value:
+            value = value.split("=", 1)[1]
+        print(value)
+except Exception as e:
+    # Catch any other unexpected errors to prevent script failure
+    sys.stderr.write(f"Error extracting --from-file parameters: {e}\n")
+    pass
+'
+}
+
+# Report validation error with consistent formatting
+# Args: file, line_num, command, error_type, [extra_info]
+report_validation_error() {
+  local file="$1"
+  local line_num="$2"
+  local command="$3"
+  local error_type="$4"
+  local extra_info="${5:-}"
+
+  case "$error_type" in
+    "from-literal")
+      echo "ERROR: $file line $line_num: kubectl create secret with --from-literal does not contain required sensitive data prefix"
+      echo "  Command: $(clean_command "$command")"
+      echo "  Hint: Add one of these prefixes to at least one value: ${SENSITIVE_PREFIXES[*]}"
+      echo "        Or use base64-encoded data containing the prefix"
+      ;;
+    "from-file")
+      echo "ERROR: $file line $line_num: kubectl create secret with --from-file uses a file without required sensitive data prefix"
+      echo "  Command: $(clean_command "$command")"
+      if [[ -n "$extra_info" ]]; then
+        echo "  File creation: $extra_info"
+      fi
+      echo "  Hint: File should contain one of these prefixes: ${SENSITIVE_PREFIXES[*]}"
+      ;;
+    *)
+      echo "ERROR: $file line $line_num: kubectl create secret does not contain required sensitive data prefix"
+      echo "  Command: $(clean_command "$command")"
+      echo "  Hint: Add one of these prefixes: ${SENSITIVE_PREFIXES[*]}"
+      ;;
+  esac
+}
+
+# Common validation logic for checking sensitive data in text
+# Args: text_to_check, file_content (for variable lookup)
+# Returns: 0 if valid (contains sensitive prefix), 1 otherwise
+validate_has_sensitive_prefix() {
+  local text_to_check="$1"
+  local file_content="$2"
+
+  # First check: Direct sensitive data in text
+  if has_sensitive_data "$text_to_check"; then
+    return 0  # OK
+  fi
+
+  # Second check: Base64-encoded sensitive data
+  if has_base64_sensitive_data "$text_to_check"; then
+    return 0  # OK
+  fi
+
+  # Third check: Variables containing sensitive data
+  if echo "$text_to_check" | grep -q '\$'; then
+    local var_names
+    var_names=$(extract_variable_names "$text_to_check")
+
+    for var in $var_names; do
+      if check_variable_definition "$file_content" "$var"; then
+        return 0  # OK - variable contains sensitive data
+      fi
+    done
+  fi
+
+  # Failed all checks
+  return 1
+}
+
+# Check --from-literal commands for sensitive data
+check_from_literal() {
+  local file="$1"
+  local file_content="$2"
+  local line_num="$3"
+  local command="$4"
+  local clean_command="$5"
+
+  # Use common validation logic
+  if validate_has_sensitive_prefix "$clean_command" "$file_content"; then
+    return 0  # OK
+  fi
+
+  # Failed validation - report error
+  report_validation_error "$file" "$line_num" "$command" "from-literal"
+  return 1
+}
+
+# Check --from-file commands for sensitive data
+check_from_file() {
+  local file="$1"
+  local file_content="$2"
+  local line_num="$3"
+  local command="$4"
+  local clean_command="$5"
+
+  local filenames
+  filenames=$(extract_from_file_params "$clean_command")
+
+  while IFS= read -r filename; do
+    [[ -z "$filename" ]] && continue
+
+    # Skip variable-based filenames
+    if echo "$filename" | grep -q '\$'; then
+      local base_var
+      base_var=$(echo "$filename" | grep -oE '\$\{?[A-Za-z_][A-Za-z0-9_]*\}?' | head -1 | sed 's/[${}]//g')
+
+      # Skip ssh-keygen generated files (binary keys)
+      if echo "$file_content" | grep -q "ssh-keygen.*$base_var"; then
+        continue
+      fi
+
+      # Skip other variable-based files (can't reliably check)
+      continue
+    fi
+
+    # Look for file creation commands
+    local file_creation
+    file_creation=$(echo "$file_content" | grep -E "(echo|cat|printf).*>.*$filename" | head -1)
+
+    if [[ -n "$file_creation" ]]; then
+      # Use common validation logic
+      if ! validate_has_sensitive_prefix "$file_creation" "$file_content"; then
+        report_validation_error "$file" "$line_num" "$command" "from-file" "$file_creation"
+        return 1
+      fi
+    fi
+  done <<< "$filenames"
+
+  return 0
+}
+
+# ============================================================================
+# Main Logic
+# ============================================================================
+
+echo "Checking kubectl create secret commands for required sensitive data prefixes..."
+echo "Required prefixes: ${SENSITIVE_PREFIXES[*]}"
+echo ""
+
+# Find files to check (using array for safe whitespace handling)
+declare -a files
+if [[ -n "${CHANGED_FILES:-}" ]]; then
+  # If CHANGED_FILES is set, only check those files
+  # Note: CHANGED_FILES should be newline or space-delimited
+  while IFS= read -r file; do
+    [[ -n "$file" ]] && [[ "$file" =~ $HOOK_FILE_PATTERN ]] && files+=("$file")
+  done < <(echo "${CHANGED_FILES}" | tr ' ' '\n')
+else
+  # Otherwise check all pre-apply-task-hook.sh files using null-delimited find
+  while IFS= read -r -d '' file; do
+    files+=("$file")
+  done < <(find tasks -path "$HOOK_DIR_PATTERN" -type f -print0 2>/dev/null || true)
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No pre-apply-task-hook.sh files to check"
+  exit $EXIT_SUCCESS
+fi
+
+# Process each file
+for file in "${files[@]}"; do
+  echo "Checking: $file"
+
+  # Read entire file content once for variable tracking
+  file_content=$(cat "$file")
+
+  # Extract and process kubectl create secret commands
+  while IFS= read -r -d '' line_and_command; do
+    check_count=$((check_count + 1))
+
+    # Split line number and command
+    line_num="${line_and_command%%:*}"
+    command="${line_and_command#*:}"
+
+    # Clean command for parsing
+    clean_cmd=$(clean_command "$command")
+
+    # Check --from-literal commands
+    if echo "$clean_cmd" | grep "kubectl create secret" | grep -q -- "--from-literal"; then
+      if ! check_from_literal "$file" "$file_content" "$line_num" "$command" "$clean_cmd"; then
+        fail_count=$((fail_count + 1))
+      fi
+    fi
+
+    # Check --from-file commands
+    if echo "$clean_cmd" | grep -q -- "--from-file"; then
+      if ! check_from_file "$file" "$file_content" "$line_num" "$command" "$clean_cmd"; then
+        fail_count=$((fail_count + 1))
+      fi
+    fi
+  done < <(extract_kubectl_secrets "$file")
+done
+
+# Summary
+echo ""
+echo "=========================================="
+echo "Checked $check_count kubectl create secret command(s)"
+echo ""
+
+if [[ $fail_count -ne 0 ]]; then
+  echo "❌ FAILED: $fail_count command(s) missing required sensitive data prefix"
+  echo ""
+  echo "To fix: Add one of these prefixes to at least one secret value:"
+  for prefix in "${SENSITIVE_PREFIXES[@]}"; do
+    echo "  - $prefix"
+  done
+  echo ""
+  echo "Example: kubectl create secret generic my-secret --from-literal=key=${SENSITIVE_PREFIXES[0]}value"
+  exit $EXIT_FAILURE
+fi
+
+echo "✅ SUCCESS: All kubectl create secret commands contain required sensitive data prefix"
+exit $EXIT_SUCCESS

--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -269,7 +269,14 @@ do
       echo "  PipelineRun $PIPELINERUN in progress (status Unknown). Waiting for update..."
       sleep 5
     done
-    tkn pr logs $PIPELINERUN
+
+    RESOURCES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    LOG_DIR="$RESOURCES_DIR/logs"
+    mkdir -p "$LOG_DIR"
+
+    tkn pr logs "$PIPELINERUN" > "$LOG_DIR/$PIPELINERUN.full.log" 2>&1
+    grep "run-task :" "$LOG_DIR/$PIPELINERUN.full.log" > "$LOG_DIR/$PIPELINERUN.summary.log" || true
+    rm -f "$LOG_DIR/$PIPELINERUN.full.log"
 
     PR_STATUS=$(kubectl get pr $PIPELINERUN -o=jsonpath='{.status.conditions[0].status}')
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -130,6 +130,22 @@ jobs:
         run: .github/scripts/tkn_check_mount_secret_as_var.sh
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+  check-secret-sensitive-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+      - name: Get changed files
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8   # v45.0.6
+        id: changed-files
+        with:
+          files: |
+            **/*.yaml
+            **/*.sh
+      - name: Run sensitive data check script
+        run: .github/scripts/check_secret_sensitive_data.sh
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
   check-readme:
     name: Check README.md files
     runs-on: ubuntu-latest

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -107,7 +107,9 @@ jobs:
       - name: Test Tekton tasks with Trusted Artifacts
         if: |
           steps.show-changed-dirs.outputs.trustedArtifactsBasedTasks != ''
-        run: .github/scripts/test_tekton_tasks.sh
+        run: |
+          mkdir -p logs
+          .github/scripts/test_tekton_tasks.sh
         env:
           DOCKER_CONFIG_JSON: ${{ steps.deploy-local-kind-registry.outputs.DOCKER_CONFIG_JSON }}
           USE_TRUSTED_ARTIFACTS: true
@@ -116,7 +118,20 @@ jobs:
       - name: Test Tekton tasks using PVC-based workspace
         if: |
           steps.show-changed-dirs.outputs.pvcBasedTasks != ''
-        run: .github/scripts/test_tekton_tasks.sh
+        run: |
+          mkdir -p logs
+          .github/scripts/test_tekton_tasks.sh
         env:
           TEST_ITEMS: >-
             ${{ steps.show-changed-dirs.outputs.pvcBasedTasks }}
+      - name: Secret Scan
+        if: |
+          steps.show-changed-dirs.outputs.trustedArtifactsBasedTasks != '' || 
+          steps.show-changed-dirs.outputs.pvcBasedTasks != ''
+        run: |
+          if grep -rE "(SENSITIVE_DATA_|sensitive-data-)" ./logs; then
+            echo "Error: Detected sensitive string 'SENSITIVE_DATA_' or 'sensitive-data-' in logs!"
+            exit 1
+          else
+            echo "Scan passed: No sensitive strings found."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,10 +256,10 @@ For reference implementation, check [create-pyxis-image/tests/](tasks/managed/cr
 
     ```sh
     #!/usr/bin/env sh
-    set -eux
+    set -eu
 
     function cosign() {
-      echo Mock cosign called with: $*
+      echo Mock cosign
       echo $* >> $(workspaces.data.path)/mock_cosign.txt
 
       if [[ "$*" != "download sbom --output-file myImageID"[12]".json imageurl"[12] ]]
@@ -272,7 +272,7 @@ For reference implementation, check [create-pyxis-image/tests/](tasks/managed/cr
     }
     ```
 
-    In the example above, you can notice two things:
+    In the example above, you can notice several things:
     - Each time the mock function is called, the full argument list is saved in a file in the
       workspace. This is optional and depends on your task's workspace name. It allows us to
       check mock calls after task execution in our test pipeline.
@@ -285,6 +285,15 @@ For reference implementation, check [create-pyxis-image/tests/](tasks/managed/cr
       `#!/bin/bash` or `#!/usr/bin/env bash` in place of `#!/usr/bin/env sh` at the top of the file. Keep in mind
       that the same shell declaration should be used in both the mock and the tekton task step script you are
       mocking to ensure the behavior during test is the same as during runtime.
+    - **Shell tracing and secret leak prevention**: The `-x` flag is intentionally omitted from `set -eu` to
+      prevent verbose shell tracing output in logs. Our CI/CD pipeline includes automated secret leak detection that
+      scans the logs of `run-task` tasks in unit test pipelineRuns for the presence of `SENSITIVE_DATA_` or
+      `sensitive-data-` prefixes using pattern matching. 
+
+      Please note that some debug statements in the previous mocks.sh script, such as
+      `echo Mock cosign called with: $*`, have been refactored. These statements previously echoed raw function
+      arguments which may contain sensitive test data. This change was implemented to prevent accidental data
+      exposure in CI logs and to avoid triggering automated leak detection alerts.
 
 1. In your `pre-apply-task-hook.sh` file (see the Test Setup section above for explanation), include
     `yq` commands to inject the `mocks.sh` file to the top of your task step scripts, e.g.:
@@ -295,12 +304,39 @@ For reference implementation, check [create-pyxis-image/tests/](tasks/managed/cr
     TASK_PATH=$1
     SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-    yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $TASK_PATH
-    yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $TASK_PATH
+    yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' $TASK_PATH
+    yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' $TASK_PATH
     ```
 
     In this case we inject the file to both steps in the task under test. This will depend on
     the given task. You only need to inject mocks for the steps where something needs to be mocked.
+    The inclusion of "set +x\n" ensures that the execution environment is reset, preventing the shell tracing settings
+    within mocks.sh from inadvertently propagating to the original task scripts.
+    
+    In this file, we may define some secrets for the test cases as below:
+    
+    ```
+    kubectl create secret generic mac-signing-credentials \
+    --from-literal=keychain_password="SENSITIVE_DATA_testkeychainpass" \
+    --from-literal=signing_identity="testidentity" --from-literal=apple_id="testid" \
+    --from-literal=team_id="testteamid" \
+    --from-literal=app_specific_password="SENSITIVE_DATA_testapppassword"
+    ```
+    **Secret leak prevention requirement**: All mock sensitive data values must be prefixed with either
+    `SENSITIVE_DATA_` (uppercase with underscore) or `sensitive-data-` (lowercase with hyphen). This naming
+    convention serves two critical purposes:
+
+    1. **Automated validation**: The CI/CD secret scanning step (`Secret Scan` in tekton_task_tests.yaml) searches
+       PipelineRun logs for these prefixes. If detected, it confirms that secret leak prevention mechanisms are
+       working correctly by catching mock credentials before they could expose real secrets.
+
+    2. **Static analysis enforcement**: The `check_secret_sensitive_data.sh` validation script ensures every
+       `kubectl create secret` command in test setup files contains at least one prefixed value, preventing
+       developers from accidentally using unprefixed (and therefore undetectable) mock data.
+
+    Please note that each Kubernetes secret resource must contain at least one value with a sensitive data prefix
+    to pass validation.
+  
 
 1. (Optional) In your test pipeline, you can have a task after the main task under test that will
     check that the mock functions had the expected calls. This only applies if you saved your mock

--- a/tasks/collectors/run-collectors/tests/mocks.sh
+++ b/tasks/collectors/run-collectors/tests/mocks.sh
@@ -4,7 +4,7 @@ set -xeo pipefail
 # mocks to be injected into task step scripts
 
 function git() {
-  echo Mock git called with: $*
+  echo Mock git
   echo $* >> $(workspaces.data.path)/mock_git.txt
 
   if [[ "$*" == "clone "* ]]

--- a/tasks/collectors/run-collectors/tests/pre-apply-task-hook.sh
+++ b/tasks/collectors/run-collectors/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/mocks.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 
 function kinit() {
-  echo "kinit $*"
+  echo "Mock kinit"
 }
 
 function curl() {
-  echo Mock curl called with: $* >&2
+  echo Mock curl >&2
 
   if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
   then

--- a/tasks/internal/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-embargoed-cves-task/tests/pre-apply-task-hook.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Create a wrapper script that includes mocks and calls the original command
 cat > /tmp/wrapped-script.sh <<'EOF'
 #!/usr/bin/env bash
-set -eux
+set -eu
 EOF
 
 # Append the mocks
@@ -22,11 +22,11 @@ cat >> /tmp/wrapped-script.sh <<'EOF'
 EOF
 
 # Replace command/args with script in the task
-yq -i '.spec.steps[0].script = load_str("/tmp/wrapped-script.sh")' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("/tmp/wrapped-script.sh")+ "set +x\n"' "$TASK_PATH"
 yq -i 'del(.spec.steps[0].command)' "$TASK_PATH"
 yq -i 'del(.spec.steps[0].args)' "$TASK_PATH"
 
 # Create a dummy osidb secret (and delete it first if it exists)
 # The secret name is hardcoded in the task so the mock secret name can't have the task name in it
 kubectl delete secret osidb-service-account --ignore-not-found
-kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=OWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0Cg== --from-literal=osidb_url=myurl
+kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=U0VOU0lUSVZFX0RBVEFfOWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0IC1uCg== --from-literal=osidb_url=myurl    # base64_keytab has SENSITIVE_DATA_

--- a/tasks/internal/check-fbc-opt-in/tests/mocks.sh
+++ b/tasks/internal/check-fbc-opt-in/tests/mocks.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function kinit() {
-  echo "Mock kinit called with: $*"
+  echo "Mock kinit"
   echo $* >> /var/workdir/mock_kinit.txt
   # Mock successful kinit
   return 0
 }
 function curl() {
-  echo "Mock curl called with: $*"
+  echo "Mock curl"
   echo $* >> /var/workdir/mock_curl.txt
 
   # Extract output file from curl arguments

--- a/tasks/internal/check-fbc-opt-in/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-fbc-opt-in/tests/pre-apply-task-hook.sh
@@ -2,15 +2,15 @@
 
 # Create the IIB service account secret (matching test parameter and upstream pattern)
 kubectl create secret generic test-iib-service-account \
-    --from-literal=keytab="$(echo 'fake-keytab-content' | base64)" \
-    --from-literal=principal="fake-principal@REDHAT.COM" || true
+    --from-literal=keytab="$(echo 'SENSITIVE_DATA_fake-keytab-content' | base64)" \
+    --from-literal=principal="SENSITIVE_DATA_fake-principal@REDHAT.COM" || true
 
 # Create the iib-services-config secret
 kubectl create secret generic iib-services-config \
-    --from-literal=krb5.conf="[libdefaults]\n  default_realm = REDHAT.COM" \
+    --from-literal=krb5.conf="[libdefaults]\n  default_realm = SENSITIVE_DATA_REDHAT.COM" \
     --from-literal=url="https://fakeiib.host" || true
 
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/internal/create-advisory-oci-artifact-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-oci-artifact-task/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function select-oci-auth() {

--- a/tasks/internal/create-advisory-oci-artifact-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/create-advisory-oci-artifact-task/tests/pre-apply-task-hook.sh
@@ -4,13 +4,13 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 kubectl delete secret quay-token-konflux-release-trusted-artifacts-secret --ignore-not-found
 
 if [ -z "${DOCKER_CONFIG_JSON}" ]; then
   DOCKER_CONFIG_JSON=$(mktemp)
-  echo -n '{"auths": {}}' > "${DOCKER_CONFIG_JSON}"
+  echo -n '{"auths": {"quay.io":{"auth":"SENSITIVE_DATA_value"}}}' > "${DOCKER_CONFIG_JSON}"
 fi
 echo "Using docker config stored in ${DOCKER_CONFIG_JSON}"
 kubectl create secret generic quay-token-konflux-release-trusted-artifacts-secret \

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function git() {
-  echo "Mock git called with: $*"
+  echo "Mock git"
 
   if [[ "$1" == "clone" ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
@@ -57,7 +57,7 @@ function git() {
 }
 
 function yq() {
-  echo "Mock yq called with: $*" >&2
+  echo "Mock yq" >&2
 
   if [[ "$1" == "eval" ]]; then
     json_file="$4"
@@ -119,7 +119,7 @@ function yq() {
 }
 
 function glab() {
-  echo "Mock glab called with: $*"
+  echo "Mock glab"
 
   if [[ "$*" != "auth login"* ]]; then
     echo Error: Unexpected call
@@ -128,7 +128,7 @@ function glab() {
 }
 
 function kinit() {
-  echo "kinit $*"
+  echo "kinit"   #remove $* to pass secret leak detection
 }
 
 function curl() {

--- a/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/create-advisory-task/tests/pre-apply-task-hook.sh
@@ -4,13 +4,13 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 kubectl delete secret create-advisory-secret --ignore-not-found
-kubectl create secret generic create-advisory-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/org/repo.git
+kubectl create secret generic create-advisory-secret --from-literal=git_author_email=SENSITIVE_DATA_tester@tester --from-literal=git_author_name=SENSITIVE_DATA_tester --from-literal=gitlab_access_token=SENSITIVE_DATA_abc --from-literal=gitlab_host=SENSITIVE_DATA_myurl --from-literal=git_repo=https://SENSITIVE_DATA_gitlab.com/org/repo.git
 
 kubectl delete secret create-stage-advisory-secret --ignore-not-found
-kubectl create secret generic create-stage-advisory-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/rhtap-release/repo.git
+kubectl create secret generic create-stage-advisory-secret --from-literal=git_author_email=SENSITIVE_DATA_tester@tester --from-literal=git_author_name=SENSITIVE_DATA_tester --from-literal=gitlab_access_token=SENSITIVE_DATA_abc --from-literal=gitlab_host=SENSITIVE_DATA_myurl --from-literal=git_repo=https://SENSITIVE_DATA_gitlab.com/rhtap-release/repo.git
 
 kubectl delete secret create-advisory-errata-secret --ignore-not-found
-kubectl create secret generic create-advisory-errata-secret --from-literal=errata_api=https://errata/api/v1 --from-literal=name=errata-tester --from-literal=base64_keytab=Zm9vCg==
+kubectl create secret generic create-advisory-errata-secret --from-literal=errata_api=https://errata/api/v1 --from-literal=name=SENSITIVE_DATA_errata-tester --from-literal=base64_keytab=U0VOU0lUSVZFX0RBVEFfZm9v

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # Mock git
 function git() {
-  echo "Mock git called with: $*"
+  echo "Mock git"
 
   if [[ "$1" == "clone" ]]; then
     mkdir -p "$6"
@@ -19,7 +19,7 @@ function git() {
 
 # Mock find
 function find() {
-  echo "Mock find called with: $*" >&2
+  echo "Mock find" >&2
 
   if echo "$*" | grep -q "not-existing-origin"; then
     # Simulate missing advisory directory
@@ -39,7 +39,7 @@ function find() {
 
 # Mock yq
 function yq() {
-  echo "Mock yq called with: $*" >&2
+  echo "Mock yq" >&2
 
   if [[ -z "$3" ]]; then
     echo "Error: Empty file path in yq command" >&2

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 kubectl delete secret filter-already-released-advisory-images-secret --ignore-not-found
-kubectl create secret generic filter-already-released-advisory-images-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/org/repo.git
+kubectl create secret generic filter-already-released-advisory-images-secret --from-literal=git_author_email=SENSITIVE_DATA_tester@tester --from-literal=git_author_name=SENSITIVE_DATA_tester --from-literal=gitlab_access_token=SENSITIVE_DATA_abc --from-literal=gitlab_host=SENSITIVE_DATA_myurl --from-literal=git_repo=https://gitlab.com/org/repo.git

--- a/tasks/internal/get-advisory-severity/tests/mocks.sh
+++ b/tasks/internal/get-advisory-severity/tests/mocks.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
-set -exo pipefail
+set -eo pipefail
 
 # mocks to be injected into task step scripts
 
 function kinit() {
-  echo "kinit $*"
+  echo "Mock kinit"
 }
 
 function curl() {
-  echo Mock curl called with: $* >&2
+  echo Mock curl >&2
 
   if [[ "$*" == "--retry 3 --negotiate -u : myurl/auth/token" ]]
   then

--- a/tasks/internal/get-advisory-severity/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/get-advisory-severity/tests/pre-apply-task-hook.sh
@@ -4,9 +4,9 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy osidb secret (and delete it first if it exists)
 # The secret name is hardcoded in the task so the mock secret name can't have the task name in it
 kubectl delete secret osidb-service-account --ignore-not-found
-kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=OWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0Cg== --from-literal=osidb_url=myurl
+kubectl create secret generic osidb-service-account --from-literal=name=myname --from-literal=base64_keytab=U0VOU0lUSVZFX0RBVEFfOWEyMmJmYzgtYzJkZi00Y2VhLWJkNWItYjMxNzYxZjFkM2M0IC1uCg== --from-literal=osidb_url=myurl   # base64_keytab has SENSITIVE_DATA_

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function git() {
@@ -10,7 +10,6 @@ function git() {
     /usr/bin/git "$@"
     exit 0
   fi
-  echo "git $*"
   if [[ "$*" == *"clone"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     mkdir -p "$gitRepo"

--- a/tasks/internal/process-file-updates-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/process-file-updates-task/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 kubectl delete secret file-updates-secret --ignore-not-found
-kubectl create secret generic file-updates-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl
+kubectl create secret generic file-updates-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=SENSITIVE_DATA_abc --from-literal=gitlab_host=myurl

--- a/tasks/internal/publish-index-image-task/tests/mocks.sh
+++ b/tasks/internal/publish-index-image-task/tests/mocks.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-set -x
 
 # mocks to be injected into task step scripts
 
 function skopeo() {
-  echo Mock skopeo called with: $* >&2
+  echo Mock skopeo >&2
 
   if [[ "$1" == "inspect" ]]; then
     # Handle `skopeo inspect`
@@ -14,7 +13,7 @@ function skopeo() {
     elif [[ "$*" == *"docker://quay.io/target"* ]]; then
       echo "sha256:target1234567890"
       return 0
-    elif [[ "$*" == *"--tls-verify=false --src-creds source docker://quay.io/source"* ]]; then
+    elif [[ "$*" == *"--tls-verify=false --src-creds SENSITIVE_DATA_source docker://quay.io/source"* ]]; then
       echo "sha256:abcdef1234567890"
       return 0
     elif [[ "$*" == *"--tls-verify=false docker://registry-proxy.engineering.redhat.com/foo"* ]]; then
@@ -28,13 +27,13 @@ function skopeo() {
     fi
   elif [[ "$1" == "copy" ]]; then
     # Handle `skopeo copy`
-    if [[ "$*" == *"--src-tls-verify=false --src-creds source docker://quay.io/source"* ]]; then
+    if [[ "$*" == *"--src-tls-verify=false --src-creds SENSITIVE_DATA_source docker://quay.io/source"* ]]; then
       return 0
     elif [[ "$*" == *"--src-tls-verify=false docker://registry-proxy.engineering.redhat.com/foo"* ]]; then
       return 0
     elif [[ "$*" == *"--src-tls-verify=false docker://registry-proxy.engineering.redhat.com/fail"* ]]; then
       return 1
-    elif [[ "$*" == *"--src-tls-verify=false --src-creds source docker://quay.io/match-source-digest"* ]]; then
+    elif [[ "$*" == *"--src-tls-verify=false --src-creds SENSITIVE_DATA_source docker://quay.io/match-source-digest"* ]]; then
       echo "Error: Copy should not be triggered when digests match"
       exit 1
     else

--- a/tasks/internal/publish-index-image-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/publish-index-image-task/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy secret (and delete it first if it exists)
 kubectl delete secret publish-index-image-secret --ignore-not-found
-kubectl create secret generic publish-index-image-secret --from-literal=sourceIndexCredential=source --from-literal=targetIndexCredential=target
+kubectl create secret generic publish-index-image-secret --from-literal=sourceIndexCredential=SENSITIVE_DATA_source --from-literal=targetIndexCredential=SENSITIVE_DATA_target

--- a/tasks/internal/pulp-push-disk-images/tests/mocks.sh
+++ b/tasks/internal/pulp-push-disk-images/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # mocks to be injected into task step scripts
 
@@ -43,7 +43,7 @@ function gzip() {
 }
 
 function pulp_push_wrapper() {
-    echo Mock pulp_push_wrapper called with: $*
+    echo Mock pulp_push_wrapper
 
     if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
         printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
@@ -51,7 +51,7 @@ function pulp_push_wrapper() {
 }
 
 function developer_portal_wrapper() {
-  echo Mock developer_portal_wrapper called with: $*
+  echo Mock developer_portal_wrapper
 
   /home/developer-portal-wrapper/developer_portal_wrapper "$@" --dry-run
 

--- a/tasks/internal/pulp-push-disk-images/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/pulp-push-disk-images/tests/pre-apply-task-hook.sh
@@ -4,30 +4,30 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
 
 # Create a dummy exodus secret (and delete it first if it exists)
 kubectl delete secret pulp-task-exodus-secret --ignore-not-found
-kubectl create secret generic pulp-task-exodus-secret --from-literal=cert=myexoduscert --from-literal=key=myexoduskey --from-literal=url=https://exodus.com
+kubectl create secret generic pulp-task-exodus-secret --from-literal=cert=SENSITIVE_DATA_myexoduscert --from-literal=key=SENSITIVE_DATA_myexoduskey --from-literal=url=https://exodus.com
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret --ignore-not-found
-kubectl create secret generic pulp-task-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://pulp.com
+kubectl create secret generic pulp-task-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=SENSITIVE_DATA_mypulpcert --from-literal=konflux-release-rhsm-pulp.key=SENSITIVE_DATA_mypulpkey --from-literal=pulp_url=https://pulp.com
 
 # Create a dummy pulp secret to fail with (and delete it first if it exists)
 # This is used to simulate the pulp_push_wrapper script failing
 kubectl delete secret pulp-task-bad-pulp-secret --ignore-not-found
-kubectl create secret generic pulp-task-bad-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://failing-pulp.com
+kubectl create secret generic pulp-task-bad-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=SENSITIVE_DATA_mypulpcert --from-literal=konflux-release-rhsm-pulp.key=SENSITIVE_DATA_mypulpkey --from-literal=pulp_url=https://failing-pulp.com
 
 # Create a dummy udc secret (and delete it first if it exists)
 kubectl delete secret pulp-task-udc-secret --ignore-not-found
-kubectl create secret generic pulp-task-udc-secret --from-literal=cert=myudccert --from-literal=key=myudckey --from-literal=url=https://udc.com
+kubectl create secret generic pulp-task-udc-secret --from-literal=cert=SENSITIVE_DATA_myudccert --from-literal=key=SENSITIVE_DATA_myudckey --from-literal=url=https://udc.com
 
 # Create a dummy cgw secret (and delete it first if it exists)
 kubectl delete secret pulp-task-cgw-secret --ignore-not-found
-kubectl create secret generic pulp-task-cgw-secret --from-literal=username=cgwuser --from-literal=token=cgwtoken
+kubectl create secret generic pulp-task-cgw-secret --from-literal=username=SENSITIVE_DATA_cgwuser --from-literal=token=SENSITIVE_DATA_cgwtoken
 
 # Create a dummy workloads secret (and delete it first if it exists)
 # The secret name here is hardcoded in the task
 kubectl delete secret redhat-workloads-token --ignore-not-found
-kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}
+kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"SENSITIVE_DATA_abcdefg"}}}

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # mocks to be injected into task step scripts
 
@@ -12,11 +12,11 @@ function check_cert_expiration() {
 }
 
 function select-oci-auth() {
-    echo Mock select-oci-auth called with: $*
+    echo Mock select-oci-auth
 }
 
 function skopeo() {
-    echo Mock skopeo called with: $*
+    echo Mock skopeo
     if [[ "$*" =~ copy.*--retry-times.* ]]; then
         # Extract destination directory from skopeo copy command
         # Format: skopeo copy --retry-times 3 --authfile FILE docker://IMAGE dir:DEST
@@ -136,7 +136,7 @@ EOF
 }
 
 function oras() {
-    echo Mock oras called with: $*
+    echo Mock oras
     if [[ "$*" =~ login.* ]]; then
         echo Simulating oras quay login
     elif [[ "$*" =~ push.* ]]; then
@@ -233,7 +233,7 @@ function oras() {
 # The skopeo mock above creates real tar files that these utilities can work with
 
 function pulp_push_wrapper() {
-    echo Mock pulp_push_wrapper called with: $*
+    echo Mock pulp_push_wrapper
 
     if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
         printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
@@ -264,7 +264,7 @@ function pulp_push_wrapper() {
 }
 
 function rsync() {
-    echo Mock rsync called with: $*
+    echo Mock rsync
 
     if [[ "$3" = "testproduct3-binary-linux-amd64.tar.gz" ]]; then
         printf "Mocked failure of exodus-rsync"
@@ -273,7 +273,7 @@ function rsync() {
 }
 
 function publish_to_cgw_wrapper() {
-  echo "Mock publish_to_cgw_wrapper called with: $*"
+  echo "Mock publish_to_cgw_wrapper"
 
   /home/publish-to-cgw-wrapper/publish_to_cgw_wrapper "$@" --dry_run
 
@@ -284,11 +284,11 @@ function publish_to_cgw_wrapper() {
 }
 
 function ssh() {
-    echo Mocking ssh call with: $*
+    echo Mocking ssh call
 }
 
 function scp() {
-    echo Mocking scp call with: $*
+    echo Mocking scp
     # Handle digest file copies - write mock digest to destination
     if [[ "$*" =~ .*digest.txt.* ]] || [[ "$*" =~ .*_digest.txt ]]; then
         args=($@)
@@ -299,7 +299,7 @@ function scp() {
 }
 
 function kinit() {
-    echo Mocking kinit call with: $*
+    echo Mocking kinit
     # Accept any kinit call with -kt flag as the user and host are now dynamic
     if [[ "$*" == *"-kt"* ]] ; then
         echo initialized

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -21,34 +20,34 @@ for((i=0;i<STEPS;i++)); do
     # Add volumeMount to the step
     yq -i '.spec.steps['$i'].volumeMounts += [{"name": "test-mocks", "mountPath": "/mnt/test-mocks"}]' "$TASK_PATH"
     # Insert source command AFTER the shebang line (not before, or bash won't be used)
-    yq -i '.spec.steps['$i'].script |= sub("^(#![^\n]*\n)", "${1}source /mnt/test-mocks/mocks.sh\n")' "$TASK_PATH"
+    yq -i '.spec.steps['$i'].script |= sub("^(#![^\n]*\n)", "${1}source /mnt/test-mocks/mocks.sh\nset +x\n")' "$TASK_PATH"
 done
 
 # Create a dummy exodus secret (and delete it first if it exists)
 kubectl delete secret pulp-task-exodus-secret --ignore-not-found
-kubectl create secret generic pulp-task-exodus-secret --from-literal=cert=myexoduscert --from-literal=key=myexoduskey --from-literal=url=https://exodus.com
+kubectl create secret generic pulp-task-exodus-secret --from-literal=cert=SENSITIVE_DATA_myexoduscert --from-literal=key=SENSITIVE_DATA_myexoduskey --from-literal=url=https://exodus.com
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret --ignore-not-found
-kubectl create secret generic pulp-task-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://pulp.com
+kubectl create secret generic pulp-task-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=SENSITIVE_DATA_mypulpcert --from-literal=konflux-release-rhsm-pulp.key=SENSITIVE_DATA_mypulpkey --from-literal=pulp_url=https://pulp.com
 
 # Create a dummy pulp secret to fail with (and delete it first if it exists)
 # This is used to simulate the pulp_push_wrapper script failing
 kubectl delete secret pulp-task-bad-pulp-secret --ignore-not-found
-kubectl create secret generic pulp-task-bad-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=mypulpcert --from-literal=konflux-release-rhsm-pulp.key=mypulpkey --from-literal=pulp_url=https://failing-pulp.com
+kubectl create secret generic pulp-task-bad-pulp-secret --from-literal=konflux-release-rhsm-pulp.crt=SENSITIVE_DATA_mypulpcert --from-literal=konflux-release-rhsm-pulp.key=SENSITIVE_DATA_mypulpkey --from-literal=pulp_url=https://failing-pulp.com
 
 # Create a dummy udc secret (and delete it first if it exists)
 kubectl delete secret pulp-task-udc-secret --ignore-not-found
-kubectl create secret generic pulp-task-udc-secret --from-literal=cert=myudccert --from-literal=key=myudckey --from-literal=url=https://udc.com
+kubectl create secret generic pulp-task-udc-secret --from-literal=cert=SENSITIVE_DATA_myudccert --from-literal=key=SENSITIVE_DATA_myudckey --from-literal=url=https://udc.com
 
 # Create a dummy cgw secret (and delete it first if it exists)
 kubectl delete secret pulp-task-cgw-secret --ignore-not-found
-kubectl create secret generic pulp-task-cgw-secret --from-literal=username=cgwuser --from-literal=token=cgwtoken
+kubectl create secret generic pulp-task-cgw-secret --from-literal=username=SENSITIVE_DATA_cgwuser --from-literal=token=SENSITIVE_DATA_cgwtoken
 
 # Create a dummy workloads secret (and delete it first if it exists)
 # The secret name here is hardcoded in the task
 kubectl delete secret redhat-workloads-token --ignore-not-found
-kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}
+kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"SENSITIVE_DATA_abcdefg"}}}
 
 # create ssh secrets
 
@@ -61,22 +60,22 @@ TMPDIR=$(mktemp -d /tmp/XXXX.tmp)
 for OS in windows mac; do
     ssh-keygen -f "${TMPDIR}/${OS}" -N ""
     kubectl delete secret "${OS}-ssh-key" --ignore-not-found
-    kubectl create secret generic "${OS}-ssh-key" --from-file="${OS}_id_rsa=${TMPDIR}/${OS}" --from-literal="${OS}"_fingerprint="$(ssh-keygen -lf "${TMPDIR}/${OS}.pub")"
+    kubectl create secret generic "${OS}-ssh-key" --from-file="${OS}_id_rsa=${TMPDIR}/${OS}" --from-literal="${OS}"_fingerprint="SENSITIVE_DATA_$(ssh-keygen -lf "${TMPDIR}/${OS}.pub")"
 done
 ssh-keygen -f "${TMPDIR}/checksum" -N ""
 kubectl create secret generic "checksum-credentials" \
-    --from-literal=keytab="" \
+    --from-literal=keytab="U0VOU0lUSVZFX0RBVEFfZW1wdHkgLW4K" \
     --from-literal=user="konflux-release-signing-sa" \
     --from-literal=host="etera-worker.hosted.upshift.rdu2.redhat.com" \
-    --from-literal=fingerprint="$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
+    --from-literal=fingerprint="SENSITIVE_DATA_$(ssh-keygen -lf "${TMPDIR}/checksum.pub")"
 
 # create quay, windows and mac secrets
-kubectl create secret generic quay-credentials --from-literal=username="testuser" --from-literal=password="testpass"
+kubectl create secret generic quay-credentials --from-literal=username="testuser" --from-literal=password="SENSITIVE_DATA_testpass"
 kubectl create secret generic windows-credentials --from-literal=username="testuser" --from-literal=port="1234" --from-literal=host="testhost"
 kubectl create secret generic mac-host-credentials --from-literal=username="testuser" --from-literal=host="testhost"
-kubectl create secret generic mac-signing-credentials --from-literal=keychain_password="testkeychainpass" \
-    --from-literal=signing_identity="testidentity" --from-literal=apple_id="testid" \
-    --from-literal=team_id="testteamid" --from-literal=app_specific_password="testapppassword"
+kubectl create secret generic mac-signing-credentials --from-literal=keychain_password="SENSITIVE_DATA_testkeychainpass" \
+    --from-literal=signing_identity="SENSITIVE_DATA_testidentity" --from-literal=apple_id="SENSITIVE_DATA_testid" \
+    --from-literal=team_id="SENSITIVE_DATA_testteamid" --from-literal=app_specific_password="SENSITIVE_DATA_testapppassword"
 
 # clean up
 rm -rf ${TMPDIR}

--- a/tasks/internal/request-advisory-oci-artifact/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/request-advisory-oci-artifact/tests/pre-apply-task-hook.sh
@@ -13,4 +13,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/internal/request-and-upload-signature/tests/mocks.sh
+++ b/tasks/internal/request-and-upload-signature/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 function check_cert_expiration() {
   local cert_file="$1"
@@ -23,18 +23,18 @@ function ssh() {
 }
 
 function pubtools-sign-msg-container-sign() {
-  >&2 echo "Mock pubtools-sign-msg-container-sign called with: $*"
+  >&2 echo "Mock pubtools-sign-msg-container-sign"
   echo "$*" >> "$(workspaces.data.path)/mock_pubtools-sign.txt"
   cat "$(workspaces.data.path)/mocked_signing_response"
 }
 
 function pubtools-pyxis-upload-signatures() {
-  >&2 echo "Mock pubtools-pyxis-upload-signatures called with: $*"
+  >&2 echo "Mock pubtools-pyxis-upload-signatures"
   echo "$*" >> "$(workspaces.data.path)/mock_pubtools-pyxis-upload-signatures.txt"
 }
 
 function openssl() {
-  >&2 echo "Mock openssl called with: $*"
+  >&2 echo "Mock openssl"
   echo "$*" >> "$(workspaces.data.path)/mock_openssl.txt"
   if [[ "$*" =~ "x509 -noout -subject" ]]; then
     echo "UID=test-mock"

--- a/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
@@ -9,8 +9,8 @@ done
 
 # Create a dummy secret for ssl cert for pyxis interactions (and delete it first if it exists)
 kubectl delete secret pyxis-ssl-cert --ignore-not-found
-kubectl create secret generic pyxis-ssl-cert --from-literal=cert=mypyxiscert --from-literal=key=mypyxiskey
+kubectl create secret generic pyxis-ssl-cert --from-literal=cert=sensitive-data-mypyxiscert --from-literal=key=sensitive-data-mypyxiskey
 
 # Create a dummy secret for ssl cert for UMB interactions (and delete it first if it exists)
 kubectl delete secret umb-ssl-cert --ignore-not-found
-kubectl create secret generic umb-ssl-cert --from-literal=cert=myumbcert --from-literal=key=myumbkey
+kubectl create secret generic umb-ssl-cert --from-literal=cert=sensitive-data-myumbcert --from-literal=key=sensitive-data-myumbkey

--- a/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/mocks.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 echo "CLAUDE_DEBUGGING: mocks.sh file loaded successfully with fix attempt $(date)" >&2
 

--- a/tasks/internal/update-fbc-catalog-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/update-fbc-catalog-task/tests/pre-apply-task-hook.sh
@@ -9,17 +9,17 @@ kubectl apply -f .github/resources/crd_rbac.yaml
 # create required secrets
 kubectl create secret generic iib-service-account-secret \
     --from-literal=principal="iib@kerberos" \
-    --from-literal=keytab="something"
+    --from-literal=keytab="SENSITIVE_DATA_something"
 kubectl create secret generic iib-services-config \
-    --from-literal=krb5.conf="" \
+    --from-literal=krb5.conf="SENSITIVE_DATA_empty" \
     --from-literal=url="https://fakeiib.host"
 
 kubectl create secret generic iib-overwrite-fromimage-credentials \
-    --from-literal=username="bot+user" \
-    --from-literal=token="token"
+    --from-literal=username="SENSITIVE_DATA_bot+user" \
+    --from-literal=token="SENSITIVE_DATA_token"
 
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/add-fbc-contribution/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/add-fbc-contribution/tests/pre-apply-task-hook.sh
@@ -14,4 +14,4 @@ kubectl delete internalrequests \
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/apply-mapping/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/apply-mapping/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/cleanup-workspace/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/cleanup-workspace/tests/pre-apply-task-hook.sh
@@ -13,4 +13,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function curl-with-retry() {
-  echo Mock curl called with: $* >&2
+  echo Mock curl >&2
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 
   if [[ "$*" == *"-u team@domain.com:abcdefg"*"Content-Type"*"https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123/transitions" ]]

--- a/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
@@ -3,8 +3,8 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=SENSITIVE_DATA_abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/collect-data/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/collect-data/tests/pre-apply-task-hook.sh
@@ -10,4 +10,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/managed/create-advisory/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/create-advisory/tests/pre-apply-task-hook.sh
@@ -14,10 +14,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step scripts
 # Step 1 is update-purl (needs oras mock), Step 2 is run-script (needs kubectl mock)
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
 
 yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mock_generic_type_advisories.sh") + .spec.steps[1].script' "$TASK_PATH"
 # Create a dummy publish-to-cgw secret (and delete it first if it exists)
 kubectl delete secret publish-to-cgw-secret --ignore-not-found
-kubectl create secret generic publish-to-cgw-secret --from-literal=username=myusername --from-literal=token=mytoken
+kubectl create secret generic publish-to-cgw-secret --from-literal=username=SENSITIVE_DATA_myusername --from-literal=token=SENSITIVE_DATA_mytoken

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -148,8 +148,6 @@ spec:
         # export variables required by the script "git-functions" in release-service-utils
         export GH_TOKEN
 
-        set -x
-
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/create-github-release-results.json"
 
         cd "$(params.dataDir)/$CONTENT_DIRECTORY"

--- a/tasks/managed/create-github-release/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/create-github-release/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy github secret (and delete it first if it exists)
 kubectl delete secret test-create-github-release-token --ignore-not-found
-kubectl create secret generic test-create-github-release-token --from-literal=token=mytoken
+kubectl create secret generic test-create-github-release-token --from-literal=token=SENSITIVE_DATA_mytoken

--- a/tasks/managed/create-pyxis-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/create-pyxis-image/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-create-pyxis-image-cert --ignore-not-found
-kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=SENSITIVE_DATA_mycert --from-literal=key=SENSITIVE_DATA_mykey

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -3,7 +3,7 @@ set -x
 
 # mocks to be injected into task step scripts
 function curl-with-retry() {
-  echo Mock curl called with: $* >&2
+  echo Mock curl >&2
   mkdir -p "$(params.dataDir)"
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 

--- a/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
@@ -3,9 +3,9 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=SENSITIVE_DATA_abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/extract-binaries-from-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-binaries-from-image/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/extract-oot-kmods/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-oot-kmods/tests/pre-apply-task-hook.sh
@@ -14,7 +14,7 @@ yq -i '.spec.steps[1].env += [{"name": "SNAPSHOT_NAME", "value": "$(params.snaps
 yq -i '.spec.steps[2].env += [{"name": "SNAPSHOT_NAME", "value": "$(params.snapshot)"}]' "$TASK_PATH"
 
 # Inject mocks into the detect-architectures step (step[1])
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Inject mocks into the extract-kmods step (step[2])
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/extract-py-artifacts/tests/mocks.sh
+++ b/tasks/managed/extract-py-artifacts/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 
@@ -10,7 +10,7 @@ function select-oci-auth() {
 }
 
 function retry() {
-  echo "Mock retry called with: $*"
+  echo "Mock retry"
   # Just run the command without retry logic
   "$@"
 }

--- a/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
@@ -11,7 +11,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Inject mocks into the get-image-urls step (step index 2)
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
 
 # Inject mocks into the extract-artifacts step (step index 3)
-yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[3].script' "$TASK_PATH"

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # mocks to be injected into task step scripts
 

--- a/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
@@ -13,4 +13,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/pre-apply-task-hook.sh
@@ -5,11 +5,11 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script (step index 1 is the filter step)
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret --ignore-not-found
 kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml='base_url = "https://dummy.com"
-client_id = "DUMMY"
-client_secret = "DUMMY"
+client_id = "SENSITIVE_DATA_DUMMY"
+client_secret = "SENSITIVE_DATA_DUMMY"
 '

--- a/tasks/managed/filter-published-fbc-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-published-fbc-images/tests/pre-apply-task-hook.sh
@@ -5,13 +5,13 @@ TASK_PATH=$1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Inject mocks into the setup-pyxis-cert step (step index 1)
-yq -i '.spec.steps[1].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Inject mocks into the filter-already-released-images step (step index 2)
-yq -i '.spec.steps[2].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
 
 # Create mock Pyxis credentials secret for testing (not used in tests, but kept for reference)
 kubectl create secret generic pyxis \
-  --from-literal=cert="mock-cert" \
-  --from-literal=key="mock-key" \
+  --from-literal=cert="SENSITIVE_DATA_mock-cert" \
+  --from-literal=key="SENSITIVE_DATA_mock-key" \
   --dry-run=client -o yaml | kubectl apply -f - || true

--- a/tasks/managed/get-ocp-version/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/get-ocp-version/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/make-repo-public/tests/mocks.sh
+++ b/tasks/managed/make-repo-public/tests/mocks.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 
 function curl() {
-  echo Mock curl called with: $* >&2
+  echo Mock curl >&2
   echo $* >> $(params.dataDir)/mock_curl.txt
 
-  if [[ "$*" == '-X POST --fail-with-body --retry 3 --header Authorization: Bearer myquaytoken --header Content-Type: application/json --data {"visibility": "public"} https://quay.io/api/v1/repository/redhat-services-'*'/myrepo'*'/changevisibility' ]]
+  if [[ "$*" == '-X POST --fail-with-body --retry 3 --header Authorization: Bearer SENSITIVE_DATA_myquaytoken --header Content-Type: application/json --data {"visibility": "public"} https://quay.io/api/v1/repository/redhat-services-'*'/myrepo'*'/changevisibility' ]]
   then
     if [[ "$*" == *redhat-services-prod/myrepofailing* ]]
     then

--- a/tasks/managed/make-repo-public/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/make-repo-public/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy registry secret (and delete it first if it exists)
 kubectl delete secret test-registry-secret --ignore-not-found
-kubectl create secret generic test-registry-secret --from-literal=token=myquaytoken
+kubectl create secret generic test-registry-secret --from-literal=token=SENSITIVE_DATA_myquaytoken

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy secret (and delete it first if it exists)
 kubectl delete secret marketplacesvm-test-secret --ignore-not-found
-kubectl create secret generic marketplacesvm-test-secret --from-literal=key=eyJ0ZXN0Ijoic2VjcmV0In0K
+kubectl create secret generic marketplacesvm-test-secret --from-literal=key=SENSITIVE_DATA_eyJ0ZXN0Ijoic2VjcmV0In0K

--- a/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
@@ -4,9 +4,9 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=SENSITIVE_DATA_abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/prepare-fbc-parameters/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/prepare-fbc-parameters/tests/pre-apply-task-hook.sh
@@ -16,4 +16,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script (collect-parameters step is the second step)
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/prepare-fbc-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/prepare-fbc-snapshot/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/promote-koji-draft-build/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/promote-koji-draft-build/tests/pre-apply-task-hook.sh
@@ -4,11 +4,11 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Delete existing secrets if they exist
 kubectl delete secret push-koji-test --ignore-not-found
 
 # Create the fake secrets for koji
 kubectl create secret generic push-koji-test \
-  --from-literal=base64_keytab="$(base64 <<< "some keytab")"
+  --from-literal=base64_keytab="$(base64 <<< "SENSITIVE_DATA_some keytab")"

--- a/tasks/managed/publish-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-index-image/tests/pre-apply-task-hook.sh
@@ -12,4 +12,4 @@ kubectl delete internalrequests --all -A
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/publish-pyxis-repository/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-pyxis-repository/tests/pre-apply-task-hook.sh
@@ -4,8 +4,8 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-publish-pyxis-repository-cert --ignore-not-found
-kubectl create secret generic test-publish-pyxis-repository-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl create secret generic test-publish-pyxis-repository-cert --from-literal=cert=SENSITIVE_DATA_mycert --from-literal=key=SENSITIVE_DATA_mykey

--- a/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-to-mrrc/tests/pre-apply-task-hook.sh
@@ -6,10 +6,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Create a dummy charon aws crendentials secret (and delete it first if it exists)
 aws_creds=$(cat <<- EOF
 [test]
-aws_user = test-user
-aws_access_key_id = justadummykey
-aws_secret_access_key = justadummyaccesskey
-region = us-east-1
+aws_user = SENSITIVE_DATA_test-user
+aws_access_key_id = SENSITIVE_DATA_justadummykey
+aws_secret_access_key = SENSITIVE_DATA_justadummyaccesskey
+region = SENSITIVE_DATA_us-east-1
 EOF
 )
 kubectl delete secret test-charon-aws-credentials --ignore-not-found
@@ -17,9 +17,9 @@ kubectl create secret generic test-charon-aws-credentials --from-literal=credent
 
 kubectl delete secret test-ca --ignore-not-found
 kubectl create secret generic test-ca \
-  --from-literal=client-key.pem="testkey" \
-  --from-literal=client-key.password="testpass" \
-  --from-literal=mrrc-signing.crt="testca"
+  --from-literal=client-key.pem="SENSITIVE_DATA_testkey" \
+  --from-literal=client-key.password="SENSITIVE_DATA_testpass" \
+  --from-literal=mrrc-signing.crt="SENSITIVE_DATA_testca"
 
 # Add mocks to the beginning of scripts
 # Step 0: use-trusted-artifact (ref - no script)
@@ -29,8 +29,8 @@ kubectl create secret generic test-ca \
 # Step 4: push-merged-maven-repo-to-registry (script)
 # Step 5: upload-merged-maven-zip (script)
 # Step 6: create-trusted-artifact (ref - no script)
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
-yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
-yq -i '.spec.steps[4].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[4].script' "$TASK_PATH"
-yq -i '.spec.steps[5].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[5].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[3].script' "$TASK_PATH"
+yq -i '.spec.steps[4].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[4].script' "$TASK_PATH"
+yq -i '.spec.steps[5].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[5].script' "$TASK_PATH"

--- a/tasks/managed/publish-to-nrrc/tests/mocks.sh
+++ b/tasks/managed/publish-to-nrrc/tests/mocks.sh
@@ -29,7 +29,7 @@ function oras(){
 }
 
 function charon(){
-  echo Mock charon called with: "$*"
+  echo Mock charon
   echo "$*" >> "$(params.dataDir)/mock_charon.txt"
 
   if [ ! -f "$HOME/.charon/charon.yaml" ]

--- a/tasks/managed/publish-to-nrrc/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/publish-to-nrrc/tests/pre-apply-task-hook.sh
@@ -8,7 +8,7 @@ aws_creds=$(cat <<- EOF
 [test]
 aws_user = test-user
 aws_access_key_id = justadummykey
-aws_secret_access_key = justadummyaccesskey
+aws_secret_access_key = sensitive-data-justadummyaccesskey
 region = us-east-1
 EOF
 )
@@ -17,10 +17,10 @@ kubectl create secret generic test-charon-aws-credentials --from-literal=credent
 
 kubectl delete secret test-ca --ignore-not-found
 kubectl create secret generic test-ca \
-  --from-literal=client-key.pem="testkey" \
-  --from-literal=client-key.password="testpass" \
+  --from-literal=client-key.pem="sensitive-data-testkey" \
+  --from-literal=client-key.password="sensitive-data-testpass" \
   --from-literal=mrrc-signing.crt="testca"
 
 # Add mocks to the beginning of scripts
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
@@ -59,4 +59,4 @@ EOF
 kubectl apply -f /tmp/configmap.json
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/push-artifacts-to-storage/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-artifacts-to-storage/tests/pre-apply-task-hook.sh
@@ -4,4 +4,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/push-disk-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-disk-images/tests/pre-apply-task-hook.sh
@@ -13,4 +13,4 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/mocks.sh
@@ -1,8 +1,8 @@
-set -eux
+set -eu
 
 # Ensure our mock az function takes precedence over any real az binary
 function az() {
-    echo "Mock 'az' called with: $*"
+    echo "Mock 'az'"
 
     case "$1" in
         login)

--- a/tasks/managed/push-oot-kmods-to-azure/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/pre-apply-task-hook.sh
@@ -62,6 +62,6 @@ echo "Injection complete. Creating Azure mock secret..."
 
 kubectl delete secret azure-mock-secret --ignore-not-found
 kubectl create secret generic azure-mock-secret \
-  --from-literal=AZURE_TENANT_ID=mock-tenant-id \
-  --from-literal=AZURE_CLIENT_ID=mock-client-id \
-  --from-literal=AZURE_CLIENT_SECRET=mock-client-secret
+  --from-literal=AZURE_TENANT_ID=SENSITIVE_DATA_mock-tenant-id \
+  --from-literal=AZURE_CLIENT_ID=SENSITIVE_DATA_mock-client-id \
+  --from-literal=AZURE_CLIENT_SECRET=SENSITIVE_DATA_mock-client-secret

--- a/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
@@ -1,4 +1,4 @@
-set -eux
+set -eu
 
 # Check if this is a multiarch test by looking for arch_count.txt
 aws() {

--- a/tasks/managed/push-oot-kmods-to-s3/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/pre-apply-task-hook.sh
@@ -43,7 +43,8 @@ yq -i '.spec.steps[0] = load("/tmp/mock-step.yaml")' "$TASK_PATH"
 rm /tmp/mock-step.yaml
 
 echo "Injecting mock/check scripts into spec.steps[2]..."
-MOCK_SCRIPT=$(cat "$SCRIPT_DIR/mocks.sh")
+MOCK_SCRIPT="$(cat "$SCRIPT_DIR/mocks.sh")
+set +x"
 ORIG_SCRIPT=$(yq '.spec.steps[2].script' "$TASK_PATH" | sed '1s|^#!/.*||')
 
 CHECK_SCRIPT="
@@ -72,5 +73,5 @@ echo "Injection complete. Creating S3 mock secret..."
 
 kubectl delete secret s3-mock-secret --ignore-not-found
 kubectl create secret generic s3-mock-secret \
-  --from-literal=aws_access_key_id=MOCK_AWS_KEY_ID \
-  --from-literal=aws_secret_access_key=MOCK_AWS_SECRET_KEY
+  --from-literal=aws_access_key_id=SENSITIVE_DATA_MOCK_AWS_KEY_ID \
+  --from-literal=aws_secret_access_key=SENSITIVE_DATA_MOCK_AWS_SECRET_KEY

--- a/tasks/managed/push-rpm-data-to-pyxis/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-rpm-data-to-pyxis/tests/pre-apply-task-hook.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-push-rpm-data-to-pyxis-cert --ignore-not-found
-kubectl create secret generic test-push-rpm-data-to-pyxis-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl create secret generic test-push-rpm-data-to-pyxis-cert --from-literal=cert=SENSITIVE_DATA_mycert --from-literal=key=SENSITIVE_DATA_mykey
 
 # Add mocks to the beginning of scripts
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/push-rpm-to-koji/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-rpm-to-koji/tests/pre-apply-task-hook.sh
@@ -4,11 +4,11 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Delete existing secrets if they exist
 kubectl delete secret push-koji-test --ignore-not-found
 
 # Create the fake secrets for koji
 kubectl create secret generic push-koji-test \
-  --from-literal=base64_keytab="$(base64 <<< "some keytab")"
+  --from-literal=base64_keytab="$(base64 <<< "SENSITIVE_DATA_some keytab")"

--- a/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # mocks to be injected into task step scripts
 

--- a/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-rpms-to-pulp/tests/pre-apply-task-hook.sh
@@ -11,21 +11,22 @@ kubectl create configmap test-mocks --from-file=mocks.sh="$SCRIPT_DIR/mocks.sh"
 yq -i '.spec.volumes += [{"name": "test-mocks", "configMap": {"name": "test-mocks"}}]' "$TASK_PATH"
 yq -i '.spec.steps[1].volumeMounts += [{"name": "test-mocks", "mountPath": "/mnt/test-mocks"}]' "$TASK_PATH"
 yq -i '.spec.steps[1].script |= sub("^(#![^\n]*\n)", "${1}source /mnt/test-mocks/mocks.sh\n")' "$TASK_PATH"
+yq -i '.spec.steps[1].script |= sub("^(#![^\n]*\n)", "${1}source /mnt/test-mocks/mocks.sh\nset +x\n")' "$TASK_PATH"
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret --ignore-not-found
 kubectl create secret generic pulp-task-pulp-secret --from-literal=cli.toml='base_url = "https://console.redhat.com"
-client_id = "mock-client-id"
-client_secret = "mock-client-secret"
+client_id = "SENSITIVE_DATA_mock-client-id"
+client_secret = "SENSITIVE_DATA_mock-client-secret"
 '
 
 # Create a dummy pulp secret for basic auth (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret-basic --ignore-not-found
 kubectl create secret generic pulp-task-pulp-secret-basic --from-literal=cli.toml='base_url = "https://console.redhat.com"
-username = "mock-user"
-password = "mock-password"
+username = "SENSITIVE_DATA_mock-user"
+password = "SENSITIVE_DATA_mock-password"
 '
 
 # Create a dummy pulp secret (and delete it first if it exists)
 kubectl delete secret pulp-task-pulp-secret-missing --ignore-not-found
-kubectl create secret generic pulp-task-pulp-secret-missing --from-literal=dummy=abcdef123
+kubectl create secret generic pulp-task-pulp-secret-missing --from-literal=dummy=SENSITIVE_DATA_abcdef123

--- a/tasks/managed/push-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-snapshot/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy configmap (and delete it first if it exists)
 kubectl delete configmap test-use-custom-ca-cert --ignore-not-found

--- a/tasks/managed/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/rh-sign-image-cosign/tests/pre-apply-task-hook.sh
@@ -6,7 +6,7 @@ kubectl delete secret test-cosign-secret test-cosign-secret-rekor --ignore-not-f
 kubectl create secret generic test-cosign-secret\
   --from-literal=AWS_DEFAULT_REGION=us-test-1\
   --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
-  --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
+  --from-literal=AWS_SECRET_ACCESS_KEY=sensitive-data-key\
   --from-literal=SIGN_KEY=aws://arn:mykey\
   --from-literal=REKOR_PUBLIC_KEY=rekor_public_key\
   --from-literal=PUBLIC_KEY=public_key
@@ -14,7 +14,7 @@ kubectl create secret generic test-cosign-secret\
 kubectl create secret generic test-cosign-secret-rekor\
   --from-literal=AWS_DEFAULT_REGION=us-test-1\
   --from-literal=AWS_ACCESS_KEY_ID=test-access-key\
-  --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-access-key\
+  --from-literal=AWS_SECRET_ACCESS_KEY=sensitive-data-key\
   --from-literal=SIGN_KEY=aws://arn:mykey\
   --from-literal=REKOR_URL=https://fake-rekor-server\
   --from-literal=REKOR_PUBLIC_KEY=rekor_public_key\
@@ -23,4 +23,4 @@ kubectl create secret generic test-cosign-secret-rekor\
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/rh-sign-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/rh-sign-image/tests/pre-apply-task-hook.sh
@@ -11,7 +11,7 @@ kubectl delete internalrequests --all -A
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-create-pyxis-image-cert --ignore-not-found
-kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=SENSITIVE_DATA_mycert --from-literal=key=SENSITIVE_DATA_mykey
 
 # Delete pipeline for signing
 kubectl delete pipeline/simple-signing-pipeline --ignore-not-found
@@ -101,4 +101,4 @@ kubectl create -f /tmp/configMap2.json
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/rh-sign-python-wheels/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/rh-sign-python-wheels/tests/pre-apply-task-hook.sh
@@ -3,13 +3,13 @@
 # Create a dummy AWS KMS secret (and delete it first if it exists)
 kubectl delete secret test-aws-kms-secret --ignore-not-found
 kubectl create secret generic test-aws-kms-secret \
-  --from-literal=AWS_DEFAULT_REGION=us-east-1 \
-  --from-literal=AWS_ACCESS_KEY_ID=test-access-key \
-  --from-literal=AWS_SECRET_ACCESS_KEY=test-secret-key \
+  --from-literal=AWS_DEFAULT_REGION=SENSITIVE_DATA_us-east-1 \
+  --from-literal=AWS_ACCESS_KEY_ID=SENSITIVE_DATA_test-access-key \
+  --from-literal=AWS_SECRET_ACCESS_KEY=SENSITIVE_DATA_test-secret-key \
   --from-literal=SIGN_KEY=awskms:///arn:aws:kms:us-east-1:123456789:key/test-key
 
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 

--- a/tasks/managed/run-file-updates/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/run-file-updates/tests/pre-apply-task-hook.sh
@@ -12,4 +12,4 @@ kubectl delete internalrequests --all -A
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/send-slack-notification/tests/mocks.sh
+++ b/tasks/managed/send-slack-notification/tests/mocks.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 
 function curl() {
-  echo Mock curl called with: $*
+  echo "Mock curl"
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 
-  if [[ "$*" != "-H Content-type: application/json --data-binary @/tmp/release.json ABCDEF"* ]]
+  if [[ "$*" != "-H Content-type: application/json --data-binary @/tmp/release.json SENSITIVE_DATA_ABCDEF"* ]]
   then
     echo Error: Unexpected call
     exit 1

--- a/tasks/managed/send-slack-notification/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/send-slack-notification/tests/pre-apply-task-hook.sh
@@ -5,9 +5,9 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create a dummy slack-notification-secret secret (and delete it first if it exists)
 kubectl delete secret my-secret --ignore-not-found
 
-kubectl create secret generic my-secret --from-literal=my-team=ABCDEF
+kubectl create secret generic my-secret --from-literal=my-team=SENSITIVE_DATA_ABCDEF

--- a/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/set-advisory-severity/tests/pre-apply-task-hook.sh
@@ -3,4 +3,4 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/sign-base64-blob/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/sign-base64-blob/tests/pre-apply-task-hook.sh
@@ -12,4 +12,4 @@ kubectl delete internalrequests --all -A
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/sign-index-image/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/sign-index-image/tests/pre-apply-task-hook.sh
@@ -11,7 +11,7 @@ kubectl delete internalrequests --all -A
 
 # Create a dummy pyxis secret (and delete it first if it exists)
 kubectl delete secret test-create-pyxis-image-cert --ignore-not-found
-kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=mycert --from-literal=key=mykey
+kubectl create secret generic test-create-pyxis-image-cert --from-literal=cert=SENSITIVE_DATA_mycert --from-literal=key=SENSITIVE_DATA_mykey
 
 # Create signing-config-map ConfigMap required by sign-index-image task
 kubectl delete configmap signing-config-map --ignore-not-found
@@ -21,4 +21,4 @@ kubectl create configmap signing-config-map \
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/sign-oot-kmods/tests/mocks.sh
+++ b/tasks/managed/sign-oot-kmods/tests/mocks.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 
 function kinit() {
-  echo "Mock kinit called with: $*"
+  echo "Mock kinit"
   
   echo "$*" >> "$(params.dataDir)/mock_kinit.txt"
 
@@ -19,7 +19,7 @@ function kinit() {
 }
 
 function ssh() {
-  echo "Mock ssh called with: $*"
+  echo "Mock ssh"
 
   echo "$*" >> "$(params.dataDir)/mock_ssh.txt"
 
@@ -62,7 +62,7 @@ function ssh() {
 }
 
 function rm() {
-  echo "Mock rm called with: $*"
+  echo "Mock rm"
 
   echo "$*" >> "$(params.dataDir)/mock_rm.txt"
 
@@ -92,7 +92,7 @@ function rm() {
 }
 
 function scp() {
-  echo "Mock scp called with: $*"
+  echo "Mock scp"
 
   echo "$*" >> "$(params.dataDir)/mock_scp.txt"
 

--- a/tasks/managed/sign-oot-kmods/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/sign-oot-kmods/tests/pre-apply-task-hook.sh
@@ -4,15 +4,14 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add test setup and mocks to the beginning of the sign-files step script (step[2])
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/test-setup.sh") + load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/test-setup.sh") + load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Create dummy secrets
 kubectl delete secret my-mocked-secret --ignore-not-found
-kubectl create secret generic my-mocked-secret --from-literal=signHost=mysigning.mock.com \
-        --from-literal=signKey=my-mock-signing-key \
+kubectl create secret generic my-mocked-secret --from-literal=signHost=mysigning.mock.com --from-literal=signKey=SENSITIVE_DATA_my-mock-signing-key \
         --from-literal=signUser=my-mock-keytab-user
-echo -e "\0005\0002\c" > my-mock.keytab
-echo "1.2.3.4 my-mock-host" > checksumFingerprint
+echo -e "SENSITIVE_DATA_\0005\0002\c" > my-mock.keytab
+echo "SENSITIVE_DATA_1.2.3.4 my-mock-host" > checksumFingerprint
 kubectl delete secret build-and-sign-keytab --ignore-not-found 
 kubectl create secret generic build-and-sign-keytab --from-file=my-mock.keytab
 kubectl delete secret checksum-fingerprint --ignore-not-found

--- a/tasks/managed/update-infra-deployments/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/update-infra-deployments/tests/pre-apply-task-hook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Create a dummy infra-deployments-pr-creator secret and delete it if it already exists
 kubectl delete secret infra-deployments-pr-creator --ignore-not-found
-echo "fake-key" > fake-key.pem
+echo "SENSITIVE_DATA_fake-key" > fake-key.pem
 kubectl create secret generic infra-deployments-pr-creator --from-file=private-key=fake-key.pem

--- a/tasks/managed/update-package-collection/tests/mocks.sh
+++ b/tasks/managed/update-package-collection/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # mocks to be injected into task step scripts
 function kinit() {
@@ -103,7 +103,7 @@ function git() {
 }
 
 function glab() {
-  echo "Mock glab called with: $*"
+  echo "Mock glab"
 
   if [[ "$*" != "auth login"* ]]; then
     echo Error: Unexpected call

--- a/tasks/managed/update-package-collection/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/update-package-collection/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@ TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Add mocks to the beginning of task step script
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' "$TASK_PATH"
 
 # Delete existing secrets if they exist
 kubectl delete secret push-koji-test --ignore-not-found
@@ -12,9 +12,9 @@ kubectl delete secret package-collection-secret --ignore-not-found
 
 # Create the fake secrets for koji
 kubectl create secret generic push-koji-test \
-  --from-literal=base64_keytab="$(base64 <<< "some keytab")"
+  --from-literal=base64_keytab="$(base64 <<< "SENSITIVE_DATA_some keytab")"
 
-kubectl create secret generic package-collection-secret --from-literal=gitlab-access-token=gitlab-access-token \
+kubectl create secret generic package-collection-secret --from-literal=gitlab-access-token=SENSITIVE_DATA_gitlab-access-token \
   --from-literal=gitlab_host=gitlab_host --from-literal=git_author_name=git_author_name \
   --from-literal=git_author_email=git_author_email --from-literal=git_repo="package-collection-utils"
 

--- a/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/update-trusted-tasks/tests/pre-apply-task-hook.sh
@@ -3,4 +3,4 @@
 TASK_PATH=$1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $TASK_PATH
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n" + .spec.steps[1].script' $TASK_PATH

--- a/tasks/managed/upload-py-pulp/tests/mocks.sh
+++ b/tasks/managed/upload-py-pulp/tests/mocks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # Mock pulp-upload script
 echo "Mock pulp-upload called"

--- a/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
@@ -4,7 +4,7 @@
 kubectl delete secret rhtl-pulp-credentials-secret --ignore-not-found
 kubectl create secret generic rhtl-pulp-credentials-secret \
   --from-literal=username=test-user \
-  --from-literal=password=test-password
+  --from-literal=password=sensitive-data-test-password
 
 # Add mocks to the upload step script
 # Steps layout:
@@ -18,5 +18,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # We need to replace the command with a script that includes mocks
 yq -i '
   del(.spec.steps[2].command) |
-  .spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh")
+  .spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + "set +x\n"
 ' "$TASK_PATH"


### PR DESCRIPTION
## Describe your changes
1. Replace the existing faked sensitive values with "SENSITIVE_DATA_" or "sensitive-data-" in unit tests .
2. Save the log of "run-task" steps in the unit tests. 
3. Add a github action to detect the strings in the log and exit if the placeholder string is found there.
4.  A check is added to ensure users follow the new convention - at least one sensitive data  in  each "kubectl create secret" command.
5.  Documentation is added in the contributing guide.
6.  Comment out some lines that print sensitive data in mocks.yaml files.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
