### PR TITLE
fix(HUM-552): fix arg list too long in filtering

### DIFF
--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -571,7 +571,12 @@ spec:
 
           # Emit component only if there is something to publish
           if [[ "$(jq 'length' <<< "${rpms_to_publish}")" -gt 0 ]]; then
-            jq --argjson rpmsToPublish "${rpms_to_publish}" '. + {rpmsToPublish: $rpmsToPublish}' <<< "${component}"
+            # Write rpms_to_publish to a temp file to avoid "Argument list too long" errors
+            # when the JSON array is large (e.g., glibc with hundreds of RPMs).
+            rpms_file="${workdir}/rpms_to_publish.json"
+            printf '%s' "${rpms_to_publish}" > "${rpms_file}"
+            jq --slurpfile rpmsToPublish "${rpms_file}" \
+              '. + {rpmsToPublish: $rpmsToPublish[0]}' <<< "${component}"
           fi
 
           rm -rf "${workdir}"

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/mocks.sh
@@ -90,6 +90,16 @@ function oras() {
       mkdir -p "${output_file_dir}/logs"
       touch "${output_file_dir}/logs/hello-2.12.1-6.fc44.x86_64.rpm.log"
       return 0
+    elif [[ "$args" == *"quay.io/test/manyrpms"* ]]; then
+      # Generate many RPMs to test "arg list too long" fix.
+      # Linux MAX_ARG_STRLEN is 128KB per argument. With 600 RPMs (~144KB JSON),
+      # the old --argjson approach fails; the --slurpfile fix handles this.
+      mkdir -p "${output_file_dir}"
+      for i in $(seq 1 600); do
+        touch "${output_file_dir}/glibc-subpkg${i}-2.38-${i}.fc44.x86_64.rpm"
+      done
+      mkdir -p "${output_file_dir}/logs"
+      return 0
     fi
 
     # Default: create empty RPM files

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-many-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-many-rpms.yaml
@@ -1,0 +1,163 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-rpms-many-rpms
+spec:
+  description: |
+    Run filter-already-released-advisory-rpms with many RPMs to verify the fix for
+    "Argument list too long" errors. The mock generates 600 RPM files (~144KB JSON),
+    exceeding Linux MAX_ARG_STRLEN (128KB) which would fail without the fix.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "rpms",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/manyrpms@sha256:12345",
+                    "name": "glibc-large"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-rpms
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: PULP_DOMAIN
+          value: "mydomain"
+        - name: PULP_SECRET_NAME
+          value: "pulp-task-pulp-secret"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: HOME
+              value: /var/workdir
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:304058ae848ca6311b53b505e80533fc337e9c1a46dedd4071ee436b14e476d9  # yamllint disable-line rule:line-length
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              snap="$(cat "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json")"
+
+              # Verify the component is kept and has rpmsToPublish
+              test "$(echo "$snap" | jq '.components | length')" = "1"
+
+              rpm_count="$(echo "$snap" | jq '.components[0].rpmsToPublish | length')"
+              echo "rpmsToPublish count: ${rpm_count}"
+
+              # Should have 600 RPMs to publish (generated by mock)
+              test "${rpm_count}" -eq 600
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
- The filter-already-released-advisory-rpms task can fail because of an "Argument list too long" error when calling jq.
- The script needs to be modified to avoid passing the large JSON blob as a command-line argument
- The Linux MAX_ARG_STRLEN limit is 128KB per single argument, so a new test was added that produces a JSON blob of ~144KB from a list of 600 RPMs

## Relevant Jira
- HUM-552

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
