### PR TITLE
refactor(RELEASE-2030): make atlas mandatory when used

### DIFF
--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -455,9 +455,6 @@ spec:
         - embargo-check
     - name: process-component-sbom
       when:
-        - input: "$(tasks.collect-atlas-params.results.secretName)"
-          operator: notin
-          values: [""]
         - input: "$(tasks.filter-already-released-advisory-rpms.results.skip_release)"
           operator: in
           values: ["false"]
@@ -507,9 +504,6 @@ spec:
         - push-rpms-to-pulp
     - name: process-product-sbom
       when:
-        - input: "$(tasks.collect-atlas-params.results.secretName)"
-          operator: notin
-          values: [""]
         - input: "$(tasks.filter-already-released-advisory-rpms.results.skip_release)"
           operator: in
           values: ["false"]
@@ -571,7 +565,8 @@ spec:
               {"systemName": "releaseNotes", "dynamic": false},
               {"systemName": "pyxis", "dynamic": false},
               {"systemName": "mapping", "dynamic": false},
-              {"systemName": "sign", "dynamic": false}
+              {"systemName": "sign", "dynamic": false},
+              {"systemName": "atlas", "dynamic": false}
             ]
         - name: ociStorage
           value: $(params.ociStorage)

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -754,9 +754,6 @@ spec:
         - collect-task-params
     - name: process-component-sbom
       when:
-        - input: "$(tasks.collect-atlas-params.results.secretName)"
-          operator: notin
-          values: [""]
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
           operator: in
           values: ["false"]
@@ -807,9 +804,6 @@ spec:
         - push-snapshot
     - name: process-product-sbom
       when:
-        - input: "$(tasks.collect-atlas-params.results.secretName)"
-          operator: notin
-          values: [""]
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
           operator: in
           values: ["false"]
@@ -911,7 +905,8 @@ spec:
               {"systemName": "releaseNotes", "dynamic": false},
               {"systemName": "pyxis", "dynamic": false},
               {"systemName": "mapping", "dynamic": false},
-              {"systemName": "sign", "dynamic": false}
+              {"systemName": "sign", "dynamic": false},
+              {"systemName": "atlas", "dynamic": false}
             ]
         - name: ociStorage
           value: $(params.ociStorage)

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -31,7 +31,8 @@
               "mapping",
               "ootsign",
               "conforma",
-              "intention"
+              "intention",
+              "atlas"
             ]
           },
           "dynamic": {
@@ -1912,6 +1913,60 @@
         "required": [
           "intention"
         ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "atlas"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "atlas"
+        ]
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "atlas"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "atlas"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "atlas": {
+            "required": [
+              "server"
+            ]
+          }
+        }
       }
     }
   ]

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-atlas.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-atlas.yaml
@@ -2,12 +2,15 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-nonexistent
+  name: test-check-data-keys-fail-missing-atlas
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-atlas-params task with a missing atlasServer key.
+    Run the check-data-keys task with the atlas key missing in the data json and
+    verify that the task fails as expected.
+  workspaces:
+    - name: tests-workspace
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -30,10 +33,15 @@ spec:
       type: string
   tasks:
     - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       taskSpec:
         results:
           - name: sourceDataArtifact
             type: string
+        workspaces:
+          - name: data
         volumes:
           - name: workdir
             emptyDir: {}
@@ -49,14 +57,20 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: setup-values
+          - name: setup
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
-              #!/usr/bin/env bash
+              #!/usr/bin/env sh
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              echo "{}" > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "someOtherData": { # just dummy data to simulate no intention field
+                  "example": "value"
+                }
+              }
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -69,10 +83,17 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: check-data-keys
       params:
         - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
+          value: $(context.pipelineRun.uid)/data.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "atlas", "dynamic": false}
+            ]
+        - name: schema
+          value: "https://get-local-schema.com"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -87,5 +108,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+      workspaces:
+        - name: data
+          workspace: tests-workspace
       runAfter:
         - setup

--- a/tasks/managed/collect-atlas-params/README.md
+++ b/tasks/managed/collect-atlas-params/README.md
@@ -3,8 +3,7 @@
 Tekton task that collects the Atlas server option from the data file. Based on
 the value of the "atlas.server" field ("stage" or "production"), outputs results
 used to push SBOMs to Atlas. Also outputs results used to push SBOMs to an S3
-bucket. If no Atlas fields are present in the data file, it outputs empty
-strings as results, indicating that the Atlas push should be skipped.
+bucket. If no Atlas fields are present in the data file, the task fails
 
 ## Parameters
 

--- a/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+++ b/tasks/managed/collect-atlas-params/collect-atlas-params.yaml
@@ -11,8 +11,7 @@ spec:
     Tekton task that collects the Atlas server option from the data file. Based on
     the value of the "atlas.server" field ("stage" or "production"), outputs results
     used to push SBOMs to Atlas. Also outputs results used to push SBOMs to an S3
-    bucket. If no Atlas fields are present in the data file, it outputs empty
-    strings as results, indicating that the Atlas push should be skipped.
+    bucket. If no Atlas fields are present in the data file, the task fails
   params:
     - name: dataPath
       type: string
@@ -148,14 +147,7 @@ spec:
         fi
 
         atlasServer=$(jq -r '.atlas.server' "$DATA_FILE")
-        if [ "$atlasServer" = "null" ]; then
-            # In this case, SBOM processing will be skipped.
-            atlasApiUrl=""
-            ssoTokenUrl=""
-            secretName=""
-            retryAWSSecretName=""
-            retryS3Bucket=""
-        elif [ "$atlasServer" = "stage" ]; then
+        if [ "$atlasServer" = "stage" ]; then
             atlasApiUrl="https://atlas.release.stage.devshift.net"
             ssoTokenUrl="https://auth.stage.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
             secretName=$(jq -r '.atlas."atlas-sso-secret-name" // "atlas-staging-sso-secret"' "$DATA_FILE")
@@ -169,6 +161,10 @@ spec:
             retryAWSSecretName=$(jq -r '.atlas."atlas-retry-aws-secret-name" // "atlas-retry-s3-production-secret"' \
               "$DATA_FILE")
             retryS3Bucket="mpp-e1-prod-sbom-e02138d3-5c5c-4d90-a38f-6c54f658604d"
+        elif [ "$atlasServer" = "null" ]; then
+            echo "ERROR: .atlas.server value is missing from the data file. This field is mandatory."
+            echo "Consult with your release engineering contact to ask why you are missing this value"
+            exit 1
         else
             echo "ERROR: Unknown .atlas.server value '$atlasServer'. Expected 'stage' or 'production'."
             exit 1


### PR DESCRIPTION
This commit updates the rh-advisories and push-rpms-to-pulp pipeline to make the atlas params required. They were optional for a while, but now all users using these pipelines should have the atlas configs defined. Consequently, it updates the collect-atlas-params task to fail when called if the atlas keys are missing in the data file, instead of exiting with the results as empty strings.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
