### PR TITLE
fix(RELEASE-2175): add 'v' prefix to GitHub download URLs

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -681,7 +681,13 @@ spec:
             # Ignore manifest files
             [[ "$filename" == *_manifest.json ]] && continue
             checksum="${CHECKSUM_MAP[$filename]}"
-            download_url="https://github.com/$owner_repo/releases/download/$GITHUB_RELEASE_VERSION/$filename"
+            # GitHub release tags typically use 'v' prefix (e.g., v1.7.2), but the version
+            # extracted from filenames may not include it. Ensure the download URL uses the tag format.
+            github_tag="$GITHUB_RELEASE_VERSION"
+            if [[ ! "$github_tag" =~ ^v ]]; then
+                github_tag="v$GITHUB_RELEASE_VERSION"
+            fi
+            download_url="https://github.com/$owner_repo/releases/download/$github_tag/$filename"
             purl="pkg:generic/$name@$GITHUB_RELEASE_VERSION?checksum=$checksum&download_url=$download_url"
             jsonString=$(jq -cn \
                 --arg component "$name" \

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -203,9 +203,9 @@ spec:
         - name: taskGitRevision
           value: "main"
         - name: github_release_version
-          value: "v1.0.0"
+          value: "1.0.0"
         - name: github_release_url
-          value: "https://github.com/some-org/some-repo/releases/tag/v1.0.0"
+          value: "https://github.com/some-org/some-repo"
         - name: binaries_dir
           value: "$(context.pipelineRun.uid)/releases"
       runAfter:
@@ -263,5 +263,15 @@ spec:
                 "$DATA_FILE")" == "CVE-123CVE-456"
               test "$(jq '.releaseNotes.content.artifacts[0].cves.fixed."CVE-123".packages | length' \
                 "$DATA_FILE")" == 2
+
+              # Verify the PURL download_url has 'v' prefix in the tag (even though github_release_version was "1.0.0")
+              # The download URL should be: https://github.com/some-org/some-repo/releases/download/v1.0.0/<filename>
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              echo "PURL: $PURL"
+              # Check that download_url contains /download/v1.0.0/ (with the v prefix)
+              [[ "$PURL" == *"download/v1.0.0/"* ]] || { echo "ERROR: download_url missing 'v' prefix"; exit 1; }
+              # Check that the version in the PURL itself is still 1.0.0 (without v prefix)
+              [[ "$PURL" == "pkg:generic/releng-test-product-binaries@1.0.0?"* ]] \
+                || { echo "ERROR: PURL version should be 1.0.0"; exit 1; }
       runAfter:
         - run-task


### PR DESCRIPTION
This fix ensures the advisory  download URL uses the tag format (v1.7.2) while keeping the PURL version as the semantic version (1.7.2).

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
