### PR TITLE
fix: tar signed kmods from push-oot-kmods

### DIFF
--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -83,6 +83,35 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
+    - name: extract-signed-files
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        cd "$(params.dataDir)"
+
+        if [ -f signed-kmods.tar.gz ]; then
+          echo "Extracting signed-kmods.tar.gz for Azure upload"
+          tar -xzf signed-kmods.tar.gz
+
+          # Verify extraction
+          ko_count=$(find signed-kmods -name "*.ko" -type f | wc -l)
+          echo "Extracted $ko_count .ko files for Azure upload"
+
+          if [ "$ko_count" -eq 0 ]; then
+            echo "WARNING: No .ko files found after extraction"
+          fi
+        else
+          echo "No signed-kmods.tar.gz found, assuming files are already extracted"
+        fi
     - name: upload-to-azure
       image: mcr.microsoft.com/azure-cli@sha256:ed67c5ef4d0a87396fe39a8114db69b6c351c4af3b17119ac205bb6c0ee3a185
       computeResources:

--- a/tasks/managed/push-oot-kmods-to-azure/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/pre-apply-task-hook.sh
@@ -9,22 +9,32 @@ echo "Injecting test scripts into Task: $TASK_PATH"
 
 echo "Neutralizing StepAction at spec.steps[0]..."
 
+# Create the mock step script that includes test setup
+cat > /tmp/mock-setup-script.sh <<EOF
+#!/usr/bin/env sh
+echo "Mocked use-trusted-artifact step. Setting up test data..."
+mkdir -p /var/workdir/release
+cd /var/workdir/release
+
+$(cat "$SCRIPT_DIR/test-setup.sh")
+EOF
+
 cat > /tmp/mock-step.yaml <<EOF
 name: use-trusted-artifact-mock
 image: alpine:latest
-script: |
-  #!/usr/bin/env sh
-  echo "Mocked use-trusted-artifact step. Doing nothing."
+script: "placeholder"
 EOF
+
+yq -i '.script = load_str("/tmp/mock-setup-script.sh")' /tmp/mock-step.yaml
+rm /tmp/mock-setup-script.sh
 
 yq -i '.spec.steps[0] = load("/tmp/mock-step.yaml")' "$TASK_PATH"
 rm /tmp/mock-step.yaml
 
-echo "Injecting mock/setup/check scripts into spec.steps[1]..."
-SETUP_SCRIPT=$(cat "$SCRIPT_DIR/test-setup.sh")
+echo "Injecting mock/check scripts into spec.steps[2]..."
 MOCK_SCRIPT=$(cat "$SCRIPT_DIR/mocks.sh")
 
-ORIG_SCRIPT=$(yq '.spec.steps[1].script' "$TASK_PATH" | sed '1s|^#!/.*||')
+ORIG_SCRIPT=$(yq '.spec.steps[2].script' "$TASK_PATH" | sed '1s|^#!/.*||')
 
 CHECK_SCRIPT="
 echo 'Running final mock assertions...'
@@ -38,9 +48,6 @@ cat > /tmp/injected-script.sh <<EOF
 # --- Injected Mock Script (defines functions) ---
 $MOCK_SCRIPT
 
-# --- Injected Setup Script (creates files) ---
-$SETUP_SCRIPT
-
 # --- Original Task Script (shebang removed) ---
 $ORIG_SCRIPT
 
@@ -48,7 +55,7 @@ $ORIG_SCRIPT
 $CHECK_SCRIPT
 EOF
 
-yq -i '.spec.steps[1].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
 rm /tmp/injected-script.sh
 
 echo "Injection complete. Creating Azure mock secret..."

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-push-oot-kmods-to-azure-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-push-oot-kmods-to-azure-multiarch.yaml
@@ -41,6 +41,11 @@ spec:
               KERNEL_VERSION=6.5.0-test
               EOF
 
+              # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+              echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+              cd "$(params.dataDir)"
+              tar -czf signed-kmods.tar.gz signed-kmods
+
               echo "Test setup completed successfully"
 
               # Validate required files exist

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
@@ -24,5 +24,14 @@ $(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '
 $(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
 EOF
 
+# Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+cd "$(params.dataDir)"
+tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
+
 echo "Test data setup complete:"
 ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+echo "Tarball created:"
+ls -la "$(params.dataDir)/signed-kmods.tar.gz"
+echo "Tarball contents:"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -82,6 +82,35 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
+    - name: extract-signed-files
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        cd "$(params.dataDir)"
+
+        if [ -f signed-kmods.tar.gz ]; then
+          echo "Extracting signed-kmods.tar.gz for Git upload"
+          tar -xzf signed-kmods.tar.gz
+
+          # Verify extraction
+          ko_count=$(find signed-kmods -name "*.ko" -type f | wc -l)
+          echo "Extracted $ko_count .ko files for Git upload"
+
+          if [ "$ko_count" -eq 0 ]; then
+            echo "WARNING: No .ko files found after extraction"
+          fi
+        else
+          echo "No signed-kmods.tar.gz found, assuming files are already extracted"
+        fi
     - name: push-to-git
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:

--- a/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
@@ -13,7 +13,9 @@ echo "Neutralizing StepAction at spec.steps[0]..."
 SETUP_SCRIPT_CONTENT=$(cat "$SCRIPT_DIR/test-setup.sh")
 cat > /tmp/mock-setup-script.sh <<EOF
 #!/usr/bin/env sh
-echo "Mocked use-trusted-artifact step. Running setup script..."
+echo "Mocked use-trusted-artifact step. Setting up test data..."
+mkdir -p /var/workdir/release
+cd /var/workdir/release
 
 # --- Injected Setup Script ---
 (
@@ -37,9 +39,9 @@ yq -i '.spec.steps[0] = load("/tmp/mock-step.yaml")' "$TASK_PATH"
 rm /tmp/mock-step.yaml
 
 
-echo "Injecting mock/check scripts into spec.steps[1]..."
+echo "Injecting mock/check scripts into spec.steps[2]..."
 MOCK_SCRIPT=$(cat "$SCRIPT_DIR/mocks.sh")
-ORIG_SCRIPT=$(yq '.spec.steps[1].script' "$TASK_PATH" | sed '1s|^#!/.*||')
+ORIG_SCRIPT=$(yq '.spec.steps[2].script' "$TASK_PATH" | sed '1s|^#!/.*||')
 
 CHECK_SCRIPT="
 echo 'Running final mock assertions...'
@@ -60,7 +62,7 @@ $ORIG_SCRIPT
 $CHECK_SCRIPT
 EOF
 
-yq -i '.spec.steps[1].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
 rm /tmp/injected-script.sh
 
 echo "Injection complete. Creating secret..."

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-push-oot-kmods-to-git-multiarch.yaml
@@ -68,6 +68,11 @@ spec:
                   Checksums: verified
               EOF
 
+              # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+              echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+              cd "$(params.dataDir)"
+              tar -czf signed-kmods.tar.gz signed-kmods
+
               echo "Multiarch Git test setup completed successfully"
 
               # Validate multiarch structure

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
@@ -38,7 +38,16 @@ DRIVER_VERSION="1.2.3"
 KERNEL_VERSION="6.5.0.x86_64"
 EOF
 
+# Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+cd "$(params.dataDir)"
+tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
+
 echo "Test data setup complete:"
 ls -la "$KMODS_DIR"
 echo "Architecture directory structure:"
 find "$ARCH_DIR" -type f | sort
+echo "Tarball created:"
+ls -la "$(params.dataDir)/signed-kmods.tar.gz"
+echo "Tarball contents:"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -83,6 +83,35 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
+    - name: extract-signed-files
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        cd "$(params.dataDir)"
+
+        if [ -f signed-kmods.tar.gz ]; then
+          echo "Extracting signed-kmods.tar.gz for S3 upload"
+          tar -xzf signed-kmods.tar.gz
+
+          # Verify extraction
+          ko_count=$(find signed-kmods -name "*.ko" -type f | wc -l)
+          echo "Extracted $ko_count .ko files for S3 upload"
+
+          if [ "$ko_count" -eq 0 ]; then
+            echo "WARNING: No .ko files found after extraction"
+          fi
+        else
+          echo "No signed-kmods.tar.gz found, assuming files are already extracted"
+        fi
     - name: upload-to-s3
       image: amazon/aws-cli@sha256:3be2a248274c72a6f76fa0ac042aec84f4ade6ff7f38894df31732da4005294d
       computeResources:

--- a/tasks/managed/push-oot-kmods-to-s3/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/pre-apply-task-hook.sh
@@ -20,6 +20,16 @@ $SETUP_SCRIPT_CONTENT
 )
 EOF
 
+# Create the mock step script that includes test setup
+cat > /tmp/mock-setup-script.sh <<EOF
+#!/usr/bin/env sh
+echo "Mocked use-trusted-artifact step. Setting up test data..."
+mkdir -p /var/workdir/release
+cd /var/workdir/release
+
+$(cat "$SCRIPT_DIR/test-setup.sh")
+EOF
+
 cat > /tmp/mock-step.yaml <<EOF
 name: use-trusted-artifact-mock
 image: alpine:latest
@@ -32,9 +42,9 @@ rm /tmp/mock-setup-script.sh
 yq -i '.spec.steps[0] = load("/tmp/mock-step.yaml")' "$TASK_PATH"
 rm /tmp/mock-step.yaml
 
-echo "Injecting mock/check scripts into spec.steps[1]..."
+echo "Injecting mock/check scripts into spec.steps[2]..."
 MOCK_SCRIPT=$(cat "$SCRIPT_DIR/mocks.sh")
-ORIG_SCRIPT=$(yq '.spec.steps[1].script' "$TASK_PATH" | sed '1s|^#!/.*||')
+ORIG_SCRIPT=$(yq '.spec.steps[2].script' "$TASK_PATH" | sed '1s|^#!/.*||')
 
 CHECK_SCRIPT="
 echo 'Running final mock assertions...'
@@ -55,7 +65,7 @@ $ORIG_SCRIPT
 $CHECK_SCRIPT
 EOF
 
-yq -i '.spec.steps[1].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("/tmp/injected-script.sh")' "$TASK_PATH"
 rm /tmp/injected-script.sh
 
 echo "Injection complete. Creating S3 mock secret..."

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
@@ -48,6 +48,11 @@ spec:
               KERNEL_VERSION=6.5.0-test
               EOF
 
+              # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+              echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+              cd "$(params.dataDir)"
+              tar -czf signed-kmods.tar.gz signed-kmods
+
               echo "Multiarch test setup completed successfully"
 
               # Validate multiarch structure

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
@@ -24,5 +24,14 @@ $(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '
 $(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
 EOF
 
+# Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+echo "Creating signed-kmods.tar.gz to simulate signing task output..."
+cd "$(params.dataDir)"
+tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
+
 echo "Test data setup complete:"
 ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+echo "Tarball created:"
+ls -la "$(params.dataDir)/signed-kmods.tar.gz"
+echo "Tarball contents:"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -644,6 +644,52 @@ spec:
             # shellcheck disable=SC2029
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" "rm -rf ~/$task_uid"
         fi
+    - name: package-signed-files
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 128Mi
+          cpu: 250m
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      env:
+        - name: SIGNED_KMODS_PATH
+          value: "$(params.dataDir)/$(params.signedKmodsPath)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Packaging signed .ko files into tar.gz for trusted artifact transfer"
+        cd "$(params.dataDir)"
+
+        # Count files before packaging
+        signed_count=$(find "$(params.signedKmodsPath)" -name "*.ko" -type f | wc -l)
+        echo "Packaging $signed_count signed .ko files"
+
+        if [ "$signed_count" -eq 0 ]; then
+            echo "ERROR: No signed .ko files found to package"
+            exit 1
+        fi
+
+        # Create tar.gz with all signed files, preserving directory structure
+        tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
+
+        # Verify the tar.gz was created successfully
+        if [ -f signed-kmods.tar.gz ]; then
+            echo "Created signed-kmods.tar.gz ($(du -h signed-kmods.tar.gz | cut -f1))"
+            echo "Archive contains:"
+            tar -tzf signed-kmods.tar.gz | grep -c '\.ko$'
+            echo ".ko files"
+
+            # Clean up original files to avoid copying both tarred and untarred
+            echo "Cleaning up original files from $(params.signedKmodsPath)"
+            rm -rf "$(params.signedKmodsPath)"
+            echo "Original files cleaned up successfully"
+        else
+            echo "ERROR: Failed to create signed-kmods.tar.gz"
+            exit 1
+        fi
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/tests/test-sign-oot-kmods.yaml
@@ -114,6 +114,24 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
+              cd "$(params.dataDir)"
+
+              # Extract signed-kmods.tar.gz if it exists (new tarball format)
+              if [ -f signed-kmods.tar.gz ]; then
+                echo "Extracting signed-kmods.tar.gz for verification"
+                tar -xzf signed-kmods.tar.gz
+
+                # Verify extraction
+                ko_count=$(find "$(params.signedKmodsPath)" -name "*.ko" -type f | wc -l)
+                echo "Extracted $ko_count .ko files for verification"
+
+                if [ "$ko_count" -eq 0 ]; then
+                  echo "WARNING: No .ko files found after extraction"
+                fi
+              else
+                echo "No signed-kmods.tar.gz found, assuming files are already extracted"
+              fi
+
               # Check for mocked signing operations in different locations depending on trusted artifacts mode
               echo "INFO: ociStorage provided, checking dataDir for mock files"
               SCP_FILE="$(params.dataDir)/mock_scp.txt"


### PR DESCRIPTION
Packaging signed .ko files in tar.gz so directory
hierarchy is preserved and also simplifies copy
between steps.

