### PR TITLE
feat(RELEASE-2052): support uncompressed .tar archives as input

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -527,9 +527,9 @@ spec:
             # Create target directory
             mkdir -p "$TARGET_DIR"
 
-            # Unpack archive to target directory (only .tar.gz supported)
+            # Unpack archive to target directory (.tar.gz and .tar supported)
             # Preserve nested directory structure from original archive
-            tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
+            tar -xf "$ARCHIVE_PATH" -C "$TARGET_DIR"
 
             # Remove the archive after successful extraction
             rm -f "$ARCHIVE_PATH"
@@ -567,9 +567,9 @@ spec:
 
             mkdir -p "$TARGET_DIR"
 
-            # Unpack archive to target directory (only .tar.gz supported)
+            # Unpack archive to target directory (.tar.gz and .tar supported)
             # Preserve nested directory structure from original archive
-            tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
+            tar -xf "$ARCHIVE_PATH" -C "$TARGET_DIR"
 
             rm -f "$ARCHIVE_PATH"
           done
@@ -1265,9 +1265,10 @@ spec:
                     echo "  Created (${ARRAY_NAME}): ${SOURCE_FILENAME}"
                     ;;
                   (windows)
-                    # Replace .tar.gz extension with .zip for Windows archives
+                    # Replace .tar.gz or .tar extension with .zip for Windows archives
                     local WINDOWS_FILENAME="${SOURCE_FILENAME}"
-                    WINDOWS_FILENAME="${WINDOWS_FILENAME%.tar.gz}.zip"
+                    WINDOWS_FILENAME="${WINDOWS_FILENAME%.tar.gz}"  # Remove .tar.gz if present
+                    WINDOWS_FILENAME="${WINDOWS_FILENAME%.tar}.zip" # Remove .tar if present, add .zip
                     # Create zip preserving nested directory structure from os/arch/
                     (cd "${ARCH_DIR}" && zip -r "${READY_FOR_DIST_DIR}/${WINDOWS_FILENAME}" .)
                     echo "  Created (${ARRAY_NAME}): ${WINDOWS_FILENAME}"
@@ -1300,7 +1301,9 @@ spec:
               SOURCE_FILENAME=$(basename "$SOURCE")
               OS=$(jq -r '.os // empty' <<< "$FILE")
               if [ "$OS" = "windows" ]; then
-                WINDOWS_SOURCE="${SOURCE%.tar.gz}.zip"
+                # Handle both .tar.gz and .tar extensions
+                WINDOWS_SOURCE="${SOURCE%.tar.gz}"
+                WINDOWS_SOURCE="${WINDOWS_SOURCE%.tar}.zip"
                 UPDATED_FILES=$(jq --arg src "$WINDOWS_SOURCE" --argjson file "$FILE" \
                   '. + [($file | .source = $src)]' <<< "$UPDATED_FILES")
               else
@@ -1551,14 +1554,22 @@ spec:
             if [[ -n "$source_path" ]]; then
               # Get the source filename from path (basename) - this is what the file is named locally
               source_filename=$(basename "$source_path")
-              # Handle windows files that may have been converted from .tar.gz to .zip
-              if [[ "$source_filename" == *"windows"* && "$source_filename" == *.tar.gz ]]; then
-                zip_filename="${source_filename%.tar.gz}.zip"
-                if [[ -f "$component_dir/$zip_filename" ]]; then
+              # Handle windows files that may have been converted from .tar.gz or .tar to .zip
+              if [[ "$source_filename" == *"windows"* ]]; then
+                if [[ "$source_filename" == *.tar.gz ]]; then
+                  zip_filename="${source_filename%.tar.gz}.zip"
+                elif [[ "$source_filename" == *.tar ]]; then
+                  zip_filename="${source_filename%.tar}.zip"
+                else
+                  zip_filename=""
+                fi
+                if [[ -n "$zip_filename" && -f "$component_dir/$zip_filename" ]]; then
                   source_filename="$zip_filename"
-                  # Also update dest_filename if it was .tar.gz
+                  # Also update dest_filename if it was .tar.gz or .tar
                   if [[ "$dest_filename" == *.tar.gz ]]; then
                     dest_filename="${dest_filename%.tar.gz}.zip"
+                  elif [[ "$dest_filename" == *.tar ]]; then
+                    dest_filename="${dest_filename%.tar}.zip"
                   fi
                 fi
               fi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -60,8 +60,8 @@ EOF
         mkdir -p temp_releases/releases
         
         # Create mock binary files based on the container image being pulled
-        # All files are .tar.gz since that's the expected source format
-        # Create actual tar.gz files with mock binary content inside
+        # Files can be .tar.gz (compressed) or .tar (uncompressed archive)
+        # Create actual tar files with mock binary content inside
         
         create_mock_tgz() {
             local filename="$1"
@@ -77,8 +77,28 @@ EOF
             tar -czf "temp_releases/releases/$filename" -C "$temp_bin_dir" "$binary_name"
             rm -rf "$temp_bin_dir"
         }
+
+        create_mock_tar() {
+            local filename="$1"
+            local binary_name="${filename%.tar}"
+            
+            # Create a temporary directory for this binary
+            local temp_bin_dir=$(mktemp -d)
+            # Create mock binary file
+            echo "Mock binary content for $binary_name" > "$temp_bin_dir/$binary_name"
+            chmod +x "$temp_bin_dir/$binary_name"
+            
+            # Create uncompressed tar file with the mock binary
+            tar -cf "temp_releases/releases/$filename" -C "$temp_bin_dir" "$binary_name"
+            rm -rf "$temp_bin_dir"
+        }
         
-        if [[ "$*" =~ ghijkl67890 ]]; then
+        if [[ "$*" =~ tarinput12345 ]]; then
+            # Test component with uncompressed .tar input files
+            create_mock_tar "tartest-binary-windows-amd64.tar"
+            create_mock_tar "tartest-binary-darwin-amd64.tar"
+            create_mock_tar "tartest-binary-linux-amd64.tar"
+        elif [[ "$*" =~ ghijkl67890 ]]; then
             # Second test component
             create_mock_tgz "testproduct2-binary-windows-amd64.tar.gz"
             create_mock_tgz "testproduct2-binary-darwin-amd64.tar.gz"
@@ -139,6 +159,13 @@ function oras() {
             touch testproduct3-binary-linux-amd64.tar.gz
         fi
 
+        if [[ "$4" =~ "tarinput12345" ]]; then
+            # For tar input test, create .zip for windows (output), and tar.gz for others (output)
+            touch tartest-binary-windows-amd64.zip
+            touch tartest-binary-darwin-amd64.tar.gz
+            touch tartest-binary-linux-amd64.tar.gz
+        fi
+
         touch testproduct-binary-windows-amd64.zip
         touch testproduct-binary-darwin-amd64.tar.gz
         touch testproduct-binary-linux-amd64.tar.gz
@@ -166,6 +193,11 @@ function oras() {
                 mkdir -p "$output_dir/macos/amd64" "$output_dir/windows/amd64"
                 touch "$output_dir/macos/amd64/testproduct3-binary-darwin-amd64"
                 touch "$output_dir/windows/amd64/testproduct3-binary-windows-amd64.exe"
+            elif [[ "$*" =~ tartest/signed ]]; then
+                # For tar input test component
+                mkdir -p "$output_dir/macos/amd64" "$output_dir/windows/amd64"
+                touch "$output_dir/macos/amd64/tartest-binary-darwin-amd64"
+                touch "$output_dir/windows/amd64/tartest-binary-windows-amd64.exe"
             else
                 mkdir -p "$output_dir/macos/amd64" "$output_dir/windows/amd64"
                 touch "$output_dir/macos/amd64/testproduct-binary-darwin-amd64"
@@ -184,6 +216,11 @@ function oras() {
             mkdir -p windows/amd64 macos/amd64
             touch windows/amd64/testproduct3-binary-windows-amd64.exe
             touch macos/amd64/testproduct3-binary-darwin-amd64
+        elif [[ "$*" =~ tartest/signed ]] || [[ "$*" =~ tartest/unsigned ]]; then
+            # For tar input test component
+            mkdir -p windows/amd64 macos/amd64
+            touch windows/amd64/tartest-binary-windows-amd64.exe
+            touch macos/amd64/tartest-binary-darwin-amd64
         else
             mkdir -p windows/amd64 macos/amd64
             touch windows/amd64/testproduct-binary-windows-amd64.exe

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-tar-input.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-tar-input.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-tar-input
+spec:
+  description: |
+    Run the push-artifacts task with uncompressed .tar archive input files
+    to verify that both .tar and .tar.gz formats are supported as input
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {
+              "application": "tar-input-test-app",
+              "artifacts": {},
+              "components": [
+                {
+                  "containerImage": "quay.io/org/tenant/tar-test-image/tar-test@sha256:tarinput12345",
+                  "contentGateway": {
+                    "productCode": "Code",
+                    "productName": "MyName",
+                    "productVersionName": "1.3-staging"
+                  },
+                  "name": "tartest",
+                  "staged": {
+                    "destination": "tartest-amd64",
+                    "version": "1.3"
+                  },
+                  "files": [
+                    {
+                      "filename": "tartest-binary-windows-amd64.tar",
+                      "source": "/releases/tartest-binary-windows-amd64.tar",
+                      "os": "windows",
+                      "arch": "amd64",
+                      "delivery_format": ["compressed", "raw"]
+                    },
+                    {
+                      "filename": "tartest-binary-darwin-amd64.tar",
+                      "source": "/releases/tartest-binary-darwin-amd64.tar",
+                      "os": "darwin",
+                      "arch": "amd64",
+                      "delivery_format": ["compressed", "raw"]
+                    },
+                    {
+                      "filename": "tartest-binary-linux-amd64.tar",
+                      "source": "/releases/tartest-binary-linux-amd64.tar",
+                      "os": "linux",
+                      "arch": "amd64",
+                      "delivery_format": ["compressed", "raw"]
+                    }
+                  ]
+                }
+              ]
+            }
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+        - name: author
+          value: testuser
+        - name: signingKeyName
+          value: testkey
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo Error: result task result expected to be Success but was not
+                exit 1
+              fi


### PR DESCRIPTION
Allow teams to provide uncompressed .tar archives in addition to .tar.gz compressed archives. This change maintains full backward compatibility with existing .tar.gz inputs.

Changes:
- Use `tar -xf` instead of `tar -xzf` for auto-detection of compression format during extraction (supports both .tar.gz and .tar)
- Update Windows filename conversion logic to correctly handle both .tar.gz and .tar inputs when converting to .zip output
- Add test case for .tar input scenarios
- Add mock functions for creating uncompressed .tar test archives

The extraction step now auto-detects the archive format, so:
- .tar.gz files continue to work as before
- .tar files are now also supported
- Windows artifacts are always converted to .zip regardless of input format

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
