### PR TITLE
feat(HUM-433) add support for pulp and mapping.rpm-repositories

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -32,7 +32,8 @@
               "ootsign",
               "conforma",
               "intention",
-              "atlas"
+              "atlas",
+              "pulp"
             ]
           },
           "dynamic": {
@@ -425,6 +426,19 @@
         }
       }
     },
+    "pulp": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The Pulp domain to use for publishing RPMs"
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The secret containing Pulp credentials"
+        }
+      }
+    },
     "atlas": {
       "type": "object",
       "additionalProperties": false,
@@ -479,6 +493,35 @@
     "mapping": {
       "type": "object",
       "properties": {
+        "rpm-repositories": {
+          "type": "array",
+          "description": "RPM repositories configuration for Pulp publishing",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name identifier for this repository configuration"
+              },
+              "arch": {
+                "type": "string",
+                "description": "The architecture for the repository (e.g. x86_64, aarch64, source)"
+              },
+              "repository_id": {
+                "type": "string",
+                "description": "The Pulp repository ID used in the PURL for an advisory"
+              },
+              "repository_name": {
+                "type": "string",
+                "description": "The actual name of the repository in Pulp"
+              },
+              "distro": {
+                "type": "string",
+                "description": "The distribution name for the repository"
+              }
+            }
+          }
+        },
         "components": {
           "type": "array",
           "items": {
@@ -1957,6 +2000,61 @@
           "atlas": {
             "required": [
               "server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pulp"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "pulp"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "pulp"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "pulp"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "pulp": {
+            "required": [
+              "domain",
+              "secretName"
             ]
           }
         }


### PR DESCRIPTION
## Describe your changes
- In order to fully describe RPMs in an advisory, we must supply the official Repository ID that product security tracks.
- For example:

```
purl: pkg:rpm/redhat/hello@2.12.1-82b9d51c?arch=x86_64&distro=testdistro&repository_id=rpm-x86_64
```

- For product and architecture, we allow the possibilty to describe the mapping to the target repository ID:

```
mapping:
      "rpm-repositories": [
        {
          "name": "rpm-x86_64",
          "arch": "x86_64",
          "repository_id": "rpm-x86_64",
          "repository_name": "x86_64",
          "distro": "testdistro"
        }
      ]
```

- This change is critical to release RPMs for Hummingbird.


## Relevant Jira
- HUM-433

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
