### PR TITLE
feat(CLOUDDST-31926): add duplicate package validation for FBC fragments

### DIFF
--- a/integration-tests/fbc-release/resources/managed/rpa.yaml
+++ b/integration-tests/fbc-release/resources/managed/rpa.yaml
@@ -23,6 +23,7 @@ spec:
       productVersion: ""
       allowedPackages:
         - "example-operator"
+        - "example-operator2"
     pyxis:
       server: stage
       secret: pyxis-${component_name}
@@ -70,6 +71,7 @@ spec:
       productVersion: ""
       allowedPackages:
         - "example-operator"
+        - "example-operator2"
     pyxis:
       server: stage
       secret: pyxis-${component_name}
@@ -117,6 +119,7 @@ spec:
       productVersion: "v2"
       allowedPackages:
         - "example-operator"
+        - "example-operator2"
     pyxis:
       server: stage
       secret: pyxis-${component_name}
@@ -164,6 +167,7 @@ spec:
       productVersion: ""
       allowedPackages:
         - "example-operator"
+        - "example-operator2"
     pyxis:
       server: stage
       secret: pyxis-${component_name}

--- a/integration-tests/fbc-release/test.env
+++ b/integration-tests/fbc-release/test.env
@@ -26,9 +26,10 @@ export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
 # Component 2 configuration (for multi-component tests)
-# Just use a branch on the same repo to simplify PAC configuration
+# Uses a different base branch to avoid duplicate package conflicts
 export component2_name=${component_type}-comp2-${uuid}
 export component2_branch=${component2_name}
+export component2_base_branch=fbc-release-multi-component-base
 export component2_repo_name=${component_repo_name}
 export component2_git_url=https://github.com/${component2_repo_name}
 

--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -132,16 +132,16 @@ configure_test_matrix() {
 # Always create both repositories for simplicity and reliability
 create_github_repository() {
     echo "🔨 Creating repositories (always dual for reliability)..."
-    
+
     # Always create component 1 repo
     "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
         "${component_base_repo_name}" "${component_base_branch}" \
         "${component_repo_name}" "${component_branch}"
-    
-    # Always create component 2 repo
+
+    # Always create component 2 repo (using different base branch to avoid duplicate packages)
     echo "  Creating component 2 repository..."
     "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
-        "${component_base_repo_name}" "${component_base_branch}" \
+        "${component_base_repo_name}" "${component2_base_branch}" \
         "${component2_repo_name}" "${component2_branch}"
 }
 

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -228,8 +228,13 @@ spec:
 
         RENDERED_CATALOG=/tmp/catalog.json
         bundle_images='[]'
+
+        # Track OCP version to components mapping for duplicate package detection
+        declare -A ocp_version_to_component_indices  # OCP version -> newline-separated component indices
+        declare -A component_to_packages              # component index -> newline-separated packages
+
         for ((i=0; i<component_count; i++)); do
-            fbc_fragment=$(jq -cr --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
+            fbc_fragment=$(jq -r --argjson i "$i" '.components[$i].containerImage' "${SNAPSHOT_PATH}")
             echo "INFO: Processing component $((i+1))/${component_count}: ${fbc_fragment}"
 
             # === PACKAGE VALIDATION ===
@@ -238,12 +243,15 @@ spec:
             echo "  INFO: Validating packages in fragment..."
             rm -f "${RENDERED_CATALOG}"
             opm render "${fbc_fragment}" > "${RENDERED_CATALOG}"
-            actual_packages=$(jq -r 'select(.schema=="olm.package") | .name' < "${RENDERED_CATALOG}" | uniq)
+            actual_packages=$(jq -r 'select(.schema=="olm.package") | .name' < "${RENDERED_CATALOG}" | sort -u)
             component_bundle_images=$(jq -r \
               'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' \
-              < "${RENDERED_CATALOG}" | uniq | jq -R . | jq -s .)
+              < "${RENDERED_CATALOG}" | sort -u | jq -R . | jq -s .)
             bundle_images=$(jq --argjson component_bundle_images \
               "$component_bundle_images" '. += $component_bundle_images' <<< "$bundle_images")
+
+            # Store packages for duplicate detection
+            component_to_packages[$i]="$actual_packages"
 
             component_package_valid=true
             disallowed_packages='[]'
@@ -305,10 +313,82 @@ spec:
             else
                 echo "    SUCCESS: Found valid OCP version: ${ocp_version}"
                 target_versions=$(jq --arg version "$ocp_version" '. += [$version]' <<< "$target_versions")
+
+                # Group components by OCP version for duplicate package detection
+                if [ -z "${ocp_version_to_component_indices[$ocp_version]:-}" ]; then
+                    ocp_version_to_component_indices[$ocp_version]="$i"
+                else
+                    ocp_version_to_component_indices[$ocp_version]+=$'\n'"$i"
+                fi
             fi
         done
         # Ensure all bundle images are unique across fragments
         bundle_images=$(jq -c 'unique' <<< "$bundle_images")
+
+        # === DUPLICATE PACKAGE VALIDATION (PER OCP VERSION) ===
+        # Prevents composition conflicts by ensuring each package appears only once per OCP version.
+        # Multiple fragments targeting the same catalog index (same OCP version) cannot contain
+        # the same package, as this would create conflicting catalog entries during index composition
+        # causing data loss. This validation enforces package uniqueness within the scope of each
+        # target OCP version, while allowing the same package to exist across different versions.
+        echo "INFO: Validating no duplicate packages within FBCs for the same OCP version..."
+
+        # For each OCP version that has multiple components
+        for ocp_ver in "${!ocp_version_to_component_indices[@]}"; do
+            component_indices="${ocp_version_to_component_indices[$ocp_ver]}"
+
+            # Count components for this OCP version (count lines, filtering empty lines)
+            component_count_for_version=$(printf '%s\n' "$component_indices" \
+              | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+
+            # Skip if only one component for this OCP version
+            if [ "$component_count_for_version" -le 1 ]; then
+                echo "  INFO: OCP version ${ocp_ver}: ${component_count_for_version} component" \
+                  "(no duplicate check needed)"
+                continue
+            fi
+
+            echo "  INFO: OCP version ${ocp_ver}: ${component_count_for_version} components -" \
+              "checking for duplicate packages..."
+
+            # Track duplicates for this specific OCP version
+            ocp_version_has_duplicates=false
+
+            # Build package -> component mapping for this OCP version
+            declare -A package_to_component
+
+            while IFS= read -r comp_idx; do
+                packages="${component_to_packages[$comp_idx]}"
+                while IFS= read -r pkg; do
+                    [ -z "$pkg" ] && continue  # Skip empty lines
+                    if [ -n "${package_to_component[$pkg]:-}" ]; then
+                        # Duplicate found!
+                        first_component_idx="${package_to_component[$pkg]}"
+                        first_component_name=$(jq -r --argjson idx "$first_component_idx" \
+                            '.components[$idx].name' "${SNAPSHOT_PATH}")
+                        current_component_name=$(jq -r --argjson idx "$comp_idx" \
+                            '.components[$idx].name' "${SNAPSHOT_PATH}")
+
+                        echo "    ERROR: Duplicate package '${pkg}' found in OCP version ${ocp_ver}"
+                        echo "      - Component ${first_component_idx} (${first_component_name}):" \
+                          "contains package '${pkg}'"
+                        echo "      - Component ${comp_idx} (${current_component_name}):" \
+                          "also contains package '${pkg}'"
+                        ocp_version_has_duplicates=true
+                        validation_failed=true
+                    else
+                        package_to_component[$pkg]="$comp_idx"
+                    fi
+                done <<< "$packages"
+            done <<< "$component_indices"
+
+            # Clean up for next iteration
+            unset package_to_component
+
+            if [ "$ocp_version_has_duplicates" != "true" ]; then
+                echo "    SUCCESS: No duplicate packages found for OCP version ${ocp_ver}"
+            fi
+        done
 
         # === CHECK ALL BUNDLE IMAGES FOR OPT-IN ===
         # Select appropriate IIB service account based on environment (moved here to fix unbound variable)

--- a/tasks/managed/prepare-fbc-parameters/tests/mocks.sh
+++ b/tasks/managed/prepare-fbc-parameters/tests/mocks.sh
@@ -15,12 +15,24 @@ function kubectl() {
   if [[ "$*" == "get internalrequest test-check-fbc-opt-in-ir -o jsonpath={.status.conditions[?(@.type==\"Succeeded\")].status}" ]]; then
     echo "True"
   elif [[ "$*" == "get internalrequest test-check-fbc-opt-in-ir -o jsonpath={.status.results}" ]]; then
-    # Check if this is the failure propagation test based on the allowedPackages in data.json
-    if [ -f "$(params.dataDir)/data.json" ] && grep -q "non-matching-package" "$(params.dataDir)/data.json"; then
-      # Return mock opt-in results for failure propagation test (all opted in, but packages will fail validation)
+    # Read what bundle images were actually requested from the internal-request call
+    requested_bundles=""
+    if [ -f "$(params.dataDir)/mock_internal-request.txt" ]; then
+      requested_bundles=$(sed -n 's/.*containerImages=\(\[.*\]\).*/\1/p' \
+        "$(params.dataDir)/mock_internal-request.txt" || echo "")
+    fi
+
+    # Determine which bundle images to return based on what was requested
+    if echo "$requested_bundles" | grep -q "operator-foundry-e2e-example-operator-bundle"; then
+      # Test with operator-foundry bundles (integration test with modified component-2)
+      echo '{"optInResults": [{"containerImage": "quay.io/joelanford/example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/joelanford/example-operator-bundle:0.2.0", "fbcOptIn": true}, {"containerImage": "quay.io/exd-guild-hello-operator/operator-foundry-e2e-example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/exd-guild-hello-operator/operator-foundry-e2e-example-operator-bundle:0.2.0", "fbcOptIn": true}]}'
+    elif [ -f "$(params.dataDir)/data.json" ] && grep -q "non-matching-package" "$(params.dataDir)/data.json"; then
+      # Failure propagation test (package validation will fail)
       echo '{"optInResults": [{"containerImage": "quay.io/joelanford/example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/joelanford/example-operator-bundle:0.2.0", "fbcOptIn": true}]}'
     else
-      # Return mock opt-in results for successful integration test - bundle images from the FBC fragment
+      # Default case: return opt-in for all known test bundle images
+      # This handles both integration test (2 components) and duplicate packages test (4 components with duplicates)
+      # The actual bundles from the test images (sha256:f6e7... and sha256:4218...)
       echo '{"optInResults": [{"containerImage": "quay.io/joelanford/example-operator-bundle:0.1.0", "fbcOptIn": true}, {"containerImage": "quay.io/joelanford/example-operator-bundle:0.2.0", "fbcOptIn": true}]}'
     fi
   else

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-duplicate-packages.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-duplicate-packages.yaml
@@ -2,9 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-validate-fbc-fragments-integration
+  name: test-validate-fbc-fragments-duplicate-packages
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
-  description: Test managed validate-fbc-fragments task integration; should succeed with valid components.
+  description: Test managed validate-fbc-fragments task detects duplicate packages within same OCP version.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -61,7 +63,10 @@ spec:
               # Ensure data directory exists
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test data for successful validation (using actual FBC test images)
+              # Create test data with duplicate components (same packages for same OCP version)
+              # Component 1 and 3 are identical (both test-fbc-component-1)
+              # Component 2 and 4 are identical (both test-fbc-component-2)
+              # All target the same OCP version (v4.16), so duplicates will be detected
               cat > "$(params.dataDir)/$(params.snapshotPath)" << 'EOF'
               {
                 "components": [
@@ -71,6 +76,14 @@ spec:
                   },
                   {
                     "name": "test-fbc-component-2",
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a"
+                  },
+                  {
+                    "name": "test-fbc-component-1-duplicate",
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297"
+                  },
+                  {
+                    "name": "test-fbc-component-2-duplicate",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a"
                   }
                 ]
@@ -95,7 +108,7 @@ spec:
               }
               EOF
 
-              echo "Test data created for integration test"
+              echo "Test data created for duplicate package validation test"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact


### PR DESCRIPTION
Implements validation to detect duplicate packages across FBC fragments targeting the same OCP version, preventing conflicts during catalog publishing of binaryless FBC fragments. This change does not hinder publishing of binary-enabled FBCs in any way.

  Changes:
  - Add duplicate package detection in prepare-fbc-parameters task
    - Track OCP version to component mapping during fragment processing
    - Store extracted packages for each component from opm render output
    - Validate no duplicate packages exist within same OCP version group
    - Report detailed errors with component names when duplicates found

  - Update test mocks to handle multiple test scenarios
    - Support both original and operator-foundry bundle images
    - Dynamically return opt-in results based on requested bundles

  - Add test-prepare-fbc-parameters-duplicate-packages.yaml
    - Verifies duplicate package validation fails correctly
    - Tests 4 components (2 pairs of duplicates) targeting same OCP version
    - Uses test/assert-task-failure annotation for expected failure

Assisted-By: Claude
