### PR TITLE
fix: correct line continuation in extraction_summary upload

### DIFF
--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -307,7 +307,8 @@ spec:
 
                       if ! AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
                           AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-                          aws s3 cp \                          "${SIGNED_KMODS_FULL_PATH}/extraction_summary.txt" \
+                          aws s3 cp \
+                          "${SIGNED_KMODS_FULL_PATH}/extraction_summary.txt" \
                           "s3://$(params.s3Bucket)/${summary_s3_path}extraction_summary.txt" \
                           --endpoint-url "$(params.s3Endpoint)" > "$AWS_LOG" 2>&1; then
     

--- a/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/mocks.sh
@@ -120,5 +120,21 @@ check_final_status() {
             echo "SUCCESS: Kernel version architecture suffix was properly stripped"
             echo "All uploads used cleaned path: 6.5.0-s3 (not 6.5.0-s3.x86_64)"
         fi
+
+        # For multiarch tests, verify extraction_summary.txt was uploaded
+        if [ -f "/var/workdir/release/arch_count.txt" ]; then
+            arch_count=$(cat "/var/workdir/release/arch_count.txt")
+            if [ "$arch_count" -gt 1 ]; then
+                echo ""
+                echo "Verifying multiarch summary files were uploaded..."
+                if ! grep -F -q "extraction_summary.txt" "$UPLOAD_LOG"; then
+                    echo "ERROR: extraction_summary.txt was not uploaded for multiarch build!"
+                    echo "Upload log:"
+                    cat "$UPLOAD_LOG"
+                    exit 1
+                fi
+                echo "SUCCESS: extraction_summary.txt upload verified"
+            fi
+        fi
     fi
 }

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-push-oot-kmods-to-s3-multiarch.yaml
@@ -4,24 +4,26 @@ kind: Pipeline
 metadata:
   name: test-push-oot-kmods-to-s3-multiarch
 spec:
-  description: Simplified test for S3 push task - validates multiarch parameter parsing only.
+  description: Test S3 push task with multiarch setup including extraction_summary.txt upload
   params:
     - name: dataDir
+      description: The location where data will be stored
       type: string
+      default: "/var/workdir/release"
     - name: taskGitUrl
       type: string
-      default: https://github.com/enriquebelarte/release-service-catalog.git
+      default: "http://localhost"
     - name: taskGitRevision
       type: string
-      default: signed-kmods-release
+      default: "development"
   tasks:
-    - name: setup-and-validate-multiarch
+    - name: setup-multiarch-data
       taskSpec:
         params:
           - name: dataDir
             type: string
         steps:
-          - name: setup-and-validate
+          - name: create-multiarch-structure
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
@@ -31,55 +33,64 @@ spec:
               mkdir -p "$(params.dataDir)"
               echo "2" > "$(params.dataDir)/arch_count.txt"
               SIGNED_KMODS_PATH="$(params.dataDir)/signed-kmods"
-              mkdir -p "$SIGNED_KMODS_PATH/amd64" "$SIGNED_KMODS_PATH/arm64"
+              mkdir -p "$SIGNED_KMODS_PATH/x86_64"
 
-              # Create test files for each architecture
-              echo "AMD64_KO_DATA" > "$SIGNED_KMODS_PATH/amd64/test.ko"
-              cat > "$SIGNED_KMODS_PATH/amd64/envfile" << 'EOF'
-              DRIVER_VENDOR=test-vendor
-              DRIVER_VERSION=1.0.0
-              KERNEL_VERSION=6.5.0-test
+              # Create test .ko files for x86_64
+              echo "X86_64_KO_DATA" > "$SIGNED_KMODS_PATH/x86_64/test.ko"
+
+              # Create envfile (KERNEL_VERSION with arch suffix to test stripping)
+              cat > "$SIGNED_KMODS_PATH/x86_64/envfile" << 'EOF'
+              DRIVER_VENDOR=test-vendor-ma
+              DRIVER_VERSION=2.0.0-multiarch
+              KERNEL_VERSION=6.5.0-test.x86_64
               EOF
 
-              echo "ARM64_KO_DATA" > "$SIGNED_KMODS_PATH/arm64/test.ko"
-              cat > "$SIGNED_KMODS_PATH/arm64/envfile" << 'EOF'
-              DRIVER_VENDOR=test-vendor
-              DRIVER_VERSION=1.0.0
-              KERNEL_VERSION=6.5.0-test
+              # Create signing_summary.txt
+              cat > "$SIGNED_KMODS_PATH/signing_summary.txt" << 'EOF'
+              Multi-architecture signing summary:
+              Total architectures processed: 2
+              Signing details:
+                x86_64: 1 signed .ko files
+                  Checksums: verified
               EOF
 
-              # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
+              # Create extraction_summary.txt (this tests the bug fix)
+              cat > "$SIGNED_KMODS_PATH/extraction_summary.txt" << 'EOF'
+              Multi-architecture extraction summary:
+              Total architectures processed: 2
+              Extraction details:
+                x86_64: 1 extracted .ko files
+              EOF
+
+              # Create signed-kmods.tar.gz file
               echo "Creating signed-kmods.tar.gz to simulate signing task output..."
               cd "$(params.dataDir)"
               tar -czf signed-kmods.tar.gz signed-kmods
 
-              echo "Multiarch test setup completed successfully"
-
-              # Validate multiarch structure
-              ARCH_COUNT=$(cat "$(params.dataDir)/arch_count.txt")
-              [ "$ARCH_COUNT" = "2" ] || { echo "ERROR: arch_count should be 2"; exit 1; }
-
-              # Validate each architecture directory
-              for arch in amd64 arm64; do
-                arch_dir="$SIGNED_KMODS_PATH/$arch"
-                [ -f "$arch_dir/test.ko" ] || { echo "ERROR: $arch test.ko missing"; exit 1; }
-                [ -f "$arch_dir/envfile" ] || { echo "ERROR: $arch envfile missing"; exit 1; }
-
-                # Check envfile content by parsing explicitly
-                DRIVER_VENDOR=$(grep "^DRIVER_VENDOR=" "$arch_dir/envfile" | cut -d= -f2)
-                DRIVER_VERSION=$(grep "^DRIVER_VERSION=" "$arch_dir/envfile" | cut -d= -f2)
-                KERNEL_VERSION=$(grep "^KERNEL_VERSION=" "$arch_dir/envfile" | cut -d= -f2)
-
-                [ -n "$DRIVER_VENDOR" ] || { echo "ERROR: $arch DRIVER_VENDOR not set"; exit 1; }
-                [ -n "$DRIVER_VERSION" ] || { echo "ERROR: $arch DRIVER_VERSION not set"; exit 1; }
-                [ -n "$KERNEL_VERSION" ] || { echo "ERROR: $arch KERNEL_VERSION not set"; exit 1; }
-
-                echo "SUCCESS: $arch architecture validated"
-                echo "S3 path for $arch: $DRIVER_VENDOR/$DRIVER_VERSION/$KERNEL_VERSION/$arch/"
-              done
-
-              echo "SUCCESS: All multiarch validation checks passed"
-              echo "Task would upload to S3 with multiarch structure"
+              echo "Multiarch test setup completed"
+              echo "Created extraction_summary.txt to verify upload fix"
       params:
         - name: dataDir
           value: $(params.dataDir)
+    - name: run-task
+      runAfter:
+        - setup-multiarch-data
+      taskRef:
+        name: push-oot-kmods-to-s3
+      params:
+        - name: signedKmodsPath
+          value: signed-kmods
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: s3Endpoint
+          value: "https://s3.mock.endpoint.com"
+        - name: s3Bucket
+          value: "mock-bucket"
+        - name: s3CredentialsSecret
+          value: "s3-mock-secret"
+        - name: sourceDataArtifact
+          value: "mock.registry/mock/artifact:latest"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)

--- a/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
+++ b/tasks/managed/push-oot-kmods-to-s3/tests/test-setup.sh
@@ -46,6 +46,35 @@ echo "Creating valid checksum file for all .ko files..."
   echo "Generated checksums for $(wc -l < signed_kmods_checksums_x86_64.txt) files"
 )
 
+# Create multiarch summary files if arch_count.txt exists with >1 arch
+# This simulates what extract-oot-kmods task produces for multiarch builds
+if [ -f "$(params.dataDir)/arch_count.txt" ]; then
+  arch_count=$(cat "$(params.dataDir)/arch_count.txt")
+  if [ "$arch_count" -gt 1 ]; then
+    echo "Creating multiarch summary files..."
+    SIGNED_KMODS_PATH_ABS="$(params.dataDir)/$(params.signedKmodsPath)"
+
+    # Create signing_summary.txt
+    cat > "$SIGNED_KMODS_PATH_ABS/signing_summary.txt" << EOF
+Multi-architecture signing summary:
+Total architectures processed: $arch_count
+Signing details:
+  x86_64: $(find "$ARCH_DIR" -name "*.ko" | wc -l) signed .ko files
+    Checksums: verified
+EOF
+
+    # Create extraction_summary.txt
+    cat > "$SIGNED_KMODS_PATH_ABS/extraction_summary.txt" << EOF
+Multi-architecture extraction summary:
+Total architectures processed: $arch_count
+Extraction details:
+  x86_64: $(find "$ARCH_DIR" -name "*.ko" | wc -l) extracted .ko files
+EOF
+
+    echo "Created signing_summary.txt and extraction_summary.txt"
+  fi
+fi
+
 # Create signed-kmods.tar.gz file to simulate what sign-oot-kmods produces
 echo "Creating signed-kmods.tar.gz to simulate signing task output..."
 cd "$(params.dataDir)"


### PR DESCRIPTION
Fixed malformed line continuation in push-oot-kmods-to-s3 task that caused AWS CLI to fail with "Unknown options" error when uploading extraction_summary.txt.

The indentation error from commit f55573e2 left the backslash continuation followed by spaces and the source path on the same line, causing AWS CLI to misinterpret the command arguments.

This fix aligns the extraction_summary.txt upload format with the correct pattern used in signing_summary.txt upload.

Fixes: f55573e2 ("fix: sensitive data leaking")

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
