### PR TITLE
chore: use single comment for qodo reviews

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -13,8 +13,8 @@ handle_push_trigger = false
 [pr_reviewer]
 # Limit review feedback to 3 findings per PR.
 num_max_findings = 3
-# Prefer inline comments rather than a single persistent summary comment.
-persistent_comment = false
+# Reuse a single summary comment rather than adding a new one on each update
+persistent_comment = true
 # Reinforce "3 inline comments" behavior.
 extra_instructions = """
 - Provide up to 3 inline review comments per PR.


### PR DESCRIPTION
## Describe your changes

We want a single reusable comment rather then a new summary comment each time qodo runs.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
