### PR TITLE
fix: prevent SIGPIPE race condition in kmod file detection

### DIFF
--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -204,7 +204,7 @@ spec:
             echo "Azure target path: ${ACCOUNT}/${CONTAINER}/${AZURE_TARGET_PATH}"
 
             # Upload .ko files (with recursive directory structure support)
-            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+            if [ -n "$(find "$source_dir" -name "*.ko" -type f -print -quit)" ]; then
                 ko_file_count=$(find "$source_dir" -name "*.ko" -type f | wc -l)
                 echo "Uploading $ko_file_count .ko files for $arch_name (preserving directory structure)"
 

--- a/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-azure/tests/test-setup.sh
@@ -3,26 +3,48 @@ set -x
 echo "Setting up test data for push-oot-kmods task..."
 
 echo "Creating dummy signed kmods and envfile in dataDir with arch-specific structure..."
-# Create architecture-specific directory structure
-mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
-echo "AZURE_SIGNED_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
-echo "AZURE_SIGNED_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
+# Create architecture-specific directory structure with large-scale nested subdirectories
+# This tests the SIGPIPE bug fix which only occurs with 100+ directories
+ARCH_DIR="$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+mkdir -p "$ARCH_DIR"
 
+echo "Creating large-scale directory structure (110 dirs) to test SIGPIPE fix..."
+# Create top-level modules
+echo "AZURE_SIGNED_MODULE1" > "$ARCH_DIR/mod1.ko"
+echo "AZURE_SIGNED_MODULE2" > "$ARCH_DIR/mod2.ko"
+
+# Create 110 driver directories with nested structure (similar to Jetson case)
+for i in $(seq 1 110); do
+  driver_dir="$ARCH_DIR/driver_$(printf "%03d" $i)"
+  mkdir -p "$driver_dir/subdir_a/subdir_b"
+  echo "AZURE_DRIVER_${i}_MODULE" > "$driver_dir/mod_${i}.ko"
+
+  # Some drivers have nested modules
+  if [ $((i % 10)) -eq 0 ]; then
+    echo "AZURE_DRIVER_${i}_NESTED" > "$driver_dir/subdir_a/subdir_b/nested_mod_${i}.ko"
+  fi
+done
+
+echo "Created $(find "$ARCH_DIR" -name "*.ko" | wc -l) .ko files in $(find "$ARCH_DIR" -type d | wc -l) directories"
+
+echo "Creating envfile in architecture directory..."
 # IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
 # This tests that the task properly strips the suffix when constructing upload paths
 # Expected: task strips .x86_64 to produce path mocked-vendor-azure/1.2.3-az/6.5.0-az/x86_64/
 # NOT: mocked-vendor-azure/1.2.3-az/6.5.0-az.x86_64/x86_64/
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
+cat > "$ARCH_DIR/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-azure"
 DRIVER_VERSION="1.2.3-az"
 KERNEL_VERSION="6.5.0-az.x86_64"
 EOF
 
-# Create architecture-specific checksum file
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/signed_kmods_checksums_x86_64.txt" << EOF
-$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '{print $1}')  mod1.ko
-$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
-EOF
+# Create architecture-specific checksum file for all .ko files
+echo "Creating valid checksum file for all .ko files..."
+(
+  cd "$ARCH_DIR" || exit
+  find . -name "*.ko" -type f -exec sha256sum {} \; | sed 's|^\([^ ]*\)  \./|\1  |' | sort -k2 > signed_kmods_checksums_x86_64.txt
+  echo "Generated checksums for $(wc -l < signed_kmods_checksums_x86_64.txt) files"
+)
 
 # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
 echo "Creating signed-kmods.tar.gz to simulate signing task output..."
@@ -30,8 +52,12 @@ cd "$(params.dataDir)"
 tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
 
 echo "Test data setup complete:"
-ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+ls -la "$(params.dataDir)/$(params.signedKmodsPath)"
+echo "Architecture directory structure (showing first 10 files):"
+find "$ARCH_DIR" -type f | sort | head -10
+echo "... and $(find "$ARCH_DIR" -type f | wc -l) total files"
 echo "Tarball created:"
 ls -la "$(params.dataDir)/signed-kmods.tar.gz"
-echo "Tarball contents:"
-tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5
+echo "Tarball contents (showing first 10 entries):"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -10
+echo "... (tarball contains $(tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | wc -l) total entries)"

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -204,7 +204,7 @@ spec:
             mkdir -p "$TARGET_DIR"
 
             # Copy .ko files (preserving directory structure)
-            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+            if [ -n "$(find "$source_dir" -name "*.ko" -type f -print -quit)" ]; then
                 echo "Copying .ko files with preserved directory structure for $arch_name..."
 
                 # Copy entire directory structure containing .ko files

--- a/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/test-setup.sh
@@ -9,22 +9,35 @@ KMODS_DIR="$(params.dataDir)/$(params.signedKmodsPath)"
 echo "1" > "$(params.dataDir)/arch_count.txt"
 
 echo "Creating dummy signed kmods in dataDir with recursive architecture subdirectory structure..."
+# Create architecture-specific directory structure with large-scale nested subdirectories
+# This tests the SIGPIPE bug fix which only occurs with 100+ directories
 ARCH_DIR="$KMODS_DIR/x86_64"
 mkdir -p "$ARCH_DIR"
-mkdir -p "$ARCH_DIR/driversA"
-mkdir -p "$ARCH_DIR/driversB"
 
-# Create .ko files in top-level and subdirectories to test recursive push
+echo "Creating large-scale directory structure (110 dirs) to test SIGPIPE fix..."
+# Create top-level modules
 echo "SIGNED_MODULE1_CONTENT" > "$ARCH_DIR/mod1.ko"
 echo "SIGNED_MODULE2_CONTENT" > "$ARCH_DIR/mod2.ko"
-echo "SIGNED_DRIVER_A_MODULE1" > "$ARCH_DIR/driversA/driverA-mod1.ko"
-echo "SIGNED_DRIVER_A_MODULE2" > "$ARCH_DIR/driversA/driverA-mod2.ko"
-echo "SIGNED_DRIVER_B_MODULE1" > "$ARCH_DIR/driversB/driverB-mod1.ko"
 
-echo "Creating valid checksum file..."
+# Create 110 driver directories with nested structure (similar to Jetson case)
+for i in $(seq 1 110); do
+  driver_dir="$ARCH_DIR/driver_$(printf "%03d" $i)"
+  mkdir -p "$driver_dir/subdir_a/subdir_b"
+  echo "SIGNED_DRIVER_${i}_MODULE" > "$driver_dir/mod_${i}.ko"
+
+  # Some drivers have nested modules
+  if [ $((i % 10)) -eq 0 ]; then
+    echo "SIGNED_DRIVER_${i}_NESTED" > "$driver_dir/subdir_a/subdir_b/nested_mod_${i}.ko"
+  fi
+done
+
+echo "Created $(find "$ARCH_DIR" -name "*.ko" | wc -l) .ko files in $(find "$ARCH_DIR" -type d | wc -l) directories"
+
+echo "Creating valid checksum file for all .ko files..."
 (
   cd "$ARCH_DIR" || exit
-  sha256sum mod1.ko mod2.ko driversA/driverA-mod1.ko driversA/driverA-mod2.ko driversB/driverB-mod1.ko > signed_kmods_checksums_x86_64.txt
+  find . -name "*.ko" -type f -exec sha256sum {} \; | sed 's|^\([^ ]*\)  \./|\1  |' | sort -k2 > signed_kmods_checksums_x86_64.txt
+  echo "Generated checksums for $(wc -l < signed_kmods_checksums_x86_64.txt) files"
 )
 
 echo "Creating envfile in architecture directory..."
@@ -45,9 +58,11 @@ tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
 
 echo "Test data setup complete:"
 ls -la "$KMODS_DIR"
-echo "Architecture directory structure:"
-find "$ARCH_DIR" -type f | sort
+echo "Architecture directory structure (showing first 10 files):"
+find "$ARCH_DIR" -type f | sort | head -10
+echo "... and $(find "$ARCH_DIR" -type f | wc -l) total files"
 echo "Tarball created:"
 ls -la "$(params.dataDir)/signed-kmods.tar.gz"
-echo "Tarball contents:"
-tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5
+echo "Tarball contents (showing first 10 entries):"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -10
+echo "... (tarball contains $(tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | wc -l) total entries)"

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -187,7 +187,7 @@ spec:
             echo "S3 target path: s3://$(params.s3Bucket)/${S3_TARGET_PATH}"
 
             # Upload .ko files (with recursive directory structure support)
-            if find "$source_dir" -name "*.ko" -type f | head -1 | grep -q "."; then
+            if [ -n "$(find "$source_dir" -name "*.ko" -type f -print -quit)" ]; then
                 ko_file_count=$(find "$source_dir" -name "*.ko" -type f | wc -l)
                 echo "Uploading $ko_file_count .ko files for $arch_name (preserving directory structure)"
 

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
@@ -3,26 +3,48 @@ set -x
 echo "Setting up test data for push-oot-kmods-s3 task..."
 
 echo "Creating dummy signed kmods and envfile in dataDir with arch-specific structure..."
-# Create architecture-specific directory structure
-mkdir -p "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
-echo "S3_MODULE1" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko"
-echo "S3_MODULE2" > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko"
+# Create architecture-specific directory structure with large-scale nested subdirectories
+# This tests the SIGPIPE bug fix which only occurs with 100+ directories
+ARCH_DIR="$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+mkdir -p "$ARCH_DIR"
 
+echo "Creating large-scale directory structure (110 dirs) to test SIGPIPE fix..."
+# Create top-level modules
+echo "S3_MODULE1" > "$ARCH_DIR/mod1.ko"
+echo "S3_MODULE2" > "$ARCH_DIR/mod2.ko"
+
+# Create 110 driver directories with nested structure (similar to Jetson case)
+for i in $(seq 1 110); do
+  driver_dir="$ARCH_DIR/driver_$(printf "%03d" $i)"
+  mkdir -p "$driver_dir/subdir_a/subdir_b"
+  echo "S3_DRIVER_${i}_MODULE" > "$driver_dir/mod_${i}.ko"
+
+  # Some drivers have nested modules
+  if [ $((i % 10)) -eq 0 ]; then
+    echo "S3_DRIVER_${i}_NESTED" > "$driver_dir/subdir_a/subdir_b/nested_mod_${i}.ko"
+  fi
+done
+
+echo "Created $(find "$ARCH_DIR" -name "*.ko" | wc -l) .ko files in $(find "$ARCH_DIR" -type d | wc -l) directories"
+
+echo "Creating envfile in architecture directory..."
 # IMPORTANT: KERNEL_VERSION includes .x86_64 architecture suffix
 # This tests that the task properly strips the suffix when constructing upload paths
 # Expected: task strips .x86_64 to produce path mocked-vendor-s3/1.2.3-s3/6.5.0-s3/x86_64/
 # NOT: mocked-vendor-s3/1.2.3-s3/6.5.0-s3.x86_64/x86_64/
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/envfile" << EOF
+cat > "$ARCH_DIR/envfile" << EOF
 DRIVER_VENDOR="mocked-vendor-s3"
 DRIVER_VERSION="1.2.3-s3"
 KERNEL_VERSION="6.5.0-s3.x86_64"
 EOF
 
-# Create architecture-specific checksum file
-cat > "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/signed_kmods_checksums_x86_64.txt" << EOF
-$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod1.ko" | awk '{print $1}')  mod1.ko
-$(sha256sum "$(params.dataDir)/$(params.signedKmodsPath)/x86_64/mod2.ko" | awk '{print $1}')  mod2.ko
-EOF
+# Create architecture-specific checksum file for all .ko files
+echo "Creating valid checksum file for all .ko files..."
+(
+  cd "$ARCH_DIR" || exit
+  find . -name "*.ko" -type f -exec sha256sum {} \; | sed 's|^\([^ ]*\)  \./|\1  |' | sort -k2 > signed_kmods_checksums_x86_64.txt
+  echo "Generated checksums for $(wc -l < signed_kmods_checksums_x86_64.txt) files"
+)
 
 # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
 echo "Creating signed-kmods.tar.gz to simulate signing task output..."
@@ -30,8 +52,12 @@ cd "$(params.dataDir)"
 tar -czf signed-kmods.tar.gz "$(params.signedKmodsPath)"
 
 echo "Test data setup complete:"
-ls -la "$(params.dataDir)/$(params.signedKmodsPath)/x86_64"
+ls -la "$(params.dataDir)/$(params.signedKmodsPath)"
+echo "Architecture directory structure (showing first 10 files):"
+find "$ARCH_DIR" -type f | sort | head -10
+echo "... and $(find "$ARCH_DIR" -type f | wc -l) total files"
 echo "Tarball created:"
 ls -la "$(params.dataDir)/signed-kmods.tar.gz"
-echo "Tarball contents:"
-tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -5
+echo "Tarball contents (showing first 10 entries):"
+tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | head -10
+echo "... (tarball contains $(tar -tzf "$(params.dataDir)/signed-kmods.tar.gz" | wc -l) total entries)"


### PR DESCRIPTION
Replace the SIGPIPE-prone pattern `find | head -1 | grep -q "."` with a safe, atomic operation `find -print -quit` in all three push tasks (git, s3, azure). The original pattern fails on large directory structures when pipefail is enabled, as find is still traversing when head closes the pipe, causing SIGPIPE (exit 141). The new pattern exits immediately after finding the first file, avoiding the race condition.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
