### PR TITLE
feat(RELEASE-1265): rh-push-to-registry-redhat-io pipeline idempotency

### DIFF
--- a/tasks/internal/check-file-updates-task/README.md
+++ b/tasks/internal/check-file-updates-task/README.md
@@ -1,0 +1,22 @@
+# check-file-updates-task
+
+Internal task to check whether Konflux `fileUpdates` changes are already complete for a
+given componentGroup and GitLab repository.
+
+This task is intentionally "best effort": on errors (missing credentials, API errors, invalid data),
+it returns file_updates_complete=false and result=Failure instead of failing the TaskRun. This enables
+managed pipelines to treat the check as incomplete and continue safely.
+
+## Parameters
+
+| Name                           | Description                                                               | Optional | Default value       |
+|--------------------------------|---------------------------------------------------------------------------|----------|---------------------|
+| upstream_repo                  | Git repository (GitLab) where fileUpdates merge requests are created      | No       | -                   |
+| componentGroup                 | Component group being released (used to identify Konflux fileUpdates MRs) | No       | -                   |
+| file_updates_secret            | Secret containing GitLab host/access token used by internal services      | Yes      | file-updates-secret |
+| apiRetryCount                  | Number of retries for GitLab API calls                                    | Yes      | 3                   |
+| apiConnectTimeout              | Connection timeout in seconds for GitLab API calls                        | Yes      | 10                  |
+| apiMaxTime                     | Maximum time in seconds for GitLab API calls                              | Yes      | 30                  |
+| caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca          |
+| caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt       |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                             | No       | -                   |

--- a/tasks/internal/check-file-updates-task/check-file-updates-task.yaml
+++ b/tasks/internal/check-file-updates-task/check-file-updates-task.yaml
@@ -1,0 +1,259 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-file-updates-task
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Internal task to check whether Konflux `fileUpdates` changes are already complete for a
+    given componentGroup and GitLab repository.
+
+    This task is intentionally "best effort": on errors (missing credentials, API errors, invalid data),
+    it returns file_updates_complete=false and result=Failure instead of failing the TaskRun. This enables
+    managed pipelines to treat the check as incomplete and continue safely.
+  params:
+    - name: upstream_repo
+      type: string
+      description: Git repository (GitLab) where fileUpdates merge requests are created
+    - name: componentGroup
+      type: string
+      description: Component group being released (used to identify Konflux fileUpdates MRs)
+    - name: file_updates_secret
+      type: string
+      description: Secret containing GitLab host/access token used by internal services
+      default: file-updates-secret
+    - name: apiRetryCount
+      type: string
+      description: Number of retries for GitLab API calls
+      default: "3"
+    - name: apiConnectTimeout
+      type: string
+      description: Connection timeout in seconds for GitLab API calls
+      default: "10"
+    - name: apiMaxTime
+      type: string
+      description: Maximum time in seconds for GitLab API calls
+      default: "30"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: internalRequestPipelineRunName
+      type: string
+      description: Name of the PipelineRun that called this task
+  results:
+    - name: result
+      type: string
+      description: Success if the check executed, Failure otherwise
+    - name: file_updates_complete
+      type: string
+      description: '"true" if latest matching fileUpdates MR is merged, otherwise "false"'
+    - name: merge_request_url
+      type: string
+      description: Web URL of the latest matching fileUpdates MR (may be empty)
+    - name: internalRequestPipelineRunName
+      type: string
+      description: Name of the PipelineRun that ran this task
+    - name: internalRequestTaskRunName
+      type: string
+      description: Name of the TaskRun that ran this task
+  volumes:
+    - name: file-updates-secret-vol
+      secret:
+        secretName: $(params.file_updates_secret)
+        defaultMode: 0444
+        optional: true
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    securityContext:
+      runAsUser: 1001
+    volumeMounts:
+      - name: file-updates-secret-vol
+        mountPath: /mnt/file-updates-secret
+        readOnly: true
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+  steps:
+    - name: check
+      image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 256Mi
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Default results (best-effort: do not fail the TaskRun)
+        echo -n "Failure" > "$(results.result.path)"
+        echo -n "false" > "$(results.file_updates_complete.path)"
+        echo -n "" > "$(results.merge_request_url.path)"
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+        echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+        GITLAB_API_PATH="/api/v4"
+        GITLAB_MR_MAX_PAGES=20
+
+        ERRORS=()
+        fail() {
+          local msg="${1:-unknown error}"
+          echo "ERROR: ${msg}" >&2
+          exit 1
+        }
+        add_error() {
+          ERRORS+=("${1}")
+        }
+        check_errors() {
+          if [ "${#ERRORS[@]}" -gt 0 ]; then
+            for err in "${ERRORS[@]}"; do
+              echo "ERROR: ${err}" >&2
+            done
+            exit 1
+          fi
+        }
+
+        upstream_repo="$(params.upstream_repo)"
+        component_group="$(params.componentGroup)"
+
+        if [ -z "${upstream_repo}" ]; then
+          add_error "upstream_repo param is required"
+        fi
+        if [ -z "${component_group}" ]; then
+          add_error "componentGroup param is required"
+        fi
+
+        if [ ! -f /mnt/file-updates-secret/gitlab_host ] || [ ! -f /mnt/file-updates-secret/gitlab_access_token ]; then
+          add_error "file updates secret missing required keys (gitlab_host and gitlab_access_token)"
+        fi
+
+        check_errors
+
+        gitlab_host="$(tr -d '\n\r' < /mnt/file-updates-secret/gitlab_host)"
+        access_token="$(tr -d '\n\r' < /mnt/file-updates-secret/gitlab_access_token)"
+
+        if [ -z "${gitlab_host}" ] || [ -z "${access_token}" ]; then
+          add_error "file updates secret contains empty gitlab_host or gitlab_access_token"
+        fi
+
+        check_errors
+
+        # Use CA bundle if present (optional)
+        ca_bundle_path="/mnt/trusted-ca/ca-bundle.crt"
+        ca_bundle_args=()
+        if [ -f "${ca_bundle_path}" ]; then
+          ca_bundle_args=(--cacert "${ca_bundle_path}")
+        fi
+
+        # Parse <group>/<project> path from upstream_repo
+        project_path=""
+        if [[ "${upstream_repo}" =~ ^https?://[^/]+/(.+)$ ]] || \
+           [[ "${upstream_repo}" =~ ^git@[^:]+:(.+)$ ]]; then
+          project_path="${BASH_REMATCH[1]}"
+        else
+          fail "could not parse upstream_repo: ${upstream_repo}"
+        fi
+
+        project_path="${project_path%/}"
+        project_path="${project_path%.git}"
+        if [ -z "${project_path}" ]; then
+          fail "parsed project path is empty from upstream_repo: ${upstream_repo}"
+        fi
+
+        base_url="${gitlab_host}"
+        if ! [[ "${base_url}" =~ ^https?:// ]]; then
+          base_url="https://${base_url}"
+        fi
+        base_url="${base_url%/}"
+        gitlab_api_url="${base_url}${GITLAB_API_PATH}"
+
+        project_path_encoded="$(jq -sRr @uri <<< "${project_path}")"
+        search_encoded="$(jq -sRr @uri <<< "Konflux release")"
+
+        curl_config="$(mktemp)"
+        chmod "600" "${curl_config}"
+        printf '%s\n' "header = \"PRIVATE-TOKEN: ${access_token}\"" > "${curl_config}"
+
+        response_file="$(mktemp)"
+        mr_base_url="${gitlab_api_url}/projects/${project_path_encoded}/merge_requests?state=all&search=${search_encoded}&order_by=created_at&sort=desc&per_page=100"
+
+        # Paginate through all results — per_page=100 (GitLab max) reduces round-trips,
+        # but a project with many "Konflux release" MRs from other component groups could
+        # push the relevant MR beyond the first page.
+        latest_mr=""
+        page=1
+        while [ "${page}" -le "${GITLAB_MR_MAX_PAGES}" ]; do
+          mr_search_url="${mr_base_url}&page=${page}"
+          http_code="$(
+            curl --retry "$(params.apiRetryCount)" --retry-all-errors \
+              --connect-timeout "$(params.apiConnectTimeout)" --max-time "$(params.apiMaxTime)" \
+              -sS "${ca_bundle_args[@]}" --config "${curl_config}" \
+              -o "${response_file}" -w "%{http_code}" \
+              "${mr_search_url}" \
+              2>/dev/null || echo "000"
+          )"
+
+          if [ "${http_code}" != "200" ]; then
+            fail "GitLab API query failed for ${project_path} (HTTP ${http_code})"
+          fi
+
+          page_count="$(jq '. | length' "${response_file}" 2>/dev/null || echo "0")"
+          if [ "${page_count}" -eq 0 ]; then
+            break
+          fi
+
+          # Find the latest MR matching this componentGroup and fileUpdates title pattern.
+          # process-file-updates-task creates titles like:
+          #   [Konflux release] <componentGroup>: fileUpdates changes <branch>
+          # Use startswith("[Konflux release] " + cg + ":") for an exact componentGroup match —
+          # contains() would be a substring match and could match a different componentGroup
+          # that has this one as a prefix (e.g. "foo" matching "foobar").
+          latest_mr="$(
+            jq -c --arg cg "${component_group}" '
+              map(
+                select((.title // "") | startswith("[Konflux release] " + $cg + ":"))
+                | select((.title // "") | contains("fileUpdates changes"))
+              )
+              | .[0] // empty
+            ' "${response_file}" 2>/dev/null || true
+          )"
+
+          if [ -n "${latest_mr}" ]; then
+            break
+          fi
+
+          page=$((page + 1))
+        done
+
+        if [ -z "${latest_mr}" ]; then
+          echo "No matching fileUpdates MR found for componentGroup=${component_group}"
+          echo -n "Success" > "$(results.result.path)"
+          exit 0
+        fi
+
+        mr_state="$(jq -r '.state // ""' <<< "${latest_mr}" 2>/dev/null || echo "")"
+        mr_url="$(jq -r '.web_url // ""' <<< "${latest_mr}" 2>/dev/null || echo "")"
+        echo -n "${mr_url}" > "$(results.merge_request_url.path)"
+
+        if [ "${mr_state}" = "merged" ]; then
+          echo -n "true" > "$(results.file_updates_complete.path)"
+        else
+          echo -n "false" > "$(results.file_updates_complete.path)"
+        fi
+
+        echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/check-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/check-file-updates-task/tests/mocks.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mocks for the check-file-updates-task test. Sourced via BASH_ENV from the mounted
+# ConfigMap (file-updates-task-mocks); see pre-apply-task-hook.sh.
+
+function curl() {
+  # Mock curl for GitLab API query
+  local output_file=""
+  local url=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o)
+        output_file="$2"
+        shift 2
+        ;;
+      -w|--retry|--connect-timeout|--max-time)
+        shift 2
+        ;;
+      --config|--cacert)
+        shift 2
+        ;;
+      -sS|--retry-all-errors|-s|-S)
+        shift 1
+        ;;
+      *)
+        if [[ ! "$1" =~ ^- ]]; then
+          url="$1"
+        fi
+        shift 1
+        ;;
+    esac
+  done
+
+  # component_group is set by the task script before invoking curl
+  local json_response="[]"
+  case "${component_group:-}" in
+    merged-app)
+      json_response='[{"title":"[Konflux release] merged-app: fileUpdates changes abc","state":"merged","web_url":"https://gitlab.example.com/merged"}]'
+      ;;
+    open-app)
+      json_response='[{"title":"[Konflux release] open-app: fileUpdates changes def","state":"opened","web_url":"https://gitlab.example.com/open"}]'
+      ;;
+    *)
+      json_response='[]'
+      ;;
+  esac
+
+  if [ -n "$output_file" ]; then
+    echo "$json_response" > "$output_file"
+  else
+    echo "$json_response"
+  fi
+
+  # Simulate curl -w "%{http_code}"
+  printf "%s" "200"
+}

--- a/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/check-file-updates-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_PATH="$1"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Mount mocks via ConfigMap and source via BASH_ENV (avoids inlining mocks into the step script)
+MOCKS_CM_NAME="file-updates-task-mocks"
+MOCKS_MOUNT_PATH="/workspace/mocks"
+kubectl delete configmap "${MOCKS_CM_NAME}" --ignore-not-found
+kubectl create configmap "${MOCKS_CM_NAME}" --from-file=mocks.sh="${SCRIPT_DIR}/mocks.sh"
+
+yq -i '.spec.volumes += [{"name": "test-mocks", "configMap": {"name": "'"${MOCKS_CM_NAME}"'"}}]' "$TASK_PATH"
+yq -i '.spec.steps[0].volumeMounts += [{"name": "test-mocks", "mountPath": "'"${MOCKS_MOUNT_PATH}"'", "readOnly": true}]' "$TASK_PATH"
+yq -i '.spec.steps[0].env += [{"name": "BASH_ENV", "value": "'"${MOCKS_MOUNT_PATH}"'/mocks.sh"}]' "$TASK_PATH"
+
+# Create test secrets (delete first if they exist)
+kubectl delete secret file-updates-secret --ignore-not-found
+kubectl create secret generic file-updates-secret \
+  --from-literal=gitlab_host="gitlab.example.com" \
+  --from-literal=gitlab_access_token="mock-token"

--- a/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-merged.yaml
+++ b/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-merged.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-file-updates-task-merged
+spec:
+  description: |
+    Verify check-file-updates-task returns complete=true when the latest matching MR is merged.
+  tasks:
+    - name: run-check
+      taskRef:
+        name: check-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://gitlab.example.com/group/project.git"
+        - name: componentGroup
+          value: "merged-app"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: internalRequestPipelineRunName
+          value: "test"
+    - name: verify
+      runAfter:
+        - run-check
+      params:
+        - name: result
+          value: "$(tasks.run-check.results.result)"
+        - name: complete
+          value: "$(tasks.run-check.results.file_updates_complete)"
+        - name: mr
+          value: "$(tasks.run-check.results.merge_request_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: complete
+            type: string
+          - name: mr
+            type: string
+        steps:
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [ "$(params.result)" != "Success" ]; then
+                echo "ERROR: expected result=Success, got: $(params.result)"
+                exit 1
+              fi
+
+              if [ "$(params.complete)" != "true" ]; then
+                echo "ERROR: expected file_updates_complete=true, got: $(params.complete)"
+                exit 1
+              fi
+
+              if [ -z "$(params.mr)" ]; then
+                echo "ERROR: expected merge_request_url to be set"
+                exit 1
+              fi

--- a/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-no-mr.yaml
+++ b/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-no-mr.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-file-updates-task-no-mr
+spec:
+  description: |
+    Verify check-file-updates-task handles the case where no matching fileUpdates MR exists
+    for the given componentGroup (GitLab returns an empty list). The task should succeed
+    with result=Success, file_updates_complete=false (the default set at task start), and
+    merge_request_url empty.
+  tasks:
+    - name: run-check
+      taskRef:
+        name: check-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://gitlab.example.com/group/project.git"
+        - name: componentGroup
+          value: "no-mr-app"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: internalRequestPipelineRunName
+          value: "test"
+    - name: verify
+      runAfter:
+        - run-check
+      params:
+        - name: result
+          value: "$(tasks.run-check.results.result)"
+        - name: complete
+          value: "$(tasks.run-check.results.file_updates_complete)"
+        - name: mr
+          value: "$(tasks.run-check.results.merge_request_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: complete
+            type: string
+          - name: mr
+            type: string
+        steps:
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [ "$(params.result)" != "Success" ]; then
+                echo "ERROR: expected result=Success, got: $(params.result)"
+                exit 1
+              fi
+
+              if [ "$(params.complete)" != "false" ]; then
+                echo "ERROR: expected file_updates_complete=false when no MR exists," \
+                  "got: $(params.complete)"
+                exit 1
+              fi
+
+              if [ -n "$(params.mr)" ]; then
+                echo "ERROR: expected merge_request_url to be empty when no MR exists," \
+                  "got: $(params.mr)"
+                exit 1
+              fi
+
+              echo "PASS: task correctly handled missing fileUpdates MR (result=Success, file_updates_complete=false)"

--- a/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-open.yaml
+++ b/tasks/internal/check-file-updates-task/tests/test-check-file-updates-task-open.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-file-updates-task-open
+spec:
+  description: |
+    Verify check-file-updates-task returns complete=false when the latest matching MR is not merged.
+  tasks:
+    - name: run-check
+      taskRef:
+        name: check-file-updates-task
+      params:
+        - name: upstream_repo
+          value: "https://gitlab.example.com/group/project.git"
+        - name: componentGroup
+          value: "open-app"
+        - name: file_updates_secret
+          value: "file-updates-secret"
+        - name: internalRequestPipelineRunName
+          value: "test"
+    - name: verify
+      runAfter:
+        - run-check
+      params:
+        - name: result
+          value: "$(tasks.run-check.results.result)"
+        - name: complete
+          value: "$(tasks.run-check.results.file_updates_complete)"
+        - name: mr
+          value: "$(tasks.run-check.results.merge_request_url)"
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: complete
+            type: string
+          - name: mr
+            type: string
+        steps:
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [ "$(params.result)" != "Success" ]; then
+                echo "ERROR: expected result=Success, got: $(params.result)"
+                exit 1
+              fi
+
+              if [ "$(params.complete)" != "false" ]; then
+                echo "ERROR: expected file_updates_complete=false, got: $(params.complete)"
+                exit 1
+              fi
+
+              if [ -z "$(params.mr)" ]; then
+                echo "ERROR: expected merge_request_url to be set"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/README.md
@@ -1,0 +1,55 @@
+# filter-already-released-by-pyxis-and-file-updates
+
+Tekton task to filter out images from a snapshot that have already been released.
+This task verifies:
+- Pyxis metadata (always required): the image IS in Pyxis — found via image_id
+  (the manifest digest stored by create-pyxis-image). The query uses the Pyxis REST
+  API field `image_id`, NOT `docker_image_digest` (which does not exist in Pyxis records).
+  Additionally, the record must have non-empty rpm_manifest.rpms (populated by
+  push-rpm-data-to-pyxis, which runs after push-snapshot). rpm_manifest.rpms being
+  present is sufficient proof the full release completed. repositories[].tags is NOT
+  checked — it is unreliable in staging and redundant given rpm_manifest.rpms.
+- fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
+
+The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
+not by calling GitLab directly from this managed task.
+
+The task overwrites the original snapshot file in place with a filtered version
+containing only components that still need release work.
+
+This task supports both Trusted Artifacts and PVC-based workflows (compliance):
+
+- **Trusted Artifacts**: Leave workspace `data` unbound; set `sourceDataArtifact` and use default
+  `dataDir` (/var/workdir/release). Snapshot/data are pulled into an emptyDir and results pushed to OCI.
+- **PVC-based**: Bind the optional workspace `data` to a PVC that already contains snapshot/data; set
+  `dataDir` to the workspace path (e.g. `/workspace/data/release`). Leave `sourceDataArtifact` empty;
+  `use-trusted-artifact` and `create-trusted-artifact` steps are skipped.
+
+Fail-safe behavior: The task fails only if Pyxis credentials are missing or
+pyxisServer is invalid. For all other issues (API errors, missing data, internal
+check errors), components are kept and the pipeline proceeds.
+
+## Parameters
+
+| Name                    | Description                                                                                                                                                       | Optional | Default value                                             |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                                                                                | No       | -                                                         |
+| dataPath                | Path to the JSON string of the merged data in the data workspace                                                                                                  | Yes      | ""                                                        |
+| request                 | Name of the internal pipeline used to check fileUpdates completion                                                                                                | Yes      | check-file-updates                                        |
+| requestTimeout          | InternalRequest timeout (seconds) for the fileUpdates completion check                                                                                            | Yes      | 300                                                       |
+| pipelineRunUid          | The uid of the current PipelineRun. Used as a label value when creating internal requests                                                                         | No       | -                                                         |
+| pyxisSecret             | The kubernetes secret for Pyxis authentication (needs keys: cert, key)                                                                                            | Yes      | pyxis-secret                                              |
+| pyxisServer             | The Pyxis server: production, production-internal, stage-internal, or stage                                                                                       | Yes      | production                                                |
+| apiRetryCount           | Number of retries for API calls to Pyxis                                                                                                                          | Yes      | 3                                                         |
+| apiConnectTimeout       | Connection timeout in seconds for API calls to Pyxis                                                                                                              | Yes      | 10                                                        |
+| apiMaxTime              | Maximum time in seconds for API calls to Pyxis                                                                                                                    | Yes      | 30                                                        |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                                                             | Yes      | trusted-ca                                                |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                                                             | Yes      | ca-bundle.crt                                             |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored. Must be provided by the pipeline (e.g., quay.io/redhat-user-workloads/workspace/application/component) | Yes      | ""                                                        |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire                                        | Yes      | 1d                                                        |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                                                            | Yes      | ""                                                        |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                                                                   | Yes      | ""                                                        |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                                                               | Yes      | ""                                                        |
+| dataDir                 | The location where data will be stored. In Trusted Artifacts mode use default; in PVC mode set to the workspace path (e.g. /workspace/data/release)               | Yes      | /var/workdir/release                                      |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored                                                                             | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                                                                    | No       | -                                                         |

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
@@ -1,0 +1,730 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-by-pyxis-and-file-updates
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Tekton task to filter out images from a snapshot that have already been released.
+    This task verifies:
+    - Pyxis metadata (always required): the image IS in Pyxis — found via image_id
+      (the manifest digest stored by create-pyxis-image). The query uses the Pyxis REST
+      API field `image_id`, NOT `docker_image_digest` (which does not exist in Pyxis records).
+      Additionally, the record must have non-empty rpm_manifest.rpms (populated by
+      push-rpm-data-to-pyxis, which runs after push-snapshot). rpm_manifest.rpms being
+      present is sufficient proof the full release completed. repositories[].tags is NOT
+      checked — it is unreliable in staging and redundant given rpm_manifest.rpms.
+    - fileUpdates completion (only when `.fileUpdates` is configured in the merged data file)
+
+    The fileUpdates completion check is performed via an InternalRequest (internal GitLab access),
+    not by calling GitLab directly from this managed task.
+
+    The task overwrites the original snapshot file in place with a filtered version
+    containing only components that still need release work.
+
+    This task supports both Trusted Artifacts and PVC-based workflows (compliance):
+
+    - **Trusted Artifacts**: Leave workspace `data` unbound; set `sourceDataArtifact` and use default
+      `dataDir` (/var/workdir/release). Snapshot/data are pulled into an emptyDir and results pushed to OCI.
+    - **PVC-based**: Bind the optional workspace `data` to a PVC that already contains snapshot/data; set
+      `dataDir` to the workspace path (e.g. `/workspace/data/release`). Leave `sourceDataArtifact` empty;
+      `use-trusted-artifact` and `create-trusted-artifact` steps are skipped.
+
+    Fail-safe behavior: The task fails only if Pyxis credentials are missing or
+    pyxisServer is invalid. For all other issues (API errors, missing data, internal
+    check errors), components are kept and the pipeline proceeds.
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+      type: string
+    - name: dataPath
+      type: string
+      description: Path to the JSON string of the merged data in the data workspace
+      default: ""
+    - name: request
+      type: string
+      description: Name of the internal pipeline used to check fileUpdates completion
+      default: "check-file-updates"
+    - name: requestTimeout
+      type: string
+      default: "300"
+      description: InternalRequest timeout (seconds) for the fileUpdates completion check
+    - name: pipelineRunUid
+      type: string
+      description: The uid of the current PipelineRun. Used as a label value when creating internal requests
+    - name: pyxisSecret
+      type: string
+      description: |-
+        The kubernetes secret for Pyxis authentication (needs keys: cert, key)
+      default: "pyxis-secret"
+    - name: pyxisServer
+      type: string
+      description: |-
+        The Pyxis server: production, production-internal, stage-internal, or stage
+      default: "production"
+    - name: apiRetryCount
+      type: string
+      description: Number of retries for API calls to Pyxis
+      default: "3"
+    - name: apiConnectTimeout
+      type: string
+      description: Connection timeout in seconds for API calls to Pyxis
+      default: "10"
+    - name: apiMaxTime
+      type: string
+      description: Maximum time in seconds for API calls to Pyxis
+      default: "30"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: ociStorage
+      description: |-
+        The OCI repository where the Trusted Artifacts are stored.
+        Must be provided by the pipeline (e.g., quay.io/redhat-user-workloads/workspace/application/component)
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: |-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: |-
+        The location where data will be stored. In Trusted Artifacts mode use default;
+        in PVC mode set to the workspace path (e.g. /workspace/data/release)
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  results:
+    - name: skip_release
+      description: Whether to skip release tasks (true if all components are already released)
+    - name: sourceDataArtifact
+      description: The location of the source data artifact in the OCI repository (empty in PVC mode)
+  workspaces:
+    - name: data
+      optional: true
+      description: |
+        Optional. When bound (PVC-based workflow), snapshot/data are read from this workspace.
+        dataDir should point to the workspace path (e.g. /workspace/data/release).
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: pyxis-secret-vol
+      secret:
+        secretName: $(params.pyxisSecret)
+        defaultMode: 0444
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: ORAS_OPTIONS
+        value: $(params.orasOptions)
+      - name: TRUSTED_ARTIFACTS_DEBUG
+        value: $(params.trustedArtifactsDebug)
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      when:
+        - input: $(params.sourceDataArtifact)
+          operator: notin
+          values: [""]
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 30m
+          memory: 64Mi
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+        - name: orasOptions
+          value: $(params.orasOptions)
+    - name: filter-already-released-by-metadata
+      image: quay.io/konflux-ci/release-service-utils@sha256:653b4782f0693c031a5d1327c026e6895d90b8126d51d8a3d07ffe940f6721fd
+      computeResources:
+        limits:
+          cpu: 250m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 1Gi
+      volumeMounts:
+        - name: pyxis-secret-vol
+          mountPath: /etc/pyxis-secrets
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        
+        echo "╔═══════════════════════════════════════════════════════════════════╗"
+        echo "║ Filter Already Released Components (Pyxis Check)                ║"
+        echo "╚═══════════════════════════════════════════════════════════════════╝"
+        # API call retry/timeout configuration (from task parameters)
+        API_RETRY_COUNT="$(params.apiRetryCount)"
+        API_CONNECT_TIMEOUT="$(params.apiConnectTimeout)"
+        API_MAX_TIME="$(params.apiMaxTime)"
+
+        # CA bundle configuration (use array to avoid word-splitting)
+        CA_BUNDLE_PATH="/mnt/trusted-ca/ca-bundle.crt"
+        if [ -f "${CA_BUNDLE_PATH}" ]; then
+          CA_BUNDLE_ARGS=(--cacert "${CA_BUNDLE_PATH}")
+        else
+          CA_BUNDLE_ARGS=()
+        fi
+
+        # Helper function for Pyxis API calls (certificate-based auth)
+        # Usage: http_get_pyxis <url> <output_file> <cert_path> <key_path>
+        # Returns: HTTP status code (always numeric, "000" on complete failure)
+        # SECURITY: Stderr redirected to /dev/null to prevent cert path leakage in error messages
+        http_get_pyxis() {
+          local url="$1"
+          local output_file="$2"
+          local cert_path="$3"
+          local key_path="$4"
+          local http_code
+          http_code=$(curl --retry "${API_RETRY_COUNT}" --retry-all-errors \
+            --connect-timeout "${API_CONNECT_TIMEOUT}" --max-time "${API_MAX_TIME}" -sS \
+            "${CA_BUNDLE_ARGS[@]}" \
+            --cert "${cert_path}" --key "${key_path}" \
+            -o "${output_file}" -w "%{http_code}" "${url}" 2>/dev/null || echo "000")
+          # Ensure we always return a numeric code
+          if [[ "${http_code}" =~ ^[0-9]{3}$ ]]; then
+            echo "${http_code}"
+          else
+            echo "000"
+          fi
+        }
+
+        # Helper function to keep a component in the filtered list
+        # Usage: keep_component <component_json> <reason_message>
+        keep_component() {
+          local component_json="$1"
+          local reason="$2"
+          echo "${reason}"
+          echo "${component_json}" >> "${FILTERED_COMPONENTS_FILE}"
+          echo ""
+        }
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+
+        # Initialize results with defaults to prevent task failure on early exits
+        if [ -n "$(params.sourceDataArtifact)" ]; then
+          echo -n "$(params.sourceDataArtifact)" > "$(results.sourceDataArtifact.path)"
+        else
+          echo -n "" > "$(results.sourceDataArtifact.path)"
+        fi
+        echo -n "false" > "$(results.skip_release.path)"
+
+        if [ ! -f "${SNAPSHOT_FILE}" ]; then
+            echo "Error: Snapshot file not found: ${SNAPSHOT_FILE}"
+            exit 1
+        fi
+
+        # Check Pyxis credentials (required)
+        if [ ! -f /etc/pyxis-secrets/cert ] || [ ! -f /etc/pyxis-secrets/key ]; then
+          echo "Error: Pyxis credentials not available"
+          exit 1
+        fi
+
+        if [[ "$(params.pyxisServer)" == "production" ]]; then
+          PYXIS_URL="https://pyxis.api.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "stage" ]]; then
+          PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "production-internal" ]]; then
+          PYXIS_URL="https://pyxis.engineering.redhat.com/"
+        elif [[ "$(params.pyxisServer)" == "stage-internal" ]]; then
+          PYXIS_URL="https://pyxis.stage.engineering.redhat.com/"
+        else
+          echo "Invalid pyxisServer parameter. Allowed values: production, production-internal, stage-internal, stage"
+          exit 1
+        fi
+
+        # Validate snapshot JSON structure (work directly on file for better performance)
+        if ! jq -e '.' "${SNAPSHOT_FILE}" >/dev/null 2>&1; then
+          echo "Error: Invalid JSON in snapshot file"
+          exit 1
+        fi
+        
+        if ! jq -e '.components | type == "array"' "${SNAPSHOT_FILE}" >/dev/null 2>&1; then
+          echo "Error: Snapshot missing required 'components' array or it is not an array"
+          exit 1
+        fi
+        
+        COMPONENT_COUNT=$(jq '.components | length' "${SNAPSHOT_FILE}")
+
+        # Skip release if snapshot is empty
+        if [ "${COMPONENT_COUNT}" -eq 0 ]; then
+          echo "Snapshot has no components - skipping release"
+          echo -n "true" > "$(results.skip_release.path)"
+          # sourceDataArtifact already initialized at start
+          exit 0
+        fi
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "Starting filter check for ${COMPONENT_COUNT} component(s)"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        FILTERED_COUNT=0
+
+        # Check fileUpdates completion (if configured in data.json). This is required
+        # to consider a component "fully released" for idempotency.
+        FILE_UPDATES_COMPLETE="true"
+        FILE_UPDATES_REQUIRED="false"
+        COMPONENT_GROUP=$(jq -r '.componentGroup // .application // ""' "${SNAPSHOT_FILE}")
+
+        if [ -n "$(params.dataPath)" ]; then
+          if [ ! -f "${DATA_FILE}" ]; then
+            echo "WARNING: dataPath provided but data file missing: ${DATA_FILE}"
+            FILE_UPDATES_REQUIRED="true"
+            FILE_UPDATES_COMPLETE="false"
+          elif ! jq -e '.' "${DATA_FILE}" >/dev/null 2>&1; then
+            echo "WARNING: Data file contains invalid JSON - preventing filtering"
+            FILE_UPDATES_REQUIRED="true"
+            FILE_UPDATES_COMPLETE="false"
+          else
+            FILE_UPDATES_LENGTH=$(jq '.fileUpdates // [] | length' "${DATA_FILE}" 2>/dev/null || echo "0")
+            if [ "${FILE_UPDATES_LENGTH}" -gt 0 ] 2>/dev/null; then
+              FILE_UPDATES_REQUIRED="true"
+
+              if [ -z "${COMPONENT_GROUP}" ] || [ "${COMPONENT_GROUP}" = "null" ]; then
+                echo "WARNING: Snapshot componentGroup is empty - cannot verify fileUpdates"
+                FILE_UPDATES_COMPLETE="false"
+              else
+                echo "Checking fileUpdates completion for ${FILE_UPDATES_LENGTH} repo(s)..."
+
+                TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
+                TASK_ID=$(context.taskRun.uid)
+                PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+                for ((fu=0; fu<FILE_UPDATES_LENGTH; fu++)); do
+                  item=$(jq -cr ".fileUpdates[$fu]" "${DATA_FILE}")
+                  upstream_repo=$(jq -r '.upstream_repo // .repo // ""' <<< "${item}")
+                  file_updates_secret=$(jq -r '.file_updates_secret // "file-updates-secret"' <<< "${item}")
+
+                  if [ -z "${upstream_repo}" ] || [ "${upstream_repo}" = "null" ]; then
+                    echo "WARNING: fileUpdates entry missing repo/upstream_repo (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  IR_OUTPUT_FILE=$(mktemp)
+                  if ! internal-request --pipeline "$(params.request)" \
+                      -p upstream_repo="${upstream_repo}" \
+                      -p componentGroup="${COMPONENT_GROUP}" \
+                      -p file_updates_secret="${file_updates_secret}" \
+                      -p taskGitUrl="$(params.taskGitUrl)" \
+                      -p taskGitRevision="$(params.taskGitRevision)" \
+                      -s "true" \
+                      -t "$(params.requestTimeout)" \
+                      -l "${TASK_LABEL}=${TASK_ID}" \
+                      -l "${PIPELINERUN_LABEL}=$(params.pipelineRunUid)" \
+                      | tee "${IR_OUTPUT_FILE}"; then
+                    echo "WARNING: Failed to create InternalRequest for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    rm -f "${IR_OUTPUT_FILE}"
+                    break
+                  fi
+
+                  IR_NAME=$(awk -F"'" '/created/ { print $2 }' "${IR_OUTPUT_FILE}")
+                  rm -f "${IR_OUTPUT_FILE}"
+
+                  if [ -z "${IR_NAME}" ]; then
+                    echo "WARNING: Could not determine InternalRequest name for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  IRjson=$(kubectl get internalrequest "${IR_NAME}" -o json 2>/dev/null || true)
+
+                  if [ -z "${IRjson}" ]; then
+                    echo "WARNING: No InternalRequest found for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  results=$(jq -c '.status.results // empty' <<< "${IRjson}" 2>/dev/null || echo "")
+                  if [ -z "${results}" ]; then
+                    echo "WARNING: InternalRequest has no status.results for fileUpdates check (index ${fu})"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  if [ "$(jq -r '.result // ""' <<< "${results}" 2>/dev/null || echo "")" != "Success" ]; then
+                    echo "WARNING: fileUpdates check did not succeed for ${upstream_repo}"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+
+                  file_updates_complete="$(
+                    jq -r '.file_updates_complete // "false"' <<< "${results}" 2>/dev/null || echo "false"
+                  )"
+                  if [ "${file_updates_complete}" != "true" ]; then
+                    echo "fileUpdates not complete for ${upstream_repo}"
+                    FILE_UPDATES_COMPLETE="false"
+                    break
+                  fi
+                done
+              fi
+            fi
+          fi
+        fi
+
+        if [ "${FILE_UPDATES_REQUIRED}" = "true" ]; then
+          echo "fileUpdates required: ${FILE_UPDATES_REQUIRED}, complete: ${FILE_UPDATES_COMPLETE}"
+        fi
+
+        # If fileUpdates are configured but not complete, we cannot consider any component
+        # "fully released" yet. Fail-safe: keep the snapshot unchanged and proceed.
+        if [ "${FILE_UPDATES_REQUIRED}" = "true" ] && [ "${FILE_UPDATES_COMPLETE}" != "true" ]; then
+          echo "fileUpdates are not complete - skipping filtering and passing snapshot unchanged."
+          exit 0
+        fi
+
+        # Create temp files once for component processing (reused in loop)
+        COMPONENT_AUTH_FILE=$(mktemp)
+        PYXIS_RESPONSE=$(mktemp)
+        # One JSON object per line; read back with --slurpfile to avoid re-parsing a
+        # growing in-memory string on every keep_component call (jq --argjson memory issue)
+        FILTERED_COMPONENTS_FILE=$(mktemp)
+
+        for ((i=0; i<COMPONENT_COUNT; i++)); do
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "Processing component $((i+1))/${COMPONENT_COUNT}"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            COMPONENT=$(jq -c ".components[$i]" "${SNAPSHOT_FILE}")
+            COMPONENT_NAME=$(jq -r '.name' <<< "${COMPONENT}")
+            CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "${COMPONENT}")
+            echo "Component: ${COMPONENT_NAME}"
+            echo "Image: ${CONTAINER_IMAGE}"
+
+            # Validate component has required fields
+            if [ -z "${COMPONENT_NAME}" ] || [ "${COMPONENT_NAME}" = "null" ]; then
+              keep_component "${COMPONENT}" "Component at index $i: KEPT (missing or null name field)"
+              continue
+            fi
+
+            if [ -z "${CONTAINER_IMAGE}" ] || [ "${CONTAINER_IMAGE}" = "null" ]; then
+              keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (missing or null containerImage field)"
+              continue
+            fi
+
+            PYXIS_COMPLETE="false"
+            DIGEST=""
+            if [[ "${CONTAINER_IMAGE}" == *@sha256:* ]]; then
+              # Extract digest from image reference (after @)
+              RAW_DIGEST="${CONTAINER_IMAGE##*@}"
+              # Remove sha256: prefix if present, then validate and re-add
+              RAW_DIGEST="${RAW_DIGEST#sha256:}"
+              if [[ "${RAW_DIGEST}" =~ ^[a-fA-F0-9]{64}$ ]]; then
+                DIGEST="sha256:${RAW_DIGEST}"
+              else
+                echo "WARNING: Invalid digest in containerImage: ${CONTAINER_IMAGE}"
+                DIGEST=""
+              fi
+            else
+              # Resolve digest using oras (reuse temp file for auth config)
+              # Add timeout to prevent hanging on slow/broken registries
+              if ! timeout 30 select-oci-auth "${CONTAINER_IMAGE}" > "${COMPONENT_AUTH_FILE}" 2>/dev/null || \
+                 [ ! -s "${COMPONENT_AUTH_FILE}" ]; then
+                  echo '{}' > "${COMPONENT_AUTH_FILE}"
+              fi
+              
+              # Add timeout to prevent hanging on slow/broken registries
+              if ! RAW_DIGEST=$(timeout 60 oras resolve --registry-config "${COMPONENT_AUTH_FILE}" \
+                  "${CONTAINER_IMAGE}" 2>/dev/null); then
+                # oras resolve failed or timed out - cannot verify this component, keep it
+                keep_component "${COMPONENT}" \
+                  "Component ${COMPONENT_NAME}: KEPT (oras resolve failed or timed out for ${CONTAINER_IMAGE})"
+                continue
+              fi
+              
+              # Normalize digest: strip whitespace, remove any prefix, ensure sha256: format
+              RAW_DIGEST=$(echo "${RAW_DIGEST}" | tr -d '[:space:]')
+              # If it contains @, extract the part after @
+              if [[ "${RAW_DIGEST}" == *@* ]]; then
+                RAW_DIGEST="${RAW_DIGEST##*@}"
+              fi
+              # Remove sha256: prefix if present
+              RAW_DIGEST="${RAW_DIGEST#sha256:}"
+              
+              # Validate it looks like a sha256 hash (64 hex chars)
+              if ! [[ "${RAW_DIGEST}" =~ ^[a-fA-F0-9]{64}$ ]]; then
+                # Invalid digest format - cannot verify this component, keep it
+                keep_component "${COMPONENT}" \
+                  "Component ${COMPONENT_NAME}: KEPT (invalid digest format from oras: ${RAW_DIGEST})"
+                continue
+              fi
+              
+              DIGEST="sha256:${RAW_DIGEST}"
+            fi
+
+            # At this point, DIGEST is guaranteed to be valid (either from containerImage or oras)
+            if [ -z "${DIGEST}" ]; then
+              # This should never happen now, but keep as safety check
+              keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (empty digest - internal error)"
+              continue
+            fi
+            
+            # Query Pyxis by image_id (the manifest digest stored by create-pyxis-image).
+            # docker_image_digest is not a filterable field in the Pyxis API.
+            FILTER_VALUE="image_id==${DIGEST}"
+            FILTER_ENCODED=$(printf '%s' "${FILTER_VALUE}" | jq -sRr @uri)
+            PYXIS_QUERY_URL="${PYXIS_URL}v1/images?filter=${FILTER_ENCODED}"
+            echo "Querying Pyxis for ${COMPONENT_NAME}..."
+            echo "  Filter: ${FILTER_VALUE}"
+            echo "  Encoded: ${FILTER_ENCODED}"
+            # Reuse temp file for this API call (overwrites previous content)
+            PYXIS_HTTP_CODE=$(http_get_pyxis "${PYXIS_QUERY_URL}" "${PYXIS_RESPONSE}" \
+              /etc/pyxis-secrets/cert /etc/pyxis-secrets/key)
+            echo "Pyxis query returned HTTP ${PYXIS_HTTP_CODE}"
+
+            if [ "${PYXIS_HTTP_CODE}" != "200" ]; then
+              # SECURITY: Only log component name and HTTP code - NOT the digest, URL, or cert paths
+              echo "Pyxis query failed for ${COMPONENT_NAME} (HTTP ${PYXIS_HTTP_CODE})"
+              PYXIS_COMPLETE="false"
+            else
+              IMAGE_COUNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+              echo "  Pyxis response: IMAGE_COUNT=${IMAGE_COUNT}"
+              if [ "${IMAGE_COUNT}" -eq 0 ] 2>/dev/null; then
+                echo "No direct Pyxis entry found for ${COMPONENT_NAME} — trying manifest list resolution"
+                # The containerImage may be a manifest list (multi-arch OCI index).
+                # Pyxis stores per-arch image records by their individual arch digest,
+                # not by the manifest list digest. Resolve the manifest and query each arch.
+                # Use oras (with registry credentials) instead of anonymous curl so that
+                # private registries (e.g. quay.io/redhat-user-workloads-stage) are accessible.
+                ML_IMAGE_REF="${CONTAINER_IMAGE%@*}@${DIGEST}"
+                if ! timeout 30 select-oci-auth "${ML_IMAGE_REF}" > "${COMPONENT_AUTH_FILE}" 2>/dev/null || \
+                   [ ! -s "${COMPONENT_AUTH_FILE}" ]; then
+                  echo '{}' > "${COMPONENT_AUTH_FILE}"
+                fi
+                ML_MANIFEST=$(timeout 30 oras manifest fetch \
+                  --registry-config "${COMPONENT_AUTH_FILE}" \
+                  "${ML_IMAGE_REF}" 2>/dev/null || echo "{}")
+                ARCH_DIGESTS=$(echo "${ML_MANIFEST}" \
+                  | jq -r '.manifests[]?.digest // empty' 2>/dev/null || echo "")
+                if [ -n "${ARCH_DIGESTS}" ]; then
+                  ARCH_COUNT=$(echo "${ARCH_DIGESTS}" | wc -l)
+                  if [ "${ARCH_COUNT}" -gt 32 ] 2>/dev/null; then
+                    echo "WARNING: Manifest list has ${ARCH_COUNT} arches (limit: 32) for" \
+                      "${COMPONENT_NAME} — keeping component as fail-safe"
+                    keep_component "${COMPONENT}" \
+                      "Component ${COMPONENT_NAME}: KEPT (manifest list exceeds 32 arches)"
+                    continue
+                  fi
+                  echo "Manifest list detected — checking ${ARCH_COUNT} per-arch digest(s) in Pyxis..."
+                  # ALL arches must have rpm_manifest.rpms — one arch having RPM data while
+                  # another does not means push-rpm-data-to-pyxis only partially completed
+                  # and the pipeline must be re-run.
+                  ALL_ARCHES_COMPLETE="true"
+                  while IFS= read -r ARCH_D; do
+                    [ -z "${ARCH_D}" ] && continue
+                    # Validate arch digest format before using it in any API call
+                    if ! [[ "${ARCH_D}" =~ ^sha256:[a-fA-F0-9]{64}$ ]]; then
+                      echo "WARNING: Skipping invalid arch digest format: ${ARCH_D}"
+                      ALL_ARCHES_COMPLETE="false"
+                      break
+                    fi
+                    ARCH_FILTER=$(printf '%s' "image_id==${ARCH_D}" | jq -sRr @uri)
+                    ARCH_HTTP=$(http_get_pyxis "${PYXIS_URL}v1/images?filter=${ARCH_FILTER}" \
+                      "${PYXIS_RESPONSE}" /etc/pyxis-secrets/cert /etc/pyxis-secrets/key)
+                    if [ "${ARCH_HTTP}" = "200" ]; then
+                      ARCH_CNT=$(jq -r '.data | length' "${PYXIS_RESPONSE}" 2>/dev/null || echo "0")
+                      if [ "${ARCH_CNT}" -gt 0 ] 2>/dev/null; then
+                        HAS_RPM_DATA=$(jq -r \
+                          '((.data[0].rpm_manifest.rpms // []) | length) > 0 | tostring' \
+                          "${PYXIS_RESPONSE}" 2>/dev/null || echo "false")
+                        if [ "${HAS_RPM_DATA}" = "true" ]; then
+                          echo "Arch ${ARCH_D}: found in Pyxis with rpm_manifest.rpms"
+                        else
+                          echo "Arch ${ARCH_D}: found but incomplete: HAS_RPM_DATA=${HAS_RPM_DATA}"
+                          ALL_ARCHES_COMPLETE="false"
+                          break
+                        fi
+                      else
+                        echo "Arch ${ARCH_D}: not found in Pyxis"
+                        ALL_ARCHES_COMPLETE="false"
+                        break
+                      fi
+                    else
+                      echo "Arch ${ARCH_D}: Pyxis query failed (HTTP ${ARCH_HTTP})"
+                      ALL_ARCHES_COMPLETE="false"
+                      break
+                    fi
+                  done <<< "${ARCH_DIGESTS}"
+                  if [ "${ALL_ARCHES_COMPLETE}" = "true" ]; then
+                    PYXIS_COMPLETE="true"
+                  else
+                    echo "Not all arch images found in Pyxis with rpm_manifest.rpms for ${COMPONENT_NAME}"
+                    PYXIS_COMPLETE="false"
+                  fi
+                else
+                  echo "No Pyxis entries found for ${COMPONENT_NAME}"
+                  PYXIS_COMPLETE="false"
+                fi
+              elif [ -z "${IMAGE_COUNT}" ]; then
+                echo "WARNING: Invalid Pyxis response for ${COMPONENT_NAME}"
+                PYXIS_COMPLETE="false"
+              else
+                # Require non-empty rpm_manifest.rpms as evidence of full release.
+                # push-rpm-data-to-pyxis runs after push-snapshot in the pipeline, so
+                # its presence is sufficient proof the release completed.
+                # repositories[].tags is NOT checked: unreliable in staging (tags may be
+                # absent even after a successful push) and redundant given rpm_manifest.rpms.
+                HAS_RPM_DATA=$(jq -r \
+                  '((.data[0].rpm_manifest.rpms // []) | length) > 0 | tostring' \
+                  "${PYXIS_RESPONSE}" 2>/dev/null || echo "false")
+                if [ "${HAS_RPM_DATA}" = "true" ]; then
+                  echo "Image found in Pyxis for ${COMPONENT_NAME} with rpm_manifest.rpms"
+                  PYXIS_COMPLETE="true"
+                else
+                  echo "Pyxis record for ${COMPONENT_NAME} incomplete: HAS_RPM_DATA=${HAS_RPM_DATA}"
+                  PYXIS_COMPLETE="false"
+                fi
+              fi
+              echo "  PYXIS_COMPLETE=${PYXIS_COMPLETE}"
+            fi
+
+            echo "  Decision: PYXIS_COMPLETE=${PYXIS_COMPLETE}"
+
+            if [ "${PYXIS_COMPLETE}" == "true" ]; then
+                echo "Component ${COMPONENT_NAME}: FILTERED (Pyxis complete)"
+                FILTERED_COUNT=$((FILTERED_COUNT + 1))
+                echo ""
+            else
+                keep_component "${COMPONENT}" "Component ${COMPONENT_NAME}: KEPT (Pyxis metadata incomplete)"
+            fi
+        done
+
+        # Write filtered snapshot atomically using temp file
+        # Create temp file in same directory as snapshot to ensure atomic mv (same filesystem)
+        SNAPSHOT_DIR=$(dirname "${SNAPSHOT_FILE}")
+        
+        # Validate target directory before creating temp file
+        if [ ! -d "${SNAPSHOT_DIR}" ]; then
+          echo "Error: Snapshot directory does not exist: ${SNAPSHOT_DIR}"
+          exit 1
+        fi
+        if [ ! -w "${SNAPSHOT_DIR}" ]; then
+          echo "Error: Snapshot directory is not writable: ${SNAPSHOT_DIR}"
+          exit 1
+        fi
+        
+        TEMP_SNAPSHOT=$(mktemp "${SNAPSHOT_DIR}/.snapshot.XXXXXX")
+        
+        # Create filtered snapshot with error handling (work directly on file)
+        if ! jq --slurpfile comps "${FILTERED_COMPONENTS_FILE}" '.components = $comps' \
+          "${SNAPSHOT_FILE}" > "${TEMP_SNAPSHOT}"; then
+          echo "Error: Failed to create filtered snapshot with jq"
+          exit 1
+        fi
+        
+        # Validate temp file before moving
+        if [ ! -s "${TEMP_SNAPSHOT}" ]; then
+          echo "Error: Filtered snapshot file is empty"
+          exit 1
+        fi
+        
+        # Validate it's valid JSON
+        if ! jq -e '.' "${TEMP_SNAPSHOT}" >/dev/null 2>&1; then
+          echo "Error: Filtered snapshot is not valid JSON"
+          exit 1
+        fi
+        
+        # All checks passed, atomically replace the original
+        mv "${TEMP_SNAPSHOT}" "${SNAPSHOT_FILE}"
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "SUMMARY:"
+        echo "  Total components: ${COMPONENT_COUNT}"
+        echo "  Filtered (already released): ${FILTERED_COUNT}"
+        echo "  To be released: $((COMPONENT_COUNT - FILTERED_COUNT))"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Skip release if all components were filtered
+        if [ "${FILTERED_COUNT}" -eq "${COMPONENT_COUNT}" ]; then
+            echo -n "true" > "$(results.skip_release.path)"
+        else
+            echo -n "false" > "$(results.skip_release.path)"
+        fi
+    - name: create-trusted-artifact
+      when:
+        - input: $(params.sourceDataArtifact)
+          operator: notin
+          values: [""]
+      computeResources:
+        limits:
+          cpu: 250m
+          memory: 128Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+        - name: orasOptions
+          value: $(params.orasOptions)

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/mocks.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mocks to be injected into task step scripts
+#
+# Pyxis query strategy (confirmed against real Pyxis stage API, March 2026):
+# - The image IS in Pyxis — found via image_id (the manifest digest stored by create-pyxis-image).
+# - Query field: image_id == sha256:...  (NOT docker_image_digest — that field does not exist)
+# - Completeness signal: rpm_manifest.rpms must be non-empty (populated by push-rpm-data-to-pyxis)
+# - URL-encoded filter: image_id%3D%3Dsha256%3A...
+
+function select-oci-auth() {
+  # Return empty auth config (all registries are accessible in tests)
+  echo '{}'
+  return 0
+}
+
+# oras is called via 'timeout 30 oras ...', which runs oras as a child process that
+# does not inherit bash functions. Create a real executable script in a temp bin dir
+# and prepend it to PATH so 'timeout' finds the mock instead of the real binary.
+_MOCK_BIN=$(mktemp -d)
+cat > "${_MOCK_BIN}/oras" << 'ORAS_MOCK_EOF'
+#!/usr/bin/env bash
+subcommand="$1"
+image_ref="${*: -1}"
+case "${subcommand}" in
+  resolve)
+    case "$image_ref" in
+      *"@sha256:4444444444444444444444444444444444444444444444444444444444444444")
+        echo "sha256:4444444444444444444444444444444444444444444444444444444444444444" ;;
+      *"@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;
+      *"@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        echo "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+      *"@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"*)
+        echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ;;
+      *)
+        if [[ "$image_ref" =~ @(sha256:[a-f0-9]+)$ ]]; then
+          echo "${BASH_REMATCH[1]}"
+        else
+          echo "Error: manifest unknown: manifest unknown" >&2; exit 1
+        fi ;;
+    esac ;;
+  manifest)
+    case "$image_ref" in
+      *"@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+        echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"}]}' ;;
+      *"@sha256:3333333333333333333333333333333333333333333333333333333333333333")
+        echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222"}]}' ;;
+      *"@sha256:8888888888888888888888888888888888888888888888888888888888888888")
+        # arch1 complete (fff), arch2 Pyxis HTTP 500 (555) → fail-safe must KEEP
+        echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:5555555555555555555555555555555555555555555555555555555555555555"}]}' ;;
+      *)
+        echo '{}' ;;
+    esac ;;
+  *)
+    echo "Error: unknown oras subcommand: ${subcommand}" >&2; exit 1 ;;
+esac
+ORAS_MOCK_EOF
+chmod +x "${_MOCK_BIN}/oras"
+export PATH="${_MOCK_BIN}:${PATH}"
+
+function curl() {
+  # Mock curl for testing
+  local output_file=""
+  local url=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o)
+        output_file="$2"
+        shift 2
+        ;;
+      -w|--retry|--connect-timeout|--max-time)
+        shift 2
+        ;;
+      --config|--cert|--key|--cacert)
+        shift 2
+        ;;
+      -sS|--retry-all-errors|-s|-S)
+        shift 1
+        ;;
+      *)
+        # Last non-flag argument is the URL
+        if [[ ! "$1" =~ ^- ]]; then
+          url="$1"
+        fi
+        shift 1
+        ;;
+    esac
+  done
+
+  local json_response="[]"
+  local http_status="200"
+  # Pyxis API: query by image_id (the manifest digest).
+  # Completeness requires: non-empty rpm_manifest.rpms (populated by push-rpm-data-to-pyxis).
+  # repositories[].tags is NOT required: unreliable in staging, redundant given rpm_manifest.rpms.
+  case "$url" in
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"*)
+      # Full release: rpm_manifest.rpms non-empty (tags also present but not required) → filtered out
+      json_response='{"data":[{"image_id":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","rpm_manifest":{"rpms":[{"name":"bash"}]},"repositories":[{"tags":[{"name":"latest"},{"name":"v1"}]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Ab"*)
+      # Partial: image found but rpm_manifest.rpms empty → push-rpm-data-to-pyxis incomplete → keep
+      json_response='{"data":[{"image_id":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","rpm_manifest":{"rpms":[]},"repositories":[{"tags":[{"name":"latest"}]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Ac"*)
+      # Partial: image found but no rpm_manifest at all → push-rpm-data-to-pyxis never ran → keep
+      json_response='{"data":[{"image_id":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","repositories":[{"tags":[{"name":"latest"}]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Ad"*)
+      # Staging scenario: rpm_manifest.rpms non-empty but repositories[].tags empty.
+      # Must be FILTERED (rpm_manifest.rpms alone is sufficient).
+      json_response='{"data":[{"image_id":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","rpm_manifest":{"rpms":[{"name":"glibc"}]},"repositories":[{"tags":[]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3Af"*)
+      # Per-arch image (arch1): complete with rpm_manifest.rpms → used by manifest list tests
+      json_response='{"data":[{"image_id":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","rpm_manifest":{"rpms":[{"name":"bash"}]},"repositories":[{"tags":[]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3A1"*)
+      # Per-arch image (arch2): complete with rpm_manifest.rpms → used by all-arches-complete test
+      json_response='{"data":[{"image_id":"sha256:1111111111111111111111111111111111111111111111111111111111111111","rpm_manifest":{"rpms":[{"name":"glibc"}]},"repositories":[{"tags":[]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3A2"*)
+      # Per-arch image (arch2 incomplete): found but empty rpm_manifest.rpms → KEPT
+      json_response='{"data":[{"image_id":"sha256:2222222222222222222222222222222222222222222222222222222222222222","rpm_manifest":{"rpms":[]},"repositories":[{"tags":[]}]}]}'
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3A4"*)
+      # Simulates a Pyxis server error (top-level digest) → fail-safe must KEEP
+      json_response='{"error":"internal server error"}'
+      http_status="500"
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3Dsha256%3A5"*)
+      # Simulates a Pyxis server error (per-arch digest in manifest list) → fail-safe must KEEP
+      json_response='{"error":"internal server error"}'
+      http_status="500"
+      ;;
+    *"pyxis.api.redhat.com/v1/images?filter=image_id%3D%3D"*)
+      # Catch-all: not found in Pyxis → triggers manifest list fallback
+      json_response='{"data":[]}'
+      ;;
+  esac
+
+  if [ -n "$output_file" ]; then
+    echo "$json_response" > "$output_file"
+  else
+    echo "$json_response"
+  fi
+
+  printf "%s" "${http_status}"
+}
+
+function curl-with-retry() {
+  curl "$@"
+}
+
+function oras() {
+  local subcommand="$1"
+  local image_ref="${*: -1}"
+
+  case "${subcommand}" in
+    resolve)
+      case "$image_ref" in
+        *"@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+          echo "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          return 0
+          ;;
+        *"@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+          echo "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          return 0
+          ;;
+        *"@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"*)
+          echo "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          return 0
+          ;;
+        *)
+          if [[ "$image_ref" =~ @(sha256:[a-f0-9]+)$ ]]; then
+            echo "${BASH_REMATCH[1]}"
+            return 0
+          fi
+          echo "Error: manifest unknown: manifest unknown" >&2
+          return 1
+          ;;
+      esac
+      ;;
+    manifest)
+      # oras manifest fetch --registry-config <file> <image_ref>
+      # Returns the OCI manifest JSON. Used by the filter task to resolve manifest lists.
+      case "$image_ref" in
+        *"@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+          # All-arches-complete manifest list: both arch digests are in Pyxis with RPM data
+          echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"}]}'
+          return 0
+          ;;
+        *"@sha256:3333333333333333333333333333333333333333333333333333333333333333")
+          # Partial-arches manifest list: arch1 complete (fff), arch2 incomplete (222)
+          echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222"}]}'
+          return 0
+          ;;
+        *"@sha256:8888888888888888888888888888888888888888888888888888888888888888")
+          # arch1 complete (fff), arch2 Pyxis HTTP 500 (555) → fail-safe must KEEP
+          echo '{"manifests":[{"digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},{"digest":"sha256:5555555555555555555555555555555555555555555555555555555555555555"}]}'
+          return 0
+          ;;
+        *)
+          echo '{}'
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      echo "Error: unknown oras subcommand: ${subcommand}" >&2
+      return 1
+      ;;
+  esac
+}
+
+function internal-request() {
+  # Mock internal-request for fileUpdates completion checks.
+  # The task parses the IR name from this output using awk '/created/ { print $2 }'.
+  echo "internalrequests.appstudio.redhat.com 'mock-ir' created"
+  return 0
+}
+
+function kubectl() {
+  # Mock the InternalRequest lookup used by the filter task.
+  #
+  # Expected shape (name-based, requires only 'get' RBAC):
+  # kubectl get internalrequest <name> -o json
+  if [ "${1:-}" = "get" ] && [ "${2:-}" = "internalrequest" ]; then
+    local complete="true"
+    if [ -n "${DATA_FILE:-}" ] && [ -f "${DATA_FILE}" ]; then
+      complete="$(
+        jq -r 'if has("mock_file_updates_complete") then .mock_file_updates_complete else true end' \
+          "${DATA_FILE}" 2>/dev/null || echo "true"
+      )"
+    fi
+
+    jq -nc --arg complete "${complete}" '
+      {
+        status: {
+          results: {
+            result: "Success",
+            file_updates_complete: ($complete == "true")
+          }
+        }
+      }
+    '
+    return 0
+  fi
+
+  echo "Error: unexpected kubectl call: $*" >&2
+  return 1
+}

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/pre-apply-task-hook.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_PATH="$1"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Add mocks to the beginning of the filter step script (standard approach)
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"
+
+# Create test secrets (delete first if they exist)
+kubectl delete secret pyxis --ignore-not-found
+kubectl create secret generic pyxis \
+  --from-literal=cert="mock-cert" \
+  --from-literal=key="mock-key"

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-all-components-filtered.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-all-components-filtered.yaml
@@ -1,0 +1,201 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-all-components-filtered
+spec:
+  description: |
+    A snapshot with two components, both fully released in Pyxis (sha256:aaa... and sha256:ddd...,
+    both have non-empty rpm_manifest.rpms). All components should be filtered out, resulting in an
+    empty snapshot and skip_release=true. This verifies the FILTERED_COUNT == COMPONENT_COUNT path
+    with multiple components (count > 1).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Both components are fully released: rpm_manifest.rpms non-empty in Pyxis mock
+              # sha256:aaa... → complete (rpm_manifest.rpms=[{"name":"bash"}])
+              # sha256:ddd... → complete (rpm_manifest.rpms=[{"name":"glibc"}], tags empty — staging)
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected 0 components (all filtered) when all are complete in Pyxis," \
+                  "got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true when all components are already released"
+                exit 1
+              fi
+
+              echo "PASS: All 2 components correctly filtered, skip_release=true"

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-complete.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-complete
+spec:
+  description: |
+    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
+    AND fileUpdates are complete. The component must be FILTERED OUT (skip_release=true).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mock_file_updates_complete": true,
+                "fileUpdates": [
+                  {
+                    "repo": "https://gitlab.com/test/project.git"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected component to be filtered, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-incomplete.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-incomplete.yaml
@@ -1,0 +1,203 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-incomplete
+spec:
+  description: |
+    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
+    but fileUpdates are configured and NOT yet complete. The component must be KEPT
+    (skip_release=false) because the full release pipeline is not done.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mock_file_updates_complete": false,
+                "fileUpdates": [
+                  {
+                    "repo": "https://gitlab.com/test/project.git"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be kept, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-file-updates-no-fileupdates.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-file-updates-no-fileupdates
+spec:
+  description: |
+    The image IS in Pyxis — found via image_id — with non-empty rpm_manifest.rpms,
+    and no fileUpdates are configured. The component must be FILTERED OUT (skip_release=true).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": ["latest", "v1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected all components to be filtered, found ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-http-error.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-http-error.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-http-error
+spec:
+  description: |
+    Pyxis returns HTTP 500 for the component's digest (sha256:444...). The fail-safe
+    behavior must KEEP the component (skip_release=false) — a Pyxis outage or transient
+    error must never cause a release to be silently skipped.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:4444444444444444444444444444444444444444444444444444444444444444"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be KEPT when Pyxis returns HTTP 500," \
+                  "got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (Pyxis error must not silently skip release)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-no-rpm-manifest.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-no-rpm-manifest.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-incomplete-no-rpm-manifest
+spec:
+  description: |
+    When Pyxis returns an image with no rpm_manifest at all (push-rpm-data-to-pyxis
+    never ran), the component must be kept. skip_release must be false.
+  params:
+    - name: ociStorage
+      type: string
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    "repositories": [{ "url": "quay.io/redhat-pending/comp1", "tags": ["latest"] }]
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              { "pyxis": { "secret": "pyxis", "server": "production" } }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-component-kept
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be kept (no rpm_manifest), found ${COUNT} components"
+                exit 1
+              fi
+              if [ "$(params.skipRelease)" = "true" ]; then
+                echo "ERROR: Expected skip_release=false when Pyxis record has no rpm_manifest"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-rpms-empty.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-incomplete-rpms-empty.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-incomplete-rpms-empty
+spec:
+  description: |
+    The image IS in Pyxis — found via image_id — but rpm_manifest.rpms is empty
+    (push-rpm-data-to-pyxis ran but wrote no RPMs). The component must be KEPT
+    because the release is not complete. skip_release must be false.
+  params:
+    - name: ociStorage
+      type: string
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "repositories": [{ "url": "quay.io/redhat-pending/comp1", "tags": ["latest"] }]
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              { "pyxis": { "secret": "pyxis", "server": "production" } }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-component-kept
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be kept (empty rpm_manifest.rpms), found ${COUNT} components"
+                exit 1
+              fi
+              if [ "$(params.skipRelease)" = "true" ]; then
+                echo "ERROR: Expected skip_release=false when Pyxis record has empty rpm_manifest.rpms"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-all-arches.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-all-arches.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-manifest-list-all-arches
+spec:
+  description: |
+    The component carries a manifest list digest (sha256:eee...) that is NOT found in Pyxis
+    directly (Pyxis stores per-arch records, not manifest list records). The filter falls back
+    to oras manifest fetch, resolves two per-arch digests (sha256:fff... and sha256:111...),
+    and queries each one individually. Both are present in Pyxis with non-empty rpm_manifest.rpms.
+    The component must be FILTERED (skip_release=true) because all arches are complete.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected component to be filtered (manifest list resolved, all" \
+                  "per-arch digests present in Pyxis with rpm_manifest.rpms), got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true (all arches complete in Pyxis)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-arch-http-error.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-arch-http-error.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-manifest-list-arch-http-error
+spec:
+  description: |
+    The component uses a manifest list digest (sha256:888...) that has no direct Pyxis entry,
+    triggering manifest list resolution. oras resolves two arch digests: sha256:fff... (complete
+    in Pyxis) and sha256:555... (Pyxis returns HTTP 500). The fail-safe behavior must KEEP the
+    component (skip_release=false) — a Pyxis error on any individual arch must not cause the
+    multi-arch image to be silently marked as complete.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:8888888888888888888888888888888888888888888888888888888888888888"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be KEPT when a per-arch Pyxis query returns HTTP 500," \
+                  "got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (per-arch Pyxis error must not silently skip release)"
+                exit 1
+              fi
+
+              echo "PASS: Multi-arch component correctly KEPT when one arch's Pyxis query returns HTTP 500"

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-partial-arches.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-manifest-list-partial-arches.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-manifest-list-partial-arches
+spec:
+  description: |
+    The component carries a manifest list digest (sha256:333...) that is NOT found in Pyxis
+    directly. The filter falls back to oras manifest fetch and resolves two per-arch digests:
+    sha256:fff... (complete, has rpm_manifest.rpms) and sha256:222... (incomplete, empty
+    rpm_manifest.rpms). Because NOT ALL arches are complete, the component must be KEPT
+    (skip_release=false) — a partial push-rpm-data-to-pyxis run must not prevent a re-run.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:3333333333333333333333333333333333333333333333333333333333333333"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be KEPT (one arch has incomplete RPM data)," \
+                  "got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (not all arches complete in Pyxis)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-partial-multi-component.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-partial-multi-component.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-partial-multi-component
+spec:
+  description: |
+    Two-component snapshot where comp1 (sha256:aaa...) is already fully released in Pyxis
+    (non-empty rpm_manifest.rpms) and comp2 (sha256:bbb...) has an incomplete Pyxis record
+    (rpm_manifest.rpms is empty). The filter must KEEP comp2 in the snapshot and set
+    skip_release=false so the pipeline re-runs for the not-yet-released component.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected exactly 1 component to remain (comp2, not yet in Pyxis)," \
+                  "got ${COUNT}"
+                exit 1
+              fi
+
+              REMAINING=$(jq -r '.components[0].name' "${FILTERED_SNAPSHOT}")
+              if [ "${REMAINING}" != "comp2" ]; then
+                echo "ERROR: Expected remaining component to be comp2, got ${REMAINING}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (comp2 not yet fully released)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-rpms-no-tags.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-by-pyxis-rpms-no-tags.yaml
@@ -1,0 +1,198 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-by-pyxis-rpms-no-tags
+spec:
+  description: |
+    The image IS in Pyxis with non-empty rpm_manifest.rpms but repositories[].tags is EMPTY
+    (staging scenario where Pyxis does not index tags for test images). The component must
+    still be FILTERED OUT (skip_release=true) because rpm_manifest.rpms alone is sufficient
+    — repositories[].tags is not required.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/comp1",
+                        "tags": []
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected component to be filtered (rpms present, empty tags is still complete)," \
+                  "found ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true (rpm_manifest.rpms alone is sufficient)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-empty-snapshot.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-empty-snapshot.yaml
@@ -1,0 +1,185 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-empty-snapshot
+spec:
+  description: |
+    Snapshot with an empty components array. The task must set skip_release=true and exit
+    before the Pyxis loop — this is distinct from "all components filtered" because it
+    takes a dedicated early-exit path (before fileUpdates or Pyxis checks run).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": []
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 0 ]; then
+                echo "ERROR: Expected empty components array to be preserved, got ${COUNT}"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "true" ]; then
+                echo "ERROR: Expected skip_release=true for empty snapshot"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-invalid-digest.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-invalid-digest.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-invalid-digest
+spec:
+  description: |
+    Component containerImage contains a malformed digest that fails the sha256 hex validation
+    (not 64 hex characters). The task must KEEP the component (skip_release=false) rather
+    than crashing — a bad digest in the snapshot is a data quality issue, not a release
+    completion signal.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:notavalidhexdigest"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component with invalid digest to be KEPT, got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (invalid digest must not skip release)"
+                exit 1
+              fi

--- a/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-oras-resolve-failure.yaml
+++ b/tasks/managed/filter-already-released-by-pyxis-and-file-updates/tests/test-filter-oras-resolve-failure.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-oras-resolve-failure
+spec:
+  description: |
+    The containerImage has no embedded sha256 digest (tag-only reference like :latest), so the
+    task must call 'oras resolve' to obtain it. The oras mock fails for tag-only refs (no
+    @sha256: suffix). The fail-safe behavior must KEEP the component (skip_release=false) — a
+    registry that cannot be resolved must not cause a release to be silently skipped.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "componentGroup": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1:latest"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-already-released-by-pyxis-and-file-updates
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: pyxisServer
+          value: "production"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: skipRelease
+          value: "$(tasks.run-filter.results.skip_release)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+          - name: snapshotPath
+            type: string
+          - name: skipRelease
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/$(params.snapshotPath)"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected component to be KEPT when oras resolve fails," \
+                  "got ${COUNT} remaining"
+                exit 1
+              fi
+
+              if [ "$(params.skipRelease)" != "false" ]; then
+                echo "ERROR: Expected skip_release=false (oras failure must not silently skip release)"
+                exit 1
+              fi
+
+              echo "PASS: Component correctly KEPT when oras resolve fails for tag-only image reference"


### PR DESCRIPTION
## Describe your changes
Added a new task filter-already-released-by-pyxis-and-file-updates to filter
snapshot components based on Pyxis metadata completion and optional file-updates
verification, with fail-safe behavior that keeps components on verification issues.
Updated rh-push-to-registry-redhat-io to use the new task.

separate MR created for the pipelines: [#2115](https://github.com/konflux-ci/release-service-catalog/pull/2115)

**Note**:
This is restored [#1835](https://github.com/konflux-ci/release-service-catalog/pull/1835) PR code that was closed for some unclear reason, and the branch was removed

**Tested with**:
https://github.com/konflux-ci/release-service-catalog/pull/2046

## Relevant Jira
[RELEASE-1265](https://issues.redhat.com/browse/RELEASE-1265)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Cursor

[RELEASE-1265]: https://redhat.atlassian.net/browse/RELEASE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ