### PR TITLE
fix(RELEASE-2270): cleanup Windows signing artifacts on failure

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -965,26 +965,39 @@ spec:
           scp "${SCP_OPTS[@]}" "$windows_signing_script_file" \
           "${WINDOWS_USER}@${WINDOWS_HOST}:${WINDOWS_SIGNING_SCRIPT_PATH}"
 
-          # Execute the script on the Windows host
+          # Execute the script on the Windows host, capture exit code
+          ssh_exit=0
+          failed_operation=""
           # shellcheck disable=SC2029,SC2086
           ssh "${SSH_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}" \
-            "${WINDOWS_SIGNING_SCRIPT_PATH}"
+            "${WINDOWS_SIGNING_SCRIPT_PATH}" \
+            || { ssh_exit=$?; failed_operation="signing"; }
 
-          # Copy signed digest back to shared volume for this component
-          # shellcheck disable=SC2029,SC2086
-          WINDOWS_DIGEST_PATH="C:/Users/${WINDOWS_USER}/AppData/Local/Temp/${WINDOWS_TEMP_DIR}/unsigned/digest.txt"
-          scp "${SCP_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}:${WINDOWS_DIGEST_PATH}" \
-          "$COMPONENT_DIR/signed_windows_digest.txt"
+          # Copy signed digest back if signing succeeded
+          if [ $ssh_exit -eq 0 ]; then
+            # shellcheck disable=SC2029,SC2086
+            WINDOWS_DIGEST_PATH="C:/Users/${WINDOWS_USER}/AppData/Local/Temp/${WINDOWS_TEMP_DIR}/unsigned/digest.txt"
+            scp "${SCP_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}:${WINDOWS_DIGEST_PATH}" \
+            "$COMPONENT_DIR/signed_windows_digest.txt" || { ssh_exit=$?; failed_operation="scp of signed digest"; }
 
-          # Remove trailing spaces, carriage returns, newlines
-          sed -i 's/[[:space:]]*$//; s/\r//g; :a;N;$!ba;s/\n//g' "$COMPONENT_DIR/signed_windows_digest.txt"
+            if [ $ssh_exit -eq 0 ]; then
+              # Remove trailing spaces, carriage returns, newlines
+              sed -i 's/[[:space:]]*$//; s/\r//g; :a;N;$!ba;s/\n//g' "$COMPONENT_DIR/signed_windows_digest.txt"
+            fi
+          fi
 
-          # Clean up the windows host now that we are done with this component
+          # Always clean up the Windows host (on success or failure)
           WINDOWS_CLEANUP_PATH="C:\\Users\\${WINDOWS_USER}\\AppData\\Local\\Temp\\${WINDOWS_TEMP_DIR}"
           # shellcheck disable=SC2029,SC2086
           ssh "${SSH_OPTS[@]}" "${WINDOWS_USER}@${WINDOWS_HOST}" \
             "Remove-Item -LiteralPath ${WINDOWS_CLEANUP_PATH} -Force -Recurse; \
-            Remove-Item -LiteralPath ${WINDOWS_SIGNING_SCRIPT_PATH} -Force"
+            Remove-Item -LiteralPath ${WINDOWS_SIGNING_SCRIPT_PATH} -Force" || true
+
+          # Fail the step if signing or scp failed
+          if [ $ssh_exit -ne 0 ]; then
+            echo "Windows ${failed_operation} failed for component: $COMPONENT_NAME (exit code: $ssh_exit)"
+            exit $ssh_exit
+          fi
         done
     - name: generate-checksums
       image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/mocks.sh
@@ -369,6 +369,10 @@ function publish_to_cgw_wrapper() {
 
 function ssh() {
     echo Mocking ssh call with: $*
+    if [[ "$*" == *"fail-windows-signing"* ]] && [[ "$*" == *".bat"* ]]; then
+        echo "Simulating Windows signing failure" >&2
+        return 1
+    fi
 }
 
 function scp() {

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-windows-signing.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-windows-signing.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-fail-windows-signing
+spec:
+  description: |
+    Run the push-artifacts task with a component name that triggers a Windows signing
+    failure in the ssh mock. Verifies that cleanup still runs and the signing error
+    is properly reported in the task result.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn-task
+      params:
+        - name: snapshot_json
+          value: >-
+            {
+              "application": "amd-bootc-1-3-qcow2-disk-image",
+              "artifacts": {},
+              "components": [
+                {
+                  "containerImage": "quay.io/org/tenant/qcow-disk-image/qcow2-disk-image@sha256:abcdef12345",
+                  "contentGateway": {
+                    "productCode": "Code",
+                    "productName": "MyName",
+                    "productVersionName": "1.3-staging"
+                  },
+                  "name": "fail-windows-signing",
+                  "staged": {
+                    "destination": "testproduct-amd64",
+                    "version": "1.3"
+                  },
+                  "files": [
+                    {
+                      "filename": "testproduct-binary-windows-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-windows-amd64.tar.gz",
+                      "os": "windows",
+                      "arch": "amd64"
+                    },
+                    {
+                      "filename": "testproduct-binary-darwin-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-darwin-amd64.tar.gz",
+                      "os": "darwin",
+                      "arch": "amd64"
+                    },
+                    {
+                      "filename": "testproduct-binary-linux-amd64.tar.gz",
+                      "source": "/releases/testproduct-binary-linux-amd64.tar.gz",
+                      "os": "linux",
+                      "arch": "amd64"
+                    }
+                  ]
+                }
+              ]
+            }
+        - name: exodusGwSecret
+          value: "pulp-task-exodus-secret"
+        - name: exodusGwEnv
+          value: "pre"
+        - name: pulpSecret
+          value: "pulp-task-pulp-secret"
+        - name: udcacheSecret
+          value: "pulp-task-udc-secret"
+        - name: cgwHostname
+          value: "https://content-gateway.com"
+        - name: cgwSecret
+          value: "pulp-task-cgw-secret"
+        - name: author
+          value: testuser
+        - name: signingKeyName
+          value: testkey
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+      taskSpec:
+        params:
+          - name: result
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            env:
+              - name: "RESULT"
+                value: '$(params.result)'
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$RESULT" == "Success" ]]; then
+                echo "Error: result should not be Success - Windows signing should have failed"
+                exit 1
+              fi
+
+              if [[ "$RESULT" != *"ERROR"* ]]; then
+                echo "Error: result should contain ERROR from failed Windows signing"
+                echo "Actual result: $RESULT"
+                exit 1
+              fi


### PR DESCRIPTION
Capture the ssh exit code from Windows signing instead of failing immediately. This allows cleanup of remote artifacts to always run regardless of signing outcome. The signed digest is only copied back on success, and the original failure is propagated after cleanup completes.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
