### PR TITLE
fix: resolve tar permission errors in trusted artifact extraction on …

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -210,6 +210,12 @@ spec:
           value: $(params.taskGitUrl)
         - name: taskGitRevision
           value: $(params.taskGitRevision)
+        # Use a subdirectory to avoid tar permission errors on the emptyDir mount point.
+        # On OpenShift, emptyDir volumes get the setgid bit from the namespace fsGroup.
+        # The trusted artifacts binary uses tar which fails to restore the setgid bit
+        # when running as non-root.
+        - name: dataDir
+          value: /var/workdir/content
       runAfter:
         - verify-enterprise-contract
 
@@ -269,6 +275,8 @@ spec:
           value: $(params.pulpRepository)
         - name: sourceDataArtifact
           value: "$(tasks.rh-sign-python-wheels.results.sourceDataArtifact)"
+        - name: dataDir
+          value: /var/workdir/content
         - name: taskGitUrl
           value: $(params.taskGitUrl)
         - name: taskGitRevision

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -70,8 +70,20 @@ spec:
     volumeMounts:
       - name: workdir
         mountPath: /var/workdir
-    workingDir: /var/workdir
   steps:
+    - name: prepare-workdir
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 32Mi
+          cpu: 10m
+        requests:
+          memory: 32Mi
+          cpu: 10m
+      command:
+        - mkdir
+        - -p
+        - $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
 # Add mocks to the task step scripts
-# Note: steps 0 and 3 use StepAction refs, so we only inject into steps 1 and 2
+# Steps layout:
+#   [0] prepare-workdir (command - no mock needed)
+#   [1] use-trusted-artifact (StepAction ref - no mock needed)
+#   [2] get-image-urls (script - inject mocks)
+#   [3] extract-artifacts (script - inject mocks)
+#   [4] create-trusted-artifact (StepAction ref - no mock needed)
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Inject mocks into the get-image-urls step (step index 1)
-yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
-
-# Inject mocks into the extract-artifacts step (step index 2)
+# Inject mocks into the get-image-urls step (step index 2)
 yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+
+# Inject mocks into the extract-artifacts step (step index 3)
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"

--- a/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
@@ -25,6 +25,7 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
+      default: /var/workdir/content
   tasks:
     - name: setup
       taskSpec:

--- a/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
@@ -7,13 +7,16 @@ kubectl create secret generic rhtl-pulp-credentials-secret \
   --from-literal=password=test-password
 
 # Add mocks to the upload step script
-# Note: step 0 uses StepAction ref, so we only inject into step 1 (upload)
+# Steps layout:
+#   [0] prepare-workdir (command - no mock needed)
+#   [1] use-trusted-artifact (StepAction ref - no mock needed)
+#   [2] upload (command - replace with mock script)
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# The upload step is step index 1 and uses command, not script
+# The upload step is step index 2 and uses command, not script
 # We need to replace the command with a script that includes mocks
 yq -i '
-  del(.spec.steps[1].command) |
-  .spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh")
+  del(.spec.steps[2].command) |
+  .spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh")
 ' "$TASK_PATH"

--- a/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+++ b/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
@@ -86,8 +86,20 @@ spec:
         readOnly: true
       - name: workdir
         mountPath: /var/workdir
-    workingDir: /var/workdir
   steps:
+    - name: prepare-workdir
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 32Mi
+          cpu: 10m
+        requests:
+          memory: 32Mi
+          cpu: 10m
+      command:
+        - mkdir
+        - -p
+        - $(params.dataDir)
     - name: use-trusted-artifact
       computeResources:
         limits:


### PR DESCRIPTION
On OpenShift, emptyDir volume mount points get the setgid bit set by the namespace's fsGroup. When the trusted artifacts binary extracts an archive directly into the mount point (/var/workdir), tar attempts to restore the setgid bit on "." but fails because user 1001 lacks the required capability, causing the task to exit with code 2:

  tar: .: Cannot utime: Operation not permitted
  tar: .: Cannot change mode to rwxr-sr-x: Operation not permitted

Fix by redirecting trusted artifact extraction to a user-owned subdirectory (/var/workdir/content) instead of the mount point root:

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
