### PR TITLE
feat(RELEASE-2251): increase compress-artifacts step resources

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -407,10 +407,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: '1'
+          cpu: 250m
         requests:
           memory: 512Mi
-          cpu: '1'
+          cpu: 250m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared
@@ -1150,11 +1150,11 @@ spec:
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
         limits:
-          memory: 256Mi
-          cpu: 150m
+          memory: 512Mi
+          cpu: 500m
         requests:
-          memory: 256Mi
-          cpu: 150m
+          memory: 512Mi
+          cpu: 500m
       volumeMounts:
         - name: shared-dir
           mountPath: /shared


### PR DESCRIPTION
Increase CPU and memory allocation for the compress-artifacts step to address slow compression times:
- CPU: 150m -> 500m request, 1 core limit
- Memory: 256Mi -> 512Mi

Compression (gzip, zip) is CPU-intensive and was bottlenecked by the previous 150m allocation. New settings align with other steps in the task.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
