### PR TITLE
chore: add time tracking

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -363,9 +363,13 @@ spec:
               echo "  ${printable_cmd}" >&2
             fi
             set +e
+            echo "Upload start: ${relpath} at $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >&2
+            upload_start_ts=$(date +%s)
             response=$(pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
               --chunk-size 2000MB --file "${file_path}" --relative-path "${relpath}")
             rc=$?
+            upload_end_ts=$(date +%s)
+            echo "Upload end: ${relpath} (took $((upload_end_ts - upload_start_ts))s)" >&2
             set -e
 
             # Consider success only when command succeeds and pulp_href is present


### PR DESCRIPTION
Add start/end time for uploads to see if they are not too slow

## Describe your changes

Adding time tracking to pulp uploads. I have suspicion about uploads being too slow. 

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
