### PR TITLE
chore: enable qodo auto-reviews

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,10 +5,17 @@
 [github_app]
 # Ignore PRs opened by these authors.
 ignore_pr_authors = ["red-hat-konflux", "release-service-bot"]
-# Disable auto-run on PR open/reopen - only run when user explicitly comments /review
-pr_commands = []
-# Disable auto-run on push - only run when user explicitly comments /review
-handle_push_trigger = false
+# Run review automatically when PRs are opened/reopened/ready.
+pr_commands = [
+  "/review",
+  "/improve",
+]
+# Run review automatically when new commits are pushed to an open PR.
+handle_push_trigger = true
+push_commands = [
+  "/review",
+  "/improve",
+]
 
 [pr_reviewer]
 # Limit review feedback to 3 findings per PR.


### PR DESCRIPTION
## Describe your changes

We were requested to enable back qodo auto-reviews. This commit is doing so.

If we find ourselves in a situation in which qodo is being too annoying, we will need to give more rules to control its behavior. Going back to manual is not an option.

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
