### PR TITLE
chore: add secret leakage prevention rules to Qodo review config

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -19,6 +19,33 @@ persistent_comment = true
 extra_instructions = """
 - Provide up to 3 inline review comments per PR.
 - Prefer inline suggestions over a single summary comment.
+
+## Secret Leakage Prevention in Pipeline Tasks
+
+Flag any code that risks leaking secrets, credentials, or sensitive data to pipeline logs.
+
+### Known "Leaky" Patterns to Flag
+
+- **OpenSSL without `-noout`**: `openssl rsa -in [key] -check` (or similar) without the `-noout` flag dumps the entire
+  private key in plain text to logs. Always require `-noout`.
+- **Curl verbose flags**: Using `-v`, `-i`, or `--verbose` on curl calls that contact authenticated endpoints can print
+  `Authorization` headers, cookies, and tokens to the console.
+- **`env` / `printenv` without filtering**: Running `env` or `printenv` to verify a single variable can expose the
+  entire environment block, including registry passwords and API keys. Use `echo "$SPECIFIC_VAR"` or
+  `printenv SPECIFIC_VAR` instead.
+- **Shell tracing (`set -x`)**: Activating trace mode expands all variables inline. If a secret is used as a command
+  argument, it is printed to logs before the command executes. Secrets must never appear in `set -x` traced commands;
+  disable tracing around sensitive sections with `set +x` or use a subshell.
+
+### Mandatory Requirements for Pipeline Tasks
+
+1. **Enforce Silence**: Identify and require "quiet" or "no-output" flags (e.g., `-q`, `-s`, `--silent`, `-noout`)
+   for any tool handling sensitive files or credentials.
+2. **Explicit Redirection**: If a command is used for validation or a health check involving credentials, redirect
+   all output to null: `[command] > /dev/null 2>&1`.
+3. **Manual Log Verification**: Remind authors that they are responsible for the security of task output. The logs of
+   the first successful run must be manually inspected to confirm no sensitive information is visible. If any secret
+   is found in logs, the task is broken and secrets must be rotated immediately.
 """
 
 [pr_code_suggestions]
@@ -29,4 +56,14 @@ num_code_suggestions_per_chunk = 3
 extra_instructions = """
 - Before suggesting a change, verify whether the PR/task already includes it (or equivalent logic). If it already exists, do not suggest it.
 - Do not repeat previously rejected suggestions in subsequent updates of the same PR if the thread was resolved without action.
+
+## Secret Leakage Prevention
+
+When suggesting code changes for pipeline tasks, always apply these rules:
+
+- If `openssl` is used on key/cert files, ensure `-noout` is present.
+- If `curl` contacts authenticated endpoints, remove `-v`, `-i`, and `--verbose` flags, or suggest `--silent` / `-s`.
+- Replace bare `env` or `printenv` with targeted variable access (e.g., `printenv SPECIFIC_VAR`).
+- If `set -x` is active, suggest wrapping sensitive sections with `set +x` ... `set -x` or running them in a subshell.
+- For validation/health-check commands involving credentials, suggest redirecting output: `> /dev/null 2>&1`.
 """


### PR DESCRIPTION
Instruct the reviewer and code suggestions to flag common patterns that leak secrets to pipeline logs: openssl without -noout, verbose curl flags, unfiltered env/printenv, and set -x tracing.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
