### PR TITLE
Check before created-trusted-artifact step

### DIFF
--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -644,6 +644,44 @@ spec:
             # shellcheck disable=SC2029
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
         fi
+    - name: verify-signed-files-before-artifact
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 64Mi
+          cpu: 30m
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      env:
+        - name: SIGNED_KMODS_PATH
+          value: "$(params.dataDir)/$(params.signedKmodsPath)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Verifying signed files are present before creating trusted artifact..."
+
+        # Count signed .ko files in the workspace
+        signed_count=$(find "${SIGNED_KMODS_PATH}" -name "*.ko" -type f | wc -l)
+        echo "Found $signed_count signed .ko files in workspace"
+
+        if [ "$signed_count" -eq 0 ]; then
+            echo "ERROR: No signed .ko files found before creating trusted artifact"
+            echo "Contents of signed-kmods directory:"
+            ls -la "${SIGNED_KMODS_PATH}" || echo "Directory not found"
+            exit 1
+        fi
+
+        # Show a sample of files for verification
+        echo "Sample signed files:"
+        find "${SIGNED_KMODS_PATH}" -name "*.ko" -type f | head -5
+
+        # Force filesystem sync to ensure all writes are committed
+        sync
+        sleep 2
+
+        echo "Verification complete: $signed_count signed .ko files ready for trusted artifact"
     - name: create-trusted-artifact
       computeResources:
         limits:


### PR DESCRIPTION
Verify that there are signed .ko files before the create-trusted-artifact step


