### PR TITLE
fix(RELEASE-2203): check return code in marketplacesvm push

### DIFF
--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -243,6 +243,7 @@ spec:
 
         # Process each component in parallel with memory-aware job management
         STABILIZATION_DELAY=2
+        success=true
         jobs_spawned=0
         jobs_collected=0
         for (( i = 0; i < NUM_COMPONENTS; i++ )); do
@@ -250,7 +251,7 @@ spec:
             # Wait for memory and concurrent limit before spawning
             wait_for_memory 80
             while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
-                wait -n
+                wait -n || success=false
                 jobs_collected=$((jobs_collected + 1))
             done
 
@@ -265,9 +266,15 @@ spec:
         # Wait for all remaining jobs - use counter to collect all exit codes
         # in case processes finished during a stabilization sleep
         while (( jobs_collected < jobs_spawned )); do
-            wait -n
+            wait -n || success=false
             jobs_collected=$((jobs_collected + 1))
         done
+
+        # This is redundant since we have set -e, but makes things a bit more clear
+        if [ $success != "true" ]; then
+          echo "ERROR: prepare_component failed for at least one component"
+          exit 1
+        fi
 
         # Change to the base directory
         cd "${BASE_DIR}"

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/mocks.sh
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/mocks.sh
@@ -5,6 +5,11 @@ set -eux
 function select-oci-auth() {
     echo Mock select-oci-auth called with: $*
     echo $* > "$(params.dataDir)/mock_select-oci-auth.txt"
+
+    if [[ "$*" == *"fail-raw-disk-image@sha256:123456" ]]; then
+        echo Simulating failed select-oci-auth
+        exit 1
+    fi
 }
 
 function oras() {

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-process-component.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-process-component.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-marketplacesvm-push-disk-images-fail-process-component
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the marketplacesvm-push-disk-images task with invalid data so that it fails in the
+    process_component function. The failure is caused by the containerImage ending in
+    fail-raw-disk-image, which is handled in the mocks. Ensure the task fails.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/results"
+              cat > "$(params.dataDir)/snapshot_spec.json" << EOF
+              {
+                "application": "amd-bootc-1-3-raw-disk-image",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/workload/tenant/test-product/fail-raw-disk-image@sha256:123456",
+                    "name": "amd-bootc-1-3-raw-disk-image",
+                    "source": {
+                      "git": {
+                        "revision": "1abbfcdbc1c5e8b7aba07673297237ed192b50e2",
+                        "url": "https://gitlab.com/konflux/test-product/disk-images/amd-bootc"
+                      }
+                    },
+                    "staged": {
+                      "destination": "test-product-1_DOT_3-x86_64-isos",
+                      "files": [
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-x86_64.raw",
+                          "source": "disk.raw"
+                        }
+                      ],
+                      "version": "1.3"
+                    },
+                    "productInfo": {
+                      "filePrefix": "test-product-amd-1.3",
+                      "productCode": "TESTPRDOCUT",
+                      "productName": "Test Product",
+                      "productVersionName": "1.3"
+                    },
+                    "starmap": [
+                      {
+                        "cloud": "aws",
+                        "mappings": {
+                          "aws-emea": {
+                            "destinations": [
+                              {
+                                "architecture": "x86_64",
+                                "destination": "00000000-0000-0000-0000-000000000000",
+                                "overwrite": false,
+                                "restrict_version": true
+                              }
+                            ],
+                            "provider": null
+                          },
+                          "aws-na": {
+                            "destinations": [
+                              {
+                                "architecture": "x86_64",
+                                "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                                "overwrite": false,
+                                "restrict_version": true
+                              }
+                            ],
+                            "provider": null
+                          }
+                        },
+                        "name": "test-product",
+                        "workflow": "stratosphere"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/starmap.json" << EOF
+              [
+                {
+                  "cloud": "aws",
+                  "mappings": {
+                    "aws-emea": {
+                      "destinations": [
+                        {
+                          "architecture": "x86_64",
+                          "destination": "00000000-0000-0000-0000-000000000000",
+                          "overwrite": false,
+                          "restrict_version": true
+                        }
+                      ],
+                      "provider": null
+                    },
+                    "aws-na": {
+                      "destinations": [
+                        {
+                          "architecture": "x86_64",
+                          "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                          "overwrite": false,
+                          "restrict_version": true
+                        }
+                      ],
+                      "provider": null
+                    }
+                  },
+                  "name": "test-product",
+                  "workflow": "stratosphere"
+                }
+              ]
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: marketplacesvm-push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: cloudMarketplacesSecret
+          value: marketplacesvm-test-secret
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup


### PR DESCRIPTION
This commit updates the marketplacesvm-push-disk-images task to check the return code of the background processes that run in parallel. Previously, if one failed, the task would continue anyways, but this fixes that.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
