### PR TITLE
refactor(RELEASE-2249): split add-fbc-contribution into discrete steps

### DIFF
--- a/tasks/managed/add-fbc-contribution/README.md
+++ b/tasks/managed/add-fbc-contribution/README.md
@@ -13,11 +13,16 @@ in series. For each OCP version, we chain together batches so that the final tar
 produced will have all fragments added. This means that the index_image from one internal
 request will be set as the fromIndex for the next request within that OCP version.
 
-Since we have seen flakiness in IIB requests in the past, we retry and failed batches
+Since we have seen flakiness in IIB requests in the past, we retry failed batches
 and internal requests can attach onto currently in progress IIB requests. We retry batches
 at the end to allow for timed out requests to finish so that we can just get the final
 result. This will slightly compress the time in which batches are entered into the IIB
 queue to reduce the effect of a full queue on a single release.
+
+The task is organized into three processing steps:
+  1. prepare-inputs: validates inputs, groups components by OCP version, writes config
+  2. process-ocp-groups: executes IIB requests per OCP group with batching and retries
+  3. collect-and-deduplicate: aggregates results, deduplicates, produces final output
 
 ## Parameters
 

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -21,11 +21,16 @@ spec:
     produced will have all fragments added. This means that the index_image from one internal
     request will be set as the fromIndex for the next request within that OCP version.
 
-    Since we have seen flakiness in IIB requests in the past, we retry and failed batches
+    Since we have seen flakiness in IIB requests in the past, we retry failed batches
     and internal requests can attach onto currently in progress IIB requests. We retry batches
     at the end to allow for timed out requests to finish so that we can just get the final
     result. This will slightly compress the time in which batches are entered into the IIB
     queue to reduce the effect of a full queue on a single release.
+
+    The task is organized into three processing steps:
+      1. prepare-inputs: validates inputs, groups components by OCP version, writes config
+      2. process-ocp-groups: executes IIB requests per OCP group with batching and retries
+      3. collect-and-deduplicate: aggregates results, deduplicates, produces final output
   params:
     - name: snapshotPath
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace
@@ -157,7 +162,183 @@ spec:
           value: $(params.sourceDataArtifact)
         - name: orasOptions
           value: $(params.orasOptions)
-    - name: add-contribution
+    - name: prepare-inputs
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        #
+        # Step 1: Validate inputs, read configuration, group components by OCP version,
+        # and write a shared config file for subsequent steps.
+        #
+        set -eo pipefail
+
+        # --- Input Validation ---
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+        if [ ! -f "${DATA_FILE}" ] ; then
+            echo "No valid data file was provided."
+            exit 1
+        fi
+
+        SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
+        if [ ! -f "$SNAPSHOT_PATH" ]; then
+            echo "ERROR: Snapshot not found at $SNAPSHOT_PATH"
+            exit 1
+        fi
+
+        # --- Write Tekton Result Paths ---
+        # Note: adding a new result as modifying the current one used breaks e2e for single component.
+        # to be handled in RELEASE-1640.
+        RESULTS_FILE="$(params.resultsDirPath)/internal-requests-results.json"
+        echo -n "$RESULTS_FILE" > "$(results.internalRequestResultsFile.path)"
+        RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/internal-requests-results.json"
+
+        echo -n "$(params.dataDir)/$(params.pipelineRunUid)/ir-$(context.taskRun.uid)-result.json" \
+          > "$(results.requestResultsFile.path)"
+
+        # --- Read Configuration from Data File ---
+        default_build_timeout_seconds="3600"
+        default_request_timeout_seconds="3600"
+
+        build_timeout_seconds=$(jq -r --arg default "${default_build_timeout_seconds}" \
+            '.fbc.buildTimeoutSeconds // $default' "${DATA_FILE}")
+        request_timeout_seconds=$(jq -r --arg default "${default_request_timeout_seconds}" \
+            '.fbc.requestTimeoutSeconds // $default' "${DATA_FILE}")
+        internal_request_service_account=$(jq -r \
+            '.fbc.internalRequestServiceAccount // "release-service-account"' "${DATA_FILE}")
+        publishing_credentials=$(jq -r \
+            '.fbc.publishingCredentials // "catalog-publishing-secret"' "$DATA_FILE")
+
+        # Pre-determined values from prepare-fbc-parameters
+        iib_service_account_secret="$(params.iibServiceAccountSecret)"
+        must_publish_index_image="$(params.mustPublishIndexImage)"
+        must_overwrite_from_index_image="$(params.mustOverwriteFromIndexImage)"
+
+        # --- Extract and Validate OCP Versions ---
+        # Components can have multiple versions: ["v4.17", "v4.18", "v4.19"]
+        # Fallback to empty array if ocpVersion is absent or null for backward compatibility
+        ocp_versions=$(jq -r '.components[] | (.ocpVersion // []) | .[]' "$SNAPSHOT_PATH" | sort -u | tr '\n' ' ')
+        echo "INFO: Found OCP versions: ${ocp_versions}"
+
+        echo "INFO: Using pre-determined values from prepare-fbc-parameters:"
+        echo "  - mustPublishIndexImage: ${must_publish_index_image}"
+        echo "  - mustOverwriteFromIndexImage: ${must_overwrite_from_index_image}"
+        echo "  - iibServiceAccountSecret: ${iib_service_account_secret}"
+
+        # Initialize results file for multi-OCP processing
+        jq -n '{"components": []}' | tee "$RESULTS_FILE"
+
+        # --- Snapshot Validation ---
+        if ! jq -e '.components | type == "array" and length > 0' "$SNAPSHOT_PATH" > /dev/null; then
+            echo "ERROR: Snapshot missing required 'components' array"
+            exit 1
+        fi
+
+        echo "INFO: Validating snapshot for processing..."
+        total_components=$(jq '.components | length' "$SNAPSHOT_PATH")
+        if [ "${total_components}" -eq 0 ]; then
+            echo "ERROR: No components found in snapshot"
+            exit 1
+        fi
+        echo "INFO: Found ${total_components} components in snapshot"
+
+        # --- Batch and Timeout Calculation ---
+        MAX_BATCH_SIZE="$(params.maxBatchSize)"
+        echo "Preparing $total_components components with maximum batch size of $MAX_BATCH_SIZE..."
+
+        NUM_BATCHES=$(( (total_components + MAX_BATCH_SIZE - 1) / MAX_BATCH_SIZE ))
+        echo "Creating $NUM_BATCHES batch(es) for $total_components components"
+
+        build_tags=$(jq -c '.fbc.buildTags // []' "${DATA_FILE}")
+        add_arches=$(jq -c '.fbc.addArches // []' "${DATA_FILE}")
+        is_staged=$(jq -r '.fbc.stagedIndex // false' "${DATA_FILE}")
+
+        finally_task_timeout=300
+        pipeline_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds + finally_task_timeout )))
+        task_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds )))
+
+        # --- Group Components by OCP Version ---
+        echo "INFO: Grouping snapshot components by OCP version"
+        groups_dir="$(params.dataDir)/ocp-groups"
+        mkdir -p "$groups_dir"
+
+        for ocp_version in $ocp_versions; do
+            group_file="${groups_dir}/${ocp_version}.json"
+
+            # Build group by expanding multi-version components
+            # Uses ocpVersionMetadata to get resolved indexes for this specific version
+            jq --arg ocp_version "$ocp_version" '
+              .components | map(
+                if (.ocpVersion | index($ocp_version)) then
+                  (.ocpVersionMetadata | map(select(.version == $ocp_version)) | .[0]) as $version_metadata |
+                  . + {
+                    ocpVersion: $ocp_version,
+                    updatedFromIndex: $version_metadata.updatedFromIndex,
+                    targetIndex: $version_metadata.targetIndex,
+                    originalName: .name,
+                    name: (if (.ocpVersion | length) > 1
+                           then .name + "-" + $ocp_version
+                           else .name end)
+                  }
+                else
+                  empty
+                end
+              )
+            ' "$SNAPSHOT_PATH" > "$group_file"
+
+            group_count=$(jq 'length' "$group_file")
+            echo "INFO: OCP version $ocp_version has $group_count component instance(s)"
+        done
+
+        # --- Write Shared Config for Subsequent Steps ---
+        STATE_DIR="$(params.dataDir)/fbc-state"
+        mkdir -p "$STATE_DIR"
+
+        jq -n \
+          --arg build_timeout_seconds "$build_timeout_seconds" \
+          --arg request_timeout_seconds "$request_timeout_seconds" \
+          --arg internal_request_service_account "$internal_request_service_account" \
+          --arg publishing_credentials "$publishing_credentials" \
+          --arg iib_service_account_secret "$iib_service_account_secret" \
+          --arg must_publish_index_image "$must_publish_index_image" \
+          --arg must_overwrite_from_index_image "$must_overwrite_from_index_image" \
+          --argjson build_tags "$build_tags" \
+          --argjson add_arches "$add_arches" \
+          --arg ocp_versions "$(echo "$ocp_versions" | tr '\n' ' ')" \
+          --arg total_components "$total_components" \
+          --arg max_batch_size "$MAX_BATCH_SIZE" \
+          --arg pipeline_timeout "$pipeline_timeout" \
+          --arg task_timeout "$task_timeout" \
+          --arg groups_dir "$groups_dir" \
+          --arg results_file "$RESULTS_FILE" \
+          --arg is_staged "$is_staged" \
+          '{
+            build_timeout_seconds: $build_timeout_seconds,
+            request_timeout_seconds: $request_timeout_seconds,
+            internal_request_service_account: $internal_request_service_account,
+            publishing_credentials: $publishing_credentials,
+            iib_service_account_secret: $iib_service_account_secret,
+            must_publish_index_image: $must_publish_index_image,
+            must_overwrite_from_index_image: $must_overwrite_from_index_image,
+            build_tags: $build_tags,
+            add_arches: $add_arches,
+            ocp_versions: $ocp_versions,
+            total_components: $total_components,
+            max_batch_size: $max_batch_size,
+            pipeline_timeout: $pipeline_timeout,
+            task_timeout: $task_timeout,
+            groups_dir: $groups_dir,
+            results_file: $results_file,
+            is_staged: $is_staged
+          }' > "${STATE_DIR}/config.json"
+
+        echo "INFO: Configuration written to ${STATE_DIR}/config.json"
+    - name: process-ocp-groups
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
         limits:
@@ -168,178 +349,197 @@ spec:
       script: |
         #!/usr/bin/env bash
         #
+        # Step 2: Execute IIB requests per OCP group with batching, chaining, and retries.
+        # Reads the config.json and ocp-groups/*.json written by prepare-inputs.
+        #
         set -eo pipefail
 
-        SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
-        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
-        if [ ! -f "${DATA_FILE}" ] ; then
-            echo "No valid data file was provided."
-            exit 1
-        fi
+        # --- Load Configuration ---
+        STATE_DIR="$(params.dataDir)/fbc-state"
+        CONFIG_FILE="${STATE_DIR}/config.json"
 
-        # The snapshot should be updated by prepare-fbc-snapshot
-        SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
-        if [ ! -f "$SNAPSHOT_PATH" ]; then
-            echo "ERROR: Snapshot not found at $SNAPSHOT_PATH"
-            exit 1
-        fi
-
-        # adding a new result as modifying the current one used breaks e2e for single component.
-        # to be handled in RELEASE-1640.
-        RESULTS_FILE="$(params.resultsDirPath)/internal-requests-results.json"
-        echo -n "$RESULTS_FILE" > "$(results.internalRequestResultsFile.path)"
-        RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/internal-requests-results.json"
-
-        echo -n "$(params.dataDir)/$(params.pipelineRunUid)/ir-$(context.taskRun.uid)-result.json" \
-          > "$(results.requestResultsFile.path)"
-
-        default_build_timeout_seconds="3600"
-        default_request_timeout_seconds="3600"
-
-        build_timeout_seconds=$(jq -r --arg build_timeout_seconds "${default_build_timeout_seconds}" \
-            '.fbc.buildTimeoutSeconds // $build_timeout_seconds' "${DATA_FILE}")
-        request_timeout_seconds=$(jq -r --arg request_timeout_seconds "${default_request_timeout_seconds}" \
-            '.fbc.requestTimeoutSeconds // $request_timeout_seconds' "${DATA_FILE}")
-        internal_request_service_account=$(jq -r '.fbc.internalRequestServiceAccount // "release-service-account"' \
-            "${DATA_FILE}")
-        publishing_credentials=$(jq -r '.fbc.publishingCredentials // "catalog-publishing-secret"' "$DATA_FILE")
-
-        # Use pre-determined values from prepare-fbc-parameters
-        iib_service_account_secret="$(params.iibServiceAccountSecret)"
-        mustPublishIndexImage="$(params.mustPublishIndexImage)"
-        mustOverwriteFromIndexImage="$(params.mustOverwriteFromIndexImage)"
-
-        # Extract OCP versions from snapshot (ocpVersion is JSON array)
-        # Components can have multiple versions: ["v4.17", "v4.18", "v4.19"]
-        # Fallback to empty array if ocpVersion is absent or null for backward compatibility
-        ocp_versions=$(jq -r '.components[] | (.ocpVersion // []) | .[]' "$SNAPSHOT_PATH" | sort -u | tr '\n' ' ')
-        echo "INFO: Found OCP versions: ${ocp_versions}"
-
-        echo "INFO: Using pre-determined values from prepare-fbc-parameters:"
-        echo "  - mustPublishIndexImage: ${mustPublishIndexImage}"
-        echo "  - mustOverwriteFromIndexImage: ${mustOverwriteFromIndexImage}"
-        echo "  - iibServiceAccountSecret: ${iib_service_account_secret}"
-
-        jq -n '{"components": []}' | tee "$RESULTS_FILE"
-
-        # Snapshot validation for multi-OCP processing
-        if ! jq -e '.components | type == "array" and length > 0' "$SNAPSHOT_PATH" > /dev/null; then
-            echo "ERROR: Snapshot missing required 'components' array"
-            exit 1
-        fi
-
-        # Validate snapshot for processing
-        echo "INFO: Validating snapshot for processing..."
-        total_components=$(jq '.components | length' "$SNAPSHOT_PATH")
-
-        if [ "${total_components}" -eq 0 ]; then
-            echo "ERROR: No components found in snapshot"
-            exit 1
-        fi
-
-        echo "INFO: Processing ${total_components} components"
+        build_timeout_seconds=$(jq -r '.build_timeout_seconds' "$CONFIG_FILE")
+        request_timeout_seconds=$(jq -r '.request_timeout_seconds' "$CONFIG_FILE")
+        internal_request_service_account=$(jq -r '.internal_request_service_account' "$CONFIG_FILE")
+        publishing_credentials=$(jq -r '.publishing_credentials' "$CONFIG_FILE")
+        iib_service_account_secret=$(jq -r '.iib_service_account_secret' "$CONFIG_FILE")
+        must_publish_index_image=$(jq -r '.must_publish_index_image' "$CONFIG_FILE")
+        must_overwrite_from_index_image=$(jq -r '.must_overwrite_from_index_image' "$CONFIG_FILE")
+        build_tags=$(jq -c '.build_tags' "$CONFIG_FILE")
+        add_arches=$(jq -c '.add_arches' "$CONFIG_FILE")
+        ocp_versions=$(jq -r '.ocp_versions' "$CONFIG_FILE")
+        MAX_BATCH_SIZE=$(jq -r '.max_batch_size' "$CONFIG_FILE")
+        pipeline_timeout=$(jq -r '.pipeline_timeout' "$CONFIG_FILE")
+        task_timeout=$(jq -r '.task_timeout' "$CONFIG_FILE")
+        groups_dir=$(jq -r '.groups_dir' "$CONFIG_FILE")
+        RESULTS_FILE=$(jq -r '.results_file' "$CONFIG_FILE")
 
         # Setup consistent labeling for FBC internal requests
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
 
-        # Create batches with size limits
-        LENGTH=$(jq -r '.components | length' "${SNAPSHOT_PATH}")
-        MAX_BATCH_SIZE="$(params.maxBatchSize)"
-        echo "Processing $LENGTH components with maximum batch size of $MAX_BATCH_SIZE..."
+        # ---------------------------------------------------------------
+        # execute_batch: Create an InternalRequest for a single batch,
+        # wait for completion, and write results to the results file.
+        # ---------------------------------------------------------------
+        execute_batch() {
+            local batch_num="$1"
+            local from_index="$2"
+            local group_ocp_version="$3"
+            local group_target_index="$4"
+            local group_build_tags="$5"
+            local batch_fragments="$6"
 
-        # Read global buildTags and addArches from data file
-        build_tags=$(jq '.fbc.buildTags // []' "${DATA_FILE}")
-        add_arches=$(jq '.fbc.addArches // []' "${DATA_FILE}")
+            echo "Executing group batch $((batch_num + 1)): fromIndex=${from_index}" \
+                "(OCP: $group_ocp_version)"
 
-        # Processing will use group-specific target indexes
-        # Each OCP version group will have its own target index resolved by prepare-fbc-parameters
-        # No single "global" target index exists - each component gets its OCP-specific target index
+            # Create InternalRequest for this batch
+            internal-request --pipeline "update-fbc-catalog" \
+                -p fromIndex="${from_index}" \
+                -p fbcFragments="$(printf '%s' "${batch_fragments}" | jq -c .)" \
+                -p iibServiceAccountSecret="${iib_service_account_secret}" \
+                -p publishingCredentials="${publishing_credentials}" \
+                -p buildTimeoutSeconds="${build_timeout_seconds}" \
+                -p buildTags="$(jq -c . <<< "${group_build_tags}")" \
+                -p addArches="$(jq -c . <<< "${add_arches}")" \
+                -p mustPublishIndexImage="${must_publish_index_image}" \
+                -p mustOverwriteFromIndexImage="${must_overwrite_from_index_image}" \
+                -p taskGitUrl="$(params.taskGitUrl)" \
+                -p taskGitRevision="$(params.taskGitRevision)" \
+                --service-account "${internal_request_service_account}" \
+                -l ${TASK_LABEL}="${TASK_ID}" \
+                -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+                --pipeline-timeout "${pipeline_timeout}" \
+                --task-timeout "${task_timeout}" \
+                -t "${request_timeout_seconds}" \
+                | tee "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log"
 
-        # Calculate number of batches needed
-        NUM_BATCHES=$(( (LENGTH + MAX_BATCH_SIZE - 1) / MAX_BATCH_SIZE ))
-        echo "Creating $NUM_BATCHES batch(es) for $LENGTH components"
+            # Extract request name from output
+            local internalRequest
+            internalRequest=$(awk -F"'" '/created/ { print $2 }' \
+                "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log")
 
-        echo "INFO: Processing snapshot components"
-        # Create groups directory
-        groups_dir="$(params.dataDir)/ocp-groups"
-        mkdir -p "$groups_dir"
+            # Validate internal request succeeded
+            local request_status
+            request_status=$(kubectl get internalrequest "${internalRequest}" \
+                -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}')
 
-        # Calculate timeout for batches
-        finally_task_timeout=300
-        pipeline_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds + finally_task_timeout )))
-        task_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds )))
+            if [ "${request_status}" != "True" ]; then
+                echo "ERROR: Batch $((batch_num + 1)) internal request failed"
+                local request_reason
+                request_reason=$(kubectl get internalrequest "${internalRequest}" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}')
+                local request_message
+                request_message=$(kubectl get internalrequest "${internalRequest}" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].message}')
+                echo "Reason: ${request_reason}"
+                echo "Message: ${request_message}"
+                return 1
+            fi
 
-        # Group components by OCP version for isolated processing
-        # Expands multi-version components into separate instances per version
-        group_components_by_ocp_version() {
-            local snapshot_file="$1"
-            local ocp_versions="$2"
+            # Extract and validate results
+            local results
+            results=$(kubectl get internalrequest "${internalRequest}" -o jsonpath='{.status.results}')
 
-            # For each OCP version, extract/expand matching components
-            for ocp_version in $ocp_versions; do
-                local group_file="${groups_dir}/${ocp_version}.json"
+            if [ -z "${results}" ] || [ "${results}" = "{}" ]; then
+                echo "ERROR: Batch $((batch_num + 1)) succeeded but returned empty results"
+                return 1
+            fi
 
-                # Build group by expanding multi-version components
-                # Uses ocpVersionMetadata to get resolved indexes for this specific version
-                jq --arg ocp_version "$ocp_version" '
-                  .components | map(
-                    # Check if component supports this OCP version (ocpVersion is JSON array)
-                    if (.ocpVersion | index($ocp_version)) then
-                      # Find metadata for this specific version
-                      (.ocpVersionMetadata | map(select(.version == $ocp_version)) | .[0]) as $version_metadata |
+            # Store raw results for this batch
+            echo "${results}" > \
+                "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-result.json"
 
-                      # Create instance for this version with resolved indexes
-                      . + {
-                        ocpVersion: $ocp_version,
-                        updatedFromIndex: $version_metadata.updatedFromIndex,
-                        targetIndex: $version_metadata.targetIndex,
-                        originalName: .name,
-                        name: (if (.ocpVersion | length) > 1
-                               then .name + "-" + $ocp_version
-                               else .name end)
-                      }
-                    else
-                      empty
-                    end
-                  )
-                ' "$snapshot_file" > "$group_file"
+            # Decompress build info for fragment processing
+            local decompressed_json_build_info
+            decompressed_json_build_info="$(jq -r '.jsonBuildInfo' <<< "${results}" \
+                | base64 -d | gunzip)"
 
-                local group_count
-                group_count=$(jq 'length' "$group_file")
-                echo "INFO: OCP version $ocp_version has $group_count component instance(s)" >&2
-            done
+            # Extract and validate completion_time from IIB build info
+            local completion_time_raw
+            completion_time_raw="$(jq -r '.updated' <<< "${decompressed_json_build_info}")"
+
+            if [[ -z "${completion_time_raw}" || "${completion_time_raw}" == "null" ]]; then
+                echo "ERROR: completion_time not found in IIB build info"
+                return 1
+            fi
+
+            echo "INFO: Extracting completion_time from IIB build info"
+            echo "  Raw value: ${completion_time_raw}"
+
+            local completion_time
+            if ! completion_time=$(date +"%s" -d "${completion_time_raw}"); then
+                echo "ERROR: Failed to parse completion_time: ${completion_time_raw}"
+                echo "Date conversion error: ${completion_time}"
+                return 1
+            fi
+            echo "  Epoch timestamp: ${completion_time}"
+
+            # Ensure completion_time contains ten digits
+            if [[ ! "${completion_time}" =~ ^[0-9]{10}$ ]]; then
+                echo "ERROR: Invalid completion_time format (expected 10 digits): ${completion_time}"
+                return 1
+            fi
+
+            # timestamped_target_index is the target_index with completion_time, unless
+            # for hotfix or pre-ga which already has it and can be the same.
+            # For staged releases, target_index is empty, so target_index_with_timestamp is also empty.
+            if [[ -z "${group_target_index}" ]]; then
+                target_index_with_timestamp=""
+            elif [[ "${group_target_index}" =~ .*[0-9]{10}$ ]]; then
+                target_index_with_timestamp="${group_target_index}"
+            else
+                target_index_with_timestamp="${group_target_index}-${completion_time}"
+            fi
+
+            # Process each fragment in this batch and append to results file
+            while read -r fragment; do
+                echo "Processing result for fragment: $fragment" \
+                    "(group batch $((batch_num + 1)), OCP: $group_ocp_version)"
+
+                local build_results
+                build_results=$(jq \
+                  --arg fragment "$fragment" \
+                  --arg target_index "${group_target_index}" \
+                  --arg target_index_with_timestamp "${target_index_with_timestamp}" \
+                  --arg ocp_version "$group_ocp_version" \
+                  --arg completion_time "$completion_time" \
+                  --argjson decompressed_json "${decompressed_json_build_info}" \
+                '{
+                  "fbc_fragment": $fragment,
+                  "target_index": $target_index,
+                  "target_index_with_timestamp": $target_index_with_timestamp,
+                  "ocp_version": $ocp_version,
+                  "image_digests": (.indexImageDigests | split(" ") | del(.[] | select(. == ""))),
+                  "index_image": $decompressed_json.index_image,
+                  "index_image_resolved": $decompressed_json.internal_index_image_copy_resolved,
+                  "completion_time": $completion_time,
+                  "iibLog": .iibLog
+                }' <<< "${results}")
+
+                export build_results
+                yq -i '.components += [ env(build_results) ]' "$RESULTS_FILE"
+            done < <(echo "$batch_fragments" | jq -r '.[]')
+
+            echo "Group batch $((batch_num + 1)) completed successfully" \
+                "for OCP $group_ocp_version"
+            return 0
         }
 
-        # Group components by OCP versions
-        group_components_by_ocp_version "$SNAPSHOT_PATH" "$ocp_versions"
-
-        # Process all OCP groups sequentially
-        process_all_ocp_groups() {
-            echo "INFO: Starting group processing"
-
-            for ocp_version in $ocp_versions; do
-                local group_file="${groups_dir}/${ocp_version}.json"
-                echo "INFO: Processing OCP group: $ocp_version"
-
-                local group_components
-                group_components=$(cat "$group_file")
-
-                process_ocp_group "$ocp_version" "$group_components"
-            done
-
-            echo "INFO: Processing completed successfully"
-        }
-
-        # Process OCP group
+        # ---------------------------------------------------------------
+        # process_ocp_group: Process a single OCP version group —
+        # extract parameters, execute batches, handle retries.
+        # ---------------------------------------------------------------
         process_ocp_group() {
             local group_ocp_version="$1"
-            local group_components="$2"
+            local group_file="${groups_dir}/${group_ocp_version}.json"
+            local group_components
+            group_components=$(cat "$group_file")
 
             echo "INFO: Processing OCP group $group_ocp_version"
 
-            # Get group-specific parameters from first component (all should have same values within group)
+            # Get group-specific parameters from first component
             local first_component
             first_component=$(jq -r '.[0]' <<< "$group_components")
             local group_from_index
@@ -347,23 +547,25 @@ spec:
             local group_target_index
             group_target_index=$(jq -r '.targetIndex // empty' <<< "$first_component")
 
-            # Group parameters are already validated globally, but verify tag format
             echo "INFO: Group parameters - fromIndex: $group_from_index, targetIndex: $group_target_index"
 
-            # Extract and validate tag from group target index for PLR identification
+            # Extract tag from group target index for PLR identification
             # For staged releases, targetIndex is empty so no tag extraction is needed
+            local group_build_tags
             if [ -n "$group_target_index" ]; then
+                local group_target_tag
                 group_target_tag=$(printf '%s' "${group_target_index}" | rev | cut -d: -f1 | rev)
                 if [[ "$group_target_tag" = "${group_target_index}" ]]; then
-                    echo "ERROR: Target index for OCP group $group_ocp_version has no tag: $group_target_index"
+                    echo "ERROR: Target index for OCP group $group_ocp_version has no tag:" \
+                        "$group_target_index"
                     exit 1
                 fi
-                echo "INFO: Using tag '$group_target_tag' for PLR identification in OCP group $group_ocp_version"
-
-                # Add group-specific PLR identifier to build tags
+                echo "INFO: Using tag '$group_target_tag' for PLR identification" \
+                    "in OCP group $group_ocp_version"
                 group_build_tags=$(echo "${build_tags}" | jq --arg tag "$group_target_tag" '. + [$tag]')
             else
-                echo "INFO: No target index for OCP group $group_ocp_version (staged release), skipping tag extraction"
+                echo "INFO: No target index for OCP group $group_ocp_version" \
+                    "(staged release), skipping tag extraction"
                 group_build_tags="$build_tags"
             fi
             echo "INFO: Group build tags for OCP $group_ocp_version:" \
@@ -383,21 +585,22 @@ spec:
             echo "INFO: Creating $group_num_batches batch(es) for $num_components components" \
                 "in OCP group $group_ocp_version"
 
-            # Determine fromIndex for batch chaining
+            # ---- Helper: determine fromIndex for batch chaining ----
             get_current_from_index() {
-                if [ "${mustOverwriteFromIndexImage}" = "true" ]; then
-                    # IIB overwrites fromIndex - keep using original consistently
+                if [ "${must_overwrite_from_index_image}" = "true" ]; then
+                    # IIB overwrites fromIndex — keep using original consistently
                     printf '%s' "${group_from_index}"
                 else
-                    # IIB creates new index - we MUST track what was actually created
+                    # IIB creates new index — track what was actually created
                     if [ ${#group_successful_batches[@]} -eq 0 ]; then
-                        # No successful batches yet - start from original fromIndex
+                        # No successful batches yet — start from original fromIndex
                         printf '%s' "${group_from_index}"
                     else
-                        # We have successful batches - MUST use latest IIB output
                         if [ -z "${group_latest_iib_index_image}" ]; then
-                            echo "FATAL ERROR: We have successful batches but group_latest_iib_index_image is empty!"
-                            echo "This would cause data loss. Group successful batches: ${group_successful_batches[*]}"
+                            echo "FATAL ERROR: Successful batches exist but" \
+                                "group_latest_iib_index_image is empty!"
+                            echo "This would cause data loss." \
+                                "Successful batches: ${group_successful_batches[*]}"
                             exit 1
                         fi
                         echo "${group_latest_iib_index_image}"
@@ -405,7 +608,7 @@ spec:
                 fi
             }
 
-            # Get batch fragments
+            # ---- Helper: get fragment list for a batch number ----
             get_batch_fragments() {
                 local batch_num="$1"
                 local start_idx=$((batch_num * MAX_BATCH_SIZE))
@@ -415,185 +618,55 @@ spec:
                 if [ "$end_idx" -gt "$group_length" ]; then
                     end_idx=$group_length
                 fi
-
                 echo "$group_components" | jq -c ".[${start_idx}:${end_idx}] | map(.containerImage)"
             }
 
-            # Execute batch with validation
-            execute_batch() {
+            # ---- Helper: extract new index image from batch results ----
+            # Returns the new index image via stdout when IIB creates new indexes.
+            # Outputs nothing when must_overwrite_from_index_image=true.
+            get_index_from_batch_result() {
                 local batch_num="$1"
-                local from_index="$2"
-
-                echo "Executing group batch $((batch_num + 1)): fromIndex=${from_index}" \
-                    "(OCP: $group_ocp_version)"
-
-                # Get batch fragments
-                local batch_fragments
-                batch_fragments=$(get_batch_fragments "$batch_num")
-
-                # Create InternalRequest for this batch
-                internal-request --pipeline "update-fbc-catalog" \
-                    -p fromIndex="${from_index}" \
-                    -p fbcFragments="$(printf '%s' "${batch_fragments}" | jq -c .)" \
-                    -p iibServiceAccountSecret="${iib_service_account_secret}" \
-                    -p publishingCredentials="${publishing_credentials}" \
-                    -p buildTimeoutSeconds="${build_timeout_seconds}" \
-                    -p buildTags="$(jq -c . <<< "${group_build_tags}")" \
-                    -p addArches="$(jq -c . <<< "${add_arches}")" \
-                    -p mustPublishIndexImage="${mustPublishIndexImage}" \
-                    -p mustOverwriteFromIndexImage="${mustOverwriteFromIndexImage}" \
-                    -p taskGitUrl="$(params.taskGitUrl)" \
-                    -p taskGitRevision="$(params.taskGitRevision)" \
-                    --service-account "${internal_request_service_account}" \
-                    -l ${TASK_LABEL}="${TASK_ID}" \
-                    -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
-                    --pipeline-timeout "${pipeline_timeout}" \
-                    --task-timeout "${task_timeout}" \
-                    -t "${request_timeout_seconds}" \
-                    | tee "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log"
-
-                # Extract request name
-                local internalRequest
-                internalRequest=$(awk -F"'" '/created/ { print $2 }' \
-                    "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-output.log")
-
-                # Validate internal request succeeded
-                local request_status
-                request_status=$(kubectl get internalrequest "${internalRequest}" \
-                    -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}')
-
-                if [ "${request_status}" != "True" ]; then
-                    echo "ERROR: Batch $((batch_num + 1)) internal request failed"
-                    local request_reason
-                    request_reason=$(kubectl get internalrequest "${internalRequest}" \
-                        -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}')
-                    local request_message
-                    request_message=$(kubectl get internalrequest "${internalRequest}" \
-                        -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].message}')
-                    echo "Reason: ${request_reason}"
-                    echo "Message: ${request_message}"
-                    return 1
+                if [ "${must_overwrite_from_index_image}" = "false" ]; then
+                    local result_file
+                    result_file="$(params.dataDir)/ir-$(context.taskRun.uid)"
+                    result_file+="-batch-$((batch_num + 1))-result.json"
+                    local batch_results
+                    batch_results=$(cat "${result_file}")
+                    local new_index
+                    new_index=$(jq -r '.jsonBuildInfo' <<< "${batch_results}" | \
+                        base64 -d | gunzip | jq -r '.index_image')
+                    echo "Updated fromIndex for next batch: ${new_index}" >&2
+                    printf '%s' "${new_index}"
                 fi
-
-                # Extract and validate results
-                local results
-                results=$(kubectl get internalrequest "${internalRequest}" -o jsonpath='{.status.results}')
-
-                if [ -z "${results}" ] || [ "${results}" = "{}" ]; then
-                    echo "ERROR: Batch $((batch_num + 1)) succeeded but returned empty results"
-                    return 1
-                fi
-
-                # Store results for this batch
-                echo "${results}" > "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-result.json"
-
-                # Process results for each fragment in this batch
-                local decompressed_json_build_info
-                decompressed_json_build_info="$(jq -r '.jsonBuildInfo' <<< "${results}" | base64 -d | gunzip)"
-
-                # Extract and validate completion_time from IIB build info
-                local completion_time_raw
-                completion_time_raw="$(jq -r '.updated' <<< "${decompressed_json_build_info}")"
-
-                if [[ -z "${completion_time_raw}" || "${completion_time_raw}" == "null" ]]; then
-                    echo "ERROR: completion_time not found in IIB build info"
-                    return 1
-                fi
-
-                echo "INFO: Extracting completion_time from IIB build info"
-                echo "  Raw value: ${completion_time_raw}"
-
-                local completion_time
-                if ! completion_time=$(date +"%s" -d "${completion_time_raw}"); then
-                    echo "ERROR: Failed to parse completion_time: ${completion_time_raw}"
-                    echo "Date conversion error: ${completion_time}"
-                    return 1
-                fi
-                echo "  Epoch timestamp: ${completion_time}"
-
-                # Ensure completion_time contains ten digits
-                if [[ ! "${completion_time}" =~ ^[0-9]{10}$ ]]; then
-                    echo "ERROR: Invalid completion_time format (expected 10 digits): ${completion_time}"
-                    return 1
-                fi
-
-                # timestamped_target_index is the target_index with completion_time, unless
-                # for hotfix or pre-ga which already has it and can be the same.
-                # For staged releases, target_index is empty, so target_index_with_timestamp is also empty.
-                if [[ -z "${group_target_index}" ]]; then
-                    target_index_with_timestamp=""
-                elif [[ "${group_target_index}" =~ .*[0-9]{10}$ ]]; then
-                    target_index_with_timestamp="${group_target_index}"
-                else
-                    target_index_with_timestamp="${group_target_index}-${completion_time}"
-                fi
-
-                # Process fragments in batch
-                local fragment_index=0
-                echo "$batch_fragments" | jq -r '.[]' | while read -r fragment; do
-                    echo "Processing result for fragment: $fragment" \
-                        "(group batch $((batch_num + 1)), OCP: $group_ocp_version)"
-
-                    # Build individual component result
-                    local build_results
-                    build_results=$(jq \
-                      --arg fragment "$fragment" \
-                      --arg target_index "${group_target_index}" \
-                      --arg target_index_with_timestamp "${target_index_with_timestamp}" \
-                      --arg ocp_version "$group_ocp_version" \
-                      --arg completion_time "$completion_time" \
-                      --argjson decompressed_json "${decompressed_json_build_info}" \
-                    '{
-                      "fbc_fragment": $fragment,
-                      "target_index": $target_index,
-                      "target_index_with_timestamp": $target_index_with_timestamp,
-                      "ocp_version": $ocp_version,
-                      "image_digests": (.indexImageDigests | split(" ") | del(.[] | select(. == ""))),
-                      "index_image": $decompressed_json.index_image,
-                      "index_image_resolved": $decompressed_json.internal_index_image_copy_resolved,
-                      "completion_time": $completion_time,
-                      "iibLog": .iibLog
-                    }' <<< "${results}")
-
-                    # Add to results file
-                    export build_results
-                    yq -i '.components += [ env(build_results) ]' "$RESULTS_FILE"
-
-                    fragment_index=$((fragment_index + 1))
-                done
-
-                echo "Group batch $((batch_num + 1)) completed successfully" \
-                    "for OCP $group_ocp_version"
-                return 0
             }
 
-            # Execute batches with failure tracking and retry logic
+            # ---- First pass: execute batches ----
             for((batch_num=0; batch_num<"$group_num_batches"; batch_num++)); do
                 echo "Processing group batch $((batch_num + 1))/${group_num_batches}" \
                     "for OCP $group_ocp_version..."
 
                 group_current_from_index=$(get_current_from_index)
+                local batch_fragments
+                batch_fragments=$(get_batch_fragments "$batch_num")
 
-                  if execute_batch "$batch_num" "$group_current_from_index"; then
+                if execute_batch "$batch_num" "$group_current_from_index" \
+                    "$group_ocp_version" "$group_target_index" \
+                    "$group_build_tags" "$batch_fragments"; then
                     group_successful_batches+=("$batch_num")
                     echo "Group batch $((batch_num + 1)) succeeded for OCP $group_ocp_version"
-
-                    # Extract latest IIB index image for next batch (only when not overwriting)
-                    if [ "${mustOverwriteFromIndexImage}" = "false" ]; then
-                        result_file="$(params.dataDir)/ir-$(context.taskRun.uid)-batch-$((batch_num + 1))-result.json"
-                        batch_results=$(cat "${result_file}")
-                        group_latest_iib_index_image=$(jq -r '.jsonBuildInfo' <<< "${batch_results}" | \
-                            base64 -d | gunzip | jq -r '.index_image')
-                        echo "Updated fromIndex for next batch: ${group_latest_iib_index_image}"
+                    local new_index
+                    new_index=$(get_index_from_batch_result "$batch_num")
+                    if [ -n "$new_index" ]; then
+                        group_latest_iib_index_image="$new_index"
                     fi
                 else
                     group_failed_batches+=("$batch_num")
-                    echo "Group batch $((batch_num + 1)) failed, will retry later for OCP $group_ocp_version"
-                    # Continue with next batch - no dependency blocking
+                    echo "Group batch $((batch_num + 1)) failed, will retry later" \
+                        "for OCP $group_ocp_version"
                 fi
             done
 
-            # Retry failed batches (order doesn't matter)
+            # ---- Retry failed batches ----
             local max_retries
             max_retries=$(params.maxRetries)
             local batch_retry_delay
@@ -611,45 +684,44 @@ spec:
 
                 for batch_num in "${group_failed_batches[@]}"; do
                     group_current_from_index=$(get_current_from_index)
+                    local batch_fragments
+                    batch_fragments=$(get_batch_fragments "$batch_num")
 
                     if execute_batch "$batch_num" "$group_current_from_index" \
-                        "$group_target_index"; then
-                        echo "Group batch $((batch_num + 1)) succeeded on retry attempt ${retry_attempt}" \
-                            "for OCP $group_ocp_version"
-
-                        # Add to successful batches and extract latest IIB index image (only when not overwriting)
+                        "$group_ocp_version" "$group_target_index" \
+                        "$group_build_tags" "$batch_fragments"; then
+                        echo "Group batch $((batch_num + 1)) succeeded on retry" \
+                            "attempt ${retry_attempt} for OCP $group_ocp_version"
                         group_successful_batches+=("$batch_num")
-                        if [ "${mustOverwriteFromIndexImage}" = "false" ]; then
-                            result_file="$(params.dataDir)/ir-$(context.taskRun.uid)"
-                            result_file+="-batch-$((batch_num + 1))-result.json"
-                            batch_results=$(cat "${result_file}")
-                            group_latest_iib_index_image=$(jq -r '.jsonBuildInfo' <<< "${batch_results}" | \
-                                base64 -d | gunzip | jq -r '.index_image')
-                            echo "Updated fromIndex for next batch: ${group_latest_iib_index_image}"
+                        local new_index
+                        new_index=$(get_index_from_batch_result "$batch_num")
+                        if [ -n "$new_index" ]; then
+                            group_latest_iib_index_image="$new_index"
                         fi
                     else
                         still_failed+=("$batch_num")
-                        echo "Group batch $((batch_num + 1)) failed retry attempt ${retry_attempt}" \
-                            "for OCP $group_ocp_version"
+                        echo "Group batch $((batch_num + 1)) failed retry" \
+                            "attempt ${retry_attempt} for OCP $group_ocp_version"
                     fi
                 done
 
                 group_failed_batches=("${still_failed[@]}")
 
-                if [ ${#group_failed_batches[@]} -gt 0 ] && [ "${retry_attempt}" -lt "${max_retries}" ]; then
+                if [ ${#group_failed_batches[@]} -gt 0 ] \
+                    && [ "${retry_attempt}" -lt "${max_retries}" ]; then
                     echo "Waiting ${batch_retry_delay} seconds before next retry attempt..."
                     sleep "${batch_retry_delay}"
                 fi
             done
 
-            # Final validation to ensure all components were processed
+            # ---- Final validation ----
             if [ ${#group_failed_batches[@]} -gt 0 ]; then
                 echo "ERROR: ${#group_failed_batches[@]} group batches failed after all retries" \
                     "for OCP $group_ocp_version:"
                 for batch_num in "${group_failed_batches[@]}"; do
                     echo "  - Group batch $((batch_num + 1))"
                 done
-                echo "Cannot proceed with partial index for OCP $group_ocp_version -" \
+                echo "Cannot proceed with partial index for OCP $group_ocp_version —" \
                     "this would result in incomplete fragment coverage"
                 exit 1
             fi
@@ -658,21 +730,51 @@ spec:
                 "successfully for OCP $group_ocp_version"
         }
 
-        # Execute the multi-OCP processing
-        process_all_ocp_groups
+        # ---------------------------------------------------------------
+        # Main: process all OCP groups sequentially
+        # ---------------------------------------------------------------
+        echo "INFO: Starting group processing"
 
-        # Classify the targets by `target_index`, but if this is a staging build, we should classify
-        # the targets by `ocp_version` instead, as `target_index` will be missing for this case.
+        for ocp_version in $ocp_versions; do
+            echo "INFO: Processing OCP group: $ocp_version"
+            process_ocp_group "$ocp_version"
+        done
+
+        echo "INFO: Processing completed successfully"
+    - name: collect-and-deduplicate
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        #
+        # Step 3: Aggregate results, deduplicate by target, and produce final output
+        # for downstream tasks (extract-index-image, sign-index-image, etc.).
+        #
+        set -eo pipefail
+
+        # --- Load Configuration ---
+        STATE_DIR="$(params.dataDir)/fbc-state"
+        CONFIG_FILE="${STATE_DIR}/config.json"
+
+        RESULTS_FILE=$(jq -r '.results_file' "$CONFIG_FILE")
+        must_publish_index_image=$(jq -r '.must_publish_index_image' "$CONFIG_FILE")
+        is_staged=$(jq -r '.is_staged' "$CONFIG_FILE")
+        ocp_versions=$(jq -r '.ocp_versions' "$CONFIG_FILE")
+
+        # --- Deduplication ---
+        # Classify targets by target_index, or by ocp_version for staged releases
+        # where target_index is empty.
         UNIQUE_TARGETS=$(jq -r '[.components[].target_index] | unique | length' "$RESULTS_FILE")
 
-        isStage=$(jq '.fbc.stagedIndex // false' "${DATA_FILE}")
-        if [ "${isStage}" == "true" ]; then
+        if [ "${is_staged}" == "true" ]; then
           UNIQUE_TARGETS=$(jq -r '[.components[].ocp_version] | unique | length' "$RESULTS_FILE")
         fi
 
-        # Deduplicate results: keep only the last component per unique target_index (the last one), or
-        # by ocp_version when target_index is set to an empty string.
-        # This ensures downstream tasks (collect-index-images, create-pyxis-image) use the correct digest.
         TOTAL_COMPONENTS=$(jq -r '.components | length' "$RESULTS_FILE")
         if [[ "$TOTAL_COMPONENTS" -gt "$UNIQUE_TARGETS" ]]; then
           echo "Found $TOTAL_COMPONENTS components for $UNIQUE_TARGETS unique targets"
@@ -695,30 +797,26 @@ spec:
           echo "No deduplication needed ($TOTAL_COMPONENTS components, $UNIQUE_TARGETS unique targets)"
         fi
 
-        # Get the final batch result for legacy compatibility (use last successful batch from any group)
-        # Find the most recent batch result file
+        # --- Legacy Compatibility: Find Latest Batch Result ---
+        # Downstream tasks expect a latest batch result for IIB log extraction
         latest_result_file=$(find "$(params.dataDir)" -name "ir-*-batch-*-result.json" \
             -type f -exec ls -t {} + 2>/dev/null | head -1)
         if [[ -n "$latest_result_file" ]]; then
             results=$(cat "$latest_result_file")
-            # Extract batch number from filename for output log
-            batch_number=$(basename "$latest_result_file" | sed 's/.*-batch-\([0-9]*\)-result.json/\1/')
-            internalRequest=$(awk -F"'" '/created/ { print $2 }' \
-                "$(params.dataDir)/ir-$(context.taskRun.uid)-batch-${batch_number}-output.log")
         else
             echo "ERROR: No batch result files found"
             exit 1
         fi
 
+        # --- Final Summary ---
         echo "Final publishing and compatibility values:"
-        echo "  - mustPublishIndexImage: ${mustPublishIndexImage}"
+        echo "  - mustPublishIndexImage: ${must_publish_index_image}"
 
-        # Output batch logs for debugging
+        # Output IIB logs for debugging
         jq -r '.iibLog' <<< "${results}"
         RC="$(jq -r '.exitCode' <<< "${results}")"
 
-        # Summarize batch results
-        if [ "$mustPublishIndexImage" = "true" ]; then
+        if [ "$must_publish_index_image" = "true" ]; then
           echo "Index image will be published."
         else
           echo "Index image will not be published (decision made by prepare-fbc-parameters)."
@@ -729,8 +827,8 @@ spec:
           exit "$RC"
         fi
 
-        # Calculate total components processed across all OCP groups
-        total_components=$(jq '.components | length' "$SNAPSHOT_PATH")
+        total_components=$(jq '.components | length' \
+            "$(params.dataDir)/$(params.snapshotPath)")
         echo "Multi-OCP batch processing completed successfully with $total_components components" \
             "across $(echo "$ocp_versions" | wc -w) OCP versions"
         echo "Results file:"

--- a/tasks/managed/add-fbc-contribution/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/add-fbc-contribution/tests/pre-apply-task-hook.sh
@@ -11,7 +11,10 @@ kubectl delete internalrequests \
   -l "internal-services.appstudio.openshift.io/pipelinerun-uid" \
   --timeout=30s || true
 
-# Add mocks to the beginning of task step script
+# Add mocks to the beginning of task step scripts
+# Step 1 (prepare-inputs) needs date mock for timestamp generation and timeout calculation
+# Step 2 (process-ocp-groups) needs internal-request, set_ir_status, and date mocks
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-batch.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-batch.yaml
@@ -1,0 +1,290 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-multi-batch
+spec:
+  description: Test add-fbc-contribution task with maxBatchSize=1 to verify batch
+    chaining logic where the output of batch 1 becomes the fromIndex of batch 2.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+    - name: sourceDataArtifact
+      description: Location of trusted artifacts to be used to populate data directory
+      type: string
+      default: ""
+  tasks:
+    - name: setup
+      params:
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+            description: Location of trusted artifacts to be used to populate data directory
+          - name: dataDir
+            type: string
+            description: The location where data will be stored
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-test-data
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Ensure data directory exists
+              mkdir -p "$(params.dataDir)"
+
+              # Create snapshot with 2 components in same OCP version to force 2 batches
+              cat > "$(params.dataDir)/snapshot.json" << 'EOF'
+              {
+                "components": [
+                  {
+                    "name": "test-fbc-component-batch1",
+                    "containerImage": "quay.io/hacbs-release-tests/test-fbc-first@sha256:aaaa",
+                    "repository": "quay.io/test/test-fbc-component",
+                    "ocpVersion": ["v4.13"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.13",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                        "targetIndex": "quay.io/redhat/redhat-operator-index:v4.13"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "test-fbc-component-batch2",
+                    "containerImage": "quay.io/hacbs-release-tests/test-fbc-second@sha256:bbbb",
+                    "repository": "quay.io/test/test-fbc-component",
+                    "ocpVersion": ["v4.13"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.13",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                        "targetIndex": "quay.io/redhat/redhat-operator-index:v4.13"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              # Create FBC data configuration for non-staged release
+              cat > "$(params.dataDir)/data.json" << 'EOF'
+              {
+                "fbc": {
+                  "fromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                  "targetIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                  "hotfix": false,
+                  "preGA": false,
+                  "stagedIndex": false,
+                  "buildTags": ["latest"],
+                  "addArches": []
+                }
+              }
+              EOF
+
+              # Create mock results directory structure
+              mkdir -p "$(params.dataDir)/results"
+
+              echo "Multi-batch test data created"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+        - name: maxBatchSize
+          value: "1"
+        - name: mustPublishIndexImage
+          value: "false"
+        - name: mustOverwriteFromIndexImage
+          value: "false"
+        - name: iibServiceAccountSecret
+          value: "iib-services-config"
+      runAfter:
+        - setup
+
+    - name: verify-results
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+            description: Location of trusted artifacts to be used to populate data directory
+          - name: dataDir
+            type: string
+            description: The location where data will be stored
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+              - name: orasOptions
+                value: $(params.orasOptions)
+          - name: verify-multi-batch
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "=== MULTI-BATCH VERIFICATION ==="
+
+              RESULTS_FILE="$(params.dataDir)/results/internal-requests-results.json"
+              if [[ ! -f "$RESULTS_FILE" ]]; then
+                echo "❌ Results file missing at $RESULTS_FILE"
+                exit 1
+              fi
+              echo "✅ Results file exists"
+
+              # After deduplication, 2 components with the same target_index
+              # should be reduced to 1 (the last batch's result)
+              COMPONENTS_COUNT=$(jq '.components | length' "$RESULTS_FILE")
+              if [[ "$COMPONENTS_COUNT" -eq 1 ]]; then
+                echo "✅ Deduplication correct: 2 components reduced to $COMPONENTS_COUNT"
+              else
+                echo "❌ Expected 1 component after dedup, got: $COMPONENTS_COUNT"
+                jq . "$RESULTS_FILE"
+                exit 1
+              fi
+
+              # The surviving component should be from batch 2 (the second fragment)
+              SURVIVING_FRAGMENT=$(jq -r '.components[0].fbc_fragment' "$RESULTS_FILE")
+              if [[ "$SURVIVING_FRAGMENT" == *"test-fbc-second"* ]]; then
+                echo "✅ Correct fragment survived dedup (batch 2): $SURVIVING_FRAGMENT"
+              else
+                echo "❌ Wrong fragment survived dedup: $SURVIVING_FRAGMENT"
+                echo "Expected fragment from batch 2 (test-fbc-second)"
+                jq . "$RESULTS_FILE"
+                exit 1
+              fi
+
+              # Verify the index_image is from IIB (mock returns redhat.com/rh-stage/iib:01)
+              INDEX_IMAGE=$(jq -r '.components[0].index_image' "$RESULTS_FILE")
+              if [[ "$INDEX_IMAGE" == "redhat.com/rh-stage/iib:01" ]]; then
+                echo "✅ Index image is from IIB: $INDEX_IMAGE"
+              else
+                echo "❌ Unexpected index image: $INDEX_IMAGE"
+                exit 1
+              fi
+
+              # Verify two batch result files were created (proves 2 batches ran)
+              BATCH_FILES=$(find "$(params.dataDir)" -name "ir-*-batch-*-result.json" -type f | wc -l)
+              if [[ "$BATCH_FILES" -eq 2 ]]; then
+                echo "✅ Two batch result files found (2 batches executed)"
+              else
+                echo "❌ Expected 2 batch result files, found: $BATCH_FILES"
+                find "$(params.dataDir)" -name "ir-*-batch-*-result.json" -type f
+                exit 1
+              fi
+
+              # Verify config.json shows maxBatchSize=1
+              CONFIG_FILE="$(params.dataDir)/fbc-state/config.json"
+              BATCH_SIZE=$(jq -r '.max_batch_size' "$CONFIG_FILE")
+              if [[ "$BATCH_SIZE" == "1" ]]; then
+                echo "✅ Batch size was correctly set to 1"
+              else
+                echo "❌ Expected batch size 1, got: $BATCH_SIZE"
+                exit 1
+              fi
+
+              echo ""
+              echo "Final results:"
+              jq . "$RESULTS_FILE"
+
+              echo "=== MULTI-BATCH TEST PASSED ==="
+      runAfter:
+        - run-task


### PR DESCRIPTION
Split the monolithic add-contribution script (~520 lines) into three focused steps for improved readability, maintainability, and debuggability:

- prepare-inputs: validates inputs, groups components by OCP version, writes shared config for subsequent steps
- process-ocp-groups: executes IIB requests per OCP group with batching, index chaining, and retries
- collect-and-deduplicate: aggregates results, deduplicates by target, produces final output

No breaking changes - all task parameters, results, and volumes are preserved. The external contract with the fbc-release pipeline and downstream tasks remains identical.

I hope this helps with reviewing this change. Let me know of any suggestions or improvements after reviewing, thanks :)
[demo](https://drive.google.com/file/d/17c_UPPAk6_iyncTBtr5UAkHPzBNiULdy/view?usp=drivesdk)
[Miro board](https://miro.com/app/board/uXjVG4AoBNI=/?share_link_id=620329272779)

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
