### PR TITLE
fix(HUM-521): increase mem for push-rpms-to-pulp

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -116,7 +116,7 @@ spec:
       - name: IMAGES_TXT
         value: $(params.dataDir)/images.txt
       - name: FILES_DIR
-        value: $(params.dataDir)/files
+        value: /var/workdir/rpm-extract
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.ociArtifactExpiresAfter)
       - name: ORAS_OPTIONS
@@ -159,11 +159,11 @@ spec:
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
         limits:
-          memory: 256Mi
-          cpu: 250m
+          memory: 3Gi
+          cpu: 1
         requests:
-          memory: 256Mi
-          cpu: 250m
+          memory: 3Gi
+          cpu: 1
       volumeMounts:
         - name: pulp-secret-name-vol
           mountPath: "/etc/secrets"


### PR DESCRIPTION
## Describe your changes
- since we increased chuck-size for pulp cli, when we encounter a large rpm it is possible to hit the memory limit.
- we are increasing the memory and cpu limits to account for this.
- in addition, we also ensure that extracted rpms do not wind up in the trusted artifact that is used downstream since the image can grow to be very large.

## Relevant Jira
- HUM-521

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
