### PR TITLE
fix(RELEASE-2299): retry and timeout improvements for e2e tests

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -60,6 +60,18 @@ check_env_vars() {
         fi
     done
 
+    # Kubernetes label values must be <= 63 characters.
+    # originating_tool is used as a label on every resource and as the cleanup selector.
+    # If the value is too long, truncate it here and re-export so both labeling and cleanup
+    # use the same value — silent mismatch is worse than a shorter label.
+    if [ -n "${originating_tool}" ] && [ "${#originating_tool}" -gt 63 ]; then
+        local truncated="${originating_tool:0:63}"
+        echo "⚠️  originating_tool is ${#originating_tool} chars (max 63 for a Kubernetes label)."
+        echo "   Auto-truncating: '${originating_tool}' → '${truncated}'"
+        echo "   Consider shortening the value in test.env to avoid this."
+        export originating_tool="${truncated}"
+    fi
+
     # Check for optional component2 variables (for multi-component tests)
     local optional_component2_vars=(
         "component2_name"
@@ -438,7 +450,7 @@ merge_github_pr() {
 # Function to wait for a PipelineRun to appear
 # Sets global variable: component_push_plr_name
 wait_for_plr_to_appear() {
-    local timeout=300  # 5 minutes timeout
+    local timeout="${PLR_APPEAR_TIMEOUT:-900}"  # default 15 min; under heavy parallel load PAC delivery is slower
     local start_time=$(date +%s)
     local current_time
     local elapsed_time
@@ -458,7 +470,7 @@ wait_for_plr_to_appear() {
         sleep 5
         echo -n "."
         # get only running pipelines
-        component_push_plr_name=$(kubectl get pr -l "pipelinesascode.tekton.dev/sha=$SHA" -n "${tenant_namespace}" --no-headers 2>/dev/null | { grep "Running" || true; } | awk '{print $1}')
+        component_push_plr_name=$(kubectl get pr -l "pipelinesascode.tekton.dev/sha=$SHA" -n "${tenant_namespace}" --no-headers 2>/dev/null | { grep "Running" || true; } | awk '{print $1}') || component_push_plr_name=""
     done
     echo
     echo "✅ Found PipelineRun: ${component_push_plr_name}"
@@ -467,13 +479,15 @@ wait_for_plr_to_appear() {
 
 # Function to wait for PipelineRun to complete
 # Relies on global variables: component_push_plr_name, tenant_namespace
+# Retries up to MAX_PLR_RETRIES times (default 2) to tolerate transient build failures
+# under parallel load (node pressure, image pull blips, quota spikes).
 wait_for_plr_to_complete() {
     local timeout=1800  # 30 minutes timeout
     local start_time=$(date +%s)
     local current_time
     local elapsed_time
     local completed=""
-    local retry_attempted="false"
+    local retries_remaining="${MAX_PLR_RETRIES:-2}"
     local taskStatus="" # taskrun status from last output
     local previousTaskStatus="" # to avoid duplicate output
 
@@ -490,8 +504,8 @@ wait_for_plr_to_complete() {
 
         sleep 5
 
-        # Check if the pipeline run is completed
-        completed=$(kubectl get pipelinerun "${component_push_plr_name}" -n "${tenant_namespace}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null)
+        # Check if the pipeline run is completed (kubectl exits 1 if PipelineRun missing; avoid failing script)
+        completed=$(kubectl get pipelinerun "${component_push_plr_name}" -n "${tenant_namespace}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null) || completed=""
 
         # If completed, check the status
         if [ -n "$completed" ]; then
@@ -507,13 +521,14 @@ wait_for_plr_to_complete() {
           elif [ "$completed" == "False" ]; then
             echo ""
             echo "❌ PipelineRun failed"
-            if [ "${retry_attempted}" == "false" ]; then
-                echo "Attempting retry for PR ${pr_number} in repo ${component_repo_name}..."
-                kubectl annotate components/${component_name} build.appstudio.openshift.io/request=trigger-pac-build -n "${tenant_namespace}"
+            if [ "${retries_remaining}" -gt 0 ]; then
+                echo "Retrying build (${retries_remaining} attempt(s) remaining) — waiting 60s before trigger..."
+                sleep 60
+                kubectl annotate "components/${component_name}" build.appstudio.openshift.io/request=trigger-pac-build -n "${tenant_namespace}"
+                retries_remaining=$(( retries_remaining - 1 ))
                 wait_for_plr_to_appear # component_push_plr_name is set here
-                retry_attempted="true"
             else
-                echo "Retry already attempted. Exiting."
+                echo "All retry attempts exhausted. Exiting."
                 exit 1
             fi
           fi
@@ -523,10 +538,177 @@ wait_for_plr_to_complete() {
     echo "PipelineRun URL: $(get_build_pipeline_run_url "${tenant_namespace}" "${application_name}" "${component_push_plr_name}")"
 }
 
+# Wait for a single component to be initialized by PaC and get its PR details.
+# Sets globals: component_pr, pr_number
+# Args: $1 = component name
+wait_for_single_component_initialization() {
+    local comp_name=$1
+    local max_attempts=90
+    local attempt=1
+    local component_annotations=""
+
+    while [ $attempt -le $max_attempts ]; do
+        component_annotations=$(kubectl get component/"${comp_name}" -n "${tenant_namespace}" -ojson 2>/dev/null | \
+            jq -r --arg k "build.appstudio.openshift.io/status" '.metadata.annotations[$k] // ""' 2>/dev/null) || component_annotations=""
+
+        if [ -n "${component_annotations}" ]; then
+            component_pr=$(jq -r '.pac."merge-url" // ""' <<< "${component_annotations}")
+            if [ -n "${component_pr}" ]; then
+                echo "✅ Component ${comp_name} initialized"
+                pr_number=$(cut -f7 -d/ <<< "${component_pr}")
+                return 0
+            fi
+        fi
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo "   Still waiting for ${comp_name} (attempt ${attempt}/${max_attempts})..."
+        fi
+        attempt=$((attempt + 1))
+        sleep 10
+    done
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "DEBUG: Component initialization timeout for ${comp_name}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    if ! kubectl get component/"${comp_name}" -n "${tenant_namespace}" &>/dev/null; then
+        echo "  Component does not exist in ${tenant_namespace}."
+        echo "  Check: kubectl get component -n ${tenant_namespace}"
+    else
+        echo "  Component exists. Annotation build.appstudio.openshift.io/status:"
+        local status_annot
+        status_annot=$(kubectl get component/"${comp_name}" -n "${tenant_namespace}" \
+            -o jsonpath='{.metadata.annotations.build\.appstudio\.openshift\.io/status}' 2>/dev/null)
+        if [ -z "${status_annot}" ]; then
+            echo "  (missing - PaC has not set it yet)"
+        else
+            echo "${status_annot}" | jq '.' 2>/dev/null || echo "${status_annot}"
+        fi
+        echo ""
+        echo "  Spec (repo/branch):"
+        kubectl get component/"${comp_name}" -n "${tenant_namespace}" -o json 2>/dev/null \
+            | jq -r '.spec' 2>/dev/null || \
+            kubectl get component/"${comp_name}" -n "${tenant_namespace}" -o yaml 2>/dev/null \
+            | grep -A 20 '^spec:'
+        echo ""
+        echo "  To inspect full resource:"
+        echo "    kubectl get component ${comp_name} -n ${tenant_namespace} -o yaml"
+        echo "  To check Pipelines as Code / build controller logs:"
+        echo "    kubectl logs -n openshift-pipelines -l app.kubernetes.io/name=pipelines-as-code --tail=100"
+        echo "    kubectl logs -n build-service -l app.kubernetes.io/name=build-service --tail=100"
+    fi
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    log_error "Component ${comp_name} failed to initialize after ${max_attempts} attempts"
+}
+
+# Merge a single component's GitHub PR.
+# Sets global: SHA
+# Args: $1 = PR number, $2 = repo name (org/repo)
+merge_single_component_pr() {
+    local pr_num=$1
+    local repo_name=$2
+    local commit_message="e2e test"
+    local merge_result
+    merge_result=$(curl -L -X PUT \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${repo_name}/pulls/${pr_num}/merge" \
+        -d "{\"commit_title\":\"e2e test\",\"commit_message\":\"${commit_message}\"}" \
+        --silent --show-error --fail-with-body)
+    SHA=$(jq -r '.sha' <<< "${merge_result}")
+}
+
+# Wait for a build PipelineRun to appear for a given commit SHA.
+# Status output goes to stderr; echoes PLR name to stdout for capture.
+# Uses PLR_APPEAR_TIMEOUT (default 900s) to tolerate PAC webhook delivery delays under load.
+# Args: $1 = commit SHA
+wait_for_single_plr_to_appear() {
+    local sha=$1
+    local timeout="${PLR_APPEAR_TIMEOUT:-900}"
+    local start_time
+    start_time=$(date +%s)
+    local found_plr_name=""
+
+    echo -n "Waiting for PipelineRun for SHA ${sha}..." >&2
+    while [ -z "$found_plr_name" ]; do
+        if [ $(($(date +%s) - start_time)) -ge $timeout ]; then
+            echo "" >&2
+            log_error "Timeout waiting for PipelineRun for SHA ${sha}"
+        fi
+        sleep 5
+        echo -n "." >&2
+        found_plr_name=$(kubectl get pr \
+            -l "pipelinesascode.tekton.dev/sha=$sha" \
+            -n "${tenant_namespace}" --no-headers 2>/dev/null \
+            | { grep "Running" || true; } | awk '{print $1}') || found_plr_name=""
+    done
+    echo "" >&2
+    echo "✅ Found PipelineRun: ${found_plr_name}" >&2
+    echo "${found_plr_name}"
+}
+
+# Wait for a single build PipelineRun to complete.
+# Retries up to MAX_PLR_RETRIES times (default 2) with a 60s cool-down before each retry.
+# Args: $1 = PipelineRun name, $2 = component name (required for retry annotation)
+wait_for_single_plr_to_complete() {
+    local plr_name=$1
+    local comp_name="${2:-}"
+    local timeout=1800
+    local start_time
+    start_time=$(date +%s)
+    local status=""
+    local retries_remaining="${MAX_PLR_RETRIES:-2}"
+
+    echo "Waiting for PipelineRun ${plr_name} to complete..."
+    while true; do
+        if [ $(($(date +%s) - start_time)) -ge $timeout ]; then
+            log_error "Timeout waiting for PipelineRun ${plr_name}"
+        fi
+        sleep 5
+        status=$(kubectl get pipelinerun "${plr_name}" -n "${tenant_namespace}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null) \
+            || status=""
+        if [ "${status}" = "True" ]; then
+            echo "✅ ${plr_name} completed successfully"
+            break
+        elif [ "${status}" = "False" ]; then
+            echo "❌ ${plr_name} failed"
+            if [ "${retries_remaining}" -gt 0 ] && [ -n "${comp_name}" ]; then
+                echo "Retrying build for ${comp_name} (${retries_remaining} attempt(s) remaining) — waiting 60s..."
+                sleep 60
+                kubectl annotate "components/${comp_name}" \
+                    build.appstudio.openshift.io/request=trigger-pac-build \
+                    -n "${tenant_namespace}"
+                retries_remaining=$(( retries_remaining - 1 ))
+                local new_plr=""
+                local wait_start
+                wait_start=$(date +%s)
+                while [ -z "${new_plr}" ]; do
+                    if [ $(($(date +%s) - wait_start)) -ge "${PLR_APPEAR_TIMEOUT:-900}" ]; then
+                        log_error "Timeout waiting for retry PipelineRun for ${comp_name}"
+                    fi
+                    sleep 5
+                    new_plr=$(kubectl get pr \
+                        -l "appstudio.openshift.io/component=${comp_name}" \
+                        -n "${tenant_namespace}" --no-headers 2>/dev/null \
+                        | grep "Running" | awk '{print $1}' | head -1) || new_plr=""
+                done
+                echo "↩️  Retry PLR: ${new_plr}"
+                plr_name="${new_plr}"
+                status=""
+            else
+                echo "All retry attempts exhausted. Exiting."
+                exit 1
+            fi
+        fi
+    done
+}
+
 # Function to wait for Releases to complete
 # Relies on global variables: component_push_plr_name, tenant_namespace, SUITE_DIR
 wait_for_releases() {
-    local timeout=300  # 5 minutes timeout
+    local timeout="${RELEASE_APPEAR_TIMEOUT:-600}"  # default 10 min; release controller can be backlogged under parallel load
     local start_time=$(date +%s)
     local current_time
     local elapsed_time
@@ -554,18 +736,39 @@ wait_for_releases() {
     RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
 
     export RELEASE_NAMESPACE=${tenant_namespace}
+    local effective_names=""
+    local output_files=()
     for release in ${release_names};
     do
+      local outfile
+      outfile=$(mktemp)
+      output_files+=("${release}:${outfile}")
       export RELEASE_NAME=${release}
+      export RELEASE_NAME_OUTPUT_FILE="${outfile}"
       "${SUITE_DIR}/../scripts/wait-for-release.sh" &
     done
+    unset RELEASE_NAME_OUTPUT_FILE
 
     # Wait for remaining processes to finish
     while (( ${RUNNING_JOBS@P} > 0 )); do
         wait -n
     done
 
-    export RELEASE_NAMES="$release_names"
+    # Build effective release names, substituting any retried Release names
+    for entry in "${output_files[@]}"; do
+      local orig="${entry%%:*}"
+      local outfile="${entry##*:}"
+      local effective
+      effective=$(cat "${outfile}" 2>/dev/null)
+      rm -f "${outfile}"
+      if [ -n "${effective}" ]; then
+        effective_names="${effective_names} ${effective}"
+      else
+        effective_names="${effective_names} ${orig}"
+      fi
+    done
+
+    export RELEASE_NAMES="${effective_names# }"
 }
 
 # Function to clean up old resources based on originating tool label
@@ -580,6 +783,10 @@ cleanup_old_resources() {
         echo "🔴 Error: originating_tool parameter is required"
         return 1
     fi
+    if [ "${#originating_tool}" -gt 63 ]; then
+        echo "⚠️  originating_tool is ${#originating_tool} chars — truncating to 63 for label selector."
+        originating_tool="${originating_tool:0:63}"
+    fi
 
     # disable exit on error to allow for cleanup of old resources
     set +e
@@ -591,7 +798,7 @@ cleanup_old_resources() {
 
     echo "🔍 Searching for resources with originating-tool=${originating_tool}"
 
-    local kinds="enterprisecontractpolicy rp rpa rolebinding sa clusterrole secret application component"
+    local kinds="enterprisecontractpolicy rp rpa rolebinding sa clusterrole secret application component release"
     for kind in $kinds; do
         local namespaces="dev-release-team-tenant managed-release-team-tenant"
         for namespace in $namespaces; do

--- a/integration-tests/scripts/wait-for-release.sh
+++ b/integration-tests/scripts/wait-for-release.sh
@@ -200,6 +200,48 @@ if [ -z "$RELEASE_NAMESPACE" ]; then
   exit 1
 fi
 
+# Returns 0 if every failing TaskRun in a managed PipelineRun failed due to
+# TaskRunImagePullFailed — meaning the failure is purely an infra/registry blip,
+# not a real test assertion or pipeline logic error.
+is_pure_image_pull_failure() {
+  local release_json="$1"
+
+  # Extract managed PLR name and namespace from the Release status
+  # .status.managedProcessing.pipelineRun is stored as "namespace/name"
+  local plr_namespaced plr_name plr_ns
+  plr_namespaced=$(echo "$release_json" | jq -r '.status.managedProcessing.pipelineRun // empty' 2>/dev/null)
+  [ -z "$plr_namespaced" ] && return 1
+  plr_ns="${plr_namespaced%%/*}"
+  plr_name="${plr_namespaced##*/}"
+  plr_ns="${plr_ns:-managed-release-team-tenant}"
+
+  [ -z "$plr_name" ] && return 1  # can't determine — assume real failure
+
+  # Collect reasons for all failed TaskRuns in this PLR
+  local failed_reasons
+  failed_reasons=$(kubectl get taskrun -n "$plr_ns" \
+    -l "tekton.dev/pipelineRun=${plr_name}" \
+    -o jsonpath='{.items[?(@.status.conditions[0].status=="False")].status.conditions[0].reason}' \
+    2>/dev/null)
+
+  [ -z "$failed_reasons" ] && return 1  # no failed tasks found — unexpected, assume real failure
+
+  # If every failure reason is TaskRunImagePullFailed, it's a pure infra issue
+  local non_imagepull
+  non_imagepull=$(echo "$failed_reasons" | tr ' ' '\n' | grep -v "^TaskRunImagePullFailed$" || true)
+  [ -z "$non_imagepull" ]
+}
+
+# MAX_RELEASE_RETRIES: how many times to re-create a Release CR when it fails
+# due to pure TaskRunImagePullFailed (default 1). Export to override.
+RELEASE_RETRIES_LEFT="${MAX_RELEASE_RETRIES:-1}"
+
+# If set, the final effective release name (which may differ from RELEASE_NAME
+# when a retry Release CR was created) is written to this file so callers can
+# read the correct name for artifact verification.
+# Usage: export RELEASE_NAME_OUTPUT_FILE=/tmp/my-release-name
+RELEASE_NAME_OUTPUT_FILE="${RELEASE_NAME_OUTPUT_FILE:-}"
+
 CONSOLEURL=$(kubectl get cm/pipelines-as-code -n openshift-pipelines -ojson | jq -r '.data."custom-console-url"')
 
 echo "======================================="
@@ -315,11 +357,48 @@ ${overAllStatusLine}"
   fi
 
   if [ "${RELEASED_STATUS}" == "\"False\"" ] && [ "${RELEASED_REASON}" == "\"Failed\"" ]; then
+    RELEASE_JSON=$(kubectl get release/${RELEASE_NAME} -n ${RELEASE_NAMESPACE} -ojson)
+
+    # --- Retry on pure image-pull infra failures ---
+    if [ "${RELEASE_RETRIES_LEFT}" -gt 0 ] && is_pure_image_pull_failure "${RELEASE_JSON}"; then
+      echo ""
+      echo "⚠️  Release ${RELEASE_NAME} failed due to TaskRunImagePullFailed (transient registry issue)."
+      local retry_delay="${RELEASE_RETRY_DELAY:-60}"
+      echo "   Retrying (${RELEASE_RETRIES_LEFT} attempt(s) left) — waiting ${retry_delay}s for registry to recover..."
+      sleep "${retry_delay}"
+
+      local_snapshot=$(jq -r '.spec.snapshot' <<< "${RELEASE_JSON}")
+      local_plan=$(jq -r '.spec.releasePlan' <<< "${RELEASE_JSON}")
+
+      # Create a fresh Release CR against the same snapshot + releasePlan
+      NEW_RELEASE_NAME=$(kubectl create -f - 2>/dev/null <<EOF | grep -oP '(?<=release\.appstudio\.redhat\.com/)[\w-]+'
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  generateName: retry-
+  namespace: ${RELEASE_NAMESPACE}
+spec:
+  snapshot: ${local_snapshot}
+  releasePlan: ${local_plan}
+EOF
+)
+      if [ -z "${NEW_RELEASE_NAME}" ]; then
+        echo "🔴 Failed to create retry Release CR — falling through to failure."
+      else
+        RELEASE_RETRIES_LEFT=$(( RELEASE_RETRIES_LEFT - 1 ))
+        RELEASE_NAME="${NEW_RELEASE_NAME}"
+        echo "↩️  Monitoring retry Release: ${RELEASE_NAME}"
+        echo "======================================="
+        echo "Release           : ${RELEASE_NAME}"
+        echo "======================================="
+        continue
+      fi
+    fi
+
+    # --- Real failure (not an image pull issue, or retries exhausted) ---
     echo ""
     echo "❌ Error: Release failed!"
     echo ""
-
-    RELEASE_JSON=$(kubectl get release/${RELEASE_NAME} -n ${RELEASE_NAMESPACE} -ojson)
 
     getLogs "${RELEASE_JSON}" "collectorsProcessing?.tenantCollectorsProcessing?"
     getLogs "${RELEASE_JSON}" "collectorsProcessing?.managedCollectorsProcessing?"
@@ -334,6 +413,7 @@ ${overAllStatusLine}"
 
   if [ "${RELEASED_STATUS}" == "\"True\"" ] && [ "${RELEASED_REASON}" == "\"Succeeded\"" ]; then
     echo "✅ Release for ${RELEASE_PLAN} succeeded!"
+    [ -n "${RELEASE_NAME_OUTPUT_FILE}" ] && echo "${RELEASE_NAME}" > "${RELEASE_NAME_OUTPUT_FILE}"
     exit 0
   fi
   sleep 5


### PR DESCRIPTION
## Describe your changes
Make integration tests more robust under heavy parallel load by replacing hardcoded timeouts with configurable env vars and adding smarter retry logic.

- PLR_APPEAR_TIMEOUT (default 15 min) and RELEASE_APPEAR_TIMEOUT (default 10 min) replace fixed 5-minute waits that were too short under PAC/release-controller backlog
- MAX_PLR_RETRIES (default 2) replaces the old single-shot retry, with a 60s delay before re-triggering a build
- wait-for-release.sh now detects failures caused entirely by TaskRunImagePullFailed and automatically re-creates a fresh Release CR (MAX_RELEASE_RETRIES, default 1) so transient registry blips don't fail the suite
- Effective release names (which may differ after a retry) are propagated back to the caller via a temp file, ensuring artifact verification uses the correct Release CR

## Relevant Jira
[RELEASE-2145](https://issues.redhat.com/browse/RELEASE-2145)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[RELEASE-2299]: https://redhat.atlassian.net/browse/RELEASE-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RELEASE-2145]: https://redhat.atlassian.net/browse/RELEASE-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ