### PR TITLE
fix(RELEASE-2237): add version verification before publishing

### DIFF
--- a/pipelines/internal/publish-index-image-pipeline/README.md
+++ b/pipelines/internal/publish-index-image-pipeline/README.md
@@ -8,6 +8,7 @@ Tekton pipeline to publish a built FBC index image using skopeo
 |-----------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
 | sourceIndex           | sourceIndex signing image                                                             | No       | -                                                         |
 | targetIndex           | targetIndex signing image                                                             | No       | -                                                         |
+| targetOcpVersion      | target OCP Version of the index image                                                 | Yes      | ""                                                        |
 | retries               | Number of skopeo retries                                                              | Yes      | 0                                                         |
 | publishingCredentials | The credentials used to access the registries                                         | No       | -                                                         |
 | requestUpdateTimeout  | Max seconds waiting for the status update                                             | Yes      | 360                                                       |

--- a/pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml
+++ b/pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml
@@ -16,6 +16,10 @@ spec:
     - name: targetIndex
       type: string
       description: targetIndex signing image
+    - name: targetOcpVersion
+      type: string
+      default: ""
+      description: target OCP Version of the index image
     - name: retries
       type: string
       default: "0"
@@ -50,6 +54,8 @@ spec:
           value: $(params.sourceIndex)
         - name: targetIndex
           value: $(params.targetIndex)
+        - name: targetOcpVersion
+          value: $(params.targetOcpVersion)
         - name: retries
           value: $(params.retries)
         - name: publishingCredentials

--- a/tasks/internal/publish-index-image-task/README.md
+++ b/tasks/internal/publish-index-image-task/README.md
@@ -8,6 +8,7 @@ Tekton task to publish a built FBC index image using skopeo
 |-----------------------|-----------------------------------------------------------------------|----------|----------------------------|
 | sourceIndex           | sourceIndex signing image                                             | No       | -                          |
 | targetIndex           | targetIndex signing image                                             | No       | -                          |
+| targetOcpVersion      | OCP Version this image was built to                                   | Yes      | ""                         |
 | retries               | Number of skopeo retries                                              | Yes      | 0                          |
 | publishingCredentials | The credentials used to access the registries                         | Yes      | fbc-publishing-credentials |
 | requestUpdateTimeout  | Max seconds waiting for the status update                             | Yes      | 360                        |

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -16,6 +16,10 @@ spec:
     - name: targetIndex
       type: string
       description: targetIndex signing image
+    - name: targetOcpVersion
+      description: OCP Version this image was built to
+      type: string
+      default: ""
     - name: retries
       type: string
       default: "0"
@@ -75,6 +79,21 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
 
+        function getIndexVersion() {
+            # if dest- and src- string is given, remove them from the auth param
+            if [[ "$#" -gt 1 ]]; then
+              shift
+              indexVersion="$(skopeo inspect --config --creds "$@" \
+                | jq -r '.config.Labels."com.redhat.index.delivery.version"')"
+            else
+              # no auth given
+              indexVersion="$(skopeo inspect --config "$@" \
+                | jq -r '.config.Labels."com.redhat.index.delivery.version"')"
+            fi
+
+            echo "$indexVersion"
+        }
+
         SOURCE_INDEX_CREDENTIAL="$(cat /mnt/publishingCredentials/sourceIndexCredential)"
         TARGET_INDEX_CREDENTIAL="$(cat /mnt/publishingCredentials/targetIndexCredential)"
 
@@ -109,6 +128,27 @@ spec:
             fi
         else
             echo "Target image does not exist. Proceeding to copy the image."
+        fi
+
+        # check to make sure the image to be published is for the intended ocpVersion
+        targetOcpVersion="$(params.targetOcpVersion)"
+        sourceVer=$(getIndexVersion "${SOURCE_AUTH_ARGS[@]}" "docker://$(params.sourceIndex)")
+        if [[ "${sourceVer}" != "${targetOcpVersion}" ]]; then
+            echo -n "The source index does not match its targetOcpVersion ($sourceVer != $targetOcpVersion)" \
+              | tee "$(results.requestMessage.path)"
+            exit 0
+        fi
+
+        # hotfix and pre-ga targetIndex should be skip the next check, as they don't exist in the upstream quay
+        # until skopeo copy runs.
+        if [[ "$(params.targetIndex)" =~ .*\:v[0-9]{1}\.[0-9]{2}$ ]]; then
+            targetVer=$(getIndexVersion "${TARGET_AUTH_ARGS[@]}" "docker://$(params.targetIndex)")
+            # check if both indexes are of the same OCP version and exit in case they mismatch.
+            if [ "${sourceVer}" != "${targetVer}" ]; then
+              echo -n "The indexes versions does not match ($sourceVer != $targetVer)" \
+              | tee "$(results.requestMessage.path)"
+              exit 0
+            fi
         fi
 
         # Proceed with copying the image

--- a/tasks/internal/publish-index-image-task/tests/mocks.sh
+++ b/tasks/internal/publish-index-image-task/tests/mocks.sh
@@ -7,8 +7,15 @@ function skopeo() {
   echo Mock skopeo called with: $* >&2
 
   if [[ "$1" == "inspect" ]]; then
+    if [[ "$*" == *"config"* ]]; then
+      if [[ "$*" == *"quay.io/mismatch-ver-target-digest"* ]]; then
+          echo '{ "config": { "Labels":  { "com.redhat.index.delivery.version": "v4.13"} } }'
+      else
+          echo '{ "config": { "Labels":  { "com.redhat.index.delivery.version": "v4.12"} } }'
+      fi
+      return 0
     # Handle `skopeo inspect`
-    if [[ "$*" == *"docker://quay.io/match-target-digest"* ]]; then
+    elif [[ "$*" == *"docker://quay.io/match-target-digest"* ]]; then
       echo "sha256:match1234567890"  # Mock target digest for idempotency check
       return 0
     elif [[ "$*" == *"docker://quay.io/target"* ]]; then
@@ -22,6 +29,12 @@ function skopeo() {
       return 0
     elif [[ "$*" == *"--tls-verify=false docker://registry-proxy.engineering.redhat.com/fail"* ]]; then
       return 1
+    elif [[ "$*" == *"registry-proxy.engineering.redhat.com/mismatchver@sha256:1234567890"* ]]; then
+      echo "sha256:target1234567890"
+      return 0
+    elif [[ "$*" == *"quay.io/mismatch-ver-target-digest"* ]]; then
+      echo "sha256:0987654321fedcba"
+      return 0
     else
       echo "Error: Unexpected inspect call"
       exit 1

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-digest-match.yaml
@@ -15,6 +15,8 @@ spec:
           value: "registry-proxy.engineering.redhat.com/match@sha256:match1234567890"
         - name: targetIndex
           value: "quay.io/match-target-digest"
+        - name: targetOcpVersion
+          value: "v4.12"
         - name: publishingCredentials
           value: "publish-index-image-secret"
     - name: check-result

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail-mismatch-ver.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail-mismatch-ver.yaml
@@ -2,20 +2,19 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-publish-index-image-registry-proxy
+  name: test-publish-index-image-fail-mismatch-ver
 spec:
   description: |
-    Run the publish-index-image task with a registry-proxy sourceIndex. Ensure the task succeeds, which can
-    only happen if --src-creds is properly added (due to the mocks.sh)
+    Run the publish-index-image task where source and target images versions mismatch
   tasks:
     - name: run-task
       taskRef:
         name: publish-index-image-task
       params:
         - name: sourceIndex
-          value: "registry-proxy.engineering.redhat.com/foo@sha256:0987654321fedcba"
+          value: "registry-proxy.engineering.redhat.com/mismatchver@sha256:1234567890"
         - name: targetIndex
-          value: "quay.io/target"
+          value: "quay.io/mismatch-ver-target-digest:v4.20"
         - name: targetOcpVersion
           value: "v4.12"
         - name: publishingCredentials
@@ -37,7 +36,12 @@ spec:
               #!/usr/bin/env bash
               set -ex
 
-              if [[ "$(params.requestMessage)" != "Index Image Published successfully" ]]; then
-                echo Error: requestMessage task result is not correct
+              ACTUAL_RESULT="$(echo -n "$(params.requestMessage)" | tr -d '\n' | xargs)"
+              EXPECTED_RESULT="The indexes versions does not match (v4.12 != v4.13)"
+
+              if [[ "$ACTUAL_RESULT" != "$EXPECTED_RESULT" ]]; then
+                echo "Error: requestMessage task result is not correct"
+                echo "Expected: '$EXPECTED_RESULT'"
+                echo "Got: '$ACTUAL_RESULT'"
                 exit 1
               fi

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail.yaml
@@ -16,6 +16,8 @@ spec:
           value: "registry-proxy.engineering.redhat.com/fail@sha256:0987654321fedcba"
         - name: targetIndex
           value: "quay.io/target"
+        - name: targetOcpVersion
+          value: "v4.12"
         - name: publishingCredentials
           value: "publish-index-image-secret"
     - name: check-result

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image.yaml
@@ -15,6 +15,8 @@ spec:
           value: "quay.io/source@sha256:abcdef1234567890"
         - name: targetIndex
           value: "quay.io/target"
+        - name: targetOcpVersion
+          value: "v4.12"
         - name: publishingCredentials
           value: "publish-index-image-secret"
     - name: check-result

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -151,8 +151,11 @@ spec:
           targetIndex=$(jq -r --argjson i "$i" \
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          sourceIndex=$(jq -r  --argjson i "$i" \
-            '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")
+          sourceIndex="$(jq -r  --argjson i "$i" \
+            '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
+
+          targetOcpVersion=$(jq -r --argjson i "$i" \
+            '.components[$i].ocp_version' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
           buildTimestamp=$(jq -r --argjson i "$i" '.components[$i].completion_time' \
             "$(params.dataDir)/$(params.internalRequestResultsFile)")
@@ -179,6 +182,7 @@ spec:
               internal-request --pipeline "${request}" \
                   -p sourceIndex="${sourceIndex}" \
                   -p targetIndex="${publishingImages[$x]}" \
+                  -p targetOcpVersion="${targetOcpVersion}" \
                   -p publishingCredentials="${credentials}" \
                   -p retries="$(params.retries)" \
                   -p taskGitUrl="$(params.taskGitUrl)" \

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -208,6 +208,11 @@ spec:
                       fi
                   fi
 
+                  if [ "$(jq -r '.targetOcpVersion' <<< "${params}")" != "v4.12" ]; then
+                    echo "targetOcpVersion does not match"
+                    exit 1
+                  fi
+
                   if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
                     echo "taskGitUrl image does not match"
                     exit 1


### PR DESCRIPTION
this PR adds checks to make sure the version of the image to be
published matches with the intended one, using two methods:

- checks if the source index verson matches the ocpTargetVersion
  (for all builds - regular, pre-GA and hotfix);
- checks if the sourceIndex and targetIndex matches (regular builds)

Signed-off-by: Leandro Mendes <lmendes@redhat.com>

## Relevant Jira

https://issues.redhat.com/browse/RELEASE-2237

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
