### PR TITLE
chore(RELEASE-2285): use new e2e-pq configMap in e2e tests

### DIFF
--- a/integration-tests/collectors/resources/managed/rpa.yaml
+++ b/integration-tests/collectors/resources/managed/rpa.yaml
@@ -21,7 +21,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
     mapping:
       defaults:

--- a/integration-tests/fbc-release/resources/managed/rpa.yaml
+++ b/integration-tests/fbc-release/resources/managed/rpa.yaml
@@ -28,7 +28,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
@@ -76,7 +76,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
@@ -124,7 +124,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
@@ -172,7 +172,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:

--- a/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
@@ -50,7 +50,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
     releaseNotes:
       product_id:

--- a/integration-tests/rh-advisories-large-snapshot/resources/managed/rpa.yaml
+++ b/integration-tests/rh-advisories-large-snapshot/resources/managed/rpa.yaml
@@ -19,7 +19,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
     mapping:
       defaults:

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
@@ -13,7 +13,7 @@ spec:
       server: stage
       secret: pyxis-${component_name}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
     mapping:
       defaults:

--- a/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
+++ b/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
@@ -22,7 +22,7 @@ spec:
     githubAppInstallationID: 52284535
     infra-deployment-update-script: "sed -i -e 's|\\(https://github.com/hacbs-release/release-service/config/default?ref=\\)\\(.*\\)|\\1{{ revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/release/development/kustomization.yaml"
     sign:
-      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
     pyxis:
       server: stage
       secret: pyxis-${component_name}


### PR DESCRIPTION
## Describe your changes

This is a copy of the e2e configMap for now and this is part of staging signing configMap cleanup.

Here's the plan:
1. Create a new hacbs-signing-pipeline-config-staging-e2e-pq configMap as a duplicate of hacbs-signing-pipeline-config-staging-e2e
2. Change data inheritance in konflux-release-data to use the new hacbs-signing-pipeline-config-staging-e2e-pq configMap
3. Change e2e to use the new hacbs-signing-pipeline-config-staging-e2e-pq configMap
4. Modify hacbs-signing-pipeline-config-staging-e2e to remove the pq key
5. Make sure nobody uses any of the other configMaps
6. Remove all the other configMaps

This change is item number 3.

## Relevant Jira

RELEASE-2285

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
