### PR TITLE
feat(RELEASE-2035): add missing cpu limits to remaining tasks

### DIFF
--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -121,6 +121,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -76,6 +76,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 10m
         requests:
           memory: 64Mi
           cpu: 10m
@@ -98,6 +99,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 10m
         requests:
           memory: 64Mi
           cpu: 10m
@@ -112,6 +114,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -134,6 +137,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -124,6 +124,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -146,6 +147,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -588,6 +590,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -135,6 +135,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 10m
         requests:
           memory: 128Mi
           cpu: 10m

--- a/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+++ b/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
@@ -92,6 +92,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 10m
         requests:
           memory: 64Mi
           cpu: 10m
@@ -116,6 +117,7 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m


### PR DESCRIPTION
Follow-up to #1734, #1961, #1962 - these tasks were missed because they weren't modified in the original PRs.

The CI check now enforces limits.cpu == requests.cpu, so any PR touching these tasks would fail. This fixes the remaining 5 tasks with 11 steps that were missing limits.cpu.

Tasks fixed:
- extract-oot-kmods
- extract-py-artifacts
- filter-already-released-advisory-rpms
- reduce-snapshot
- upload-py-pulp

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
