### PR TITLE
fix: sensitive data leaking

### DIFF
--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -126,7 +126,7 @@ spec:
           readOnly: true
       script: |
         #!/usr/bin/env bash
-        set -euxo pipefail
+        set -euo pipefail
 
         PUSH_TOKEN=$(cat /var/secrets/git-token/gitlab-gr-maintenance-token)
         SIGNED_KMODS_PATH="$(params.dataDir)/$(params.signedKmodsPath)"

--- a/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-oot-kmods-to-git/tests/pre-apply-task-hook.sh
@@ -68,4 +68,4 @@ rm /tmp/injected-script.sh
 echo "Injection complete. Creating secret..."
 
 kubectl delete secret git-token-secret --ignore-not-found
-kubectl create secret generic git-token-secret --from-literal=gitlab-gr-maintenance-token=MYVERYSECRETTOKEN
+kubectl create secret generic git-token-secret --from-literal=gitlab-gr-maintenance-token=SENSITIVE_DATA_MYVERYSECRETTOKEN

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -51,7 +51,7 @@ spec:
         secretName: $(params.s3CredentialsSecret)
   stepTemplate:
     securityContext:
-      runAsUser: 1001 
+      runAsUser: 1001
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
@@ -130,9 +130,7 @@ spec:
         set -euo pipefail
 
         AWS_ACCESS_KEY_ID=$(cat /var/secrets/s3/aws_access_key_id)
-        export AWS_ACCESS_KEY_ID
         AWS_SECRET_ACCESS_KEY=$(cat /var/secrets/s3/aws_secret_access_key)
-        export AWS_SECRET_ACCESS_KEY
 
         set -x
 
@@ -156,8 +154,10 @@ spec:
 
             # Read envfile to get version information and ARCH override
             if [ -f "$source_dir/envfile" ]; then
+                set +x
                 # shellcheck source=/dev/null
                 . "$source_dir/envfile"
+                set -x
             else
                 echo "ERROR: envfile not found in $source_dir"
                 return 1
@@ -198,13 +198,23 @@ spec:
                     echo "  ... (showing first 10 files)"
                 fi
 
-                aws s3 cp \
+                set +x
+                AWS_LOG="/tmp/aws_s3_cp_kmods.log"
+                if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" aws s3 cp \
                   "$source_dir" \
                   "s3://$(params.s3Bucket)/${S3_TARGET_PATH}" \
                   --endpoint-url "$(params.s3Endpoint)" \
                   --recursive \
                   --exclude "*" \
-                  --include "*.ko"
+                  --include "*.ko" > "$AWS_LOG" 2>&1; then
+                  echo "ERROR: S3 .ko files upload failed. Sanitized logs below:"
+                  sed -e "s/${AWS_SECRET_ACCESS_KEY}/[REDACTED]/g" \
+                      -e "s/${AWS_ACCESS_KEY_ID}/[REDACTED]/g" "$AWS_LOG"
+                  rm -f "$AWS_LOG"
+                  exit 1
+                fi
+                rm -f "$AWS_LOG"
+                set -x
             else
                 echo "WARNING: No .ko files found for architecture $arch_name"
                 return 1
@@ -213,19 +223,39 @@ spec:
             # Upload checksum file (always use arch-specific filename)
             if [ -f "$source_dir/signed_kmods_checksums_${arch_name}.txt" ]; then
                 echo "Uploading architecture-specific checksums for $arch_name"
-                aws s3 cp \
+                set +x
+                AWS_LOG="/tmp/aws_s3_cp_checksum.log"
+                if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" aws s3 cp \
                   "$source_dir/signed_kmods_checksums_${arch_name}.txt" \
                   "s3://$(params.s3Bucket)/${S3_TARGET_PATH}signed_kmods_checksums_${arch_name}.txt" \
-                  --endpoint-url "$(params.s3Endpoint)"
+                  --endpoint-url "$(params.s3Endpoint)" > "$AWS_LOG" 2>&1; then
+                  echo "ERROR: S3 checksums upload failed. Sanitized logs below:"
+                  sed -e "s/${AWS_SECRET_ACCESS_KEY}/[REDACTED]/g" \
+                      -e "s/${AWS_ACCESS_KEY_ID}/[REDACTED]/g" "$AWS_LOG"
+                  rm -f "$AWS_LOG"
+                  exit 1
+                fi
+                rm -f "$AWS_LOG"
+                set -x
             fi
 
             # Upload envfile for reference
             if [ -f "$source_dir/envfile" ]; then
                 echo "Uploading envfile for $arch_name"
-                aws s3 cp \
+                set +x
+                AWS_LOG="/tmp/aws_s3_cp_envfile.log"
+                if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" aws s3 cp \
                   "$source_dir/envfile" \
                   "s3://$(params.s3Bucket)/${S3_TARGET_PATH}envfile" \
-                  --endpoint-url "$(params.s3Endpoint)"
+                  --endpoint-url "$(params.s3Endpoint)" > "$AWS_LOG" 2>&1; then
+                  echo "ERROR: S3 envfile upload failed. Sanitized logs below:"
+                  sed -e "s/${AWS_SECRET_ACCESS_KEY}/[REDACTED]/g" \
+                      -e "s/${AWS_ACCESS_KEY_ID}/[REDACTED]/g" "$AWS_LOG"
+                  rm -f "$AWS_LOG"
+                  exit 1
+                fi
+                rm -f "$AWS_LOG"
+                set -x
             fi
 
             return 0
@@ -240,24 +270,57 @@ spec:
                 # Use first architecture's envfile for base path information
                 first_arch_dir=$(find "${SIGNED_KMODS_FULL_PATH}" -mindepth 1 -maxdepth 1 -type d | head -1)
                 if [ -n "$first_arch_dir" ] && [ -f "$first_arch_dir/envfile" ]; then
+                    set +x
                     # shellcheck source=/dev/null
                     . "$first_arch_dir/envfile"
+                    set -x
                     # Strip architecture suffix from KERNEL_VERSION
                     KERNEL_VERSION_CLEAN=$(echo "$KERNEL_VERSION" | \
                       sed -E 's/\.(x86_64|amd64|aarch64|arm64|ppc64le|s390x)(\+.*)?$//')
                     summary_s3_path="${DRIVER_VENDOR}/${DRIVER_VERSION}/${KERNEL_VERSION_CLEAN}/multi-arch-summary/"
 
+                    set +x
+                    AWS_LOG="/tmp/aws_s3_cp.log"
                     echo "Uploading multi-architecture summary to s3://$(params.s3Bucket)/${summary_s3_path}"
-                    aws s3 cp \
-                      "${SIGNED_KMODS_FULL_PATH}/signing_summary.txt" \
-                      "s3://$(params.s3Bucket)/${summary_s3_path}signing_summary.txt" \
-                      --endpoint-url "$(params.s3Endpoint)"
+                    if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+                          AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+                          aws s3 cp \
+                        "${SIGNED_KMODS_FULL_PATH}/signing_summary.txt" \
+                        "s3://$(params.s3Bucket)/${summary_s3_path}signing_summary.txt" \
+                        --endpoint-url "$(params.s3Endpoint)" > "$AWS_LOG" 2>&1; then
+
+                        echo "ERROR: S3 upload failed. Sanitized logs below:"
+                        sed -e "s/${AWS_SECRET_ACCESS_KEY}/[REDACTED]/g" \
+                            -e "s/${AWS_ACCESS_KEY_ID}/[REDACTED]/g" "$AWS_LOG"
+                        rm -f "$AWS_LOG"
+                        exit 1
+                    fi
+                    rm -f "$AWS_LOG"
+                    echo "SUCCESS: Multi-architecture signing summary uploaded to S3."
+                    set -x
 
                     if [ -f "${SIGNED_KMODS_FULL_PATH}/extraction_summary.txt" ]; then
-                        aws s3 cp \
-                          "${SIGNED_KMODS_FULL_PATH}/extraction_summary.txt" \
+                      set +x
+                      AWS_LOG="/tmp/aws_s3_cp.log"
+
+                      echo "INFO: Uploading extraction_summary.txt to S3..."
+
+                      if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+                          AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+                          aws s3 cp \                          "${SIGNED_KMODS_FULL_PATH}/extraction_summary.txt" \
                           "s3://$(params.s3Bucket)/${summary_s3_path}extraction_summary.txt" \
-                          --endpoint-url "$(params.s3Endpoint)"
+                          --endpoint-url "$(params.s3Endpoint)" > "$AWS_LOG" 2>&1; then
+    
+                          echo "ERROR: S3 upload failed. Sanitized logs below:"
+    
+                          sed -e "s/${AWS_SECRET_ACCESS_KEY}/[REDACTED]/g" \
+                              -e "s/${AWS_ACCESS_KEY_ID}/[REDACTED]/g" "$AWS_LOG"
+                          rm -f "$AWS_LOG"
+                          exit 1
+                      fi
+                      rm -f "$AWS_LOG"
+                      echo "SUCCESS: Extraction summary uploaded to S3."
+                      set -x
                     fi
                 fi
             fi

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -185,12 +185,16 @@ spec:
             export signing_author
             export signKey
             echo "Executing SSH command to sign OOT kernel modules for architecture: $arch_name"
+            # Disable debug trace to avoid leaking signKey
+            set +x
             # shellcheck disable=SC2029  # Intentional client-side expansion
             ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
             "export KEY='${signKey}'; export ARCH='${arch_name}'; \
              export TASK_UID='${task_uid}'; \
              export SIGNING_AUTHOR='${signing_author}'; \
              bash -s" <<'EOF'
+        set -x
+
         echo "Remote: Signing OOT kernel modules for architecture $ARCH using $KEY key..."
 
         # Construct the remote directory path using the remote server's HOME
@@ -228,6 +232,8 @@ spec:
 
         echo "Remote: Finished signing process for architecture $ARCH"
         EOF
+            # Re-enable debug trace
+            set -x
         }
 
         # Set up Kerberos and SSH

--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -346,11 +346,13 @@ spec:
         setup_git_repository() {
           cd /tmp
 
+          set +x
           # Source utility functions
           source_utility_functions
 
           # Clone and setup repository
           git_clone_and_checkout --repository "$GIT_REPO" --revision "$(params.repo_branch)"
+          set -x
 
           # Install dependencies and setup environment
           uv sync


### PR DESCRIPTION
tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
signkey leaking:
     ssh "${SSH_OPTS[@]}" "${signUser}@${signHost}" \
            "export KEY='${signKey}'; export ARCH='${arch_name}'; \
             export TASK_UID='${task_uid}'; \
             export SIGNING_AUTHOR='${signing_author}'; \
             bash -s" <<'EOF'
      ...
      EOF
solution: add "set +x"/"set-x" before and after code block

tasks/managed/update-package-collection/update-package-collection.yaml
GITHUB_TOKEN leaking:
          # Source utility functions
          source_utility_functions

          # Clone and setup repository
          git_clone_and_checkout --repository "$GIT_REPO" --revision "$(params.repo_branch)"
solution: add "set +x"/"set-x" before and after code block

tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml‎
high potential leaking code:
     . "$source_dir/envfile"
     and
     aws s3 cp \...    (similar commands are used in several places of the file)
solution: add "set +x"/"set-x" before and after code block and handle error outputs to prevent leaking sensitive data.

tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-git.yaml
githlab token leaking
solution: remove -x since there is a 'set -x' nearby

Assisted-By: Cursor

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
