### PR TITLE
workaround for chunking

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -354,7 +354,7 @@ spec:
           # Build a printable command string for logging (no secrets included)
           local printable_cmd
           printable_cmd="pulp --config \"${PULP_CONFIG_FILE}\" --domain \"${PULP_DOMAIN}\" rpm content upload"
-          printable_cmd+=" --chunk-size 20MB --file \"${file_path}\" --relative-path \"${relpath}\""
+          printable_cmd+=" --chunk-size 2000MB --file \"${file_path}\" --relative-path \"${relpath}\""
 
           for ((i=1; i<=attempts; i++)); do
             # For retries (i > 1) make it explicit which command is being retried
@@ -364,7 +364,7 @@ spec:
             fi
             set +e
             response=$(pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
-              --chunk-size 20MB --file "${file_path}" --relative-path "${relpath}")
+              --chunk-size 2000MB --file "${file_path}" --relative-path "${relpath}")
             rc=$?
             set -e
 


### PR DESCRIPTION
## Describe your changes

We want to disable the default chunking in the pulp-cli. But while that work is happening, this should provide a workaround

With big RPMs, having too many chunks makes the process of "putting back" the file too slow, which leads to Gateway Timeouts to the backend service. 
And in general, chunks are slowing down the uploads in our case. Having one big uninterrupted upload provides for better upload speeds. 

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
