### PR TITLE
fix: strip CRD validations in test setup

### DIFF
--- a/.github/scripts/install_crds.sh
+++ b/.github/scripts/install_crds.sh
@@ -9,7 +9,9 @@
 install_appstudio_repo_crds () {
     git clone https://github.com/$1/$2
     pushd $2
-    kubectl create -f config/crd/bases
+    for crd in config/crd/bases/*.yaml; do
+        yq 'del(.. | .x-kubernetes-validations?)' "$crd" | kubectl create -f -
+    done
     popd
 }
 


### PR DESCRIPTION
## Describe your changes

The application-api CRDs now include x-kubernetes-validations (CEL)
rules that are not compatible with the simplified resources used in
tests. Strip these validations when installing CRDs to prevent test
failures.

## Relevant Jira

## Checklist before requesting a review
- [X] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [X] My commit message includes `Signed-off-by: My name <email>`
- [X] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [X] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
