### PR TITLE
fix(HUM-521): change chunk size to be 100MB

### DIFF
--- a/tasks/managed/push-rpms-to-pulp/README.md
+++ b/tasks/managed/push-rpms-to-pulp/README.md
@@ -22,3 +22,4 @@ A task to push rpm packages from an OCI artifact to a Pulp repository.
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                            |
 | caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca                   |
 | caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt                |
+| pulpUploadChunkSize     | The chunk size to use when uploading RPMs to Pulp                                                                          | Yes      | 100MB                        |

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -69,6 +69,10 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
+    - name: pulpUploadChunkSize
+      type: string
+      description: The chunk size to use when uploading RPMs to Pulp
+      default: "100MB"
   results:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
@@ -123,6 +127,8 @@ spec:
         value: $(params.orasOptions)
       - name: DEBUG
         value: $(params.trustedArtifactsDebug)
+      - name: PULP_UPLOAD_CHUNK_SIZE
+        value: $(params.pulpUploadChunkSize)
     volumeMounts:
       - name: workdir
         mountPath: "/var/workdir"
@@ -354,7 +360,8 @@ spec:
           # Build a printable command string for logging (no secrets included)
           local printable_cmd
           printable_cmd="pulp --config \"${PULP_CONFIG_FILE}\" --domain \"${PULP_DOMAIN}\" rpm content upload"
-          printable_cmd+=" --chunk-size 2000MB --file \"${file_path}\" --relative-path \"${relpath}\""
+          printable_cmd+=" --chunk-size ${PULP_UPLOAD_CHUNK_SIZE} --file \"${file_path}\""
+          printable_cmd+=" --relative-path \"${relpath}\""
 
           for ((i=1; i<=attempts; i++)); do
             # For retries (i > 1) make it explicit which command is being retried
@@ -364,7 +371,7 @@ spec:
             fi
             set +e
             response=$(pulp --config "$PULP_CONFIG_FILE" --domain "${PULP_DOMAIN}" rpm content upload \
-              --chunk-size 2000MB --file "${file_path}" --relative-path "${relpath}")
+              --chunk-size "${PULP_UPLOAD_CHUNK_SIZE}" --file "${file_path}" --relative-path "${relpath}")
             rc=$?
             set -e
 


### PR DESCRIPTION
## Describe your changes
- For large RPMs, it is possible for the upload to fail due to a **Gateway Timeout** on the pulp side.
- To workaround this issue, we need a **chunk size value** that is a compromise between a performant upload and reduced load on pulp to process the large RPM.
- After significant testing, '**100MB**' seems to a good default setting for chunk size.
- Testing involved a loop of pulp uploads of a 1.3 GB rpm.
- Note there is still an issue on the pulp side being tracked

## Relevant Jira
- HUM-521

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
