### PR TITLE
feat(ISV-6831): update collect-tpa-params (collect-atlas-params) to support TSF

### DIFF
--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -646,7 +646,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+            value: tasks/managed/collect-tpa-params/collect-tpa-params.yaml
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -774,7 +774,7 @@ spec:
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
           operator: in
-          values: ["false"]
+          values: [ "false" ]
       taskRef:
         resolver: "git"
         params:
@@ -783,7 +783,7 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/collect-atlas-params/collect-atlas-params.yaml
+            value: tasks/managed/collect-tpa-params/collect-tpa-params.yaml
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"

--- a/tasks/managed/collect-tpa-params/README.md
+++ b/tasks/managed/collect-tpa-params/README.md
@@ -1,15 +1,25 @@
-# collect-atlas-params
+# collect-tpa-params
 
-Tekton task that collects the Atlas server option from the data file. Based on
-the value of the "atlas.server" field ("stage" or "production"), outputs results
-used to push SBOMs to Atlas. Also outputs results used to push SBOMs to an S3
-bucket. If no Atlas fields are present in the data file, the task fails
+Tekton task that collects the TPA server option from the data file.
+It can either parse the cluster configuration stored in konflux-info
+namespace or parse a dataPath JSON file for values.
+
+If the desired configmap is present in konflux-info, it will be used
+as a preferred option.
+
+Otherwise it outputs values based on the value of the "atlas.server" or
+"tpa.servers" field ("stage" or "production"), the output values are used
+to push SBOMs to TPA. Also outputs results used to push SBOMs to an S3
+bucket.
+
+If the configmap in konflux-info cannot be parsed and no TPA fields
+are present in the data file, the task fails.
 
 ## Parameters
 
 | Name                    | Description                                                                                                                | Optional | Default value        |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
-| dataPath                | Path to the JSON string of the merged data containing the Atlas config                                                     | No       | -                    |
+| dataPath                | Path to the JSON string of the merged data containing the TPA config                                                       | Yes      | ""                   |
 | ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
 | ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
@@ -20,3 +30,5 @@ bucket. If no Atlas fields are present in the data file, the task fails
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
 | caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
 | caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |
+| configMapNamespace      | The namespace where the ConfigMap is located                                                                               | Yes      | konflux-info         |
+| configMapName           | The name of the ConfigMap to read TPA parameters from                                                                      | Yes      | cluster-config       |

--- a/tasks/managed/collect-tpa-params/collect-tpa-params.yaml
+++ b/tasks/managed/collect-tpa-params/collect-tpa-params.yaml
@@ -2,21 +2,32 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: collect-atlas-params
+  name: collect-tpa-params
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
   description: |-
-    Tekton task that collects the Atlas server option from the data file. Based on
-    the value of the "atlas.server" field ("stage" or "production"), outputs results
-    used to push SBOMs to Atlas. Also outputs results used to push SBOMs to an S3
-    bucket. If no Atlas fields are present in the data file, the task fails
+    Tekton task that collects the TPA server option from the data file.
+    It can either parse the cluster configuration stored in konflux-info
+    namespace or parse a dataPath JSON file for values.
+    
+    If the desired configmap is present in konflux-info, it will be used
+    as a preferred option.
+    
+    Otherwise it outputs values based on the value of the "atlas.server" or
+    "tpa.servers" field ("stage" or "production"), the output values are used
+    to push SBOMs to TPA. Also outputs results used to push SBOMs to an S3
+    bucket.
+    
+    If the configmap in konflux-info cannot be parsed and no TPA fields
+    are present in the data file, the task fails.
   params:
     - name: dataPath
       type: string
       description: |
-        Path to the JSON string of the merged data containing the Atlas config
+        Path to the JSON string of the merged data containing the TPA config
+      default: ""
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored
       type: string
@@ -56,11 +67,19 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
+    - name: configMapNamespace
+      type: string
+      description: The namespace where the ConfigMap is located
+      default: konflux-info
+    - name: configMapName
+      type: string
+      description: The name of the ConfigMap to read TPA parameters from
+      default: cluster-config
   results:
     - name: atlasApiUrl
       type: string
       description: |
-        URL of the Atlas API.
+        URL of the TPA API.
     - name: ssoTokenUrl
       type: string
       description: |
@@ -68,7 +87,7 @@ spec:
     - name: secretName
       type: string
       description: |
-        The kubernetes secret to use to authenticate to Atlas.
+        The kubernetes secret to use to authenticate to TPA.
     - name: retryAWSSecretName
       type: string
       description: |
@@ -126,7 +145,7 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
-    - name: collect-atlas-params
+    - name: collect-tpa-params
       image:
         quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
@@ -140,33 +159,56 @@ spec:
         #!/usr/bin/env bash
         set -x
 
+        KFLX_CONFIG_PATH='/tmp/konflux_config.json'
+
+        echo 'Checking for configuration...'
+        if retry 3 kubectl get configmap "$(params.configMapName)" -n "$(params.configMapNamespace)" -o json > \
+         "$KFLX_CONFIG_PATH"; then
+          atlasApiURL=$(jq -r '.data.trustifyServerExternalUrl // ""' "$KFLX_CONFIG_PATH")
+          ssoTokenBaseURL=$(jq -r '.data.trustifyOIDCIssuerUrl // ""' "$KFLX_CONFIG_PATH")
+          if [ -n "$atlasApiURL" ] && [ -n "$ssoTokenBaseURL" ]; then
+            echo 'Detected cluster-config, gathering information...'
+            ssoTokenFullURL="${ssoTokenBaseURL}/protocol/openid-connect/token"
+            echo -n "$atlasApiURL" > "$(results.atlasApiUrl.path)"
+            echo -n "$ssoTokenFullURL" > "$(results.ssoTokenUrl.path)"
+            echo -n 'release-sso-secret' > "$(results.secretName.path)"
+            # TSF doesn't use AWS S3, but empty secret names are invalid in K8s
+            echo -n 'secret-not-present' > "$(results.retryAWSSecretName.path)"
+            echo -n '' > "$(results.retryS3Bucket.path)"
+            echo 'Gathered info from cluster-config, shutting down script.'
+            exit 0
+          fi
+        fi
+
+        echo 'Gathering data from data file...'
+
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "ERROR: No valid data file was provided."
             exit 1
         fi
-
-        atlasServer=$(jq -r '.atlas.server' "$DATA_FILE")
+        atlasServer=$(jq -r '(.atlas // .tpa).server' "$DATA_FILE")
         if [ "$atlasServer" = "stage" ]; then
             atlasApiUrl="https://atlas.release.stage.devshift.net"
             ssoTokenUrl="https://auth.stage.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
-            secretName=$(jq -r '.atlas."atlas-sso-secret-name" // "atlas-staging-sso-secret"' "$DATA_FILE")
-            retryAWSSecretName=$(jq -r '.atlas."atlas-retry-aws-secret-name" // "atlas-retry-s3-staging-secret"' \
-              "$DATA_FILE")
+            secretName=$(jq -r \
+              '(.atlas // .tpa)."atlas-sso-secret-name" // "atlas-staging-sso-secret"' "$DATA_FILE")
+            retryAWSSecretName=$(jq -r \
+              '(.atlas // .tpa)."atlas-retry-aws-secret-name" // "atlas-retry-s3-staging-secret"' "$DATA_FILE")
             retryS3Bucket="mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"
         elif [ "$atlasServer" = "production" ]; then
             atlasApiUrl="https://atlas.release.devshift.net"
             ssoTokenUrl="https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
-            secretName=$(jq -r '.atlas."atlas-sso-secret-name" // "atlas-prod-sso-secret"' "$DATA_FILE")
-            retryAWSSecretName=$(jq -r '.atlas."atlas-retry-aws-secret-name" // "atlas-retry-s3-production-secret"' \
-              "$DATA_FILE")
+            secretName=$(jq -r '(.atlas // .tpa)."atlas-sso-secret-name" // "atlas-prod-sso-secret"' "$DATA_FILE")
+            retryAWSSecretName=$(jq -r \
+              '(.atlas // .tpa)."atlas-retry-aws-secret-name" // "atlas-retry-s3-production-secret"' "$DATA_FILE")
             retryS3Bucket="mpp-e1-prod-sbom-e02138d3-5c5c-4d90-a38f-6c54f658604d"
         elif [ "$atlasServer" = "null" ]; then
-            echo "ERROR: .atlas.server value is missing from the data file. This field is mandatory."
+            echo "ERROR: .(tpa/atlas).server value is missing from the data file. This field is mandatory."
             echo "Consult with your release engineering contact to ask why you are missing this value"
             exit 1
         else
-            echo "ERROR: Unknown .atlas.server value '$atlasServer'. Expected 'stage' or 'production'."
+            echo "ERROR: Unknown .(tpa/atlas).server value '$atlasServer'. Expected 'stage' or 'production'."
             exit 1
         fi
 

--- a/tasks/managed/collect-tpa-params/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/collect-tpa-params/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add RBAC so that the SA executing the tests can manage configmaps
+kubectl apply -f .github/resources/crd_rbac.yaml

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-bad-value.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-bad-value.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-nonexistent
+  name: test-collect-tpa-params-bad-value
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-atlas-params task with a missing atlasServer key.
+    Run the collect-tpa-params task with a bad value as atlasServer.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -56,7 +56,13 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              echo "{}" > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "atlas": {
+                  "server": "invalid"
+                }
+              }
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -69,7 +75,7 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: collect-tpa-params
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
@@ -87,5 +93,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: configMapNamespace
+          value: "$(context.pipelineRun.namespace)"
+        - name: configMapName
+          value: "nonexistent-configmap"
       runAfter:
         - setup

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-empty-configmap.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-empty-configmap.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-stage-custom-secret
+  name: test-collect-tpa-params-empty-configmap
 spec:
   description: |
-    Run the collect-atlas-params task with custom secret params in the RPA and verify the results.
+    Run the collect-tpa-params task with a configmap that exists but lacks
+    TSF values. Verify the task falls through to the RH internal workflow.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -48,18 +49,20 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
               set -eux
+
+              kubectl create configmap test-cluster-config-empty \
+                --from-literal=unrelatedKey="some-value"
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "atlas": {
-                  "server": "stage",
-                  "atlas-sso-secret-name": "some-other-secret-name",
-                  "atlas-retry-aws-secret-name": "another-secret-name"
+                  "server": "stage"
                 }
               }
               EOF
@@ -75,7 +78,7 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: collect-tpa-params
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
@@ -93,31 +96,69 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: configMapName
+          value: test-cluster-config-empty
+        - name: configMapNamespace
+          value: $(context.pipelineRun.namespace)
       runAfter:
         - setup
     - name: check-result
       params:
         - name: secretName
           value: $(tasks.run-task.results.secretName)
+        - name: ssoTokenUrl
+          value: $(tasks.run-task.results.ssoTokenUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
         - name: retryAWSSecretName
           value: $(tasks.run-task.results.retryAWSSecretName)
+        - name: retryS3Bucket
+          value: $(tasks.run-task.results.retryS3Bucket)
       taskSpec:
         params:
           - name: secretName
             type: string
+          - name: ssoTokenUrl
+            type: string
+          - name: atlasApiUrl
+            type: string
           - name: retryAWSSecretName
+            type: string
+          - name: retryS3Bucket
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'
+              - name: "SSO_TOKEN_URL"
+                value: '$(params.ssoTokenUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
               - name: "RETRY_AWS_SECRET_NAME"
                 value: '$(params.retryAWSSecretName)'
+              - name: "RETRY_S3_BUCKET"
+                value: '$(params.retryS3Bucket)'
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              test "$SECRET_NAME" = "some-other-secret-name"
-              test "$RETRY_AWS_SECRET_NAME" = "another-secret-name"
+              test "$ATLAS_API_URL" = "https://atlas.release.stage.devshift.net"
+              test "$SSO_TOKEN_URL" = \
+                "https://auth.stage.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
+              test "$SECRET_NAME" = "atlas-staging-sso-secret"
+              test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-staging-secret"
+              test "$RETRY_S3_BUCKET" = \
+                "mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-configmap
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              kubectl delete configmap test-cluster-config-empty --ignore-not-found

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-konflux-info.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-konflux-info.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-prod
+  name: test-collect-tpa-params-konflux-info
 spec:
   description: |
-    Run the collect-atlas-params task and verify the results.
+    Run the collect-tpa-params task with a configmap present and verify
+    that the TSF workflow produces the expected results.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -48,19 +49,17 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
-              {
-                "atlas": {
-                  "server": "production"
-                }
-              }
-              EOF
+              kubectl create configmap test-cluster-config \
+                --from-literal=trustifyServerExternalUrl="https://trustify.example.com" \
+                --from-literal=trustifyOIDCIssuerUrl="https://sso.example.com/realms/chicken"
+
+              mkdir -p "$(params.dataDir)"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -73,10 +72,8 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: collect-tpa-params
       params:
-        - name: dataPath
-          value: "$(context.pipelineRun.uid)/data.json"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -91,6 +88,10 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: configMapName
+          value: test-cluster-config
+        - name: configMapNamespace
+          value: $(context.pipelineRun.namespace)
       runAfter:
         - setup
     - name: check-result
@@ -119,7 +120,8 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'
@@ -135,8 +137,19 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              test "$SECRET_NAME" = "atlas-prod-sso-secret"
-              test "$SSO_TOKEN_URL" = "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
-              test "$ATLAS_API_URL" = "https://atlas.release.devshift.net"
-              test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-production-secret"
-              test "$RETRY_S3_BUCKET" = "mpp-e1-prod-sbom-e02138d3-5c5c-4d90-a38f-6c54f658604d"
+              test "$ATLAS_API_URL" = "https://trustify.example.com"
+              test "$SSO_TOKEN_URL" = \
+                "https://sso.example.com/realms/chicken/protocol/openid-connect/token"
+              test "$SECRET_NAME" = "release-sso-secret"
+              test "$RETRY_AWS_SECRET_NAME" = "secret-not-present"
+              test "$RETRY_S3_BUCKET" = ""
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-configmap
+            image:
+              quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              kubectl delete configmap test-cluster-config --ignore-not-found

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-nonexistent.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-nonexistent.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-bad-value
+  name: test-collect-tpa-params-nonexistent
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the collect-atlas-params task with a bad value as atlasServer.
+    Run the collect-tpa-params task with a missing atlasServer key.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -56,13 +56,7 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
-              {
-                "atlas": {
-                  "server": "invalid"
-                }
-              }
-              EOF
+              echo "{}" > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -75,7 +69,7 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: collect-tpa-params
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
@@ -93,5 +87,9 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: configMapNamespace
+          value: "$(context.pipelineRun.namespace)"
+        - name: configMapName
+          value: "nonexistent-configmap"
       runAfter:
         - setup

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-prod.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-prod.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-tpa-params-prod
+spec:
+  description: |
+    Run the collect-tpa-params task and verify the results.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "atlas": {
+                  "server": "production"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: collect-tpa-params
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: configMapNamespace
+          value: "$(context.pipelineRun.namespace)"
+        - name: configMapName
+          value: "nonexistent-configmap"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: secretName
+          value: $(tasks.run-task.results.secretName)
+        - name: ssoTokenUrl
+          value: $(tasks.run-task.results.ssoTokenUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
+        - name: retryAWSSecretName
+          value: $(tasks.run-task.results.retryAWSSecretName)
+        - name: retryS3Bucket
+          value: $(tasks.run-task.results.retryS3Bucket)
+      taskSpec:
+        params:
+          - name: secretName
+            type: string
+          - name: ssoTokenUrl
+            type: string
+          - name: atlasApiUrl
+            type: string
+          - name: retryAWSSecretName
+            type: string
+          - name: retryS3Bucket
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            env:
+              - name: "SECRET_NAME"
+                value: '$(params.secretName)'
+              - name: "SSO_TOKEN_URL"
+                value: '$(params.ssoTokenUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
+              - name: "RETRY_AWS_SECRET_NAME"
+                value: '$(params.retryAWSSecretName)'
+              - name: "RETRY_S3_BUCKET"
+                value: '$(params.retryS3Bucket)'
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              test "$SECRET_NAME" = "atlas-prod-sso-secret"
+              test "$SSO_TOKEN_URL" = "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token"
+              test "$ATLAS_API_URL" = "https://atlas.release.devshift.net"
+              test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-production-secret"
+              test "$RETRY_S3_BUCKET" = "mpp-e1-prod-sbom-e02138d3-5c5c-4d90-a38f-6c54f658604d"

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-stage-custom-secret.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-stage-custom-secret.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-atlas-params-stage
+  name: test-collect-tpa-params-stage-custom-secret
 spec:
   description: |
-    Run the collect-atlas-params task and verify the results.
+    Run the collect-tpa-params task with custom secret params in the RPA and verify the results.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -56,8 +56,10 @@ spec:
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
-                "atlas": {
-                  "server": "stage"
+                "tpa": {
+                  "server": "stage",
+                  "atlas-sso-secret-name": "some-other-secret-name",
+                  "atlas-retry-aws-secret-name": "another-secret-name"
                 }
               }
               EOF
@@ -73,7 +75,7 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: collect-atlas-params
+        name: collect-tpa-params
       params:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
@@ -91,31 +93,23 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: configMapNamespace
+          value: "$(context.pipelineRun.namespace)"
+        - name: configMapName
+          value: "nonexistent-configmap"
       runAfter:
         - setup
     - name: check-result
       params:
         - name: secretName
           value: $(tasks.run-task.results.secretName)
-        - name: ssoTokenUrl
-          value: $(tasks.run-task.results.ssoTokenUrl)
-        - name: atlasApiUrl
-          value: $(tasks.run-task.results.atlasApiUrl)
         - name: retryAWSSecretName
           value: $(tasks.run-task.results.retryAWSSecretName)
-        - name: retryS3Bucket
-          value: $(tasks.run-task.results.retryS3Bucket)
       taskSpec:
         params:
           - name: secretName
             type: string
-          - name: ssoTokenUrl
-            type: string
-          - name: atlasApiUrl
-            type: string
           - name: retryAWSSecretName
-            type: string
-          - name: retryS3Bucket
             type: string
         steps:
           - name: check-result
@@ -123,21 +117,11 @@ spec:
             env:
               - name: "SECRET_NAME"
                 value: '$(params.secretName)'
-              - name: "SSO_TOKEN_URL"
-                value: '$(params.ssoTokenUrl)'
-              - name: "ATLAS_API_URL"
-                value: '$(params.atlasApiUrl)'
               - name: "RETRY_AWS_SECRET_NAME"
                 value: '$(params.retryAWSSecretName)'
-              - name: "RETRY_S3_BUCKET"
-                value: '$(params.retryS3Bucket)'
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              test "$SECRET_NAME" = "atlas-staging-sso-secret"
-              test "$SSO_TOKEN_URL" = "https://auth.stage.redhat.com/auth/realms\
-              /EmployeeIDP/protocol/openid-connect/token"
-              test "$ATLAS_API_URL" = "https://atlas.release.stage.devshift.net"
-              test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-staging-secret"
-              test "$RETRY_S3_BUCKET" = "mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"
+              test "$SECRET_NAME" = "some-other-secret-name"
+              test "$RETRY_AWS_SECRET_NAME" = "another-secret-name"

--- a/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-stage.yaml
+++ b/tasks/managed/collect-tpa-params/tests/test-collect-tpa-params-stage.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-tpa-params-stage
+spec:
+  description: |
+    Run the collect-tpa-params task and verify the results.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "atlas": {
+                  "server": "stage"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: collect-tpa-params
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: configMapNamespace
+          value: "$(context.pipelineRun.namespace)"
+        - name: configMapName
+          value: "nonexistent-configmap"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: secretName
+          value: $(tasks.run-task.results.secretName)
+        - name: ssoTokenUrl
+          value: $(tasks.run-task.results.ssoTokenUrl)
+        - name: atlasApiUrl
+          value: $(tasks.run-task.results.atlasApiUrl)
+        - name: retryAWSSecretName
+          value: $(tasks.run-task.results.retryAWSSecretName)
+        - name: retryS3Bucket
+          value: $(tasks.run-task.results.retryS3Bucket)
+      taskSpec:
+        params:
+          - name: secretName
+            type: string
+          - name: ssoTokenUrl
+            type: string
+          - name: atlasApiUrl
+            type: string
+          - name: retryAWSSecretName
+            type: string
+          - name: retryS3Bucket
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            env:
+              - name: "SECRET_NAME"
+                value: '$(params.secretName)'
+              - name: "SSO_TOKEN_URL"
+                value: '$(params.ssoTokenUrl)'
+              - name: "ATLAS_API_URL"
+                value: '$(params.atlasApiUrl)'
+              - name: "RETRY_AWS_SECRET_NAME"
+                value: '$(params.retryAWSSecretName)'
+              - name: "RETRY_S3_BUCKET"
+                value: '$(params.retryS3Bucket)'
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              test "$SECRET_NAME" = "atlas-staging-sso-secret"
+              test "$SSO_TOKEN_URL" = "https://auth.stage.redhat.com/auth/realms\
+              /EmployeeIDP/protocol/openid-connect/token"
+              test "$ATLAS_API_URL" = "https://atlas.release.stage.devshift.net"
+              test "$RETRY_AWS_SECRET_NAME" = "atlas-retry-s3-staging-secret"
+              test "$RETRY_S3_BUCKET" = "mpp-e1-preprod-sbom-29093454-2ea7-4fd0-b4cf-dc69a7529ee0"


### PR DESCRIPTION
New test assisted by Claude-4.6-Opus, other work done manually

If this PR is merged, https://github.com/konflux-ci/release-service-catalog/pull/2074 has to be rebased, as it is already based on top of these changes.

Assisted-by: Claude-4.6-Opus

## Describe your changes

Updated collect-atlas params:

* Renamed to collect-tpa-params
* Updated the key reading to be dynamic (according to the json, looks for either `data.tpa` or `data.atlas`
* Added TSF support - populating values from Konflux-info

## Relevant Jira

[ISV-6831](https://issues.redhat.com/browse/ISV-6831)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[ISV-6831]: https://redhat.atlassian.net/browse/ISV-6831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ