### PR TITLE
fix(ROK-1793): update the tasks dependencies on push rpm pipelines

### DIFF
--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -259,7 +259,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - collect-task-params
+        - verify-conforma
       when:
         - input: $(tasks.collect-task-params.results.extractedValues[3])
           operator: notin
@@ -335,7 +335,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - collect-task-params
+        - verify-conforma
       when:
         - input: $(tasks.collect-task-params.results.extractedValues[3])
           operator: in


### PR DESCRIPTION
* Update push-rpm-to-koji, make the conforma check happen before push tasks.
* In theory, the conforma check must pass before the pipeline take any actions, so the push tasks
   happens after the verify-conforma task after this change and the collect-task-params happens before
   verify-conforma

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
